### PR TITLE
First pass at auto install.

### DIFF
--- a/InstallSpinnaker.sh
+++ b/InstallSpinnaker.sh
@@ -118,6 +118,11 @@ function set_google_region() {
   GOOGLE_REGION=`echo $GOOGLE_REGION | tr '[:upper:]' '[:lower:]'`
 }
 
+
+if [[ "$0" == "bash" ]]; then
+    CLOUD_PROVIDER="auto"
+fi
+
 process_args "$@"
 
 if [ "x$CLOUD_PROVIDER" == "x" ]; then
@@ -143,6 +148,8 @@ case $CLOUD_PROVIDER in
       set_aws_region
       set_google_region
       ;;
+  auto)
+      ;;       
   *)
       echo "ERROR: invalid cloud provider '$CLOUD_PROVIDER'"
       print_usage
@@ -204,9 +211,65 @@ rm -f packer_0.8.6_linux_amd64.zip
 apt-get install -y --force-yes --allow-unauthenticated spinnaker
 
 
+function write_default_value() {
+  name="$1"
+  value="$2"
+  if egrep "^$name=" /etc/default/spinnaker > /dev/null; then
+      sudo sed -i "s/^$name=.*/$name=$value/" /etc/default/spinnaker
+  else
+      sudo bash -c "echo $name=$value >> /etc/default/spinnaker"
+  fi
+}
 
-if [[ "${CLOUD_PROVIDER,,}" == "amazon" || "${CLOUD_PROVIDER,,}" == "google" || "${CLOUD_PROVIDER,,}" == "both" ]]; then
+GOOGLE_METADATA_URL="http://metadata.google.internal/computeMetadata/v1"
+function get_google_metadata_value() {
+  local path="$1"
+  local value=$(curl -s -f -H "Metadata-Flavor: Google" \
+                     $GOOGLE_METADATA_URL/$path)
+  if [[ $? -eq 0 ]]; then
+    echo "$value"
+  else
+    echo ""
+  fi
+}
+
+function set_google_defaults_from_environ() {
+    full_zone=$(get_google_metadata_value "$GOOGLE_METADATA_URL/instance/zone"
+
+    write_default_value "SPINNAKER_GOOGLE_ENABLED" "true"
+    write_default_value "SPINNAKER_GOOGLE_PROJECT_ID" \
+        $(get_google_metadata_value "project/project-id")
+    write_default_value "SPINNAKER_GOOGLE_DEFAULT_ZONE" $(basename $full_zone)
+    write_default_value "SPINNAKER_GOOGLE_DEFAULT_REGION" \
+        ${SPINNAKER_GOOGLE_DEFAULT_ZONE%-*}
+}
+
+function set_defaults_from_environ() {
+  local on_platform=""
+  if get_google_metadata_attribute "/project/project-id"; then
+      on_platform="google"
+      set_google_defaults_from_environ
+  fi
+
+  if [[ "$on_platform" != "" ]]; then
+      echo "Customized to manage your local $on_platform environment."
+  else
+      echo "No providers are enabled by default."
+  fi
+  cat <<EOF
+To modify the available cloud providers:
+   Edit /opt/spinnaker/config/spinnaker-local.yml
+   And/Or  /etc/default/spinnaker
+
+   Then restart clouddriver with sudo service clouddriver restart
+EOF
+}
+
+if [[ "${CLOUD_PROVIDER,,}" == "amazon" || "${CLOUD_PROVIDER,,}" == "google" || "${CLOUD_PROVIDER,,}" == "both" || "${CLOUD_PROVIDER,,}" == "auto" ]]; then
   case $CLOUD_PROVIDER in
+    auto)
+        set_defaults_from_environ
+        ;;
     amazon)
         sed -i.bak -e "s/SPINNAKER_AWS_ENABLED=.*$/SPINNAKER_AWS_ENABLED=true/" -e "s/SPINNAKER_AWS_DEFAULT_REGION.*$/SPINNAKER_AWS_DEFAULT_REGION=${AWS_REGION}/" \
         	-e "s/SPINNAKER_GOOGLE_ENABLED=.*$/SPINNAKER_GOOGLE_ENABLED=false/" /etc/default/spinnaker

--- a/config/default-spinnaker-local.yml
+++ b/config/default-spinnaker-local.yml
@@ -24,14 +24,14 @@ providers:
     # Enabling google is independent of other providers.
     enabled: ${SPINNAKER_GOOGLE_ENABLED}
     defaultRegion: ${SPINNAKER_GOOGLE_DEFAULT_REGION}
-    defaultZone: ${SPINNAKER_GOOGLE_DEFAULT_REGION}-b
+    defaultZone: ${SPINNAKER_GOOGLE_DEFAULT_ZONE}
     primaryCredentials:
       name: my-google-account
       # The project is the Google Project ID for the project to manage with Spinnaker.
       # The jsonPath is a path to the JSON service credentials downloaded from the
       # Google Developer's Console.
       project: ${SPINNAKER_GOOGLE_PROJECT_ID}
-      jsonPath:
+      jsonPath: ${SPINNAKER_GOOGLE_PROJECT_CREDENTIALS_PATH}
 
 services:
   default:

--- a/etc/default/spinnaker
+++ b/etc/default/spinnaker
@@ -11,6 +11,15 @@ SPINNAKER_AWS_DEFAULT_REGION=us-west-2
 
 # If you plan on using Google Compute Engine set this to true
 SPINNAKER_GOOGLE_ENABLED=false
+# The primary project ID that you will be managing resources in
+SPINNAKER_GOOGLE_PROJECT_ID=
+# The path the the JSON service credentials downloaded from the
+# Google Developer's Console to access the project is required
+# if you are not running Spinnaker on an instance in the
+# same SPINNAKER_GOOGLE_PROJECT_ID.
+SPINNAKER_GOOGLE_PROJECT_CREDENTIALS_PATH=
 # Default region you desire to operate in
-SPINNAKER_GOOGLE_DEFAULT_REGION=us-central1-b
+SPINNAKER_GOOGLE_DEFAULT_REGION=us-central1
+# Default zone you desire to operate in
+SPINNAKER_GOOGLE_DEFAULT_ZONE=us-central1-b
 


### PR DESCRIPTION
@dstengle 
This was my first pass. Not sure it works yet but dont want to hold you up.

The gist is that if you run through bash then it sets the provider to auto.
If the provider is auto it tries to autodetect from your environment.
There's a place to detect aws then break out into an aws specific method
There is a common method to update/write into the /etc/default/spinnaker.
