### PR TITLE
Add default address so it's easy to bind to public IP across the board.

### DIFF
--- a/google/config/spinnaker.yml
+++ b/google/config/spinnaker.yml
@@ -128,6 +128,6 @@ providers:
     defaultRegion: us-east-1
     defaultSimpleDBDomain: CLOUD_APPLICATIONS
     primaryCredentials:
-      name: my-aws-account
+      name: default
       aws_access_key:
       aws_secret_key: 


### PR DESCRIPTION
Also moved serviceProtocol into services.default.protocol for encapsulation.

@ttomsu or @duftler
