### PR TITLE
Rosco needs access to the aws keys to pass on to the packer template.

### DIFF
--- a/config/rosco.yml
+++ b/config/rosco.yml
@@ -7,6 +7,9 @@ redis:
 
 aws:
   enabled: ${providers.aws.enabled:false}
+  bakeryDefaults:
+    awsAccessKey: ${providers.aws.primaryCredentials.access_key_id}
+    awsSecretKey: ${providers.aws.primaryCredentials.secret_key}
 
 docker:
   enabled: ${services.docker.enabled:false}


### PR DESCRIPTION
@ewiseblatt please review.
