### PR TITLE
replace let statements with var statements

### DIFF
--- a/config/settings.js
+++ b/config/settings.js
@@ -4,42 +4,42 @@
 /**
  * This section is managed by scripts/reconfigure_spinnaker.sh
  * If hand-editing, only add comment lines that look like
- * '// let VARIABLE = VALUE'
+ * '// var VARIABLE = VALUE'
  * and let scripts/reconfigure manage the actual values.
  */
 // BEGIN reconfigure_spinnaker
 
-// let gateUrl = ${services.gate.baseUrl};
-// let bakeryBaseUrl = ${services.bakery.baseUrl};
-// let awsDefaultRegion = ${providers.aws.defaultRegion};
-// let awsPrimaryAccount = ${providers.aws.primaryCredentials.name};
-// let googleDefaultRegion = ${providers.google.defaultRegion};
-// let googleDefaultZone = ${providers.google.defaultZone};
-// let googlePrimaryAccount = ${providers.google.primaryCredentials.name};
+// var gateUrl = ${services.gate.baseUrl};
+// var bakeryBaseUrl = ${services.bakery.baseUrl};
+// var awsDefaultRegion = ${providers.aws.defaultRegion};
+// var awsPrimaryAccount = ${providers.aws.primaryCredentials.name};
+// var googleDefaultRegion = ${providers.google.defaultRegion};
+// var googleDefaultZone = ${providers.google.defaultZone};
+// var googlePrimaryAccount = ${providers.google.primaryCredentials.name};
 
 // END reconfigure_spinnaker
 /**
- * Any additional custom let statements can go below without
+ * Any additional custom var statements can go below without
  * being affected by scripts/reconfigure_spinnaker.sh
  */
 
 window.spinnakerSettings = {
-  gateUrl: `${gateUrl}`,
-  bakeryDetailUrl: `${bakeryBaseUrl}/api/v1/global/logs/{{context.status.id}}?html=true`,
+  gateUrl: gateUrl,
+  bakeryDetailUrl: bakeryBaseUrl + '/api/v1/global/logs/{{context.status.id}}?html=true',
   pollSchedule: 30000,
   defaultTimeZone: 'America/New_York', // see http://momentjs.com/timezone/docs/#/data-utilities/
   providers: {
     gce: {
       defaults: {
-        account: `${googlePrimaryAccount}`,
-        region: `${googleDefaultRegion}`,
-        zone: `${googleDefaultZone}`,
+        account: googlePrimaryAccount,
+        region: googleDefaultRegion,
+        zone: googleDefaultZone,
       }
     },
     aws: {
       defaults: {
-        account: `${awsPrimaryAccount}`,
-        region: `${awsDefaultRegion}`
+        account: awsPrimaryAccount,
+        region: awsDefaultRegion
       }
     }
   },
@@ -47,8 +47,6 @@ window.spinnakerSettings = {
   feature: {
     pipelines: true,
     notifications: false,
-    fastProperty: false,
-    vpcMigrator: false,
     rebakeControlEnabled: true,
     netflixMode: false,
   },

--- a/experimental/packer/configure.sh
+++ b/experimental/packer/configure.sh
@@ -145,29 +145,29 @@ webpackJsonp([1,2],[
 	/**
 	 * This section is managed by scripts/reconfigure_spinnaker.sh
 	 * If hand-editing, only add comment lines that look like
-	 * '// let VARIABLE = VALUE'
+	 * '// var VARIABLE = VALUE'
 	 * and let scripts/reconfigure manage the actual values.
 	 */
 	// BEGIN reconfigure_spinnaker
 
-	// let gateUrl = \${services.gate.baseUrl};
+	// var gateUrl = \${services.gate.baseUrl};
 	var gateUrl = '/gate';
-	// let bakeryBaseUrl = \${services.bakery.baseUrl};
+	// var bakeryBaseUrl = \${services.bakery.baseUrl};
 	var bakeryBaseUrl = '/bakery';
-	// let awsDefaultRegion = \${providers.aws.defaultRegion};
+	// var awsDefaultRegion = \${providers.aws.defaultRegion};
 	var awsDefaultRegion = 'us-west-2';
-	// let awsPrimaryAccount = \${providers.aws.primaryCredentials.name};
+	// var awsPrimaryAccount = \${providers.aws.primaryCredentials.name};
 	var awsPrimaryAccount = 'my-aws-account';
-	// let googleDefaultRegion = \${providers.google.defaultRegion};
+	// var googleDefaultRegion = \${providers.google.defaultRegion};
 	var googleDefaultRegion = 'us-central1';
-	// let googleDefaultZone = \${providers.google.defaultZone};
+	// var googleDefaultZone = \${providers.google.defaultZone};
 	var googleDefaultZone = 'us-central1-f';
-	// let googlePrimaryAccount = \${providers.google.primaryCredentials.name};
+	// var googlePrimaryAccount = \${providers.google.primaryCredentials.name};
 	var googlePrimaryAccount = 'my-google-account';
 
 	// END reconfigure_spinnaker
 	/**
-	 * Any additional custom let statements can go below without
+	 * Any additional custom var statements can go below without
 	 * being affected by scripts/reconfigure_spinnaker.sh
 	 */
 
@@ -182,45 +182,20 @@ webpackJsonp([1,2],[
 	        account: '' + googlePrimaryAccount,
 	        region: '' + googleDefaultRegion,
 	        zone: '' + googleDefaultZone
-	      },
-	      primaryAccounts: ['' + googlePrimaryAccount],
-	      challengeDestructiveActions: ['' + googlePrimaryAccount]
+	      }
 	    },
 	    aws: {
 	      defaults: {
 	        account: '' + awsPrimaryAccount,
 	        region: '' + awsDefaultRegion
-	      },
-	      primaryAccounts: ['' + awsPrimaryAccount],
-	      primaryRegions: ['eu-west-1', 'us-east-1', 'us-west-1', 'us-west-2'],
-	      challengeDestructiveActions: ['' + awsPrimaryAccount],
-	      preferredZonesByAccount: {}
+	      }
 	    }
-	  },
-	  whatsNew: {
-	    gistId: '32526cd608db3d811b38',
-	    fileName: 'news.md'
 	  },
 	  authEnabled: false,
 	  feature: {
 	    pipelines: true,
 	    notifications: false,
-	    canary: false,
-	    parallelPipelines: true,
-	    fastProperty: false,
-	    vpcMigrator: false
 	  }
-	};
-
-	window.spinnakerSettings.providers.aws.preferredZonesByAccount['' + awsPrimaryAccount] = {
-	  'us-east-1': ['us-east-1a', 'us-east-1b', 'us-east-1d', 'us-east-1e'],
-	  'us-west-1': ['us-west-1a', 'us-west-1b', 'us-west-1c'],
-	  'us-west-2': ['us-west-2a', 'us-west-2b', 'us-west-2c'],
-	  'eu-west-1': ['eu-west-1a', 'eu-west-1b', 'eu-west-1c'],
-	  'ap-northeast-1': ['ap-northeast-1a', 'ap-northeast-1b', 'ap-northeast-1c'],
-	  'ap-southeast-1': ['ap-southeast-1a', 'ap-southeast-1b'],
-	  'ap-southeast-2': ['ap-southeast-2a', 'ap-southeast-2b'],
-	  'sa-east-1': ['sa-east-1a', 'sa-east-1b']
 	};
 
 /***/ }

