### PR TITLE
Add Contributing to Spinnaker submenu under Community top navigation …

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -17,6 +17,7 @@
 -
   title: Community
   children:
+    - contributing_guidelines
     - collab_dev
     - code_of_conduct
 -

--- a/online_docs/community/contributing_guidelines.md
+++ b/online_docs/community/contributing_guidelines.md
@@ -1,0 +1,59 @@
+---
+layout: toc-page
+title: Contributing to Spinnaker
+id: contributing_guidelines
+lang: en
+---
+
+* Table of contents. This line is required to start the list.
+{:toc}
+
+# Contributing guidelines
+
+## Filing issues
+
+Please file issues through the [Spinnaker GitHub issue tracker](https://github.com/spinnaker/spinnaker/issues).
+
+## How to Become a Contributor
+
+### Contributor License Agreements
+
+We'd love to accept your patches! Before we can take them, we have to
+jump through a couple of legal hurdles.
+
+Please fill out either the individual or corporate Contributor License
+Agreement (CLA).
+
+* If you are an individual writing original source code and you're
+  sure you own the intellectual property, then you'll need to sign an
+  {% include link.to id="individual_cla" text="individual CLA" %}.
+* If you work for a company that wants to allow you to contribute your
+  work, then you'll need to sign a {% include link.to
+  id="corporate_cla" text="corporate CLA" %}.
+
+Follow either of the two links above to access the appropriate CLA and
+instructions for how to sign and return it. Once we receive it, we'll
+be able to accept your pull requests.
+
+Only original source code from you and other people that have signed
+the CLA can be accepted into the main repository.
+
+We use gradle for builds; all third-party dependencies should be
+brought in using gradle's dependency management support.
+
+### Contributing a Patch
+
+1. Submit an issue describing your proposed change to the repo in question.
+1. The repo owner will respond to your issue promptly.
+1. If your proposed change is accepted, and you haven't already done
+so, sign a Contributor License Agreement (see details above).
+1. Fork the desired repo, develop and test your code changes.
+1. Submit a pull request.
+
+### Protocols for Collaborative Development
+
+Please read {% include link.to id="collab_dev" text="this doc" %} for
+information on how we're running development for the project. Also,
+take a look at the {% include link.to id="developer_guide"
+text="developer's guide" %} for information on how to setup your
+environment, run tests, manage dependencies, etc.

