### PR TITLE
Fix race condition configuring on first boot

### DIFF
--- a/InstallSpinnaker.sh
+++ b/InstallSpinnaker.sh
@@ -338,7 +338,6 @@ function install_redis_server() {
     echo "Manually downloading and installing redis-server..."
     mkdir /tmp/deppkgs && pushd /tmp/deppkgs
     curl -L -O http://mirrors.kernel.org/ubuntu/pool/universe/j/jemalloc/libjemalloc1_3.5.1-2_amd64.deb
-    curl -L -O https://launchpad.net/~chris-lea/+archive/ubuntu/redis-server/+build/8137860/+files/redis-tools_3.0.5-1chl1~trusty1_amd64.deb
     curl -L -O https://launchpad.net/~chris-lea/+archive/ubuntu/redis-server/+build/8137860/+files/redis-server_3.0.5-1chl1~trusty1_amd64.deb
     dpkg -i *.deb
     popd

--- a/dev/build_google_image.packer
+++ b/dev/build_google_image.packer
@@ -6,7 +6,7 @@
     "update_os": "false",
     "json_credentials":  "",
     "zone": "us-central1-f",
-    "source_image": "ubuntu-1404-trusty-v20151113",
+    "source_image": "ubuntu-1404-trusty-v20160114e",
     "target_image": "{{env `USER`}}-spinnaker-{{timestamp}}"
  },
 
@@ -32,11 +32,16 @@
         "/tmp/install_spinnaker.sh --repository {{user `debian_repo`}} --cloud_provider google --google_region us-central1 --quiet"
      ]
   },
+
   {
     "type": "shell",
     "inline": [
-        "if [ '{{user `update_os`}}' = 'true' ]; then apt-get update -y; apt-get -y dist-upgrade; sed -i 's/start_rpc: false/start_rpc: true/' /etc/cassandra/cassandra.yaml; fi"
+        "dpkg --list | grep linux-image | awk '{ print $2 }' | sort -V | sed -n '/'`uname -r`'/q;p' | xargs sudo apt-get -y purge",
+        "if [ '{{user `update_os`}}' = 'true' ]; then apt-get update -y; apt-get -y dist-upgrade; sed -i 's/start_rpc: false/start_rpc: true/' /etc/cassandra/cassandra.yaml; fi",
+        "apt-get autoremove -y"
      ]
   }
- ]
+ ],
+
+ "_comment": "inline shell command above will: (1) Prune off the older kernels that might have been in the source image. (2) Upgrade the remaining kernels. (3) Remove anything that is no longer used."
 }

--- a/dev/build_google_image.sh
+++ b/dev/build_google_image.sh
@@ -14,7 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+CURRENT_IMAGE=$(gcloud compute images list 2>1 | grep ubuntu-1404 | tail -1 | awk '{print $1}')
+
 VARS="-var 'install_path=$(dirname $0)/../InstallSpinnaker.sh'"
+VARS="$VARS -var 'source_image=$CURRENT_IMAGE'"
 
 function process_args() {
   PROJECT_ID="ok"


### PR DESCRIPTION
We perform a dist-upgrade in the boot for security reasons. This could take several minutes,
especially as the image grows stale and security patches grow. Before the upgrade occurred
at the beginning of the script meaning the guts of the script block on the upgrade completing.
Since spinnaker images typically auto upstart spinnaker on boot, that means that Spinnaker
is running during the upgrade but has not yet been configured as the VM was directed.

This CL moves the security upgrade to the end of the script so that the configuration
is properly in place.

One could argue that we should not run Spinnaker at all until the upgrade has finished.
Since it was already running, I'm not changing that policy. Also, this script is an
explicit choice passed into the VM so is not actually forced as a condition for using
spinnaker. It is used by C2D (and other adhoc VM creation techniques), which is
user-interactive introduction so I'd argue a timely boot is more important.

Otherwise, the "start spinnaker" call should be moved to the very end of the script.
I added a control parameter to allow this change, though would be happy to remove it
in favor of requiring either one of the policies.

Another speedup here is that I remove old kernels from the image we are building.
This is another "not sure if I should" decision, but think it makes sense. The
source images seem to include two kernels on them. It is standard practice to have
two kernels so that there is a fallback in case the upgrade fails. However since we
are baking and testing these images, and they are going to boot as is, I dont expect
anyone to ever boot off the older image and if there is a problem with the kernel, then
we should pick that up before releasing the image. The dist-upgrade seems to be doing
work for each of the kernels, so removing the old kernel knocks at least 45 seconds off
startup for the rebuild step, plus whatever other download and update work was needed
prior to that.

Finally, I noticed that the packer source image was old so I updated it. This might have
been adding additional time from being a further out delta to upgrade from. I changed the
wrapper script to inject the current version as the source image so things should generally
stay up to date when following standard processes using the provided scripts.

Unfortunately packer is based on JSON and JSON does not support comments so I couldnt
what's going on in the packer script. I added a crude comment to the best of packer's
commenting support.

@duftler
Together these reduce the startup script execution time (one time measurement) from about 6:30 to 4:20 (n1-standard-4) where the correctly configured spinnaker availability is around 5 minutes earlier than before where I dont dist-upgrade the image to simulate a stale build (i.e. deploying an older image today).