### PR TITLE
rosco.yml had incorrect value for redis

### DIFF
--- a/config/rosco.yml
+++ b/config/rosco.yml
@@ -3,7 +3,7 @@ server:
   address: ${services.rosco.host:localhost}
 
 redis:
-  host: ${services.redis.host:localhost}
+  connection: ${services.redis.connection:redis://localhost:6379}
 
 aws:
   enabled: ${providers.aws.enabled:false}


### PR DESCRIPTION
From https://github.com/spinnaker/rosco/blob/master/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/persistence/config/JedisConfig.groovy#L32

@duftler PTAL