### PR TITLE
Fixed non-gce install

### DIFF
--- a/google/dev/create_dev_vm.py
+++ b/google/dev/create_dev_vm.py
@@ -149,7 +149,8 @@ def create_instance(options):
     os.write(fd, content)
     os.close(fd)
 
-    startup_command = 'install_development.py'
+    startup_command = ['install_development.py',
+                       '--package_manager']
 
     metadata_files = [
         'startup-script={install_dir}/google_install_loader.py'
@@ -165,7 +166,7 @@ def create_instance(options):
 
     metadata = ','.join([
         'startup_py_command={startup_command}'.format(
-            startup_command=startup_command),
+            startup_command='+'.join(startup_command)),
         'startup_loader_files='
         'py_install_utils'
         '+py_install_development'

--- a/google/dev/create_gce_image.py
+++ b/google/dev/create_gce_image.py
@@ -141,6 +141,7 @@ def create_prototype_instance(options):
     """Create an instance and install spinnaker onto it."""
     print 'Creating prototype instance with spinnaker installation...'
     startup_command = ['install_spinnaker.py',
+                       '--package_manager',
                        '--release={0}'.format(options.release)]
     if not options.spinnaker:
         startup_command.append('--nospinnaker')

--- a/google/dev/install_development.py
+++ b/google/dev/install_development.py
@@ -24,7 +24,6 @@ from install.install_utils import run
 from install.install_utils import run_or_die
 
 import install.install_runtime_dependencies
-import install.install_spinnaker
 
 
 NODE_VERSION = '0.12'

--- a/google/install/first_time_boot.sh
+++ b/google/install/first_time_boot.sh
@@ -79,7 +79,7 @@ function replace_startup_script() {
   local original=$(get_instance_metadata_attribute "startup-script")
   echo "$original" > "$SPINNAKER_INSTALL_DIR/scripts/original_startup_script.sh"
   write_instance_metadata \
-      "startup-script=$SPINNAKER_INSTALL_DIR/scripts/start_spinnaker"
+      "startup-script=$SPINNAKER_INSTALL_DIR/scripts/start_spinnaker.sh"
 }
 
 function extract_spinnaker_config() {

--- a/google/install/install_fake_openjdk8.sh
+++ b/google/install/install_fake_openjdk8.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+#
+# Copyright 2015 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The Spinnaker debian packages have dependencies on openjdk-8-jre.
+# If you have a different JDK 1.8 installed then we need to subvert
+# the requirement checks.
+#
+# This script creates a fake debian package that claims to offer openjdk-8-jre.
+# Installing it will satisfy other dependency checks, though obviously this does
+# not actually provide openjdk-8-jre.
+
+cd /tmp
+cat > ignore-openjdk-8-jre.txt <<EOF
+Section: misc
+Priority: optional
+Standards-Version: 3.9.2
+
+Package: fake-openjdk-8-jre
+Version: 1.0
+Provides: openjdk-8-jre
+Description: Fake openjdk-8-jre dependency
+EOF
+
+if ! which equivs-build; then
+    print 'installing equivs...'
+    sudo apt-get install -y equivs
+fi
+equivs-build fake-openjdk-8-jre.txt
+echo "For the record, "Java -version" says\n$(java -version)"
+echo "Installing 'fake-openjdk-8-jre' package to suppress openjdk-8-jre checks".
+sudo dpkg -i fake-openjdk-8-jre_1.0_all.deb


### PR DESCRIPTION
Note that I made install_spinnaker explicitly require whether or not to
use the package manager. On GCE (and create_dev) the startup scripts do
this on your behalf so there is no real visible change.
