### PR TITLE
change to put a "hold" on cassandra packages

### DIFF
--- a/InstallSpinnaker.sh
+++ b/InstallSpinnaker.sh
@@ -322,6 +322,7 @@ sudo apt-get update
 sudo apt-get install -y openjdk-8-jdk
 ## Cassandra
 sudo apt-get install -y --force-yes cassandra=2.1.11 cassandra-tools=2.1.11
+sudo apt-mark hold cassandra cassandra-tools
 # Let cassandra start
 if ! nc -z localhost 7199; then
     echo_status "Waiting for Cassandra to start..."

--- a/pylib/spinnaker/spinnaker_runner.py
+++ b/pylib/spinnaker/spinnaker_runner.py
@@ -307,7 +307,7 @@ class Runner(object):
         if pid:
           started_list.append((subsys, pid))
 
-    docker_address = self.__bindings.get('services.docker.baseUrl')
+    docker_address = self.__bindings.get('services.docker.targetRepository')
     jenkins_address = self.__bindings.get(
         'services.jenkins.defaultMaster.baseUrl')
     igor_enabled = self.__bindings.get('services.igor.enabled')


### PR DESCRIPTION
using apt-mark within the InstallSpinnaker script to put a hold on cassandra and cassandra-tools to keep them at the required 2.1 version