--- a/online_docs/community/corporate_cla.md
+++ b/online_docs/community/corporate_cla.md
@@ -1,0 +1,115 @@
+---
+layout: toc-page
+title: Corporate CLA
+id: corporate_cla
+lang: en
+---
+
+* Table of contents. This line is required to start the list.
+{:toc}
+
+# Contributor License Agreements
+
+# **TODO(Netflix): NEED TO MAKE SIGNING THESE THINGS ELECTRONIC.**
+
+## Netflix Software Grant and Corporate Contributor License Agreement
+
+In order to clarify the intellectual property license granted with
+Contributions from any person or entity, Netflix Inc. ("Netflix") must
+have a Contributor License Agreement (CLA) on file that has been
+signed by each Contributor, indicating agreement to the license terms
+below. This license is for your protection as a Contributor as well as
+the protection of Netflix and its users; it does not change your rights
+to use your own Contributions for any other purpose.
+
+This version of the Agreement allows an entity (the "Corporation") to
+submit Contributions to Netflix, to authorize Contributions submitted
+by its designated employees to Netflix, and to grant copyright and
+patent licenses thereto.
+
+You accept and agree to the following terms and conditions for Your
+present and future Contributions submitted to Netflix. Except for the
+license granted herein to Netflix and recipients of software
+distributed by Netflix, You reserve all right, title, and interest in
+and to Your Contributions.
+
+1. Definitions.
+<br><br>
+"You" (or "Your") shall mean the copyright owner or legal entity
+authorized by the copyright owner that is making this Agreement with
+Netflix. For legal entities, the entity making a Contribution and all
+other entities that control, are controlled by, or are under common
+control with that entity are considered to be a single
+Contributor. For the purposes of this definition, "control" means (i)
+the power, direct or indirect, to cause the direction or management of
+such entity, whether by contract or otherwise, or (ii) ownership of
+fifty percent (50%) or more of the outstanding shares, or (iii)
+beneficial ownership of such entity.
+<br><br>
+"Contribution" shall mean the code, documentation or any original work
+of authorship, including any modifications or additions to an existing
+work, that is intentionally submitted by You to Netflix for inclusion
+in, or documentation of, any of the products owned or managed by
+Netflix (the "Work"). For the purposes of this definition, "submitted"
+means any form of electronic, verbal, or written communication sent to
+Netflix or its representatives, including but not limited to
+communication on electronic mailing lists, source code control
+systems, and issue tracking systems that are managed by, or on behalf
+of, Netflix for the purpose of discussing and improving the Work, but
+excluding communication that is conspicuously marked or otherwise
+designated in writing by You as "Not a Contribution."
+
+1. Grant of Copyright License. Subject to the terms and conditions of
+this Agreement, You hereby grant to Netflix and to recipients of
+software distributed by Netflix a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable copyright license to reproduce,
+prepare derivative works of, publicly display, publicly perform,
+sublicense, and distribute Your Contributions and such derivative
+works.
+
+1. Grant of Patent License. Subject to the terms and conditions of
+this Agreement, You hereby grant to Netflix and to recipients of
+software distributed by Netflix a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this
+section) patent license to make, have made, use, offer to sell, sell,
+import, and otherwise transfer the Work, where such license applies
+only to those patent claims licensable by You that are necessarily
+infringed by Your Contribution(s) alone or by combination of Your
+Contribution(s) with the Work to which such Contribution(s) was
+submitted. If any entity institutes patent litigation against You or
+any other entity (including a cross-claim or counterclaim in a
+lawsuit) alleging that your Contribution, or the Work to which you
+have contributed, constitutes direct or contributory patent
+infringement, then any patent licenses granted to that entity under
+this Agreement for that Contribution or Work shall terminate as of the
+date such litigation is filed.
+
+1. You represent that You are legally entitled to grant the above
+license. You represent further that each employee of the Corporation
+designated by You is authorized to submit Contributions on behalf of
+the Corporation.
+
+1. You represent that each of Your Contributions is Your original
+creation (see section 7 for submissions on behalf of others).
+
+1. You are not expected to provide support for Your Contributions,
+except to the extent You desire to provide support. You may provide
+support for free, for a fee, or not at all. Unless required by
+applicable law or agreed to in writing, You provide Your Contributions
+on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied, including, without limitation, any
+warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY,
+or FITNESS FOR A PARTICULAR PURPOSE.
+
+1. Should You wish to submit work that is not Your original creation,
+You may submit it to Netflix separately from any Contribution,
+identifying the complete details of its source and of any license or
+other restriction (including, but not limited to, related patents,
+trademarks, and license agreements) of which you are personally aware,
+and conspicuously marking the work as "Submitted on behalf of a
+third-party: [named here]".
+
+1. It is your responsibility to notify Netflix when any change is
+required to the list of designated employees authorized to submit
+Contributions on behalf of the Corporation, or to the Corporation's
+Point of Contact with Netflix.

