### PR TITLE
Updated config to specify host/port for spinnaker services.

### DIFF
--- a/google/config/clouddriver-local.yml
+++ b/google/config/clouddriver-local.yml
@@ -1,9 +1,10 @@
 server:
-  port: 7002
+  port: ${CLOUDDRIVER_PORT:7002}
+  address: $CLOUDDRIVER_HOST
 
 services:
   front50:
-    baseUrl: http://localhost:8080
+    baseUrl: http://$FRONT50_HOST:$FRONT50_PORT
 
 redis:
   connection: redis://$REDIS_HOST:6379
@@ -14,7 +15,7 @@ aws:
 google:
   enabled: ${GOOGLE_ENABLED:false}
 
-  kmsServer: http://localhost:7909
+  kmsServer: http://$KMS_HOST:$KMS_PORT
   accounts:
     $GOOGLE_CREDENTIALS_REFERENCE
 

--- a/google/config/default_spinnaker_config.cfg
+++ b/google/config/default_spinnaker_config.cfg
@@ -5,6 +5,10 @@
 # by running /opt/spinnaker/scripts/reconfigure_spinnaker.sh
 
 
+##############################################################################
+##  Cloud Platform Configuration
+##############################################################################
+
 # Google Compute Engine Configuration
 #
 GOOGLE_ENABLED=true
@@ -53,6 +57,9 @@ GOOGLE_PRIMARY_JSON_CREDENTIAL_PATH=
 # A @GOOGLE_CREDENTIALS for the primary credentials specified above is already
 # implied so does not need to be added.
 
+GOOGLE_DEFAULT_REGION=us-central1
+GOOGLE_DEFAULT_ZONE=us-central1-f
+
 
 # Amazon Web Services Configuration
 #
@@ -60,14 +67,28 @@ AWS_ENABLED=false
 AWS_ACCESS_KEY=
 AWS_SECRET_KEY=
 
+AWS_PRIMARY_ACCOUNT_NAME=default
+AWS_DEFAULT_REGION=us-east-1
+
+
 # If this is set to true, SimpleDB will be used for Application metadata
 # for AWS accounts. If false, Cassandra will be used.
 AWS_SIMPLEDBENABLED=false
 
 
+
+##############################################################################
+##  External Service Configuration
+##############################################################################
+
 # Cassandra Configuration
 #
 SPINNAKER_CASSANDRA_ENABLED=true
+
+# External Dependency Bindings
+CASSANDRA_HOST=localhost
+REDIS_HOST=localhost
+REDIS_PORT=6379
 
 
 # Docker Configuration
@@ -81,6 +102,9 @@ DOCKER_ADDRESS=
 DOCKER_ENABLED=false
 DOCKER_TARGET_REPOSITORY=
 
+DOCKER_REGISTRY_PORT=5000
+DOCKER_REGISTRY_HOST=localhost
+
 
 # Jenkins Configuration
 #
@@ -88,6 +112,11 @@ DOCKER_TARGET_REPOSITORY=
 JENKINS_ADDRESS=
 JENKINS_USERNAME=
 JENKINS_PASSWORD=
+JENKINS_MASTER_NAME=jenkins1
+
+##############################################################################
+##  Spinnaker Subsystem Configuration
+##############################################################################
 
 # Spinnaker Igor subsystem.
 # TODO: This is tied to using Jenkins.
@@ -96,7 +125,41 @@ JENKINS_PASSWORD=
 # and false if it is not.
 IGOR_ENABLED=
 
+CLOUDDRIVER_PORT=7002
+CLOUDDRIVER_HOST=localhost
 
