### PR TITLE
Always check if log dirs exist before starting services via spinnaker…

### DIFF
--- a/etc/init/spinnaker.conf
+++ b/etc/init/spinnaker.conf
@@ -14,6 +14,11 @@ pre-start script
 
   for i in front50 clouddriver  echo  gate  igor  orca  rosco  rush
   do
+    if [ ! -d "/var/log/spinnaker/$i" ]; then
+      echo "/var/log/spinnaker/$i does not exist. Creating it..."
+      install --mode=755 --owner=spinnaker --group=spinnaker --directory /var/log/spinnaker/$i
+    fi
+
     start $i
   done
 end script

--- a/install/first_google_boot.sh
+++ b/install/first_google_boot.sh
@@ -256,5 +256,6 @@ echo "$STATUS_PREFIX  Cleaning Up"
 replace_startup_script
 
 echo "$STATUS_PREFIX  Restarting Spinnaker"
-restart spinnaker
+stop spinnaker
+start spinnaker
 echo "$STATUS_PREFIX  Spinnaker is now configured"


### PR DESCRIPTION
… umbrella service.

Stop/start spinnaker instead of restart since restart seems not happy about a service that is not already running.
@skorten or @dpeterka please review.