### PR TITLE
Integrated AWS configuration

### DIFF
--- a/google/config/clouddriver.yml
+++ b/google/config/clouddriver.yml
@@ -12,8 +12,10 @@ redis:
 
 aws:
   enabled: ${providers.aws.enabled:false}
-  aws_access_key: ${providers.aws.primaryCredentials.aws_access_key}
-  aws_secret_key: ${providers.aws.primaryCredentials.aws_secret_key}
+  # Credentials are passed either as environment variables or through
+  # a standard AWS file $HOME/.aws/credentials
+  # See providers.aws.primaryCredentials in spinnaker.yml for more
+  # info on setting environment variables.
 
 google:
   enabled: ${providers.google.enabled:false}

--- a/google/config/default-spinnaker-local.yml
+++ b/google/config/default-spinnaker-local.yml
@@ -1,3 +1,7 @@
+# This file is intended to override the default configuration in the spinnaker.yml file.
+# In order for Spinnaker to discover it, it must be copied to a file named
+# "spinnaker-local.yml" and placed in the $HOME/.spinnaker directory.
+
 providers:
   aws:
     # If you want to deploy some services to Amazon Web Services (AWS),
@@ -7,8 +11,11 @@ providers:
     defaultRegion: us-east-1
     primaryCredentials:
       name: my-aws-account
-      aws_access_key:
-      aws_secret_key:
+      # You can use a standard $HOME/.aws/credentials file instead of providing
+      # these here. If provided here, then start_spinnaker will set environment
+      # variables before starting up the subsystems that interact with AWS.
+      access_key_id:
+      secret_key:
 
   google:
     # If you want to deploy some services to Google Cloud Platform (google),
@@ -19,11 +26,14 @@ providers:
     defaultZone: us-central1-f
     primaryCredentials:
       name: my-google-account
+      # The project is the Google Project ID for the project to manage with Spinnaker.
+      # The jsonPath is a path to the JSON service credentials downloaded from the
+      # Google Developer's Console.
       project:
       jsonPath:
 
 services:
-  defaults:
+  default:
     # These defaults can be modified to change all the spinnaker subsystems
     # (clouddriver, gate, etc) at once, but not external systems (jenkins, etc).
     # Individual systems can still be overriden using their own section entry

--- a/google/config/sample-spinnaker-local.yml
+++ b/google/config/sample-spinnaker-local.yml
@@ -4,8 +4,8 @@ providers:
     defaultRegion: us-east-1
     primaryCredentials:
       name: my-aws-account
-      aws_access_key:
-      aws_secret_key:
+      access_key_id:
+      secret_key:
 
   google:
     enabled: true

--- a/google/config/spinnaker.yml
+++ b/google/config/spinnaker.yml
@@ -1,9 +1,21 @@
+# This file is intended to serve as a master configuration for a Spinnaker deployment.
+# Customizations to the deployment should be made in another file named
+# "spinnaker-local.yml". The distribution has a prototype called
+# "default-spinnaker-local.yml" which calls out the subset of attributes of general
+# interest. It can be copied into a "spinnaker-local.yml" to start with. The prototype
+# does not change any of the default values here, it just surfaces the more critical
+# attributes.
+
 global:
   spinnaker:
     environment: test
 
 services:
   default:
+    # These defaults can be modified to change all the spinnaker subsystems
+    # (clouddriver, gate, etc) at once, but not external systems (jenkins, etc).
+    # Individual systems can still be overriden using their own section entry
+    # directly under 'services'.
     host: localhost
     protocol: http
     primaryAccountName: service-default-primaryAcountName-not-defined
@@ -30,6 +42,8 @@ services:
     baseUrl: ${services.default.protocol}://${services.gate.host}:${services.gate.port}
 
   igor:
+    # If you are integrating Jenkins then you must also enable Spinnaker's
+    # "igor" subsystem.
     enabled: false
     host: ${services.default.host}
     port: 8088
@@ -62,6 +76,9 @@ services:
     baseUrl: ${services.default.protocol}://${services.rosco.host}:${services.rosco.port}
 
   rush:
+    # Spinnaker's "rush" subsystem is used by the "rosco" bakery.
+    # You'll need to provide it a Spinnaker account to use.
+    # Here we are assuming the default primary acccount.
     host: ${services.default.host}
     port: 8085
     baseUrl: ${services.default.protocol}://${services.rush.host}:${services.rush.port}
@@ -75,11 +92,18 @@ services:
     propagateCloudProviderType: true
 
   docker:
+    # Spinnaker's "rush" subsystem uses docker to run internal jobs.
+    # Note that docker is not installed with Spinnaker so you must obtain this
+    # on your own if you are interested.
     enabled: false
     baseUrl: # Expected in spinnaker-local.yaml
 
