### PR TITLE
Allow Cassandra and Redis to be configured to run other than localhost.

### DIFF
--- a/google/config/clouddriver-local.yml
+++ b/google/config/clouddriver-local.yml
@@ -5,6 +5,9 @@ services:
   front50:
     baseUrl: http://localhost:8080
 
+redis:
+  connection: redis://$REDIS_HOST:6379
+
 aws:
   enabled: ${AWS_ENABLED:false}
 

--- a/google/config/default_spinnaker_config.cfg
+++ b/google/config/default_spinnaker_config.cfg
@@ -60,3 +60,9 @@ JENKINS_PASSWORD=
 # Spinnaker Igor subsystem.
 # TODO: This is tied to using Jenkins.
 IGOR_ENABLED=false
+
+
+# External Dependency Bindings
+CASSANDRA_HOST=localhost
+ELASTICSEARCH_HOST=localhost
+REDIS_HOST=localhost

--- a/google/config/echo-local.yml
+++ b/google/config/echo-local.yml
@@ -3,6 +3,7 @@ server:
 
 cassandra:
   embedded: false
+  host: $CASSANDRA_HOST
 
 front50:
   baseUrl: http://localhost:8080

--- a/google/config/front50-local.yml
+++ b/google/config/front50-local.yml
@@ -3,6 +3,7 @@ server:
 
 cassandra:
   embedded: false
+  host: $CASSANDRA_HOST
 
 aws:
   simpleDBEnabled: false
@@ -11,6 +12,8 @@ aws:
 spinnaker:
   cassandra:
     enabled: true
+    host: $CASSANDRA_HOST
+    port: 9042
     cluster: CASS_SPINNAKER
     keyspace: front50
     name: global

--- a/google/config/gate-local.yml
+++ b/google/config/gate-local.yml
@@ -21,3 +21,7 @@ services:
   igor:
     enabled: ${IGOR_ENABLED:false}
     baseUrl: http://localhost:8088
+
+redis:
+  connection: redis://$REDIS_HOST:6379      
+

--- a/google/config/orca-local.yml
+++ b/google/config/orca-local.yml
@@ -32,5 +32,5 @@ default:
     securityGroups:
 
 redis:
-  connection: redis://localhost:6379
+  connection: redis://$REDIS_HOST:6379
 

--- a/google/config/rosco-local.yml
+++ b/google/config/rosco-local.yml
@@ -1,6 +1,9 @@
 server:
   port: 8087
 
+redis:
+  host: $REDIS_HOST
+
 aws:
   enabled: $AWS_ENABLED
 

--- a/google/config/rush-local.yml
+++ b/google/config/rush-local.yml
@@ -3,6 +3,7 @@ server:
 
 cassandra:
   embedded: false
+  host: $CASSANDRA_HOST
 
 docker:
   accounts:

--- a/google/dev/create_gce_image.py
+++ b/google/dev/create_gce_image.py
@@ -112,6 +112,9 @@ def init_argument_parser(parser):
     parser.add_argument(
         '--nodependencies', dest='dependencies', action='store_true')
 
