### PR TITLE
Fix cassandra cluster declaration in rush.

### DIFF
--- a/google/config/rush.yml
+++ b/google/config/rush.yml
@@ -6,6 +6,11 @@ cassandra:
   embedded: ${services.cassandra.embedded:false}
   host: ${services.cassandra.host:localhost}
 
+spinnaker:
+  cassandra:
+    cluster: ${services.cassandra.cluster:spinnaker}
+    keyspace: 'rush'
+
 docker:
   accounts:
     - name: ${services.docker.primaryAccount.name}


### PR DESCRIPTION
@duftler 
I was reworking rush's main and this surfaced.
I'm not entirely sure why this is coming up now and not before.

On one hand, it looks like this is defined to have 'spinnaker' as a default,
but it looks like elsewhere is using CASS_SPINNAKER (which is in spinnaker.yml)
so please weigh in. This change "feels" right (there's only supposed to be one cluster, right?)

On the other hand, the error I am not sure how it was getting at that value before and why
it isnt now. I am assuming that is a matter for the other changes I made, in the rush repository,
which are independent of this CL.
