### PR TITLE
Preserve original credentials of spinnaker-local.yml when transforming it.

### DIFF
--- a/dev/create_google_dev_vm.py
+++ b/dev/create_google_dev_vm.py
@@ -378,9 +378,11 @@ def maybe_copy_master_yml(options):
                              ' which does not exist.'
                                  .format(options.master_yml,
                                          json_credential_path))
+
         content = content.replace(json_credential_path, gcp_credential_path)
 
     fd, temp_path = tempfile.mkstemp()
+    os.fchmod(fd, os.stat(options.master_yml).st_mode)  # Copy original mode
     os.write(fd, content)
     os.close(fd)
     actual_path = temp_path


### PR DESCRIPTION
@duftler 
Just a recap of the past few commits:

I used to explicitly set the mode of files after copying them over within create_dev_vm.
I took that out to simplify a bit since gcloud already preserves files. However, there is a temp file created within create_dev to transform the jsonPath used in the new instance. That temp file was not being protected. In this PR, I copy the original file modes for the temp file.

When all is said and done, this can still result in new failures due to the check of sensitive file permissions within run_dev. However, these are legit in the sense that they would only occur if the source machine files were not properly protected.