### PR TITLE
Mark /etc/default/spinnaker as a configuration file so it is not sile…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,7 +81,9 @@ ospackage {
     user = 'root'
     permissionGroup = 'root'    
     fileMode = 0644
-  }  
+  }
+
+  configurationFile('/etc/default/spinnaker\n')
 
   File configDir
   FileCollection collection = files { configDir.listFiles() }


### PR DESCRIPTION
…ntly overwritten on an upgrade.
@dpeterka please review.