--- a/pylib/spinnaker/configurator.py
+++ b/pylib/spinnaker/configurator.py
@@ -192,17 +192,17 @@ class Configurator(object):
     original_block = source[offset:end]
     # Remove all the explicit declarations in this block
     # Leaving us with just comments
-    block = re.sub('\n\s*let\s+\w+\s*=(.+)\n', '\n', original_block)
+    block = re.sub('\n\s*var\s+\w+\s*=(.+)\n', '\n', original_block)
     settings = [source[:offset]]
 
-    # Now iterate over the comments looking for let specifications
+    # Now iterate over the comments looking for var specifications
     offset = 0
-    for match in re.finditer('//\s*let\s+(\w+)\s*=\s*(.+?);?\n', block) or []:
+    for match in re.finditer('//\s*var\s+(\w+)\s*=\s*(.+?);?\n', block) or []:
       settings.append(block[offset:match.end()])
       offset = match.end()
       name = match.group(1)
       value = self.bindings.replace(match.group(2))
-      settings.append('let {name} = {value!r};\n'.format(
+      settings.append('var {name} = {value!r};\n'.format(
          name=name, value=value))
 
     settings.append(block[offset:])

--- a/unittest/configurator_test.py
+++ b/unittest/configurator_test.py
@@ -54,20 +54,20 @@ SECOND=two
         template = """
 preamble
 // BEGIN reconfigure_spinnaker
-// let gateUrl = ${{services.gate.baseUrl}};
+// var gateUrl = ${{services.gate.baseUrl}};
 {gate_url_value}
-// let bakeryBaseUrl = ${{services.bakery.baseUrl}};
+// var bakeryBaseUrl = ${{services.bakery.baseUrl}};
 {bakery_url_value}
 // END reconfigure_spinnaker
-// let gateUrl = ${{services.gate.baseUrl}};
+// var gateUrl = ${{services.gate.baseUrl}};
 stuff here is left along.
 """
         # This was originally just a comment, which was preserved.
-        bakery_url_assignment = ("let bakeryBaseUrl = 'BAKERY_BASE_URL';"
+        bakery_url_assignment = ("var bakeryBaseUrl = 'BAKERY_BASE_URL';"
                                  "\n# comment")
 
         # This was originally a different let statement that was removed.
-        gate_url_assignment = "let gateUrl = 'GATE_BASE_URL';"
+        gate_url_assignment = "var gateUrl = 'GATE_BASE_URL';"
         bindings = YamlBindings()
         bindings.import_dict({
             'services': {
@@ -82,7 +82,7 @@ stuff here is left along.
             source_settings_path = os.path.join(temp_sourcedir, 'settings.js')
             target_settings_path = os.path.join(temp_targetdir, 'settings.js')
             with open(source_settings_path, 'w') as f:
-                f.write(template.format(gate_url_value="let gateUrl='old';",
+                f.write(template.format(gate_url_value="var gateUrl='old';",
                                         bakery_url_value='# comment'))
 
             configurator.update_deck_settings()


### PR DESCRIPTION
Safari and (possibly) Firefox throw exceptions on `let` statements in strict mode. This changeset attempts to get around this issue by foregoing some of the ES6 sugar we've introduced (`let`, string templates).

I honestly have no idea if this will resolve the issues we've been hearing about from Safari users. It's been over a week since I tried to perform a clean install of Spinnaker via the documentation, and I was never able to get it to work. Hoping @ewiseblatt or @tomaslin or @duftler can take a look and see if these changes do the trick.

Also updating the scripts to remove some very Netflix-specific settings (feature flags) and obsolete settings (preferred zones, primary account, challenge destructive actions) that should be coming from Clouddriver's /credentials endpoint.