-# External Dependency Bindings
-CASSANDRA_HOST=localhost
-REDIS_HOST=localhost
+ECHO_PORT=8089
+ECHO_HOST=localhost
+
+FRONT50_PORT=8080
+FRONT50_HOST=localhost
+
+GATE_PORT=8084
+GATE_HOST=localhost
+
+IGOR_PORT=8088
+IGOR_HOST=localhost
+
+KATO_PORT=$CLOUDDRIVER_PORT
+KATO_HOST=localhost
+
+KMS_PORT=7909
+KMS_HOST=localhost
+
+MORT_PORT=$CLOUDDRIVER_PORT
+MORT_HOST=localhost
+
+ORCA_PORT=8083
+ORCA_HOST=localhost
+
+OORT_PORT=$CLOUDDRIVER_PORT
+OORT_HOST=localhost
+
+RUSH_PORT=8085
+RUSH_HOST=localhost
+
+BAKERY_PORT=$ROSCO_PORT
+BAKERY_HOST=$ROSCO_HOST
+
+ROSCO_PORT=8087
+ROSCO_HOST=localhost

--- a/google/config/echo-local.yml
+++ b/google/config/echo-local.yml
@@ -1,15 +1,16 @@
 server:
-  port: 8089
+  port: ${ECHO_PORT:8089}
+  address: $ECHO_HOST
 
 cassandra:
   embedded: false
   host: $CASSANDRA_HOST
 
 front50:
-  baseUrl: http://localhost:8080
+  baseUrl: http://$FRONT50_HOST:$FRONT50_PORT
 
 orca:
-  baseUrl: http://localhost:8083
+  baseUrl: http://$ORCA_HOST:$ORCA_PORT
   enabled: true
 
 endpoints.health.sensitive: false

--- a/google/config/front50-local.yml
+++ b/google/config/front50-local.yml
@@ -1,5 +1,6 @@
 server:
-  port: 8080
+  port: ${FRONT50_PORT:8080}
+  address: $FRONT50_HOST
 
 cassandra:
   embedded: false

--- a/google/config/gate-local.yml
+++ b/google/config/gate-local.yml
@@ -1,27 +1,28 @@
 server:
-  port: 8084
+  port: ${GATE_PORT:8084}
+  address: $GATE_HOST
 
 services:
   oort:
-    baseUrl: http://localhost:7002
+    baseUrl: http://$OORT_HOST:$OORT_PORT
   orca:
-    baseUrl: http://localhost:8083
+    baseUrl: http://$ORCA_HOST:$ORCA_PORT
   front50:
-    baseUrl: http://localhost:8080
+    baseUrl: http://$FRONT50_HOST:$FRONT50_PORT
   mort:
-    baseUrl: http://localhost:7002
+    baseUrl: http://$MORT_HOST:$MORT_PORT
   kato:
-    baseUrl: http://localhost:7002
+    baseUrl: http://$KATO_HOST:$KATO_PORT
 #optional services:
   echo:
     enabled: true
-    baseUrl: http://localhost:8089
+    baseUrl: http://$ECHO_HOST:$ECHO_PORT
   flapjack:
     enabled: false
   igor:
     enabled: ${IGOR_ENABLED:false}
-    baseUrl: http://localhost:8088
+    baseUrl: http://$IGOR_HOST:$IGOR_PORT
 
 redis:
-  connection: redis://$REDIS_HOST:6379      
+  connection: redis://$REDIS_HOST:$REDIS_PORT
 

--- a/google/config/gce-kms-local.yml
+++ b/google/config/gce-kms-local.yml
@@ -1,5 +1,6 @@
 server:
-  port: 7909
+  port: ${KMS_PORT:7909}
+  address: $KMS_HOST
 
 credentials:
   accounts:

--- a/google/config/igor-local.yml
+++ b/google/config/igor-local.yml
@@ -1,13 +1,14 @@
 server:
-  port: 8088
+  port: ${IGOR_PORT:8088}
+  address: $IGOR_HOST
 
 jenkins:
   masters:
-    - name: jenkins1
+    - name: $JENKINS_MASTER_NAME
       address: http://$JENKINS_ADDRESS
       username: $JENKINS_USERNAME
       password: $JENKINS_PASSWORD
 
 services:
   echo:
-    baseUrl: http://localhost:8089
+    baseUrl: http://$ECHO_HOST:$ECHO_PORT

--- a/google/config/orca-local.yml
+++ b/google/config/orca-local.yml
@@ -1,24 +1,25 @@
 server:
-  port: 8083
+  port: ${ORCA_PORT:8083}
+  address: $ORCA_HOST
 
 oort:
