### PR TITLE
fix linking error on post install during upgrade

### DIFF
--- a/pkg_scripts/postInstall.sh
+++ b/pkg_scripts/postInstall.sh
@@ -5,7 +5,9 @@
 chmod +x /opt/spinnaker/install/first_google_boot.sh
 
 # Deprecated. Will be removed in the future.
-ln -s /opt/spinnaker/bin /opt/spinnaker/scripts
+if [ `readlink -f /opt/spinnaker/scripts` != "/opt/spinnaker/bin" ]; then
+  ln -s /opt/spinnaker/bin /opt/spinnaker/scripts
+fi
 
 # Create master config
 cp /opt/spinnaker/config/default-spinnaker-local.yml /opt/spinnaker/config/spinnaker-local.yml


### PR DESCRIPTION
When upgrading via apt-get this error pops up:

    Setting up spinnaker (0.15.0-3) ...
    ln: failed to create symbolic link ‘/opt/spinnaker/scripts/bin’: File exists
    dpkg: error processing package spinnaker (--configure):
     subprocess installed post-installation script returned error exit status 1
    Errors were encountered while processing:
     spinnaker
    E: Sub-process /usr/bin/dpkg returned an error code (1)


This PR just adds some logic to only create that link if it doesn't already exist.