### PR TITLE
Without these changes, spinnaker-local.yml ends up in the /root/.spin…

### DIFF
--- a/experimental/kubernetes/2-repControllers.yml
+++ b/experimental/kubernetes/2-repControllers.yml
@@ -62,7 +62,7 @@ spec:
       volumes:
       - name: config-volume
         hostPath:
-          path: /root/.spinnaker/
+          path: /root/.spinnaker/config/
       - name: aws-creds
         hostPath:
           path: /root/.spinnaker/.aws/
@@ -120,7 +120,7 @@ spec:
       volumes:
       - name: config-volume
         hostPath:
-          path: /root/.spinnaker/
+          path: /root/.spinnaker/config/
 ---
 ### gate
 ---
@@ -172,7 +172,7 @@ spec:
       volumes:
       - name: config-volume
         hostPath:
-          path: /root/.spinnaker/
+          path: /root/.spinnaker/config/
 ---
 ### rush
 ---
@@ -224,7 +224,7 @@ spec:
       volumes:
       - name: config-volume
         hostPath:
-          path: /root/.spinnaker/
+          path: /root/.spinnaker/config/
 ---
 ### rosco
 ---
@@ -276,7 +276,7 @@ spec:
       volumes:
       - name: config-volume
         hostPath:
-          path: /root/.spinnaker/
+          path: /root/.spinnaker/config/
 ---
 ### echo
 ---
@@ -328,7 +328,7 @@ spec:
       volumes:
       - name: config-volume
         hostPath:
-          path: /root/.spinnaker/
+          path: /root/.spinnaker/config/
 ---
 ### front50
 ---
@@ -380,7 +380,7 @@ spec:
       volumes:
       - name: config-volume
         hostPath:
-          path: /root/.spinnaker/
+          path: /root/.spinnaker/config/
 ---
 ### deck
 ---
@@ -438,4 +438,4 @@ spec:
       volumes:
       - name: config-volume
         hostPath:
-          path: /root/.spinnaker/
+          path: /root/.spinnaker/config/

--- a/experimental/kubernetes/README.md
+++ b/experimental/kubernetes/README.md
@@ -76,7 +76,7 @@ Spinnaker needs the set of [configuration files](../../config) to be available t
 1. Copy the edited `spinnaker-local.yml` file to the config directory on the node.
 
   ```
-  $ gcloud compute copy-files ./spinnaker-local.yml root@$MY_GKE_NODE:/root/.spinnaker
+  $ gcloud compute copy-files ./spinnaker-local.yml root@$MY_GKE_NODE:/root/.spinnaker/config
   ```
 
 1. Create and download your JSON credentials for this project in the [Google Developers Console](https://console.developers.google.com/).


### PR DESCRIPTION
…naker directory instead of in /root/.spinnaker/config. There will be two spinnaker-local.yml files instead of the modified one overwriting the standard one in the typical location.

Also, each service will look for its config in /root/.spinnaker (which will only contain spinnaker-local.yml) instead of in /root/.spinnaker/config.

@ttomsu please review.