### PR TITLE
3 deck

### DIFF
--- a/google/config/clouddriver.yml
+++ b/google/config/clouddriver.yml
@@ -20,3 +20,4 @@ google:
   accounts:
     - name: ${providers.google.primaryCredentials.name}
       project: ${providers.google.primaryCredentials.project}
+      jsonPath: ${providers.google.primaryCredentials.jsonPath}

--- a/google/config/deprecated/clouddriver-local.yml
+++ b/google/config/deprecated/clouddriver-local.yml
@@ -17,5 +17,5 @@ google:
 
   kmsServer: http://$KMS_HOST:$KMS_PORT
   accounts:
-    $GOOGLE_CREDENTIALS_REFERENCE
+    $GOOGLE_CREDENTIALS_DECLARATION
 

--- a/google/config/sample-spinnaker-local.yml
+++ b/google/config/sample-spinnaker-local.yml
@@ -1,6 +1,16 @@
 providers:
+  aws:
+    enabled: false
+    defaultRegion: us-east-1
+    primaryCredentials:
+      name: my-aws-account
+      aws_access_key:
+      aws_secret_key:
+
   google:
     enabled: true
+    defaultRegion: us-central1
+    defaultZone: us-central1-f
     primaryCredentials:
       name: my-account-name
       project: ewiseblatt-spinnaker-0000

--- a/google/config/settings.js
+++ b/google/config/settings.js
@@ -1,32 +1,54 @@
 'use strict';
 
