### PR TITLE
Various cleanups.

### DIFF
--- a/google/config/clouddriver.yml
+++ b/google/config/clouddriver.yml
@@ -12,6 +12,8 @@ redis:
 
 aws:
   enabled: ${providers.aws.enabled:false}
+  aws_access_key: ${providers.aws.primaryCredentials.aws_access_key}
+  aws_secret_key: ${providers.aws.primaryCredentials.aws_secret_key}
 
 google:
   enabled: ${providers.google.enabled:false}

--- a/google/config/default-spinnaker-local.yml
+++ b/google/config/default-spinnaker-local.yml
@@ -30,6 +30,7 @@ services:
     # directly under 'services'.
     protocol: http    # Assume all spinnaker subsystems are using http
     host: localhost   # Assume all spinnaker subsystems are on localhost
+    primaryAccountName: ${providers.google.primaryCredentials.name}
 
   redis:
     # If you are using a remote redis server, you can set the host here.
@@ -48,26 +49,38 @@ services:
     # Spinnaker's "rush" subsystem uses docker to run internal jobs.
     # Note that docker is not installed with Spinnaker so you must obtain this
     # on your own if you are interested.
-    host:
-    port:
+    enabled: false
+    baseUrl: # Expected in spinnaker-local.yaml
 
     # You'll need to provide it a Spinnaker account to use.
-    # Here we are assuming the primary google account,
-    # but you may want ${providers.aws.primaryCredentials.name}
-    # or some other entirely different account.
+    # Here we are assuming the default primary acccount.
+    #
+    # If you have multiple accounts using docker then you will need to
+    # provide a rush-local.yml.
+    # For more info see docker.accounts in config/rush.yml.
     primaryAccount:
-       name: ${providers.google.primaryCredentials.name}
+      name: ${services.default.primaryAccountName}
+      url:  ${services.docker.baseUrl}
+      registry: ${services.dockerRegistry.baseUrl}
+
+  dockerRegistry:
+    baseUrl:
 
   jenkins:
-    # If you are integrating Jenkins, set its location here using the addressPath
+    # If you are integrating Jenkins, set its location here using the baseUrl
     # field and provide the username/password credentials.
     # You must also enable the "igor" service listed seperately.
     #
-    # Note that jenkins is not installed with Spinnaekr so you must obtain this
+    # If you have multiple jenkins servers, you will need to list
+    # them in an igor-local.yml. See jenkins.masters in config/igor.yml.
+    #
+    # Note that jenkins is not installed with Spinnaker so you must obtain this
     # on your own if you are interested.
-    host:
-    username:
-    password:
+    defaultMaster:
+      name: Jenkins # The display name for this server
+      baseUrl:
+      username:
+      password:
 
   igor:
     # If you are integrating Jenkins then you must also enable Spinnaker's
@@ -77,7 +90,5 @@ services:
   rush:
     # Spinnaker's "rush" subsystem is used by the "rosco" bakery.
     # You'll need to provide it a Spinnaker account to use.
-    # Here we are assuming the primary google account,
-    # but you may want ${providers.aws.primaryCredentials.name}
-    # or some other entirely different account.
-    primaryAccount: ${providers.google.primaryCredentials.name}
+    # Here we are assuming the default primary acccount.
+    primaryAccount: ${services.default.primaryAccountName}

--- a/google/config/igor.yml
+++ b/google/config/igor.yml
@@ -4,10 +4,10 @@ server:
 
 jenkins:
   masters:
-    - name: ${services.jenkins.name}
-      address: ${services.jenkins.baseUrl}
-      username: ${services.jenkins.username}
-      password: ${services.jenkins.password}
+    - name: ${services.jenkins.defaultMaster.name}
+      address: ${services.jenkins.defaultMaster.baseUrl}
+      username: ${services.jenkins.defaultMaster.username}
+      password: ${services.jenkins.defaultMaster.password}
 
 # This is recursive
 #services:

--- a/google/config/orca.yml
+++ b/google/config/orca.yml
@@ -17,7 +17,9 @@ bakery:
     extractBuildDetails: ${services.bakery.extractBuildDetails:true}
     propagateCloudProviderType: ${services.bakery.propagateCloudProviderType:true}
 echo:
+    enabled: ${services.echo.enabled:false}
     baseUrl: ${services.echo.baseUrl:8089}
