### PR TITLE
Support multiple credentials in master configuration file

### DIFF
--- a/google/config/clouddriver-local.yml
+++ b/google/config/clouddriver-local.yml
@@ -16,5 +16,5 @@ google:
 
   kmsServer: http://localhost:7909
   accounts:
-    - name: $GOOGLE_ACCOUNT_NAME  # A spinnaker account used for GCE
-      project: $GOOGLE_MANAGED_PROJECT_ID
+    $GOOGLE_CREDENTIALS_REFERENCE
+

--- a/google/config/default_spinnaker_config.cfg
+++ b/google/config/default_spinnaker_config.cfg
@@ -9,17 +9,40 @@
 #
 GOOGLE_ENABLED=true
 
-# The spinnaker Account Name for GCE Credentials
+# The primary spinnaker Account Name for GCP Credentials.
+# This cannot be blank if GOOGLE_ENABLED is true.
 GOOGLE_ACCOUNT_NAME=my-account-name
 
-# The GOOGLE_MANAGED_PROJECT_ID of the GCE project being managed by spinnaker.
+# The primary GCE project id being managed by spinnaker.
+# If this is blank then use the project that spinnaker is running in.
 GOOGLE_MANAGED_PROJECT_ID=
 
-# Path to credentials on the GCE instance itself.
+# Path to credentials for the primary GCP managed project id.
 # The initial value is written automatically with the
 # captured credentials. However if you modify the configuration
 # after the fact, then you may need to point to another JSON file.
 GOOGLE_JSON_CREDENTIAL_PATH=
+
+
+# @GOOGLE_CREDENTIALS is a special variable that can be added multiple times.
+# Each entry denotes a different account and its set of credentials.
+#
+# It can be repeated once per account.
+# The binding is in the form <account name>:<project id>:<json credential path>.
+#
+# If the <project id> is blank, then the spinnaker project id will be used
+# If the <json credential path> is blank, then there are no associated
+# credentials, so will attempt to use spinnaker's credentials.
+# Note that using spinnakers project and credentials is only viable if spinnaker
+# is deployed on GCE. Otherwise Spinnaker won't have a project or credentials.
+
+# A @GOOGLE_CREDENTIALS for the primary credentials specified above is already
+# implied so does not need to be added.
+#
+# You can add additional credentials here by adding one @GOOGLE_CREDENTIALS
+# line for each, looking something like this:
+# @GOOGLE_CREDENTIALS=nth-account:my-other-project:~/.spinnaker/nth_json.json
+
 
 
 # Amazon Web Services Configuration

--- a/google/config/gce-kms-local.yml
+++ b/google/config/gce-kms-local.yml
@@ -3,6 +3,4 @@ server:
 
 credentials:
   accounts:
-   - name: $GOOGLE_ACCOUNT_NAME
-     project: $GOOGLE_MANAGED_PROJECT_ID
-     jsonPath: $GOOGLE_JSON_CREDENTIAL_PATH
+    $GOOGLE_CREDENTIALS_DECLARATION

--- a/google/pylib/spinnaker_runner.py
+++ b/google/pylib/spinnaker_runner.py
@@ -47,7 +47,7 @@ class Runner(object):
     self.__bindings = configure_util.ConfigureUtil(
         self.__installation).load_bindings()
 
-    for name,value in self.__bindings.items():
+    for name,value in self.__bindings.variables.items():
       # Add bindings as environment variables so they can be picked up by
       # embedded YML files and maybe internally within the implementation
       # (e.g. amos needs the AWS_*_KEY but isnt clear if that could be
@@ -116,7 +116,7 @@ class Runner(object):
         'REDIS_HOST={host}'
         ' LOG_DIR={log_dir}'
         ' {run_dir}/start_redis.sh'
-        .format(host=self.__bindings.get('REDIS_HOST', 'localhost'),
+        .format(host=self.__bindings.get_variable('REDIS_HOST', 'localhost'),
                 log_dir=self.__installation.LOG_DIR,
                 run_dir=run_dir),
         echo=True)
@@ -125,7 +125,7 @@ class Runner(object):
         'CASSANDRA_HOST={host}'
         ' CASSANDRA_DIR={install_dir}/cassandra'
         ' {run_dir}/start_cassandra.sh'
-        .format(host=self.__bindings.get('CASSANDRA_HOST', 'localhost'),
+        .format(host=self.__bindings.get_variable('CASSANDRA_HOST', 'localhost'),
                 install_dir=self.__installation.SPINNAKER_INSTALL_DIR,
                 run_dir=run_dir),
          echo=True)
@@ -145,19 +145,19 @@ class Runner(object):
         if pid:
           started_list.append((subsys, pid))
 
-    if self.__bindings.get('DOCKER_ADDRESS', ''):
+    if self.__bindings.get_variable('DOCKER_ADDRESS', ''):
       pid = self.maybe_start_job(jobs, 'rush')
       if pid:
          started_list.append(('rush', pid))
     else:
       print 'Not using rush because docker is not configured.'
 
-    if self.__bindings.get('JENKINS_ADDRESS', ''):
-        if self.__bindings.get('IGOR_ENABLED', 'false') == 'false':
+    if self.__bindings.get_variable('JENKINS_ADDRESS', ''):
+        if self.__bindings.get_variable('IGOR_ENABLED', 'false') == 'false':
             sys.stderr.write(
                 'WARNING: Not starting igor because IGOR_ENABLED=false'
                 ' even though JENKINS_ADDRESS="{address}"'.format(
-                      address=self.__bindings['JENKINS_ADDRESS']))
+                      address=self.__bindings.get_variable('JENKINS_ADDRESS')))
         else:
             pid = self.maybe_start_job(jobs, 'igor')
             if pid:


### PR DESCRIPTION
Added @GOOGLE_CREDENTIALS notation to spinnaker_config.cfg to declare
multiple credentials, and special $GOOGLE_CREDENTIALS_DECLARATION and REFERENCE
parameters. It's a special case, but the yaml files still look like
variable expressions.

The old single account configuraiton parameters are still used, but repurposed
to indicate the "primary" account. @GOOGLE_CREDENTIALS is used for all the
remaining accounts. The primary account information is automatically added
to $GOOGLE_CREDENTIALS_[DECLARATION|REFERENCE] so the parameters are only
used by other modules (e.g. rush, tests) that only care about the primary
account.
