### PR TITLE
Adds in migration to new configuration.

### DIFF
--- a/google/dev/abstract_packer_builder.py
+++ b/google/dev/abstract_packer_builder.py
@@ -163,7 +163,7 @@ class AbstractPackerBuilder(object):
       if eq > 0:
          self.__var_map[arg[0:eq]] = arg[eq + 1:]
       else:
-         self.__var_map[arg] = a[i + 1]
+         self.__var_map[arg] = arg[i + 1]
          i += 1
 
   @classmethod

--- a/google/dev/build_release.py
+++ b/google/dev/build_release.py
@@ -301,7 +301,7 @@ class Builder(object):
           target_config = os.path.join(self.__release_dir, 'config', yml)
           self.__config_list.append(yml)
           processes.append(self.start_copy_file(source_config, target_config))
-      
+
       # Copy subsystem configuration files.
       for subsys in SUBSYSTEM_LIST:
           processes.append(self.start_copy_debian_target(subsys))

--- a/google/dev/dev_runner.py
+++ b/google/dev/dev_runner.py
@@ -181,7 +181,8 @@ class DevRunner(spinnaker_runner.Runner):
     to console will stop once this process is terminated. However, the
     logging will still continue into the LOG_DIR.
     """
-    self.reconfigure_subsystems(options)
+    if self.using_deprecated_config:
+      self.reconfigure_subsystems(options)
 
     ignore_tail_jobs = self.tail_error_logs()
     super(DevRunner, self).start_all(options)

--- a/google/pylib/configure_util.py
+++ b/google/pylib/configure_util.py
@@ -406,5 +406,8 @@ class ConfigureUtil(object):
     with open(source_path, 'r') as f:
       content = f.read()
     content = bindings.replace_variables(content)
+
+    if not os.path.exists(os.path.dirname(target_path)):
+      os.makedirs(target_path)
     with open(target_path, 'w') as f:
       f.write(content)

--- a/google/pylib/yaml_util.py
+++ b/google/pylib/yaml_util.py
@@ -1,0 +1,93 @@
+# Copyright 2015 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+import yaml
+
+
+class YamlBindings(object):
+  """Implements a map from yaml using variable references similar to spring."""
+
+  @property
+  def map(self):
+    return self.__map
+
+  def __init__(self):
+    self.__map = {}
+
+  def get(self, field):
+    return self.__get_value(field, [], original=field)
+
+  def import_dict(self, d):
+    for name,value in d.items():
+      self.__update_field(name, value, self.__map)
+
+  def import_string(self, str):
+    self.import_dict(yaml.load(str, Loader=yaml.Loader))
+
+  def import_path(self, path):
+    with open(path, 'r') as f:
+      self.import_dict(yaml.load(f, Loader=yaml.Loader))
+
+  def __update_field(self, name, value, container):
+    if not isinstance(value, dict) or not name in container:
+      container[name] = value
+      return
+
+    container_value = container[name]
+    if not isinstance(container_value, dict):
+      container[name] = value
+      return
+
+    for child_name, child_value in value.items():
+      self.__update_field(child_name, child_value, container_value)
+
+  def __get_node(self, field):
+    path = field.split('.')
+    node = self.__map
+    for part in path:
+      if not isinstance(node, dict) or not part in node:
+        raise KeyError(field)
+      if isinstance(node, list):
+        node = node[0][part]
+      else:
+        node = node[part]
+    return node
+
+  def __get_value(self, field, saw, original):
+    value = self.__get_node(field)
+    if not isinstance(value, basestring) or not value.startswith('$'):
+      return value
+
+    result = ''
+    offset = 0
+    if field in saw:
+      raise ValueError('Cycle looking up variable ' + original)
+    saw.append(field)
+
+    re_variable = re.compile('\${([a-zA-Z_][a-zA-Z0-0_\.]+)(:.+)?}')
+    for match in re_variable.finditer(value) or []:
+        result += value[offset:match.pos]
+        offset = match.endpos
+        match_value = match.group(1)
+        try:
+          result += self.__get_value(match_value, saw, original)
+        except KeyError:
+          def_value = match.group(2)
+          if def_value:
+            result += def_value[1:]  # stream leading ':'
+          else:
+            result += value
+    result += value[offset:]
+    return result

--- a/google/unittest/yaml_util_test.py
+++ b/google/unittest/yaml_util_test.py
@@ -1,0 +1,147 @@
+# Copyright 2015 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import tempfile
+import unittest
+
+from pylib.yaml_util import YamlBindings
+
+
+class YamlUtilTest(unittest.TestCase):
+  def test_load_dict(self):
+    expect = {'a': 'A',
+              'b': 0,
+              'c': ['A','B'],
+              'd': {'child': {'grandchild': 'x'}},
+              'e': None}
+
+    bindings = YamlBindings()
+    bindings.import_dict(expect)
+    self.assertEqual(expect, bindings.map)
+
+  def test_load_string(self):
+    yaml = """
+a: A
+b: 0
+c:
+  - A
+  - B
+d:
+  child:
+    grandchild: x
+e:
+"""
+    expect = {'a': 'A',
+              'b': 0,
+              'c': ['A','B'],
+              'd': {'child': {'grandchild': 'x'}},
+              'e': None}
+
+    bindings = YamlBindings()
+    bindings.import_string(yaml)
+    self.assertEqual(expect, bindings.map)
+
+  def test_load_path(self):
+    yaml = """
+a: A
+b: 0
+c:
+  - A
+  - B
+d:
+  child:
+    grandchild: x
+e:
+"""
+    expect = {'a': 'A',
+              'b': 0,
+              'c': ['A','B'],
+              'd': {'child': {'grandchild': 'x'}},
+              'e': None}
+
+    fd, temp_path = tempfile.mkstemp()
+    os.write(fd, yaml)
+    os.close(fd)
+
+    bindings = YamlBindings()
+    bindings.import_path(temp_path)
+    self.assertEqual(expect, bindings.map)
+
+  def test_update_field_union(self):
+    bindings = YamlBindings()
+    bindings.import_dict({'a': 'A'})
+    bindings.import_dict({'b': 'B'})
+    self.assertEqual({'a': 'A', 'b': 'B'}, bindings.map)
+
+  def test_update_field_union_child(self):
+    bindings = YamlBindings()
+    bindings.import_dict({'parent1': {'a': 'A'}, 'parent2': {'x': 'X'}})
+    bindings.import_dict({'parent1': {'b': 'B'}})
+    self.assertEqual({'parent1': {'a': 'A', 'b': 'B'},
+                      'parent2': {'x': 'X'}},
+                     bindings.map)
+
+  def test_update_field_replace_child(self):
+    bindings = YamlBindings()
+    bindings.import_dict({'parent': {'a': 'A', 'b': 'B', 'c': 'C'}})
+    bindings.import_dict({'parent': {'a': 'X', 'b': 'Y', 'z': 'Z'}})
+    self.assertEqual({'parent': {'a': 'X', 'b': 'Y', 'z': 'Z', 'c': 'C'}},
+                     bindings.map)
+
+  def test_load_not_found(self):
+    bindings = YamlBindings()
+    bindings.import_dict({'field': '${injected.value}'})
+    self.assertEqual('${injected.value}', bindings.get('field'))
+
+  def test_load_tail_not_found(self):
+    bindings = YamlBindings()
+    bindings.import_dict({'field': '${injected.value}', 'injected': {}})
+    self.assertEqual('${injected.value}', bindings.get('field'))
+
+  def test_load_default(self):
+    bindings = YamlBindings()
+    bindings.import_dict({'field': '${injected.value:HELLO}'})
+    self.assertEqual('HELLO', bindings.get('field'))
+
+  def test_load_transitive(self):
+    bindings = YamlBindings()
+    bindings.import_dict({'field': '${injected.value}'})
+    bindings.import_dict({'injected': {'value': 'HELLO'}})
+    self.assertEqual('HELLO', bindings.get('field'))
+
+  def test_load_transitive_indirect(self):
+    bindings = YamlBindings()
+    bindings.import_dict({'field': '${injected.value}', 'found': 'FOUND'})
+    bindings.import_dict({'injected': {'value': '${found}'}})
+    self.assertEqual('FOUND', bindings.get('field'))
+
+  def test_load_key_not_found(self):
+    bindings = YamlBindings()
+    bindings.import_dict({'field': '${injected.value}', 'injected': {}})
+    with self.assertRaises(KeyError):
+      bindings.get('unknown')
+
+  def test_cyclic_reference(self):
+    bindings = YamlBindings()
+    bindings.import_dict({'field': '${injected.value}',
+                          'injected': {'value': '${field}'}})
+    with self.assertRaises(ValueError):
+      bindings.get('field')
+
+
+if __name__ == '__main__':
+  loader = unittest.TestLoader()
+  suite = loader.loadTestsFromTestCase(YamlUtilTest)
+  unittest.TextTestRunner(verbosity=2).run(suite)


### PR DESCRIPTION
Add support to install/start/run with new config.

Brings up spinnaker in prod, assuming the /opt files have added
the spring.config.location

Add config/ to spring path in production and gradle

For this to work in dev, you need to say
   ../spinnaker/google/dev/refresh_sources.sh --nobuild --hack_gradle
from the build directory to change the spring path in the gradle files.
This is temporary until the files themselves are modified to accomodate
the new strategy.

The --hack_gradle is not required for production enablement.
Either old or new style is available for any release.
Except this CL requires deck be manually configured to use the new style.
