### PR TITLE
[almost] build an aws ami

### DIFF
--- a/dev/build_aws_ami.packer
+++ b/dev/build_aws_ami.packer
@@ -1,0 +1,37 @@
+{
+ "variables": {
+   "release_path": null,
+   "installer_path": null,
+   "aws_access_key": "",
+   "aws_secret_key": "",
+   "region": "us-east-1",
+   "source_ami": "ami-d05e75b8",
+   "target_ami": "{{env `USER`}}-spinnaker-{{timestamp}}",
+   "install_args": ""
+ },
+
+ "builders": [{
+   "type": "amazon-ebs",
+   "access_key": "{{user `aws_access_key`}}",
+   "secret_key": "{{user `aws_secret_key`}}",
+   "region": "{{user `region`}}",
+   "source_ami": "{{user `source_ami`}}",
+   "instance_type": "m4.large",
+   "ssh_username": "ubuntu",
+   "ami_name": "{{user `target_ami`}}"
+ }],
+
+ "provisioners": [
+  {
+    "type": "file",
+    "source": "{{user `installer_path`}}",
+    "destination": "/tmp/install_spinnaker.py.zip"
+  },
+  {
+    "type": "shell",
+    "inline": ["sudo apt-get update -y",
+               "sudo apt-get install -y awscli",
+               "python /tmp/install_spinnaker.py.zip --package_manager --release_path={{user `release_path`}} --region={{user `region`}} {{user `install_args`}}"]
+  }
+ ]
+}

--- a/dev/build_aws_ami.py
+++ b/dev/build_aws_ami.py
@@ -1,0 +1,48 @@
+#!/usr/bin/python
+#
+# Copyright 2015 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Creates an image in the default project named with the release name.
+# python buidl_aws_ami.py --release_uri $RELEASE_URI
+
+import os
+import re
+import sys
+
+from abstract_packer_builder import AbstractPackerBuilder
+
+
+class AmiPackerBuilder(AbstractPackerBuilder):
+  PACKER_TEMPLATE = os.path.dirname(sys.argv[0]) + '/build_aws_ami.packer'
+
+  def _do_prepare(self):
+    self.add_packer_variable(
+        'target_ami', os.path.basename(self.options.release_path))
+
+  def _do_get_next_steps(self):
+      last_line = self.packer_output.split()[-1]
+      match = re.match('^(-a-z0-9]+): (.+)$', last_line)
+      region_name = match.group(1) if match else None
+      ami_name = match.group(2) if match else None
+
+      match = re.match('amazon-ebs: Creating the AMI: (.+)\n',
+                       self.packer_output)
+      image_name = match.group(1) if match else None
+
+      return 'Region={region}\nAMI={ami}\nImage={image}'.format(
+          region=region_name, ami=ami_name, image=image_name)
+
+if __name__ == '__main__':
+    AmiPackerBuilder.main()

--- a/dev/build_aws_ami.sh
+++ b/dev/build_aws_ami.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+#
+# Copyright 2015 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+PYTHONPATH=$(dirname $0)/../pylib \
+python \
+$(dirname $0)/build_aws_ami.py "$@"

--- a/install/install_spinnaker.py
+++ b/install/install_spinnaker.py
@@ -84,6 +84,10 @@ def init_argument_parser(parser):
         '--release_path', default=None,
         help='The path to the release being installed.')
 
+    parser.add_argument(
+        '--region', default=None,
+        help='The region is only needed if copying from an S3 release_uri.')
+
 
 def safe_mkdir(dir):
     """Create a local directory if it does not already exist.


### PR DESCRIPTION
This doesnt quite work because I dont know how to properly set up S3
permissions so the packer instance can get at it. I assume that's easy
enough for someone else to fix.

To use this:
   (assuming ~/.aws/credentials exists)
   S3_RELEASE_PATH=s3://my-release-bucket
   mkdir build
   cd build

   ../spinnaker/dev/refresh_source.sh --github_user="upstream" --pull_origin
   ../spinnaker/dev/build_release.sh --release_path=$S3_RELEASE_PATH
   ../spinnaker/dev/build_aws_ami.sh --release_path=$S3_RELEASE_PATH

This will result in an error, something like:
    amazon-ebs: RuntimeError: The path "s3://ewiseblatt-20151029" does not seem to exist within S3. aws s3 ls returned "Unable to locate credentials. You can configure credentials by running "aws configure"."