### PR TITLE
Patch in ewiseblatt's work from the pending PR.

### DIFF
--- a/config/default-spinnaker-local.yml
+++ b/config/default-spinnaker-local.yml
@@ -27,7 +27,7 @@ providers:
       # The jsonPath is a path to the JSON service credentials downloaded from the
       # Google Developer's Console.
       project: ${SPINNAKER_GOOGLE_PROJECT_ID}
-      jsonPath: ${SPINNAKER_GOOGLE_PROJECT_CREDENTIALS_PATH}
+      jsonPath: ${SPINNAKER_GOOGLE_PROJECT_CREDENTIALS_PATH:}
 
 services:
   default:

--- a/etc/default/spinnaker
+++ b/etc/default/spinnaker
@@ -11,6 +11,10 @@ SPINNAKER_AWS_DEFAULT_REGION=us-west-2
 
 # If you plan on using Google Compute Engine set this to true
 SPINNAKER_GOOGLE_ENABLED=false
+# GCP project you intend to manage
+SPINNAKER_GOOGLE_PROJECT_ID=
 # Default region you desire to operate in
-SPINNAKER_GOOGLE_DEFAULT_REGION=us-central1-b
+SPINNAKER_GOOGLE_DEFAULT_REGION=us-central1
+# Default zone you desire to operate in
+SPINNAKER_GOOGLE_DEFAULT_ZONE=us-central1-f
 


### PR DESCRIPTION
Add support for deriving project id, region and zone from GCE environment.
Get generic bits in place to derive aws creds from env as well.
Derived parameters are used as defaults for each prompt.
Explicitly passed command-line arguments take precedence.
