### PR TITLE
Wait for cassandra before starting spinnaker

### DIFF
--- a/etc/init/spinnaker.conf
+++ b/etc/init/spinnaker.conf
@@ -4,6 +4,14 @@ start on filesystem or runlevel [2345]
 stop on shutdown
 
 pre-start script
+  if ! nc -z localhost 9042; then
+    echo "Waiting for cassandra"
+    while ! nc -z localhost 9042; do
+      sleep 1
+    done
+    echo "Cassandra is ready"
+  fi
+
   for i in front50 clouddriver  echo  gate  igor  orca  rosco  rush
   do
     start $i


### PR DESCRIPTION
@dstengle, @cfieber , @duftler

Should this also attempt to start cassandra? Is there danger in doing that? Should front50 and echo do similar things?

I tested this by rebooting my machine. It went through the loop showing it was waiting and done so I think it works. But I'm not familiar with the mechanics of upstart to know if this is the proper way to achieve the solution.