+
 igor:
     baseUrl: ${services.igor.baseUrl:8088}
 

--- a/google/config/settings.js
+++ b/google/config/settings.js
@@ -1,64 +1,52 @@
 'use strict';
 
 
-#################################################################
-# This section is managed by scripts/reconfigure_spinnaker.sh
-# If hand-editing, only add comment lines that look like
-# '# let VARIABLE = VALUE'
-# and let scripts/reconfigure manage the actual values.
-#################################################################
-# BEGIN reconfigure_spinnaker
+/**
+ * This section is managed by scripts/reconfigure_spinnaker.sh
+ * If hand-editing, only add comment lines that look like
+ * '// let VARIABLE = VALUE'
+ * and let scripts/reconfigure manage the actual values.
+ */
+// BEGIN reconfigure_spinnaker
 
-# let gateUrl = ${services.gate.baseUrl};
-# let bakeryBaseUrl = ${services.bakery.baseUrl};
-# let awsDefaultRegion = ${providers.aws.defaultRegion};
-# let awsPrimaryAccount = ${providers.aws.primaryCredentials.name};
-# let googleDefaultRegion = ${providers.google.defaultRegion};
-# let googleDefaultZone = ${providers.google.defaultZone};
-# let googlePrimaryAccount = ${providers.google.primaryCredentials.name;
+// let gateUrl = ${services.gate.baseUrl};
+// let bakeryBaseUrl = ${services.bakery.baseUrl};
+// let awsDefaultRegion = ${providers.aws.defaultRegion};
+// let awsPrimaryAccount = ${providers.aws.primaryCredentials.name};
+// let googleDefaultRegion = ${providers.google.defaultRegion};
+// let googleDefaultZone = ${providers.google.defaultZone};
+// let googlePrimaryAccount = ${providers.google.primaryCredentials.name;
 
