### PR TITLE
Fixes to support click to deploy

### DIFF
--- a/google/dev/dev_runner.py
+++ b/google/dev/dev_runner.py
@@ -82,7 +82,7 @@ class DevRunner(spinnaker_runner.Runner):
     match = re.search('(?m)^[^ ]+ +([0-9]+) .* {program}'.format(
         program=program), stdout)
     return int(match.groups()[0]) if match else None
-    
+
   def start_deck(self):
     pid = self.get_deck_pid()
     if pid:
@@ -148,7 +148,7 @@ class DevRunner(spinnaker_runner.Runner):
     deck_port = self.__installation.DECK_PORT
     print 'Waiting for deck to start on port {port}'.format(port=deck_port)
 
-    # Dont just wait for port to be ready,  but for deck to repsond
+    # Dont just wait for port to be ready,  but for deck to respond
     # because it takes a long time to startup once port is ready.
     while True:
       code, ignore = fetch('http://localhost:{port}/'.format(port=deck_port))

--- a/google/dev/publish_gce_release.sh
+++ b/google/dev/publish_gce_release.sh
@@ -103,7 +103,7 @@ function process_args() {
            shift
            ;;
          *)
-           echo "ERROR: Unknown argument '$1'"
+           echo "ERROR: Unknown argument '$key'"
            exit -1
       esac
   done

--- a/google/pylib/configure_util.py
+++ b/google/pylib/configure_util.py
@@ -81,6 +81,16 @@ class Bindings(dict):
       raise ValueError('@ Can only be used for GOOGLE_CREDENTIALS')
     substituted_value = self.__just_replace_variables(value)
     parts = substituted_value.split(':')
+    if len(parts) == 4:
+        # Sometimes project names can be in the form <domain>:project
+        # since we're using ':' to separate, there is a conflct.
+        # We could consider using a different separator, but the obvious
+        # ones are also taken or awkward for other reasons.
+        # The domain case is rare. We'll join them together if it exists.
+
+        if re.match('^[a-z]+\.[a-z]+$', parts[1]):
+            parts = [parts[0], parts[1] + ':' + parts[2], parts[3]]
+
     if len(parts) != 3:
       raise ValueError('@{0}={1} is not in the form <account>:<project>:<path>'
                        .format(name, value))

--- a/google/pylib/spinnaker_runner.py
+++ b/google/pylib/spinnaker_runner.py
@@ -153,7 +153,8 @@ class Runner(object):
       print 'Not using rush because docker is not configured.'
 
     if self.__bindings.get_variable('JENKINS_ADDRESS', ''):