-    # If there are multiple accounts then you will need to list them in
-    # rush-local.yml. See the docker.accounts section in config/rush.yml.
+    # You'll need to provide it a Spinnaker account to use.
+    # Here we are assuming the default primary acccount.
+    #
+    # If you have multiple accounts using docker then you will need to
+    # provide a rush-local.yml.
+    # For more info see docker.accounts in config/rush.yml.
     primaryAccount:
       name: ${services.default.primaryAccountName}
       url:  ${services.docker.baseUrl}
@@ -94,6 +118,9 @@ services:
     #
     # If you have multiple jenkins servers, you will need to list
     # them in an igor-local.yml. See jenkins.masters in config/igor.yml.
+    #
+    # Note that jenkins is not installed with Spinnaker so you must obtain this
+    # on your own if you are interested.
     defaultMaster:
       name: Jenkins
       baseUrl:   # Expected in spinnaker-local.yml
@@ -113,25 +140,33 @@ services:
 
 
 providers:
-  google:
-    enabled: false
-    defaultRegion: us-central1
-    defaultZone: us-central1-f
-    primaryCredentials:
-      name: my-account-name
-      project: 
-      jsonPath:
-    credentials:
-      name: ${providers.google.primaryCredentials.name}
-      project: ${providers.google.primaryCredentials.project}
-      jsonPath: ${providers.google.primaryCredentials.jsonPath}
-
   aws:
+    # If you want to deploy some services to Amazon Web Services (AWS),
+    # set enabled and provide primary credentials for deploying.
+    # Enabling AWS is independent of other providers.
     enabled: false
     simpleDBEnabled: false
     defaultRegion: us-east-1
     defaultSimpleDBDomain: CLOUD_APPLICATIONS
     primaryCredentials:
       name: default
-      aws_access_key:
-      aws_secret_key: 
+      # You can use a standard $HOME/.aws/credentials file instead of providing
+      # these here. If provided here, then start_spinnaker will set environment
+      # variables before starting up the subsystems that interact with AWS.
+      access_key_id:
+      secret_key: 
+
+  google:
+    # If you want to deploy some services to Google Cloud Platform (google),
+    # set enabled and provide primary credentials for deploying.
+    # Enabling google is independent of other providers.
+    enabled: false
+    defaultRegion: us-central1
+    defaultZone: us-central1-f
+    primaryCredentials:
+      name: my-account-name
+      # The project is the Google Project ID for the project to manage with Spinnaker.
+      # The jsonPath is a path to the JSON service credentials downloaded from the
+      # Google Developer's Console.
+      project: 
+      jsonPath:

--- a/google/install/first_google_boot.sh
+++ b/google/install/first_google_boot.sh
@@ -129,6 +129,11 @@ function extract_spinnaker_local_yaml() {
 }
 
 function extract_spinnaker_credentials() {
+    extract_spinnaker_google_credentials
+    extract_spinnaker_aws_credentials
+}
+
+function extract_spinnaker_google_credentials() {
   local json_path="$CONFIG_DIR/ManagedProjectCredentials.json"
   mkdir -p $(dirname $json_path)
   if clear_metadata_to_file "managed_project_credentials" $json_path; then
@@ -140,6 +145,7 @@ function extract_spinnaker_credentials() {
     sed -i s/^None$//g $json_path
     if [[ -s $json_path ]]; then
       chmod 400 $json_path
+      echo "Extracted google credentials to $json_path"
     else
        rm $json_path
     fi
@@ -163,6 +169,27 @@ function extract_spinnaker_credentials() {
           "$CONFIG_DIR/spinnaker_config.cfg"
       echo "GOOGLE_PRIMARY_JSON_CREDENTIAL_PATH=$json_path" \
           >> "$CONFIG_DIR/spinnaker_config.cfg"
+  fi
+}
+
+function extract_spinnaker_aws_credentials() {
+  local credentials_path="$HOME/.aws/credentials"
+  mkdir -p $(dirname $credentials_path)
+  if clear_metadata_to_file "aws_credentials" $credentials_path; then
+    # This is a workaround for difficulties using the Google Deployment Manager
+    # to express no value. We'll use the value "None". But we dont want
+    # to officially support this, so we'll just strip it out of this first
+    # time boot if we happen to see it, and assume the Google Deployment Manager
+    # got in the way.
+    sed -i s/^None$//g $credentials_path
+    if [[ -s $credentials_path ]]; then
+      chmod 400 $credentials_path
+      echo "Extracted aws credentials to $credentials_path"
+    else
+       rm $credentials_path
+    fi
+  else
+    clear_instance_metadata "aws_credentials"
   fi
 }
 


### PR DESCRIPTION
If credentials are provided in spinnaker-local.yml then set environment variables
Support transferring of an .aws/credentials file elsewhere.
Net effect is that you can use an .aws/credentials file for standard AWS
usage, but if you want to set environment variables, you can use the YML file
for that.