--- a/online_docs/community/individual_cla.md
+++ b/online_docs/community/individual_cla.md
@@ -1,0 +1,117 @@
+---
+layout: toc-page
+title: Individual CLA
+id: individual_cla
+lang: en
+---
+
+* Table of contents. This line is required to start the list.
+{:toc}
+
+# Contributor License Agreements
+
+# **TODO(Netflix): NEED TO MAKE SIGNING THESE THINGS ELECTRONIC.**
+
+## Netflix Individual Contributor License Agreement
+
+In order to clarify the intellectual property license granted with
+Contributions from any person or entity, Netflix Inc. ("Netflix") must
+have a Contributor License Agreement ("CLA") on file that has been
+signed by each Contributor, indicating agreement to the license terms
+below. This license is for your protection as a Contributor as well as
+the protection of Netflix; it does not change your rights to use your
+own Contributions for any other purpose.
+
+You accept and agree to the following terms and conditions for Your
+present and future Contributions submitted to Netflix. Except for the
+license granted herein to Netflix and recipients of software
+distributed by Netflix, You reserve all right, title, and interest in
+and to Your Contributions.
+
+1. Definitions.<br><br>
+"You" (or "Your") shall mean the copyright owner or legal entity
+authorized by the copyright owner that is making this Agreement with
+Netflix. For legal entities, the entity making a Contribution and all
+other entities that control, are controlled by, or are under common
+control with that entity are considered to be a single
+Contributor. For the purposes of this definition, "control" means (i)
+the power, direct or indirect, to cause the direction or management of
+such entity, whether by contract or otherwise, or (ii) ownership of
+fifty percent (50%) or more of the outstanding shares, or (iii)
+beneficial ownership of such entity.
+<br><br>
+"Contribution" shall mean any original work of authorship, including
+any modifications or additions to an existing work, that is
+intentionally submitted by You to Netflix for inclusion in, or
+documentation of, any of the products owned or managed by Netflix (the
+"Work"). For the purposes of this definition, "submitted" means any
+form of electronic, verbal, or written communication sent to Netflix
+or its representatives, including but not limited to communication on
+electronic mailing lists, source code control systems, and issue
+tracking systems that are managed by, or on behalf of, Netflix for the
+purpose of discussing and improving the Work, but excluding
+communication that is conspicuously marked or otherwise designated in
+writing by You as "Not a Contribution."
+
+1. Grant of Copyright License. Subject to the terms and conditions of
+this Agreement, You hereby grant to Netflix and to recipients of
+software distributed by Netflix a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable copyright license to reproduce,
+prepare derivative works of, publicly display, publicly perform,
+sublicense, and distribute Your Contributions and such derivative
+works.
+
+1. Grant of Patent License. Subject to the terms and conditions of
+this Agreement, You hereby grant to Netflix and to recipients of
+software distributed by Netflix a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this
+section) patent license to make, have made, use, offer to sell, sell,
+import, and otherwise transfer the Work, where such license applies
+only to those patent claims licensable by You that are necessarily
+infringed by Your Contribution(s) alone or by combination of Your
+Contribution(s) with the Work to which such Contribution(s) was
+submitted. If any entity institutes patent litigation against You or
+any other entity (including a cross-claim or counterclaim in a
+lawsuit) alleging that your Contribution, or the Work to which you
+have contributed, constitutes direct or contributory patent
+infringement, then any patent licenses granted to that entity under
+this Agreement for that Contribution or Work shall terminate as of the
+date such litigation is filed.
+
+1. You represent that you are legally entitled to grant the above
+license. If your employer(s) has rights to intellectual property that
+you create that includes your Contributions, you represent that you
+have received permission to make Contributions on behalf of that
+employer, that your employer has waived such rights for your
+Contributions to Netflix, or that your employer has executed a
+separate Corporate CLA with Netflix.
+
+1. You represent that each of Your Contributions is Your original
+creation (see section 7 for submissions on behalf of others). You
+represent that Your Contribution submissions include complete details
+of any third-party license or other restriction (including, but not
+limited to, related patents and trademarks) of which you are
+personally aware and which are associated with any part of Your
+Contributions.
+
+1. You are not expected to provide support for Your Contributions,
+except to the extent You desire to provide support. You may provide
+support for free, for a fee, or not at all. Unless required by
+applicable law or agreed to in writing, You provide Your Contributions
+on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied, including, without limitation, any
+warranties or conditions of TITLE, NON- INFRINGEMENT, MERCHANTABILITY,
+or FITNESS FOR A PARTICULAR PURPOSE.
+
+1. Should You wish to submit work that is not Your original creation,
+You may submit it to Netflix separately from any Contribution,
+identifying the complete details of its source and of any license or
+other restriction (including, but not limited to, related patents,
+trademarks, and license agreements) of which you are personally aware,
+and conspicuously marking the work as "Submitted on behalf of a
+third-party: [[]named here]".
+
+1. You agree to notify Netflix of any facts or circumstances of which
+you become aware that would make these representations inaccurate in
+any respect.
+


### PR DESCRIPTION
…menu,

including guidelines for contributing and first drafts of Individual and
Corporate CLAs.

@aglover: Please review. Note:
1. The CLA text itself is adapted from Apache2.
2. I have left warning signs and placeholders in the text where we should find a way to add electronic signing. (If we can't figure it out, then we'll need to setup manual signing in the meantime.) Screenshot of navigation menu with "Contributing to Spinnaker" menu item below:

![image](https://cloud.githubusercontent.com/assets/6616961/11039854/9c768b62-86d7-11e5-96e5-234a663dffa3.png)