-  baseUrl: http://localhost:7002
+  baseUrl: http://$OORT_HOST:$OORT_PORT
 front50:
-  baseUrl: http://localhost:8080
+  baseUrl: http://$FRONT50_HOST:$FRONT50_PORT
 mort:
-  baseUrl: http://localhost:7002
+  baseUrl: http://$MORT_HOST:$MORT_PORT
 kato:
-  baseUrl: http://localhost:7002
+  baseUrl: http://$KATO_HOST:$KATO_PORT
 rush:
-  baseUrl: http://localhost:8085
+  baseUrl: http://$RUSH_HOST:$RUSH_PORT
 bakery:
-  baseUrl: http://localhost:8087
+  baseUrl: http://$BAKERY_HOST:$BAKERY_PORT
   extractBuildDetails: true
   propagateCloudProviderType: true
 echo:
-  baseUrl: http://localhost:8089
+  baseUrl: http://$ECHO_HOST:$ECHO_PORT
 igor:
-  baseUrl: http://localhost:8088
+  baseUrl: http://$IGOR_HOST:$IGOR_PORT
 
 # TODO(duftler): Remove this once flex is conditionally-enabled in orca.
 flex:
@@ -32,5 +33,5 @@ default:
     securityGroups:
 
 redis:
-  connection: redis://$REDIS_HOST:6379
+  connection: redis://$REDIS_HOST:$REDIS_PORT
 

--- a/google/config/rosco-local.yml
+++ b/google/config/rosco-local.yml
@@ -1,5 +1,6 @@
 server:
-  port: 8087
+  port: ${ROSCO_PORT:8087}
+  address: $ROSCO_HOST
 
 redis:
   host: $REDIS_HOST

--- a/google/config/rush-local.yml
+++ b/google/config/rush-local.yml
@@ -1,5 +1,6 @@
 server:
-  port: 8085
+  port: ${RUSH_PORT:8085}
+  address: $RUSH_HOST
 
 cassandra:
   embedded: false
@@ -9,4 +10,4 @@ docker:
   accounts:
     - name: $GOOGLE_PRIMARY_ACCOUNT_NAME
       url: http://$DOCKER_ADDRESS
-      registry: http://localhost:5000
+      registry: http://$DOCKER_REGISTRY_HOST:$DOCKER_REGISTRY_PORT

--- a/google/config/settings.js
+++ b/google/config/settings.js
@@ -1,32 +1,32 @@
 'use strict';
 