+    parser.add_argument('--extra_install_flags', default='',
+                        help='Extra arguments to pass to --install_spinnaker'
+                             ' when setting up the prototype instance.')
     parser.add_argument('--create_image', dest='image')
     parser.add_argument('--image', default='', help='Name of image to create.')
     parser.add_argument('--image_project', default=default_project,
@@ -145,6 +148,8 @@ def create_prototype_instance(options):
         startup_command.append('--nodependencies')
     if options.update_os:
         startup_command.append('--update_os')
+    if options.extra_install_flags:
+        startup_command.extend(options.extra_install_flags.split())
 
     script_dir = os.path.dirname(sys.argv[0])
     install_dir = os.path.join(script_dir, '../install')

--- a/google/install/first_time_boot.sh
+++ b/google/install/first_time_boot.sh
@@ -116,14 +116,10 @@ function extract_spinnaker_credentials() {
     # got in the way.
     sed -i s/^None$//g $json_path
     if [[ -s $json_path ]]; then
-      chmod 600 $json_path
+      chmod 400 $json_path
     else
        rm $json_path
     fi
-  elif clear_metadata_to_file "gce-kms-credentials" $json_path; then
-    # DEPRECATED, this is the old metadata value. We'll keep support around
-    # until the client scripts are updated.
-    chmod 600 $json_path
   else
     clear_instance_metadata "managed_project_credentials"
     json_path=""

--- a/google/pylib/reconfigure_spinnaker.py
+++ b/google/pylib/reconfigure_spinnaker.py
@@ -25,5 +25,3 @@ if __name__ == '__main__':
     util.update_all_config_files(bindings)
   except SystemExit:
     sys.exit(-1)
-
-

--- a/google/pylib/spinnaker_runner.py
+++ b/google/pylib/spinnaker_runner.py
@@ -54,7 +54,6 @@ class Runner(object):
       # injected through a yaml).
       os.environ[name] = value
 
-
   # These are all the spinnaker subsystems in total.
   @classmethod
   def get_all_subsystem_names(cls):
@@ -112,21 +111,31 @@ class Runner(object):
 
   def start_dependencies(self):
     run_dir = self.__installation.EXTERNAL_DEPENDENCY_SCRIPT_DIR
-    run_or_die('LOG_DIR={log_dir} {run_dir}/start_redis.sh'
-                   .format(log_dir=self.__installation.LOG_DIR,
-                           run_dir=run_dir),
-                echo=False)
 
-    out,err = run_or_die(
-              'CASSANDRA_DIR={install_dir}/cassandra '
-              '{run_dir}/start_cassandra.sh'
-                  .format(install_dir=self.__installation.SPINNAKER_INSTALL_DIR,
-                          run_dir=run_dir),
-               echo=True)
+    run_or_die(
+        'REDIS_HOST={host}'
+        ' LOG_DIR={log_dir}'
+        ' {run_dir}/start_redis.sh'
+        .format(host=self.__bindings.get('REDIS_HOST', 'localhost'),
+                log_dir=self.__installation.LOG_DIR,
+                run_dir=run_dir),
+        echo=True)
 
-    run_or_die('{run_dir}/start_elasticsearch.sh'.format(run_dir=run_dir),
-               echo=False)
+    run_or_die(
+        'CASSANDRA_HOST={host}'
+        ' CASSANDRA_DIR={install_dir}/cassandra'
+        ' {run_dir}/start_cassandra.sh'
+        .format(host=self.__bindings.get('CASSANDRA_HOST', 'localhost'),
+                install_dir=self.__installation.SPINNAKER_INSTALL_DIR,
+                run_dir=run_dir),
+         echo=True)
 
+    run_or_die(
+        'ELASTICSEARCH_HOST={host}'
+        ' {run_dir}/start_elasticsearch.sh'
+        .format(host=self.__bindings.get('ELASTICSEARCH_HOST', 'localhost'),
+                run_dir=run_dir),
+        echo=False)
 
   def maybe_start_job(self, jobs, subsystem):
       if subsystem in jobs:
@@ -149,7 +158,6 @@ class Runner(object):
          started_list.append(('rush', pid))
     else:
       print 'Not using rush because docker is not configured.'
-
 
     if self.__bindings.get('JENKINS_ADDRESS', ''):
         if self.__bindings.get('IGOR_ENABLED', 'false') == 'false':

--- a/google/runtime/start_cassandra.sh
+++ b/google/runtime/start_cassandra.sh
@@ -14,26 +14,40 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-CASSANDRA_DIR=${CASSANDRA_DIR:-"$0/../cassandra"}
+CASSANDRA_DIR=${CASSANDRA_DIR:-"$(dirname $0)/../cassandra"}
 CASSANDRA_PORT=${CASSANDRA_PORT:-9042}
+CASSANDRA_HOST=${CASSANDRA_HOST:-127.0.0.1}
+export CQLSH_HOST=$CASSANDRA_HOST
 
-if nc -z localhost $CASSANDRA_PORT; then
-  echo "Cassandra is already up."
+function maybe_start_cassandra() {
+  if [[ "$CASSANDRA_HOST" != "localhost" ]] && \
+      ! ifconfig | grep " inet addr:${CASSANDRA_HOST} "  > /dev/null; then
+      echo "Using remote Cassandra from $CASSANDRA_HOST"
+  else
+    echo "Starting Cassandra on $CASSANDRA_HOST"
+    sudo service cassandra start
+  fi
+}
+
+if nc -z $CASSANDRA_HOST $CASSANDRA_PORT; then
+  echo "Cassandra is already up on $CASSANDRA_HOST:$CASSANDRA_PORT."
 else
-  echo "Starting Cassandra..."
-  sudo service cassandra start
-
-  echo "Waiting for Cassandra to start accepting requests on port $CASSANDRA_PORT..."
-  while ! nc -z localhost $CASSANDRA_PORT; do sleep 0.1; done; echo "Cassandra is up."
+  maybe_start_cassandra
+  echo "Waiting for Cassandra to start accepting requests on" \
+       "$CASSANDRA_HOST:$CASSANDRA_PORT..."
+  while ! nc -z $CASSANDRA_HOST $CASSANDRA_PORT; do sleep 0.1; done;
+  echo "Cassandra is up."
 fi
+
 
 # Create Cassandra keyspaces.
 echo "Creating Cassandra keyspaces..."
 DELAY=1
-while ! cqlsh -f $CASSANDRA_DIR/create_echo_keyspace.cql && [ "$DELAY" -lt 32 ]; do
-        sleep $DELAY
-        let DELAY*=2
-done;
+while ! cqlsh -f $CASSANDRA_DIR/create_echo_keyspace.cql && [ "$DELAY" -lt 32 ]
+do
+    sleep $DELAY
+    let DELAY*=2
+done
 
 cqlsh -f $CASSANDRA_DIR/create_front50_keyspace.cql
 


### PR DESCRIPTION
Cassandra and redis are currently still installed but they will not be
started up if the configuration says remote. The installation of these
is not affected, so they are still run locally when run. On the positive
side, this means you can currently easily change the configuration back to
localhost. But this isnt useful in the long run.

There is no installation support for a remote cassandra and redis.
It is assumed to already exist or be provided externally
Presumably you could install these from launcher, though I did not get
that to work on my first attempt.

In order to get this to work/verify, I installed
a second VM with spinnaker, then configured redis and cassandra to bind to
their internal IP address and started just them up (i.e. it was a vanilla
redis and cassandra installation). Then I conigured the remote
spinnaker_config.cfg to point to it as the CASSANDRA_HOST and REDIS_HOST
and ran start_spinnaker.sh as normal. There is no redis or cassandra running
locally and spinnaker starts up (and configures the remote cassandra schemas).

ElasticSearch is not included here. A followup CL is going to remove it.