-# END reconfigure_spinnaker
-####################################################################
-# Any additional custom let statements can go below without being
-# affected by scripts/reconfigure_spinnaker.sh
-####################################################################
-
+// END reconfigure_spinnaker
+/**
+ * Any additional custom let statements can go below without
+ * being affected by scripts/reconfigure_spinnaker.sh
+ */
 
 window.spinnakerSettings = {
-  gateUrl: '${gateUrl}',
-  bakeryDetailUrl: '${bakeryBaseUrl}/api/v1/global/logs/{{context.status.id}}?html=true',
+  gateUrl: `${gateUrl}`,
+  bakeryDetailUrl: `${bakeryBaseUrl}/api/v1/global/logs/{{context.status.id}}?html=true`,
   pollSchedule: 30000,
   defaultTimeZone: 'America/New_York', // see http://momentjs.com/timezone/docs/#/data-utilities/
   providers: {
     gce: {
       defaults: {
-        account: '${googlePrimaryAccount}',
-        region: '${googleDefaultRegion}',
-        zone: '${googleDefaultZone}',
+        account: `${googlePrimaryAccount}`,
+        region: `${googleDefaultRegion}`,
+        zone: `${googleDefaultZone}`,
       },
-      primaryAccounts: ['${googlePrimaryAccount}'],
-      challengeDestructiveActions: ['${googlePrimaryAccount}'],
+      primaryAccounts: [`${googlePrimaryAccount}`],
+      challengeDestructiveActions: [`${googlePrimaryAccount}`],
     },
     aws: {
       defaults: {
-        account: '${awsPrimaryAccount}',
-        region: '${awsDefaultRegion}'
+        account: `${awsPrimaryAccount}`,
+        region: `${awsDefaultRegion}`
       },
-      primaryAccounts: ['${awsPrimaryAccount}'],
+      primaryAccounts: [`${awsPrimaryAccount}`],
       primaryRegions: ['eu-west-1', 'us-east-1', 'us-west-1', 'us-west-2'],
-      challengeDestructiveActions: ['${awsPrimaryAccount}'],
-      preferredZonesByAccount: {
-        ${awsPrimaryAccount}: {
-          'us-east-1': ['us-east-1a', 'us-east-1b', 'us-east-1d', 'us-east-1e'],
-          'us-west-1': ['us-west-1a', 'us-west-1b', 'us-west-1c'],
-          'us-west-2': ['us-west-2a', 'us-west-2b', 'us-west-2c'],
-          'eu-west-1': ['eu-west-1a', 'eu-west-1b', 'eu-west-1c'],
-          'ap-northeast-1': ['ap-northeast-1a', 'ap-northeast-1b', 'ap-northeast-1c'],
-          'ap-southeast-1': ['ap-southeast-1a', 'ap-southeast-1b'],
-          'ap-southeast-2': ['ap-southeast-2a', 'ap-southeast-2b'],
-          'sa-east-1': ['sa-east-1a', 'sa-east-1b']
-        }
-      }
+      challengeDestructiveActions: [`${awsPrimaryAccount}`],
+      preferredZonesByAccount: {}
     }
   },
   whatsNew: {
@@ -72,6 +60,17 @@ window.spinnakerSettings = {
     canary: false,
     parallelPipelines: true,
     fastProperty: false,
-    vpcMigrator: true,
+    vpcMigrator: false,
   },
+};
+
+window.spinnakerSettings.providers.aws.preferredZonesByAccount[`${awsPrimaryAccount}`] = {
+  'us-east-1': ['us-east-1a', 'us-east-1b', 'us-east-1d', 'us-east-1e'],
+  'us-west-1': ['us-west-1a', 'us-west-1b', 'us-west-1c'],
+  'us-west-2': ['us-west-2a', 'us-west-2b', 'us-west-2c'],
+  'eu-west-1': ['eu-west-1a', 'eu-west-1b', 'eu-west-1c'],
+  'ap-northeast-1': ['ap-northeast-1a', 'ap-northeast-1b', 'ap-northeast-1c'],
+  'ap-southeast-1': ['ap-southeast-1a', 'ap-southeast-1b'],
+  'ap-southeast-2': ['ap-southeast-2a', 'ap-southeast-2b'],
+  'sa-east-1': ['sa-east-1a', 'sa-east-1b']
 };

--- a/google/config/spinnaker.yml
+++ b/google/config/spinnaker.yml
@@ -6,6 +6,7 @@ services:
   default:
     host: localhost
     protocol: http
+    primaryAccountName: service-default-primaryAcountName-not-defined
 
   clouddriver:
     host: ${services.default.host}
@@ -64,7 +65,7 @@ services:
     host: ${services.default.host}
     port: 8085
     baseUrl: ${services.default.protocol}://${services.rush.host}:${services.rush.port}
-    primaryAccount: # Expected in spinnaker-local.yml
+    primaryAccount: ${services.default.primaryAccountName}
 
   bakery:
     host: ${services.rosco.host}
@@ -75,26 +76,29 @@ services:
 
   docker:
     enabled: false
-    host: # Expected in spinnaker-local.yaml
-    port: # Expected in spinnaker-local.yaml
-    baseUrl: http://${services.docker.host}:${services.docker.port}
+    baseUrl: # Expected in spinnaker-local.yaml
 
+    # If there are multiple accounts then you will need to list them in
+    # rush-local.yml. See the docker.accounts section in config/rush.yml.
     primaryAccount:
-      - name: docker-name-not-set # Expected in spinnaker-local.yml
-        url:  ${services.docker.baseUrl}
-        registry: ${services.dockerRegistry.baseUrl}
+      name: ${services.default.primaryAccountName}
+      url:  ${services.docker.baseUrl}
+      registry: ${services.dockerRegistry.baseUrl}
 
   dockerRegistry:
-    host: ${services.default.host}
-    port: 5000
-    baseUrl: http://${services.dockerRegistry.host}:${services.dockerRegistry.port}
+    baseUrl: #  Expected in spinnaker-local.yml
 
   jenkins:
-    host:  # Expected in spinnaker-local.yml
-    port:  # Expected in spinnaker-local.yml
-    username:  # Expected in spinnaker-local.yml
-    password:  # Expected in spinnaker-local.yml
-    baseUrl: http://${services.jenkins.host}:${services.jenkins.port}
+    # The "name" entry is used for the display name when selecting
+    # this server.
+    #
+    # If you have multiple jenkins servers, you will need to list
+    # them in an igor-local.yml. See jenkins.masters in config/igor.yml.
+    defaultMaster:
+      name: Jenkins
+      baseUrl:   # Expected in spinnaker-local.yml
+      username:  # Expected in spinnaker-local.yml
+      password:  # Expected in spinnaker-local.yml
 
   redis:
     host: ${services.default.host}

--- a/google/dev/build_google_image.py
+++ b/google/dev/build_google_image.py
@@ -72,12 +72,12 @@ To deploy this image, use a command like:
         --scopes=compute-rw \\
         --metadata=startup-script=/opt/spinnaker/install/first_google_boot.sh \\
         --metadata-from-file=\\
-spinnaker_config=$SPINNAKER_CONFIG_PATH,\\
+spinnaker_local=$SPINNAKER_YML_PATH,\\
 managed_project_credentials=$GOOGLE_PRIMARY_JSON_CREDENTIAL_PATH
 
   You can leave off the managed_project_credentials metadata if
   $SPINNAKER_PROJECT is the same as the GOOGLE_PRIMARY_MANAGED_PROJECT_ID
-  in the spinnaker_config.
+  in the spinnaker-local.yml.
 """.format(
     image=image_name,
     image_project=self.options.image_project)

--- a/google/dev/build_release.py
+++ b/google/dev/build_release.py
@@ -166,7 +166,7 @@ class Builder(object):
   def __init__(self, options):
       if options.release:
         # DEPRECATED take out options.release_path check below and require it.
-        print 'WARNING: --release is depcreated. Use --release_path instead.\n'
+        print 'WARNING: --release is deprecated. Use --release_path instead.\n'
         options.release_path = 'gs://' + options.release
 
       if not options.release_path:

--- a/google/dev/create_dev_vm.py
+++ b/google/dev/create_dev_vm.py
@@ -311,7 +311,7 @@ def copy_master_config(options):
               '{instance}:.spinnaker/spinnaker_config.cfg'.format(
                     instance=options.instance))
 
-    print 'Fixing credentials.'
+    print 'Setting credential permissions.'
     # Ideally this should be a parameter to copy-files so it is always
     # protected, but there doesnt seem to be an API for it.
     check_run_quick('gcloud compute ssh --command "{fix_permissions}"'

--- a/google/dev/refresh_source.py
+++ b/google/dev/refresh_source.py
@@ -295,7 +295,12 @@ bash -c "(./gradlew $DEF_SYS_PROPERTIES $@ > $LOG_DIR/{name}.log) 2>&1\
 cd $(dirname $0)
 LOG_DIR=${{LOG_DIR:-../logs}}
 
-npm install >& $LOG_DIR/{name}.log
+if [[ node_modules -ot .git ]]; then
+  # Update npm, otherwise assume nothing changed and we're good.
+  npm install >& $LOG_DIR/deck.log
+else
+  echo "deck npm node_modules looks up to date already."
+fi
 
 # Append to the log file we just started.
 bash -c "(npm start >> $LOG_DIR/{name}.log) 2>&1\

--- a/google/install/first_google_boot.sh
+++ b/google/install/first_google_boot.sh
@@ -201,13 +201,9 @@ fi
 echo "$STATUS_PREFIX  Extracting Credentials"
 extract_spinnaker_credentials
 
-if [[ ! -f /root/.spinnaker/spinnaker-local.yml ]]; then
-  # DEPRECATED
-  # Reconfigure the instance before replacing the script so that
-  # if it fails, and we reboot, we'll continue where we left off.
-  echo "$STATUS_PREFIX  Configuring Spinnaker"
-  $SPINNAKER_INSTALL_DIR/scripts/reconfigure_spinnaker.sh
-fi
+echo "$STATUS_PREFIX  Configuring Spinnaker"
+$SPINNAKER_INSTALL_DIR/scripts/reconfigure_spinnaker.sh
+
 
 # Replace this first time boot with the normal startup script
 # that just starts spinnaker (and its dependencies) without configuring anymore.

--- a/google/pylib/spinnaker/configure_util.py
+++ b/google/pylib/spinnaker/configure_util.py
@@ -433,16 +433,16 @@ class ConfigureUtil(object):
       f.write(''.join(settings))
 
   def process_deck_settings(self, source, yaml_bindings):
-    offset = source.find('# BEGIN reconfigure_spinnaker')
+    offset = source.find('// BEGIN reconfigure_spinnaker')
     if offset < 0:
       raise ValueError(
         'deck settings file does not contain a'
         ' "# BEGIN reconfigure_spinnaker" marker.')
-    end = source.find('# END reconfigure_spinnaker')
+    end = source.find('// END reconfigure_spinnaker')
     if end < 0:
       raise ValueError(
         'deck settings file does not contain a'
-        ' "# END reconfigure_spinnaker" marker.')
+        ' "// END reconfigure_spinnaker" marker.')
 
     original_block = source[offset:end]
     # Remove all the explicit declarations in this block
@@ -452,14 +452,14 @@ class ConfigureUtil(object):
 
     # Now iterate over the comments looking for let specifications
     offset = 0
-    for match in re.finditer('#\s*let\s+(\w+)\s*=\s*(.+);?\n', block) or []:
+    for match in re.finditer('//\s*let\s+(\w+)\s*=\s*(.+?);?\n', block) or []:
       settings.append(block[offset:match.end()])
       offset = match.end()
       name = match.group(1)
       value = yaml_bindings.replace(match.group(2))
-      settings.append('let {name} = {value!r}\n'.format(
+      settings.append('let {name} = {value!r};\n'.format(
          name=name, value=value))
 
     settings.append(block[offset:])
-    settings.append(source[end + 1:])
+    settings.append(source[end:])
     return ''.join(settings)

--- a/google/pylib/spinnaker/spinnaker_runner.py
+++ b/google/pylib/spinnaker/spinnaker_runner.py
@@ -254,7 +254,8 @@ class Runner(object):
 
     if self.__new_bindings:
       docker_address = self.__new_bindings.get('services.docker.baseUrl')
-      jenkins_address = self.__new_bindings.get('services.jenkins.baseUrl')
+      jenkins_address = self.__new_bindings.get(
+          'services.jenkins.defaultMaster.baseUrl')
       igor_enabled = self.__new_bindings.get('services.igor.enabled')
     else:
       docker_address = self.__old_bindings.get_variable('DOCKER_ADDRESS', '')
@@ -273,7 +274,7 @@ class Runner(object):
         if not igor_enabled:
             sys.stderr.write(
                 'WARNING: Not starting igor because IGOR_ENABLED=false'
-                ' even though JENKINS_ADDRESS="{address}"'.format(
+                ' even though JENKINS_ADDRESS="{address}"\n'.format(
                       address=jenkins_address))
         else:
             pid = self.maybe_start_job(jobs, 'igor')
@@ -467,7 +468,6 @@ Proceeding anyway.
   def start_all(self, options):
     self.check_configuration(options)
 
-    self.stop_deck()
     try:
       os.makedirs(self.__installation.LOG_DIR)
     except OSError:
@@ -561,15 +561,6 @@ Proceeding anyway.
   def check_configuration(self, options):
     if os.path.exists(
         os.path.join(self.__installation.CONFIG_DIR, 'spinnaker-local.yml')):
-      # Rush is non-standard and wont find the rush.yml file, so move the
-      # normal system one here. It doesnt normally need to be overriden, and if
-      # so then just override whatever is here anyway.
-      local_rush = os.path.join(self.__installation.CONFIG_DIR,
-                                'rush-local.yml')
-      if not os.path.exists(local_rush):
-         rush = self.__installation.SPINNAKER_INSTALL_DIR + '/config/rush.yml'
-         if os.path.exists(rush):
-            shutil.copyfile(rush, local_rush)
       return
 
     # DEPRECATED, but this is currently the reliable way to use it


### PR DESCRIPTION
Propagate aws access/secret key to clouddriver

Added services.default.primaryAccountName to spinnaker.yml as a single place
to update the default account to use. This avoids spreading the choice between
aws and google throughout and localizing it to one easy-to-find place.

Added docker and dockerRegistry to spinnaker-local.

Use baseUrl for docker and jenkins to simplify local yaml

Moved "server.jenkins" fields into "server.jenkins.defaultMaster"
to clarify that it's just a single instance. Added comments throughout
where multiple values are possible but require editing the -local.yml directly.
This is a spring config limitation.

Propagate echo.enabled

Fixed settings.js syntax.
Set vpcMigrator: false

When generating deck's start_dev, put a guard around installing npm
every time. This speeds startup significantly.

Dont stop_deck when restarting all.
