### PR TITLE
Simplify repository management.

### DIFF
--- a/google/dev/build_release.py
+++ b/google/dev/build_release.py
@@ -412,8 +412,8 @@ if __name__ == '__main__':
     options = parser.parse_args()
 
     builder = cls(options)
-    if options.refresh_from_origin:
-        builder.refresher.refresh_all_from_origin()
+    if options.pull_origin:
+        builder.refresher.pull_all_from_origin()
 
     builder.build_packages()
     builder.copy_dependency_files()


### PR DESCRIPTION
@rbuskens 
Changed flags, deprecating the old one
--pull_upstream
    Pulls the master branch from the upstream repository (if in master branch)

--pull_origin
    Pulls the current branch from the origin repository

--push_master
    Pushes the master branch to the origin repository (if in master branch)

No options are set by default. Previously the equivalent of pull_origin was set.

I'm leaving the old options around for the time being for compatability with
existing users and jenkins etc.

However the default pull_origin behavior is changed.
