### PR TITLE
update settings.js, removing preferredZones config

### DIFF
--- a/config/settings.js
+++ b/config/settings.js
@@ -34,24 +34,14 @@ window.spinnakerSettings = {
         account: `${googlePrimaryAccount}`,
         region: `${googleDefaultRegion}`,
         zone: `${googleDefaultZone}`,
-      },
-      primaryAccounts: [`${googlePrimaryAccount}`],
-      challengeDestructiveActions: [`${googlePrimaryAccount}`],
+      }
     },
     aws: {
       defaults: {
         account: `${awsPrimaryAccount}`,
         region: `${awsDefaultRegion}`
-      },
-      primaryAccounts: [`${awsPrimaryAccount}`],
-      primaryRegions: ['eu-west-1', 'us-east-1', 'us-west-1', 'us-west-2'],
-      challengeDestructiveActions: [`${awsPrimaryAccount}`],
-      preferredZonesByAccount: {}
+      }
     }
-  },
-  whatsNew: {
-    gistId: '32526cd608db3d811b38',
-    fileName: 'news.md',
   },
   authEnabled: false,
   feature: {
@@ -62,15 +52,4 @@ window.spinnakerSettings = {
     rebakeControlEnabled: true,
     netflixMode: false,
   },
-};
-
-window.spinnakerSettings.providers.aws.preferredZonesByAccount[`${awsPrimaryAccount}`] = {
-  'us-east-1': ['us-east-1a', 'us-east-1b', 'us-east-1d', 'us-east-1e'],
-  'us-west-1': ['us-west-1a', 'us-west-1b', 'us-west-1c'],
-  'us-west-2': ['us-west-2a', 'us-west-2b', 'us-west-2c'],
-  'eu-west-1': ['eu-west-1a', 'eu-west-1b', 'eu-west-1c'],
-  'ap-northeast-1': ['ap-northeast-1a', 'ap-northeast-1b', 'ap-northeast-1c'],
-  'ap-southeast-1': ['ap-southeast-1a', 'ap-southeast-1b'],
-  'ap-southeast-2': ['ap-southeast-2a', 'ap-southeast-2b'],
-  'sa-east-1': ['sa-east-1a', 'sa-east-1b']
 };


### PR DESCRIPTION
`primaryAccounts` and `challengeDestructiveActions` should be coming from Clouddriver now (https://github.com/spinnaker/clouddriver/blob/master/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/CredentialsController.groovy#L73), as should `preferredZones` (https://github.com/spinnaker/clouddriver/blob/master/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/AmazonCredentials.java#L132)

`whatsNew` is a Netflix-only component, so should not need to be in settings.js.

@duftler or @ewiseblatt can you review/sanity-check this?