-let gateHost = '${services.gate.host}:${services.gate.port}';
+
+#################################################################
+# This section is managed by scripts/reconfigure_spinnaker.sh
+# If hand-editing, only add comment lines that look like
+# '# let VARIABLE = VALUE'
+# and let scripts/reconfigure manage the actual values.
+#################################################################
+# BEGIN reconfigure_spinnaker
+
+# let gateUrl = ${services.gate.baseUrl};
+# let bakeryBaseUrl = ${services.bakery.baseUrl};
+# let awsDefaultRegion = ${providers.aws.defaultRegion};
+# let awsPrimaryAccount = ${providers.aws.primaryCredentials.name};
+# let googleDefaultRegion = ${providers.google.defaultRegion};
+# let googleDefaultZone = ${providers.google.defaultZone};
+# let googlePrimaryAccount = ${providers.google.primaryCredentials.name;
+
+# END reconfigure_spinnaker
+####################################################################
+# Any additional custom let statements can go below without being
+# affected by scripts/reconfigure_spinnaker.sh
+####################################################################
+
 
 window.spinnakerSettings = {
-  gateUrl: `${services.gate.baseUrl}`,
-  bakeryDetailUrl: '${services.bakery.baseUrl}/api/v1/global/logs/{{context.status.id}}?html=true',
+  gateUrl: '${gateUrl}',
+  bakeryDetailUrl: '${bakeryBaseUrl}/api/v1/global/logs/{{context.status.id}}?html=true',
   pollSchedule: 30000,
   defaultTimeZone: 'America/New_York', // see http://momentjs.com/timezone/docs/#/data-utilities/
   providers: {
     gce: {
       defaults: {
-        account: '${providers.google.primaryCredentials.name}',
-        region: '${providers.google.defaultRegion}',
-        zone: '${providers.google.defaultZone}',
+        account: '${googlePrimaryAccount}',
+        region: '${googleDefaultRegion}',
+        zone: '${googleDefaultZone}',
       },
-      primaryAccounts: ['${providers.google.primaryCredentials.name}'],
-      challengeDestructiveActions: ['${providers.google.primaryCredentials.name}'],
+      primaryAccounts: ['${googlePrimaryAccount}'],
+      challengeDestructiveActions: ['${googlePrimaryAccount}'],
     },
     aws: {
       defaults: {
-        account: '${providers.aws.primaryCredentials.name}',
-        region: '${providers.aws.defaultRegion}',
+        account: '${awsPrimaryAccount}',
+        region: '${awsDefaultRegion}'
       },
-      primaryAccounts: ['${providers.aws.primaryCredentials.name}]',
+      primaryAccounts: ['${awsPrimaryAccount}'],
       primaryRegions: ['eu-west-1', 'us-east-1', 'us-west-1', 'us-west-2'],
-      challengeDestructiveActions: ['${providers.aws.primaryCredentials.name}'],
+      challengeDestructiveActions: ['${awsPrimaryAccount}'],
       preferredZonesByAccount: {
-        ${providers.aws.primaryCredentials.name}: {
+        ${awsPrimaryAccount}: {
           'us-east-1': ['us-east-1a', 'us-east-1b', 'us-east-1d', 'us-east-1e'],
           'us-west-1': ['us-west-1a', 'us-west-1b', 'us-west-1c'],
           'us-west-2': ['us-west-2a', 'us-west-2b', 'us-west-2c'],

--- a/google/config/spinnaker.yml
+++ b/google/config/spinnaker.yml
@@ -113,6 +113,8 @@ services:
 providers:
   google:
     enabled: false
+    defaultRegion: us-central1
+    defaultZone: us-central1-f
     primaryCredentials:
       name: my-account
       project: 
@@ -125,6 +127,9 @@ providers:
   aws:
     enabled: false
     simpleDBEnabled: false
+    defaultRegion: us-east-1
     defaultSimpleDBDomain: CLOUD_APPLICATIONS
-    # aws_access_key:
-    # aws_secret_key: 
+    primaryCredentials:
+      name: my-account
+      aws_access_key:
+      aws_secret_key: 

--- a/google/dev/create_dev_vm.py
+++ b/google/dev/create_dev_vm.py
@@ -23,6 +23,7 @@ import time
 
 from spinnaker.run import run_quick
 from spinnaker.run import check_run_quick
+from spinnaker.yaml_util import YamlBindings
 
 
 __NEXT_STEP_INSTRUCTIONS = """
@@ -92,6 +93,9 @@ def init_argument_parser(parser):
         '--copy_private_files', default=False, action='store_true',
         help='Also copy private files (.ssh/id_rsa*, .git-credentials, etc)')
 
+    parser.add_argument(
+        '--master_yml', default=None,
+        help='If specified, the path to the master spinnaker-local.yml file.')
     parser.add_argument(
         '--master_config', default=None,
         help='If specified, the path to the master config file.')
@@ -227,6 +231,9 @@ def create_instance(options):
       os.remove(temp_install_runtime)
 
 
+# DEPRECATED
+# This is the old style config. Replaced by copy_yaml_config.
+# Keep this around until people are comfortable transitioning.
 def copy_master_config(options):
     """Copy the specified master spinnaker_config.cfg file, and credentials.
 
@@ -240,6 +247,15 @@ def copy_master_config(options):
         about the instance we're going to copy to, as well as the source
         of the master spinnaker_config.cfg file.
     """
+    print """
+*****************************************************************************
+** WARNING:
+** --master_config is being deprecated.
+**
+** Please use --master_yaml and provide a spinnaker-local.yml instead.
+** Your builds will still support both styles for the interim.
+*****************************************************************************
+"""
     print 'Creating .spinnaker directory...'
     check_run_quick('gcloud compute ssh --command "mkdir -p .spinnaker"'
                     ' --project={project} --zone={zone} {instance}'
@@ -309,6 +325,84 @@ def copy_master_config(options):
       os.remove(temp_path)
 
 
+def copy_master_yml(options):
+    """Copy the specified master spinnaker-local.yml, and credentials.
+
+    This will look for paths to credentials within the spinnaker-local.yml, and
+    copy those as well. The paths to the credentials (and the reference
+    in the config file) will be changed to reflect the filesystem on the
+    new instance, which may be different than on this instance.
+
+    Args:
+      options [Namespace]: The parser namespace options contain information
+        about the instance we're going to copy to, as well as the source
+        of the master spinnaker_config.cfg file.
+    """
+    print 'Creating .spinnaker directory...'
+    check_run_quick('gcloud compute ssh --command "mkdir -p .spinnaker"'
+                    ' --project={project} --zone={zone} {instance}'
+                    .format(project=get_project(options),
+                            zone=options.zone,
+                            instance=options.instance),
+                    echo=False)
+
+    bindings = YamlBindings()
+    bindings.import_path(options.master_yml)
+
+    try:
+      json_credential_path = bindings.get(
+          'providers.google.primaryCredentials.jsonPath')
+    except KeyError:
+      json_credential_path = None
+
+    gcp_home = os.path.join('/home', os.environ['LOGNAME'], '.spinnaker')
+
+    # If there are credentials, write them to this path
+    gcp_credential_path = os.path.join(gcp_home, 'google-credentials.json')
+
+    fix_permissions = [
+        'cd {gcp_home}'.format(gcp_home=gcp_home),
+        'chmod 600 spinnaker-local.yml'
+    ]
+
+    with open(options.master_yml, 'r') as f:
+        content = f.read()
+
+    # Replace all the occurances of the original credentials path with the
+    # path that we are going to place the file in on the new instance.
+    if json_credential_path:
+        new_content = content.replace(json_credential_path, gcp_credential_path)
+
+    fd, temp_path = tempfile.mkstemp()
+    os.write(fd, new_content)
+    os.close(fd)
+    actual_path = temp_path
+
+    # Copy the credentials here. The cfg file will be copied after.
+    copy_file(options, actual_path,
+              '{instance}:.spinnaker/spinnaker-local.yml'.format(
+                    instance=options.instance))
+
+    if json_credential_path:
+        copy_file(options, json_credential_path,
+                  '{instance}:.spinnaker/google-credentials.json'.format(
+                        instance=options.instance))
+        fix_permissions.append('chmod 600 google-credentials.json')
+
+    print 'Fixing credentials.'
+    # Ideally this should be a parameter to copy-files so it is always
+    # protected, but there doesnt seem to be an API for it.
+    check_run_quick('gcloud compute ssh --command "{fix_permissions}"'
+                    ' --project={project} --zone={zone} {instance}'
+                    .format(fix_permissions=';'.join(fix_permissions),
+                            project=get_project(options),
+                            zone=options.zone,
+                            instance=options.instance),
+                    echo=False)
+    if temp_path:
+      os.remove(temp_path)
+
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     init_argument_parser(parser)
@@ -329,6 +423,9 @@ if __name__ == '__main__':
 
     if options.master_config:
       copy_master_config(options)
+
+    if options.master_yml:
+      copy_master_yml(options)
 
     print __NEXT_STEP_INSTRUCTIONS.format(
         project=get_project(options),

--- a/google/dev/dev_runner.py
+++ b/google/dev/dev_runner.py
@@ -183,6 +183,9 @@ class DevRunner(spinnaker_runner.Runner):
     """
     if self.using_deprecated_config:
       self.reconfigure_subsystems(options)
+    else:
+      util = configure_util.ConfigureUtil(self.__installation)
+      util.update_deck_settings(self.new_bindings)
 
     ignore_tail_jobs = self.tail_error_logs()
     super(DevRunner, self).start_all(options)

--- a/google/dev/refresh_source.py
+++ b/google/dev/refresh_source.py
@@ -250,6 +250,16 @@ class Refresher(object):
     for repository in all_repos:
         self.pull_from_origin(repository)
 
+  def __determine_spring_config_location(self):
+    root = '{dir}/config'.format(
+        dir=os.path.abspath(os.path.join(os.path.dirname(sys.argv[0]), '..')))
+    home = os.path.join(os.environ['HOME'] + '/.spinnaker')
+    return ('{root}/spinnaker.yml'
+            ',{home}/spinnaker-local.yml'
+            ',{root}/'
+            ',{home}/'
+            .format(home=home, root=root))
+
   def write_gradle_run_script(self, repository):
       """Generate a dev_run.sh script for the local repository.
 
@@ -258,14 +268,22 @@ class Refresher(object):
       """
       name = repository.name
       path = '{name}/start_dev.sh'.format(name=name)
+
       with open(path, 'w') as f:
           f.write("""#!/bin/bash
 cd $(dirname $0)
 LOG_DIR=${{LOG_DIR:-../logs}}
 
+if [[ -f $HOME/.spinnaker/spinnaker-local.yml ]]; then
+   if [[ "$SPRING_CONFIG_LOCATION" != "" ]]; then
+     echo "WARNING: SPRING_CONFIG_LOCATION is overriden as $SPRING_CONFIG_LOCATION"
+   else
+     export SPRING_CONFIG_LOCATION="{spring_location}"
+   fi
+fi
 bash -c "(./gradlew $@ > $LOG_DIR/{name}.log) 2>&1\
  | tee -a $LOG_DIR/{name}.log >& $LOG_DIR/{name}.err &"
-""".format(name=name))
+""".format(name=name, spring_location=self.__determine_spring_config_location()))
       os.chmod(path, 0777)
 
   def write_deck_run_script(self, repository):
@@ -300,56 +318,6 @@ bash -c "(npm start >> $LOG_DIR/{name}.log) 2>&1\
         self.write_deck_run_script(repository)
       else:
         self.write_gradle_run_script(repository)
-        if self.__options.hack_gradle:
-            self.update_build_gradle(repository)
-
-  def update_build_gradle(self, repository):
-    """Add the spring.config.location override to the repository build.gradle.
-
-    Args:
-      repository [string]: The name of the local repository to generate in.
-    """
-    name = repository.name
-    search = [ '{name}/build.gradle'.format(name=name),
-               '{name}/{name}-web/{name}-web.gradle'.format(name=name)
-    ]
-    for path in search:
-      if not os.path.exists(path):
-        continue
-      if self.__update_build_gradle_helper(path):
-        return True
-    raise ValueError('Could not find gradle file for ' + name)
-
-  def __update_build_gradle_helper(self, path):
-    with open(path, 'r') as f:
-      content = f.read()
-
-    match = re.search('\napplicationDefaultJvmArgs *= *\[(.+)\]', content)
-    if not match:
-      return False
-
-    value = match.group(1)
-    if value.find('-Dspring.config.location=') >= 0:
-      return True
-
-    new_content = [content[0:match.start(1)]]
-    root = '{dir}/config'.format(
-        dir=os.path.abspath(os.path.join(os.path.dirname(sys.argv[0]), '..')))
-    home = os.path.join(os.environ['HOME'] + '/.spinnaker')
-    new_content.append('"-Dspring.config.location='
-                       '{root}/spinnaker.yml'
-                       ',{home}/spinnaker-local.yml'
-                       ',{root}/'
-                       ',{home}/"'
-                       .format(home=home, root=root))
-    if match.group(1).strip():
-      new_content.append(', ')
-    new_content.append(content[match.start(1):])
-
-    with open(path, 'w') as f:
-      f.write(''.join(new_content))
-
-    return True
 
   @classmethod
   def init_extra_argument_parser(cls, parser):
@@ -444,13 +412,6 @@ bash -c "(npm start >> $LOG_DIR/{name}.log) 2>&1\
                           help='Pull from this github user\'s repositories.'
                                ' If the user is "default" then use the'
                                ' authoritative (upstream) repository.')
-
-      parser.add_argument(
-        '--hack_gradle',  default=False, action='store_true',
-        help='Enable experiment to change the spring.config.location for'
-             ' using the new config files.\n'
-             'WARNING: This will make local changes to the build.gradle files'
-             ' that should not be submitted.')
 
   @classmethod
   def main(cls):

--- a/google/install/install_spinnaker.py
+++ b/google/install/install_spinnaker.py
@@ -463,7 +463,7 @@ def install_spinnaker(options):
                              os.path.join(bucket, 'install'),
                              install_dir))
   jobs.append(start_copy_dir(options,
-                             os.path.join(bucket, 'scripts'), script_dir))
+                             os.path.join(bucket, 'runtime'), script_dir))
   jobs.append(start_copy_dir(options,
                              os.path.join(bucket, 'pylib'), pylib_dir))
 

--- a/google/pylib/spinnaker/reconfigure_spinnaker.py
+++ b/google/pylib/spinnaker/reconfigure_spinnaker.py
@@ -14,14 +14,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import sys
 import configure_util
+import yaml_util
 
 if __name__ == '__main__':
   try:
     util = configure_util.ConfigureUtil()
-    util.validate_or_die()
-    bindings = util.load_bindings()
-    util.update_all_config_files(bindings)
+
+    root_dir = os.environ.get('SPINNAKER_HOME', '/opt/spinnaker')
+    config_dir = os.path.join(root_dir, 'config')
+    yaml_bindings = yaml_util.load_new_bindings(config_dir, only_if_local=True)
+    if yaml_bindings:
+      util.update_deck_settings(yaml_bindings)
+    else:   
+      util.validate_or_die()
+      bindings = util.load_bindings()
+      util.update_all_config_files(bindings)
   except SystemExit:
     sys.exit(-1)

--- a/google/unittest/yaml_util_test.py
+++ b/google/unittest/yaml_util_test.py
@@ -79,6 +79,13 @@ e:
     bindings.import_path(temp_path)
     self.assertEqual(expect, bindings.map)
 
+  def test_load_composite_value(self):
+    bindings = YamlBindings()
+    bindings.import_dict({'a': 'A', 'b':'B'})
+    bindings.import_string('test: ${a}/${b}')
+    print str(bindings.map)
+    self.assertEqual('A/B', bindings.get('test'))
+
   def test_update_field_union(self):
     bindings = YamlBindings()
     bindings.import_dict({'a': 'A'})
@@ -130,6 +137,7 @@ e:
   def test_load_key_not_found(self):
     bindings = YamlBindings()
     bindings.import_dict({'field': '${injected.value}', 'injected': {}})
+
     with self.assertRaises(KeyError):
       bindings.get('unknown')
 
@@ -140,6 +148,11 @@ e:
     with self.assertRaises(ValueError):
       bindings.get('field')
 
+  def test_replace(self):
+    bindings = YamlBindings()
+    bindings.import_dict({'a': 'A', 'container': {'b': 'B'}})
+    self.assertEqual('This is A B or C',
+                     bindings.replace('This is ${a} ${container.b} or ${c:C}'))
 
 if __name__ == '__main__':
   loader = unittest.TestLoader()


### PR DESCRIPTION
@duftler 
This fixes deck configuration to work off the YAML file.
You need to run "reconfigure_spinnaker" for that to happen, but that's all reconfigure_spinnaker does.
You can now run build/run deployments with the new configuration exactly as before. The difference is
Create a spinnaker-local.yml  (see google/config/sample-spinnaker-local.yml) instead of the spinnaker_config.cfg

Run the gcloud command to create an instance, but instead of setting a metadata attribute "spinnaker_config=...", set one called spinnaker_local=..." pointing to your spinnaker-local.yml.

I need to submit some gradle fixes to tomas for run_dev.sh to work, but those are issues in the other repositories.
