### PR TITLE
Standard configuration files for a Spinnaker deployment.

### DIFF
--- a/config/clouddriver.yml
+++ b/config/clouddriver.yml
@@ -1,0 +1,32 @@
+server:
+  port: ${services.clouddriver.port:7002}
+  address: ${services.clouddriver.host:localhost}
+
+#circular
+#services:
+#  front50:
+#    baseUrl: ${services.front50.baseUrl:localhost:8080}
+
+redis:
+  connection: ${services.redis.connection:redis://localhost:6379}
+
+aws:
+  enabled: ${providers.aws.enabled:false}
+  # Credentials are passed either as environment variables or through
+  # a standard AWS file $HOME/.aws/credentials
+  # See providers.aws.primaryCredentials in spinnaker.yml for more
+  # info on setting environment variables.
+  #
+  # TODO(ewiseblatt):
+  # This only works for root credentials, which you arent supposed to use.
+  # I havent been able to figure out how to get normal user accounts to work.
+  # I'm leaving this broken for now hoping that once this gets mainlined some
+  # body else will be able to fix it.
+
+google:
+  enabled: ${providers.google.enabled:false}
+
+  accounts:
+    - name: ${providers.google.primaryCredentials.name}
+      project: ${providers.google.primaryCredentials.project}
+      jsonPath: ${providers.google.primaryCredentials.jsonPath}

--- a/config/default-spinnaker-local.yml
+++ b/config/default-spinnaker-local.yml
@@ -1,0 +1,104 @@
+# This file is intended to override the default configuration in the spinnaker.yml file.
+# In order for Spinnaker to discover it, it must be copied to a file named
+# "spinnaker-local.yml" and placed in the $HOME/.spinnaker directory.
+
+providers:
+  aws:
+    # If you want to deploy some services to Amazon Web Services (AWS),
+    # set enabled and provide primary credentials for deploying.
+    # Enabling AWS is independent of other providers.
+    enabled: false
+    defaultRegion: us-east-1
+    primaryCredentials:
+      name: my-aws-account
+      # You can use a standard $HOME/.aws/credentials file instead of providing
+      # these here. If provided here, then start_spinnaker will set environment
+      # variables before starting up the subsystems that interact with AWS.
+      access_key_id:
+      secret_key:
+
+  google:
+    # If you want to deploy some services to Google Cloud Platform (google),
+    # set enabled and provide primary credentials for deploying.
+    # Enabling google is independent of other providers.
+    enabled: false
+    defaultRegion: us-central1
+    defaultZone: us-central1-f
+    primaryCredentials:
+      name: my-google-account
+      # The project is the Google Project ID for the project to manage with Spinnaker.
+      # The jsonPath is a path to the JSON service credentials downloaded from the
+      # Google Developer's Console.
+      project:
+      jsonPath:
+
+services:
+  default:
+    # These defaults can be modified to change all the spinnaker subsystems
+    # (clouddriver, gate, etc) at once, but not external systems (jenkins, etc).
+    # Individual systems can still be overriden using their own section entry
+    # directly under 'services'.
+    protocol: http    # Assume all spinnaker subsystems are using http
+    host: localhost   # Assume all spinnaker subsystems are on localhost
+    primaryAccountName: ${providers.google.primaryCredentials.name}
+
+  redis:
+    # If you are using a remote redis server, you can set the host here.
+    # If the remote server is on a different port or url, you can add
+    # a "port" or "baseUrl" field here instead.
+    host: localhost
+
+  cassandra:
+    # If you are using a remote cassandra server, you can set the host here.
+    # If the remote server is on a different port or url, you can add
+    # a "port" or "baseUrl" field here instead. You may also need to set
+    # the cluster name. See the main spinnaker.yml file for more attributes.
+    host: localhost
+
+  docker:
+    # Spinnaker's "rush" subsystem uses docker to run internal jobs.
+    # Note that docker is not installed with Spinnaker so you must obtain this
+    # on your own if you are interested.
+    enabled: false
+    baseUrl: # Expected in spinnaker-local.yaml
+
+    # You'll need to provide it a Spinnaker account to use.
+    # Here we are assuming the default primary acccount.
+    #
+    # If you have multiple accounts using docker then you will need to
+    # provide a rush-local.yml.
+    # For more info see docker.accounts in config/rush.yml.
+    primaryAccount:
+      name: ${services.default.primaryAccountName}
+      url:  ${services.docker.baseUrl}
+      registry: ${services.dockerRegistry.baseUrl}
+
+  dockerRegistry:
+    baseUrl:
+
+  jenkins:
+    # If you are integrating Jenkins, set its location here using the baseUrl
+    # field and provide the username/password credentials.
+    # You must also enable the "igor" service listed seperately.
+    #
+    # If you have multiple jenkins servers, you will need to list
+    # them in an igor-local.yml. See jenkins.masters in config/igor.yml.
+    #
+    # Note that jenkins is not installed with Spinnaker so you must obtain this
+    # on your own if you are interested.
+    defaultMaster:
+      name: Jenkins # The display name for this server
+      baseUrl:
+      username:
+      password:
+
+  igor:
+    # If you are integrating Jenkins then you must also enable Spinnaker's
+    # "igor" subsystem.
+    enabled: false
+
+  rush:
+    # Spinnaker's "rush" subsystem is used by the "rosco" bakery.
+    # You'll need to provide it a Spinnaker account to use.
+    # Here we are assuming the default primary acccount.
+    primaryAccount: ${services.default.primaryAccountName}

--- a/config/echo.yml
+++ b/config/echo.yml
@@ -1,0 +1,15 @@
+server:
+  port: ${services.echo.port:8089}
+  address: ${services.echo.host:localhost}
+
+cassandra:
+  embedded: ${services.cassandra.embedded:false}
+  host: ${services.cassandra.host:localhost}
+
+front50:
+  baseUrl: ${services.front50.baseUrl:http://localhost:8080}
+
+orca:
+  baseUrl: ${services.orca.baseUrl:http://localhost:8083}
+
+endpoints.health.sensitive: false

--- a/config/front50.yml
+++ b/config/front50.yml
@@ -1,0 +1,20 @@
+server:
+  port: ${services.front50.port:7002}
+  address: ${services.front50.host:localhost}
+
+cassandra:
+  embedded: ${services.cassandra.embedded:false}
+  host: ${services.cassandra.host:localhost}
+
+aws:
+  simpleDBEnabled: ${providers.aws.simpleDBEnabled:false}
+  defaultSimpleDBDomain: ${providers.aws.defaultSimpleDBDomain}
+
+spinnaker:
+  cassandra:
+    enabled: true
+    host: ${services.cassandra.host:localhost}
+    port: ${services.cassandra.port:9042}
+    cluster: ${services.cassandra.cluster:CASS_SPINNAKER}
+    keyspace: front50
+    name: global

--- a/config/gate.yml
+++ b/config/gate.yml
@@ -1,0 +1,29 @@
+server:
+  port: ${services.gate.port:8084}
+  address: ${services.gate.host:localhost}
+
+# Circular references since we're already using 'services'
+# services:
+#   oort:
+#     baseUrl: ${services.oort.baseUrl:localhost:7002}
+#   orca:
+#     baseUrl: ${services.orca.baseUrl:localhost:8083}
+#   front50:
+#     baseUrl: ${services.front50.baseUrl:localhost:8080}
+#   mort:
+#     baseUrl: ${services.mort.baseUrl:localhost:7002}
+#   kato:
+#     baseUrl: ${services.kato.baseUrl:localhost:7002}
+# #optional services:
+#   echo:
+#     enabled: ${services.echo.enabled:true}
+#     baseUrl: ${services.echo.baseUrl:8089}
+#   flapjack:
+#     enabled: ${services.flapjack.enabled:false}
+#   igor:
+#     enabled: ${services.igor.enabled:false}
+#     baseUrl: ${services.igor.baseUrl:8088}
+
+redis:
+  connection: ${services.redis.connection}
+

--- a/config/igor.yml
+++ b/config/igor.yml
@@ -1,0 +1,15 @@
+server:
+  port: ${services.igor.port:8088}
+  address: ${services.igor.host:localhost}
+
+jenkins:
+  masters:
+    - name: ${services.jenkins.defaultMaster.name}
+      address: ${services.jenkins.defaultMaster.baseUrl}
+      username: ${services.jenkins.defaultMaster.username}
+      password: ${services.jenkins.defaultMaster.password}
+
+# This is recursive
+#services:
+#  echo:
+#    baseUrl: ${services.echo.baseUrl}

--- a/config/orca.yml
+++ b/config/orca.yml
@@ -1,0 +1,40 @@
+server:
+    port: ${services.orca.port:8083}
+    address: ${services.orca.host:localhost}
+
+oort:
+    baseUrl: ${services.oort.baseUrl:localhost:7002}
+front50:
+    baseUrl: ${services.front50.baseUrl:localhost:8080}
+mort:
+    baseUrl: ${services.mort.baseUrl:localhost:7002}
+kato:
+    baseUrl: ${services.kato.baseUrl:localhost:7002}
+rush:
+    baseUrl: ${services.rush.baseUrl:localhost:8085}
+bakery:
+    baseUrl: ${services.bakery.baseUrl:localhost:8087}
+    extractBuildDetails: ${services.bakery.extractBuildDetails:true}
+    propagateCloudProviderType: ${services.bakery.propagateCloudProviderType:true}
+echo:
+    enabled: ${services.echo.enabled:false}
+    baseUrl: ${services.echo.baseUrl:8089}
+
+igor:
+    baseUrl: ${services.igor.baseUrl:8088}
+
+# TODO(duftler): Remove this once flex is conditionally-enabled in orca.
+flex:
+  baseUrl: http://not-a-host
+
+default:
+  bake:
+    account: ${providers.aws.primaryCredentials.name}
+  securityGroups:
+  vpc:
+    securityGroups:
+
+redis:
+  connection: ${services.redis.connection}
+
+

--- a/config/rosco.yml
+++ b/config/rosco.yml
@@ -1,0 +1,21 @@
+server:
+  port: ${services.rosco.port:8087}
+  address: ${services.rosco.host:localhost}
+
+redis:
+  host: ${services.redis.host:localhost}
+
+aws:
+  enabled: ${providers.aws.enabled:false}
+
+docker:
+  enabled: ${services.docker.enabled:false}
+
+google:
+  enabled: ${providers.google.enabled:false}
+  gce:
+    bakeryDefaults:
+      project: ${providers.google.primaryCredentials.project}
+
+rush:
+  credentials: ${services.rush.primaryAccount}

--- a/config/rush.yml
+++ b/config/rush.yml
@@ -1,0 +1,18 @@
+server:
+    port: ${services.rush.port:8085}
+    address: ${services.rush.host:localhost}
+
+cassandra:
+  embedded: ${services.cassandra.embedded:false}
+  host: ${services.cassandra.host:localhost}
+
+spinnaker:
+  cassandra:
+    cluster: ${services.cassandra.cluster:spinnaker}
+    keyspace: 'rush'
+
+docker:
+  accounts:
+    - name: ${services.docker.primaryAccount.name}
+      url: ${services.docker.primaryAccount.url}
+      registry: ${services.docker.primaryAccount.registry}

--- a/config/settings.js
+++ b/config/settings.js
@@ -1,0 +1,76 @@
+'use strict';
+
+
+/**
+ * This section is managed by scripts/reconfigure_spinnaker.sh
+ * If hand-editing, only add comment lines that look like
+ * '// let VARIABLE = VALUE'
+ * and let scripts/reconfigure manage the actual values.
+ */
+// BEGIN reconfigure_spinnaker
+
+// let gateUrl = ${services.gate.baseUrl};
+// let bakeryBaseUrl = ${services.bakery.baseUrl};
+// let awsDefaultRegion = ${providers.aws.defaultRegion};
+// let awsPrimaryAccount = ${providers.aws.primaryCredentials.name};
+// let googleDefaultRegion = ${providers.google.defaultRegion};
+// let googleDefaultZone = ${providers.google.defaultZone};
+// let googlePrimaryAccount = ${providers.google.primaryCredentials.name;
+
+// END reconfigure_spinnaker
+/**
+ * Any additional custom let statements can go below without
+ * being affected by scripts/reconfigure_spinnaker.sh
+ */
+
+window.spinnakerSettings = {
+  gateUrl: `${gateUrl}`,
+  bakeryDetailUrl: `${bakeryBaseUrl}/api/v1/global/logs/{{context.status.id}}?html=true`,
+  pollSchedule: 30000,
+  defaultTimeZone: 'America/New_York', // see http://momentjs.com/timezone/docs/#/data-utilities/
+  providers: {
+    gce: {
+      defaults: {
+        account: `${googlePrimaryAccount}`,
+        region: `${googleDefaultRegion}`,
+        zone: `${googleDefaultZone}`,
+      },
+      primaryAccounts: [`${googlePrimaryAccount}`],
+      challengeDestructiveActions: [`${googlePrimaryAccount}`],
+    },
+    aws: {
+      defaults: {
+        account: `${awsPrimaryAccount}`,
+        region: `${awsDefaultRegion}`
+      },
+      primaryAccounts: [`${awsPrimaryAccount}`],
+      primaryRegions: ['eu-west-1', 'us-east-1', 'us-west-1', 'us-west-2'],
+      challengeDestructiveActions: [`${awsPrimaryAccount}`],
+      preferredZonesByAccount: {}
+    }
+  },
+  whatsNew: {
+    gistId: '32526cd608db3d811b38',
+    fileName: 'news.md',
+  },
+  authEnabled: false,
+  feature: {
+    pipelines: true,
+    notifications: false,
+    canary: false,
+    parallelPipelines: true,
+    fastProperty: false,
+    vpcMigrator: false,
+  },
+};
+
+window.spinnakerSettings.providers.aws.preferredZonesByAccount[`${awsPrimaryAccount}`] = {
+  'us-east-1': ['us-east-1a', 'us-east-1b', 'us-east-1d', 'us-east-1e'],
+  'us-west-1': ['us-west-1a', 'us-west-1b', 'us-west-1c'],
+  'us-west-2': ['us-west-2a', 'us-west-2b', 'us-west-2c'],
+  'eu-west-1': ['eu-west-1a', 'eu-west-1b', 'eu-west-1c'],
+  'ap-northeast-1': ['ap-northeast-1a', 'ap-northeast-1b', 'ap-northeast-1c'],
+  'ap-southeast-1': ['ap-southeast-1a', 'ap-southeast-1b'],
+  'ap-southeast-2': ['ap-southeast-2a', 'ap-southeast-2b'],
+  'sa-east-1': ['sa-east-1a', 'sa-east-1b']
+};

--- a/config/spinnaker.yml
+++ b/config/spinnaker.yml
@@ -1,0 +1,178 @@
+# This file is intended to serve as a master configuration for a Spinnaker deployment.
+# Customizations to the deployment should be made in another file named
+# "spinnaker-local.yml". The distribution has a prototype called
+# "default-spinnaker-local.yml" which calls out the subset of attributes of general
+# interest. It can be copied into a "spinnaker-local.yml" to start with. The prototype
+# does not change any of the default values here, it just surfaces the more critical
+# attributes.
+
+global:
+  spinnaker:
+    environment: test
+
+services:
+  default:
+    # These defaults can be modified to change all the spinnaker subsystems
+    # (clouddriver, gate, etc) at once, but not external systems (jenkins, etc).
+    # Individual systems can still be overriden using their own section entry
+    # directly under 'services'.
+    host: localhost
+    protocol: http
+    primaryAccountName: service-default-primaryAcountName-not-defined
+
+  clouddriver:
+    host: ${services.default.host}
+    port: 7002
+    baseUrl: ${services.default.protocol}://${services.clouddriver.host}:${services.clouddriver.port}
+
+  echo:
+    enabled: true
+    host: ${services.default.host}
+    port: 8089
+    baseUrl: ${services.default.protocol}://${services.echo.host}:${services.echo.port}
+
+  front50:
+    host: ${services.default.host}
+    port: 8080
+    baseUrl: ${services.default.protocol}://${services.front50.host}:${services.front50.port}
+
+  gate:
+    host: ${services.default.host}
+    port: 8084
+    baseUrl: ${services.default.protocol}://${services.gate.host}:${services.gate.port}
+
+  igor:
+    # If you are integrating Jenkins then you must also enable Spinnaker's
+    # "igor" subsystem.
+    enabled: false
+    host: ${services.default.host}
+    port: 8088
+    baseUrl: ${services.default.protocol}://${services.igor.host}:${services.igor.port}
+
+  kato:
+    host: ${services.clouddriver.host}
+    port: ${services.clouddriver.port}
+    baseUrl: ${services.clouddriver.baseUrl}
+
+  mort:
+    host: ${services.clouddriver.host}
+    port: ${services.clouddriver.port}
+    baseUrl: ${services.clouddriver.baseUrl}
+
+  orca:
+    host: ${services.default.host}
+    port: 8083
+    baseUrl: ${services.default.protocol}://${services.orca.host}:${services.orca.port}
+    enabled: true
+
+  oort:
+    host: ${services.clouddriver.host}
+    port: ${services.clouddriver.port}
+    baseUrl: ${services.clouddriver.baseUrl}
+
+  rosco:
+    host: ${services.default.host}
+    port: 8087
+    baseUrl: ${services.default.protocol}://${services.rosco.host}:${services.rosco.port}
+
+  rush:
+    # Spinnaker's "rush" subsystem is used by the "rosco" bakery.
+    # You'll need to provide it a Spinnaker account to use.
+    # Here we are assuming the default primary acccount.
+    host: ${services.default.host}
+    port: 8085
+    baseUrl: ${services.default.protocol}://${services.rush.host}:${services.rush.port}
+    primaryAccount: ${services.default.primaryAccountName}
+
+  bakery:
+    host: ${services.rosco.host}
+    port: ${services.rosco.port}
+    baseUrl: ${services.rosco.baseUrl}
+    extractBuildDetails: true
+    propagateCloudProviderType: true
+
+  docker:
+    # Spinnaker's "rush" subsystem uses docker to run internal jobs.
+    # Note that docker is not installed with Spinnaker so you must obtain this
+    # on your own if you are interested.
+    enabled: false
+    baseUrl: # Expected in spinnaker-local.yaml
+
+    # You'll need to provide it a Spinnaker account to use.
+    # Here we are assuming the default primary acccount.
+    #
+    # If you have multiple accounts using docker then you will need to
+    # provide a rush-local.yml.
+    # For more info see docker.accounts in config/rush.yml.
+    primaryAccount:
+      name: ${services.default.primaryAccountName}
+      url:  ${services.docker.baseUrl}
+      registry: ${services.dockerRegistry.baseUrl}
+
+  dockerRegistry:
+    baseUrl: #  Expected in spinnaker-local.yml
+
+  jenkins:
+    # The "name" entry is used for the display name when selecting
+    # this server.
+    #
+    # If you have multiple jenkins servers, you will need to list
+    # them in an igor-local.yml. See jenkins.masters in config/igor.yml.
+    #
+    # Note that jenkins is not installed with Spinnaker so you must obtain this
+    # on your own if you are interested.
+    defaultMaster:
+      name: Jenkins
+      baseUrl:   # Expected in spinnaker-local.yml
+      username:  # Expected in spinnaker-local.yml
+      password:  # Expected in spinnaker-local.yml
+
+  redis:
+    host: ${services.default.host}
+    port: 6379
+    connection: redis://${services.redis.host}:${services.redis.port}
+
+  cassandra:
+    host: ${services.default.host}
+    port: 9042
+    embedded: false
+    cluster: CASS_SPINNAKER
+
+
+providers:
+  aws:
+    # If you want to deploy some services to Amazon Web Services (AWS),
+    # set enabled and provide primary credentials for deploying.
+    # Enabling AWS is independent of other providers.
+    enabled: false
+    simpleDBEnabled: false
+    defaultRegion: us-east-1
+    defaultSimpleDBDomain: CLOUD_APPLICATIONS
+    primaryCredentials:
+      # TODO(ewiseblatt):
+      # This only works for root credentials, which you arent supposed to use.
+      # I havent been able to figure out how to get normal user accounts to
+      # work.  I'm leaving this broken for now hoping that once this gets
+      # mainlined somebody else will be able to fix it.
+
+      name: default
+      # You can use a standard $HOME/.aws/credentials file instead of providing
+      # these here. If provided here, then start_spinnaker will set environment
+      # variables before starting up the subsystems that interact with AWS.
+      access_key_id:
+      secret_key:
+
+  google:
+    # If you want to deploy some services to Google Cloud Platform (google),
+    # set enabled and provide primary credentials for deploying.
+    # Enabling google is independent of other providers.
+    enabled: false
+    defaultRegion: us-central1
+    defaultZone: us-central1-f
+    primaryCredentials:
+      name: my-account-name
+      # The project is the Google Project ID for the project to manage with
+      # Spinnaker. The jsonPath is a path to the JSON service credentials
+      # downloaded from the Google Developer's Console.
+      project:
+      jsonPath:


### PR DESCRIPTION
@cfieber, @anotherchrisberry (for settings.js)
These files are intended to be installed at the base of a spring config path.
The default-spinnaker-local.yml is intended to be copied into a
spinnaker-local.yml and modified for a custom deployment. The other files can
be modified as <subsystem>-local.yml as well if needed.

This PR is more about the structure and policy than the details though I
would like to get the basic namespace right. I'm primarily using "services"
but maybe this should be "spinnaker".

The spinnaker.yml file contains the system wide policy and values shared among
multiple systems. The individual system files contain the particular
configuration for a given subsystem. The namespace in the spinnaker.yml is
intentionally disjoint from those in the individual system files requiring
the systems to explicitly document their configuration -- both how it is
standard (by referencing spinnaker.yml values) and how it is non-standard
(by not referencing spinnaker.yml values).

There are future CLs that add more scripting and support of this but
fundamentally using this assumes setting the spring.config.location system
property to something like

$INSTALL/config/spinnaker.yml,\
$INSTALL/config/,\
$HOME/.spinnaker/spinnaker-local.yml,\
$HOME/.spinnaker/

Recently the module spring loader was changed to look for 'spinnaker.yml'
so the config location would be $INSTALL/config,$HOME/.spinnaker/
If the subsystems config yaml files in this PR were moved into the subsystems
themselves, then the spring location could remain the default $HOME/.spinnaker/

With this approach, users typically ovewrite a single spinnaker-local.yml file
for most needs. The spring expression language cannot handle "subtrees", only
values. Therefore configuration of repeated nodes requires overriding the
<subsystem>-local.yml in order to add the lists in. Otherwise, the
spinnaker.yml defines "primary" values and the <subsystem_local.yml provide
a list containing the "primary" value so that the spinnaker-local.yml can
still serve as a central configuration.

Deck is a different story.

I'm including a "settings.js" here as a placeholder. This is what I actively
use, but it is out of date from chris' current work. The only "interesting"
thing here is the use of variable declarations that reference the
spinnaker.yml namespace. There is a script (in a future CL) that can
substitute that block with current config values. For purposes of this CL,
the details of settings.js can be changed later without worry. It's the
policy of calling out key configuration variables that may be needed and
resolving them with a script (I'll provide later) that is of interest for
this PR.

CAVEAT:

I've been having trouble getting AWS to work.

I can get it to work using root credentials when I run out of debian packages
(on GCE) and use environment variables (with a launch script that sets them
based on the YAML file) but the same strategy does not work for gradlew runs.
The gradle runs complain that it does not know about the "default profile".
I can run out of gradle if I have an .aws/config [sic] file (e.g. from an
awscli). I can run the debian packages with an .aws/credentials file.
It seems user credentials need more attributes in clouddriver. For example a
role. However roles are not valid with root credentials and a null role is
not valid either, so it seems clouddriver-local.yml may have to exist for
maintaining aws credentials.
