### PR TITLE
Encapsulate the "Spinnaker" release package as a tar file.

### DIFF
--- a/dev/abstract_packer_builder.py
+++ b/dev/abstract_packer_builder.py
@@ -140,7 +140,7 @@ class AbstractPackerBuilder(object):
 
     self.__in_subprocess = True
     check_run_quick(
-        '{program} cp {release}/install/install_spinnaker.py.zip {path}'
+        '{program} cp {release}/install_spinnaker.sh {path} && chmod +x {path}'
         .format(program=program,
                 release=self.options.release_path,
                 path=installer_path))

--- a/dev/build_google_image.packer
+++ b/dev/build_google_image.packer
@@ -23,11 +23,12 @@
   {
     "type": "file",
     "source": "{{user `installer_path`}}",
-    "destination": "/tmp/install_spinnaker.py.zip"
+    "destination": "/tmp/install_spinnaker.sh"
   },
   {
     "type": "shell",
-    "inline": ["python /tmp/install_spinnaker.py.zip --package_manager --release_path={{user `release_path`}} {{user `install_args`}}"]
+    "inline": ["chmod +x /tmp/install_spinnaker.sh",
+               "/tmp/install_spinnaker.sh --release_path {{user `release_path`}} --package_manager {{user `install_args`}}"]
   }
  ]
 }

--- a/install/install_spinnaker.sh
+++ b/install/install_spinnaker.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+# Install Spinnaker from source
+
+# Usage:
+#   install_spinnaker.sh [--release_path <path to bucket>]
+
+function download_gcs() {
+  gsutil cp $1 $2
+}
+
+function download_s3() {
+    awscli s3 cp $1 $2
+}
+
+
+PACKAGE_SOURCE=""  # Eventually this can be default bintray location
+function determine_package_source() {
+    result=$(getopt -q --longoptions release_path --name "$0" -- "$@")
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --release_path)
+                PACKAGE_SOURCE="$2"
+                return 0
+        esac
+        shift
+    done
+    return 1
+}
+
+function main() {
+    determine_package_source "$@"
+    if [[ "$PACKAGE_SOURCE" == "" ]]; then
+        echo "Missing --release_path."
+        exit -1
+    fi
+    from="$PACKAGE_SOURCE/spinnaker.tar.gz"
+    to="install/spinnaker.tar.gz"
+
+    echo "Downloading package"
+    mkdir -p /opt/spinnaker/install
+    cd /opt/spinnaker
+
+    if [[ "$from" =~ ^gs:// ]]; then
+      download_gcs $from $to
+    elif [[ "$from" =~ ^s3:// ]]; then
+      download_s3 $from $to
+    else
+      cp $from $to
+    fi
+
+    echo "Installing package"
+    tar xzf $to
+    PYTHONPATH=pylib python install/install_spinnaker.py \
+        --release_path=$PACKAGE_SOURCE \
+        "$@"
+}
+
+main "$@"


### PR DESCRIPTION
This does not include the subsystem debian packages, only the spinnaker.git
project artifacts.

This is accomplished by having build_release generate a tar file and copying
that to the --release_path rather than building a filesystem. The install
script in turn copies and untars this rather than individual files.

The intent is that the debian packages would get written to bintray
(or some apt-repository source) not the --release_path. That leaves just
the tar file, (and new install_spinnaker.sh) which should eventually be
packaged together as a debian package or could be placed somewhere
(e.g. bintray) for an easy curl download. The placement and easy download
will be addressed later.

The interfaces for building a release and running the installer are
still unchanged from before, however this change does not provide backward
compatability for the installers. That should not matter since the
--release_path and installer area already paired in practice.