-let gateHost = 'localhost:8084';
+let gateHost = '$GATE_HOST:$GATE_PORT';
 
 window.spinnakerSettings = {
   gateUrl: `http://${gateHost}`,
-  bakeryDetailUrl: 'http://localhost:8087/api/v1/global/logs/{{context.status.id}}?html=true',
+  bakeryDetailUrl: 'http://$BAKERY_HOST:$BAKERY_PORT/api/v1/global/logs/{{context.status.id}}?html=true',
   pollSchedule: 30000,
   defaultTimeZone: 'America/New_York', // see http://momentjs.com/timezone/docs/#/data-utilities/
   providers: {
     gce: {
       defaults: {
         account: '$GOOGLE_PRIMARY_ACCOUNT_NAME',
-        region: 'us-central1',
-        zone: 'us-central1-f',
+        region: '$GOOGLE_DEFAULT_REGION',
+        zone: '$GOOGLE_DEFAULT_ZONE',
       },
       primaryAccounts: ['$GOOGLE_PRIMARY_ACCOUNT_NAME'],
       challengeDestructiveActions: ['$GOOGLE_PRIMARY_ACCOUNT_NAME'],
     },
     aws: {
       defaults: {
-        account: 'default',
-        region: 'us-east-1'
+        account: '$AWS_PRIMARY_ACCOUNT_NAME',
+        region: '$AWS_DEFAULT_REGION'
       },
-      primaryAccounts: ['default'],
+      primaryAccounts: ['$AWS_PRIMARY_ACCOUNT_NAME'],
       primaryRegions: ['eu-west-1', 'us-east-1', 'us-west-1', 'us-west-2'],
-      challengeDestructiveActions: ['default'],
+      challengeDestructiveActions: ['$AWS_PRIMARY_ACCOUNT_NAME'],
       preferredZonesByAccount: {
-        default: {
+        $AWS_PRIMARY_ACCOUNT_NAME: {
           'us-east-1': ['us-east-1a', 'us-east-1b', 'us-east-1d', 'us-east-1e'],
           'us-west-1': ['us-west-1a', 'us-west-1b', 'us-west-1c'],
           'us-west-2': ['us-west-2a', 'us-west-2b', 'us-west-2c'],

--- a/google/dev/create_dev_vm.py
+++ b/google/dev/create_dev_vm.py
@@ -145,6 +145,7 @@ def create_instance(options):
         # the things it is importing (no need for PYTHONPATH)
         content = f.read()
         content = content.replace('install.install', 'install')
+        content = content.replace('pylib.', '')
 
     fd, temp_install_development = tempfile.mkstemp()
     os.write(fd, content)
@@ -156,13 +157,15 @@ def create_instance(options):
     metadata_files = [
         'startup-script={install_dir}/google_install_loader.py'
         ',py_install_utils={install_dir}/install_utils.py'
+        ',py_fetch={pylib_dir}/fetch.py'
+        ',py_run={pylib_dir}/run.py'
         ',py_install_development={temp_install_development}'
         ',py_install_spinnaker={install_dir}/install_spinnaker.py'
         ',sh_bootstrap_vm={dev_dir}/bootstrap_vm.sh'
         ',py_install_runtime_dependencies='
         '{install_dir}/install_runtime_dependencies.py'
         .format(install_dir=install_dir,
-                dev_dir=dev_dir,
+                dev_dir=dev_dir, pylib_dir=pylib_dir,
                 temp_install_development=temp_install_development)]
 
     metadata = ','.join([
@@ -170,6 +173,8 @@ def create_instance(options):
             startup_command='+'.join(startup_command)),
         'startup_loader_files='
         'py_install_utils'
+        '+py_fetch'
+        '+py_run'
         '+py_install_development'
         '+py_install_spinnaker'
         '+py_install_runtime_dependencies'

--- a/google/pylib/fetch.py
+++ b/google/pylib/fetch.py
@@ -1,0 +1,140 @@
+#!/usr/bin/python
+#
+# Copyright 2015 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import collections
+import os
+import socket
+import sys
+import urllib2
+
+from run import check_run_quick
+
+GOOGLE_METADATA_URL = 'http://metadata.google.internal/computeMetadata/v1'
+GOOGLE_INSTANCE_METADATA_URL = GOOGLE_METADATA_URL + '/instance'
+GOOGLE_OAUTH_URL = 'https://www.googleapis.com/auth'
+AWS_METADATA_URL = 'http://169.254.169.254/latest/meta-data/'
+
+
+class FetchResult(collections.namedtuple(
+        'FetchResult', ['httpcode', 'content'])):
+  """Captures the result of fetching a url.
+
+  Attributes:
+    httpcode [int]: The HTTP code returned or -1 if the request raised
+        an exception.
+    content [string or error]: The HTTP payload result, or the error raised.
+  """
+  def ok(self):
+      return self.httpcode >= 200 and self.httpcode < 300
+
+
+def fetch(url, google=False):
+    request = urllib2.Request(url)
+    if google:
+      request.add_header('Metadata-Flavor', 'Google')
+    try:
+      response = urllib2.urlopen(request)
+      return FetchResult(response.getcode(), response.read())
+
+    except urllib2.HTTPError as e:
+      return FetchResult(-1, e)
+
+    except urllib2.URLError as e:
+      return FetchResult(-1, e)
+
+
+def check_fetch(url, google=False):
+    response = fetch(url, google)
+    if not response.ok():
+        sys.stderr.write('{code}: {url}\n{result}\n'.format(
+            code=response.httpcode, url=url, result=response.content))
+        raise SystemExit('FAILED')
+    return response
+
+
+__IS_ON_GOOGLE = None
+__IS_ON_AWS = None
+__ZONE = None
+
+
+def is_google_instance():
+  """Determine if we are running on a Google Cloud Platform instance."""
+  global __IS_ON_GOOGLE
+  if __IS_ON_GOOGLE is None:
+    __IS_ON_GOOGLE = fetch(GOOGLE_METADATA_URL, google=True).ok()
+  return __IS_ON_GOOGLE
+
+
+def is_aws_instance():
+  """Determine if we are running on an Amazon Web Services instance."""
+  global __IS_ON_AWS
+  if __IS_ON_AWS == None:
+    __IS_ON_AWS = fetch(AWS_METADATA_URL).ok()
+  return __IS_ON_AWS
+
+
+def check_write_instance_metadata(name, value):
+  """Add a name/value pair to our instance metadata.
+
+  Args:
+    name [string]: The key name.
+    value [string]: The key value.
+
+  Raises
+    UnsupportedError if not on a platform with metadata.
+  """
+  if is_google_instance():
+    check_run_quick(
+        'gcloud compute instances add-metadata'
+        ' {hostname} --zone={zone} --metadata={name}={value}'
+        .format(hostname=socket.gethostname(),
+                zone=check_get_zone(), name=name, value=value))
+
+  elif is_aws_instance():
+    result = check_fetch(os.path.join(AWS_METADATA_URL, 'instance-id'))
+    id = result.content.strip()
+
+    result = check_fetch(os.path.join(AWS_METADATA_URL,
+                                      'placement/availability-zone'))
+    region = result.content.strip()[:-1]
+
+    command = ['aws ec2 create-tags --resources', id,
+               '--region', region,
+               '--tags Key={key},Value={value}'.format(key=name, value=value)]
+    check_run_quick(' '.join(command), echo=False)
+
+  else:
+    raise UnsupportedError('This platform does not support metadata.')
+
+
+def get_google_project():
+  """Return the Google project this is running in, or None."""
+  result = fetch(GOOGLE_METADATA_URL + '/project/project-id', google=True)
+  return result.content if result.ok() else None
+
+
+def check_get_zone():
+  global __ZONE
+  if __ZONE is None:
+    if is_google_instance():
+      result = check_fetch(GOOGLE_INSTANCE_METADATA_URL + '/zone', google=True)
+      __ZONE = os.path.basename(result.content)
+    elif is_aws_instance():
+      result = check_fetch(AWS_METADATA_URL + '/placement/availability-zone')
+      __ZONE = result.content
+    else:
+      raise UnsupportedError('This platform does not support zones.')
+  return __ZONE

--- a/google/pylib/run.py
+++ b/google/pylib/run.py
@@ -1,0 +1,185 @@
+#!/usr/bin/python
+#
+# Copyright 2015 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Provides support functions for running shell commands."""
+
+import collections
+import fcntl
+import os
+import subprocess
+import sys
+
+
+class RunResult(collections.namedtuple('RunResult',
+                                       ['returncode', 'stdout', 'stderr'])):
+  """Captures the result of running a subprocess.
+
+  If output was not captured then stdout and stderr will be None.
+  """
+  pass
+
+
+def __collect_from_stream(stream, buffer, echo_stream):
+  """Read all the input from a stream.
+
+  Args:
+    stream [File]: The file to read() from.
+    buffer [list of string]: The buffer to append the collected data to.
+       This will write a single chunk if any data was read.
+    echo_stream [stream]: If not None, the File to write() for logging
+       the stream.
+
+  Returns:
+    Number of additional bytes added to the buffer.
+  """
+  collected = []
+  try:
+    while True:
+      got = os.read(stream.fileno(), 1)
+      if not got:
+        break
+      collected.append(got)
+      if echo_stream:
+        echo_stream.write(got)
+        echo_stream.flush()
+  except OSError:
+    pass
+
+  # Chunk together all the data we just received.
+  if collected:
+      buffer.append(''.join(collected))
+  return len(collected)
+
+
+def run_and_monitor(command, echo=True, input=None):
+  """Run the provided command in a subprocess shell.
+
+  Args:
+    command [string]: The shell command to execute.
+    echo [bool]: If True then echo the command and output to stdout.
+    input [string]: If non-empty then feed this to stdin.
+
+  Returns:
+    RunResult with result code and output from running the command.
+  """
+  if echo:
+    print command
+
+  sys.stdout.flush()
+  stdin = subprocess.PIPE if input else None
+  process = subprocess.Popen(
+      command,
+      stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=stdin,
+      shell=True, close_fds=True)
+
+  # Setup for nonblocking reads
+  fl = fcntl.fcntl(process.stdout, fcntl.F_GETFL)
+  fcntl.fcntl(process.stdout, fcntl.F_SETFL, fl | os.O_NONBLOCK)
+  fl = fcntl.fcntl(process.stderr, fcntl.F_GETFL)
+  fcntl.fcntl(process.stderr, fcntl.F_SETFL, fl | os.O_NONBLOCK)
+
+  if stdin:
+      process.stdin.write(input)
+      process.stdin.close()
+
+  out = []
+  err = []
+  echo_out = sys.stdout if echo else None
+  echo_err = sys.stderr if echo else None
+  while (__collect_from_stream(process.stdout, out, echo_out)
+         or  __collect_from_stream(process.stderr, err, echo_err)
+         or process.poll() is None):
+      pass
+
+  # Get any trailing data from termination race condition
+  __collect_from_stream(process.stdout, out, echo_out)
+  __collect_from_stream(process.stderr, err, echo_err)
+
+  return RunResult(process.returncode, ''.join(out), ''.join(err))
+
+
+def run_quick(command, echo=True):
+  """A more efficient form of run_and_monitor that doesnt monitor output.
+
+  Args:
+    command [string]: The shell command to run.
+    echo [bool]: If True then echo the command and output to stdout.
+
+  Returns:
+    RunResult with result code and output from running the command.
+       The content of stderr will be joined into stdout.
+       stderr itself will be None.
+  """
+  p = subprocess.Popen(command, shell=True, close_fds=True,
+                         stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+  stdout, stderr = p.communicate()
+  if echo:
+    print command
+    print stdout
+
+  return RunResult(p.returncode, stdout, None)
+
+
+def check_run_and_monitor(command, echo=True, input=None):
+  """Runs the command in a subshell and throws an exception if it fails.
+
+  Args:
+    command [string]: The shell command to run.
+    echo [bool]: If True then echo the command and output to stdout.
+    input [string]: If non-empty then feed this to stdin.
+
+  Returns:
+    RunResult with result code and output from running the command.
+
+  Raises:
+    RuntimeError if command failed.
+  """
+  result = run_and_monitor(command, echo=echo, input=input)
+  if result.returncode != 0:
+    error = 'FAILED {command} with exit code {code}\n{err}'.format(
+        command=command, code=result.returncode, err=result.stderr.strip())
+    sys.stderr.write(error + '\n')
+    raise RuntimeError(error)
+
+  return result
+
+
+def check_run_quick(command, echo=True):
+  """A more efficient form of check_run_and_monitor that doesnt monitor output.
+
+  Args:
+    command [string]: The shell command to run.
+    echo [bool]: If True then echo the command and output to stdout.
+
+  Returns:
+    RunResult with result code and output from running the command.
+       The content of stderr will be joined into stdout.
+       stderr itself will be None.
+
+  Raises:
+    RuntimeError if command failed.
+  """
+  result = run_quick(command, echo)
+  if result.returncode:
+     error = ('FAILED with exit code {code}'
+              '\n\nCommand was {command}'
+              '\n\nError was {stdout}'.format(
+                 code=result.returncode,
+                command=command,
+                stdout=result.stdout))
+     raise RuntimeError(error)
+  return result
+


### PR DESCRIPTION
This is so they can be bound to localhost for enhanced security.
And so it is easy to rebind the ports.

Dont set environment variables if they were already set,
and use the environment variable as the actual value for override.

Variables can be set off other variables transitively.

Also added run/fetch modules to start factoring these out of the installer
to be able to generalize the scripts. For now the old implementation is
still there and untouched because lots of other modules use it. This is
the first of several files waning off it.

Updated the run scripts to consider the host binding when checking up.
Also the script to the updated run/fetch apis.
