### PR TITLE
Add Community Code of Conduct. Link as submenu to top navigation menu.

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -18,6 +18,7 @@
   title: Community
   children:
     - collab_dev
+    - code_of_conduct
 -
   title: Videos
   children:

--- a/online_docs/community/code_of_conduct.md
+++ b/online_docs/community/code_of_conduct.md
@@ -1,0 +1,66 @@
+---
+layout: toc-page
+title: Community Code of Conduct
+id: code_of_conduct
+lang: en
+---
+
+* Table of contents. This line is required to start the list.
+{:toc}
+
+# Spinnaker Community Code of Conduct
+
+Please note that this project is released with a Contributor Code of
+Conduct. By participating in this project you agree to abide by its
+terms.
+
+## Contributor Code of Conduct
+
+As contributors and maintainers of this project, and in the interest
+of fostering an open and welcoming community, we pledge to respect all
+people who contribute through reporting issues, posting feature
+requests, updating documentation, submitting pull requests or patches,
+and other activities.
+
+We are committed to making participation in this project a
+harassment-free experience for everyone, regardless of level of
+experience, gender, gender identity and expression, sexual
+orientation, disability, personal appearance, body size, race,
+ethnicity, age, religion, or nationality.
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery
+* Personal attacks
+* Trolling or insulting/derogatory comments
+* Public or private harassment
+* Publishing each other's private information, such as physical or electronic addresses, without explicit permission
+* Other unethical or unprofessional conduct.
+
+Project maintainers have the right and responsibility to remove, edit,
+or reject comments, commits, code, wiki edits, issues, and other
+contributions that are not aligned to this Code of Conduct, or to ban
+temporarily or permanently any contributor for other behaviors that
+they deem inappropriate, threatening, offensive, or harmful.
+
+By adopting this Code of Conduct, project maintainers commit
+themselves to fairly and consistently applying these principles to
+every aspect of managing this project. Project maintainers who do not
+follow or enforce the Code of Conduct may be permanently removed from
+the project team.
+
+This Code of Conduct applies both within project spaces and in public
+spaces when an individual is representing the project or its
+community.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior
+may be reported by opening an issue or contacting one or more of the
+project maintainers. All complaints will be reviewed and investigated
+and will result in a response that is deemed necessary and appropriate
+to the circumstances. Maintainers are obligated to maintain
+confidentiality with regard to the reporter of the incident.
+
+This code of conduct is adapted from the Contributor Covenant
+([http://contributor-convenant.org](http://contributor-covenant.org)),
+version 1.3.0, available at
+[http://contributor-convenant.org/verson/1/3/0](http://contributor-convenant.org/verson/1/3/0).


### PR DESCRIPTION
@aglover: Please review. Adapted from the kubernetes Code of Conduct.