-        if self.__bindings.get_variable('IGOR_ENABLED', 'false') == 'false':
+        if self.__bindings.get_variable('IGOR_ENABLED',
+                                        'false').lower() == 'false':
             sys.stderr.write(
                 'WARNING: Not starting igor because IGOR_ENABLED=false'
                 ' even though JENKINS_ADDRESS="{address}"'.format(

--- a/google/pylib/validate_configuration.py
+++ b/google/pylib/validate_configuration.py
@@ -57,7 +57,7 @@ class ValidateConfig(object):
       self.__errors.append('Missing "{name}".'.format(name=name))
       return False
 
-    if value in ['true', 'false']:
+    if value.lower() in ['true', 'false']:
       return True
 
     self._errors.append('{name}="{value}" is not valid.'
@@ -157,7 +157,7 @@ class ValidateConfig(object):
     # Without a source I'm being overly generous.
     aws_key_regex = '^[/a-zA-Z0-9]+$'
 
-    if self.__bindings.get_variable('AWS_ENABLED', '') != 'true':
+    if self.__bindings.get_variable('AWS_ENABLED', '').lower() != 'true':
       return True
 
     # Intentionally keeping these values private in the errors.
@@ -189,6 +189,8 @@ class ValidateConfig(object):
     # (e.g. adding a health check) for created components will push beyond GCE
     # limits.
     gce_name_regex = '^[a-z]([-a-z0-9]{0,61}[a-z0-9])?$'
+    gce_project_with_domain_regex = ('^[a-z]+\.[a-z]+'
+                                     ':[a-z]([-a-z0-9]{0,61}[a-z0-9])?$')
     managed_project_id = self.__bindings.get_variable(
         'GOOGLE_MANAGED_PROJECT_ID', '')
     ok = True
@@ -199,7 +201,8 @@ class ValidateConfig(object):
             ' you are running in a Google Cloud Platform project to default to.')
         ok = False
     else:
-      if not re.match(gce_name_regex, managed_project_id):
+      if (not re.match(gce_name_regex, managed_project_id)
+          and not re.match(gce_project_with_domain_regex, managed_project_id)):
         ok = False
         self.__errors.append(
             'GOOGLE_MANAGED_PROJECT_ID="{id}" does not look like {regex}.'
@@ -235,7 +238,7 @@ class ValidateConfig(object):
           and ok)
 
     if self.verify_true_false('DOCKER_ENABLED'):
-      if (self.__bindings.get_variable('DOCKER_ENABLED', '') == 'true'
+      if (self.__bindings.get_variable('DOCKER_ENABLED', '').lower() == 'true'
           and not self.__bindings.get_variable('DOCKER_TARGET_REPOSITORY', '')):
         ok = False
         self.__errors.append('DOCKER_ENABED but DOCKER_TARGET_REPOSITORY'
@@ -247,7 +250,7 @@ class ValidateConfig(object):
     if self.__bindings.get_variable('JENKINS_ADDRESS', ''):
         # TODO(ewiseblatt): 20140925
         # Look into the IGOR_ENABLED flag (used at least in gate)
-        igor_enabled = self.__bindings.get_variable('IGOR_ENABLED', '')
+        igor_enabled = self.__bindings.get_variable('IGOR_ENABLED', '').lower()
         if igor_enabled == 'false':
           # Dont bother checking other things since they dont matter.
           print ('WARNING: JENKINS_ADDRESS is provided but'

--- a/google/unittest/configure_util_test.py
+++ b/google/unittest/configure_util_test.py
@@ -64,6 +64,19 @@ CREDENTIALS_LIST = [
      'jsonPath': '/test/path/credentials'}]
 
 
+CONSTRAINED_CREDENTIALS_CONFIG_DATA="""
+@GOOGLE_CREDENTIALS=test-nopath-account:google.com:test-project:
+@GOOGLE_CREDENTIALS=test-full-account:google.com:test-project:/test/path/credentials
+"""
+
+CONSTRAINED_CREDENTIALS_LIST = [
+    {'name': 'test-nopath-account',
+     'project': 'google.com:test-project'},
+    {'name': 'test-full-account',
+     'project': 'google.com:test-project',
+     'jsonPath': '/test/path/credentials'}]
+
+
 PARAMETERIZED_CREDENTIALS_CONFIG_DATA="""
 ACCOUNT=parameterized-account
 PROJECT=parameterized-project
@@ -127,6 +140,17 @@ class ConfigureUtilTest(unittest.TestCase):
     os.remove(path)
     self.assertEqual(
         CREDENTIALS_LIST,
+        bindings.get_yaml('GOOGLE_CREDENTIALS_DECLARATION', None))
+
+  def test_parse_constrained_credentials(self):
+    bindings = configure_util.Bindings()
+    fd,path = tempfile.mkstemp()
+    os.write(fd, CONSTRAINED_CREDENTIALS_CONFIG_DATA)
+    os.close(fd)
+    bindings.update_from_config(path)
+    os.remove(path)
+    self.assertEqual(
+        CONSTRAINED_CREDENTIALS_LIST,
         bindings.get_yaml('GOOGLE_CREDENTIALS_DECLARATION', None))
 
   def test_render_credentials(self):


### PR DESCRIPTION
- Permit project ids in the form google.com:my-account-name
  This isnt really needed by click to deploy, but the project I
  created to work on click to deploy wound up being in this form.
- The boolean configuration variables are case insensitive.
