### PR TITLE
Changed deck install folder to /opt/deck/html (Fix for issue#723)

### DIFF
--- a/etc/apache2/sites-available/spinnaker.conf
+++ b/etc/apache2/sites-available/spinnaker.conf
@@ -1,3 +1,7 @@
 <VirtualHost 127.0.0.1:9000>
-  DocumentRoot /var/www/html
+  DocumentRoot /opt/deck/html
+  
+  <Directory "/opt/deck/html/">
+    Require all granted
+  </Directory>
 </VirtualHost>

--- a/pylib/spinnaker/configurator.py
+++ b/pylib/spinnaker/configurator.py
@@ -61,7 +61,7 @@ class InstallationParameters(object):
 
   INSTALLED_CONFIG_DIR = SPINNAKER_INSTALL_DIR + '/config'
 
-  DECK_INSTALL_DIR = '/var/www/html'
+  DECK_INSTALL_DIR = '/opt/deck/html'
   HACK_DECK_SETTINGS_FILENAME = 'settings.js'
   ENVIRONMENT_VARIABLE_PATH = '/etc/default/spinnaker'
 


### PR DESCRIPTION
This is related to the deck PR https://github.com/spinnaker/deck/pull/1941
Deck install folder has been changed from /var/www/html to /opt/deck/html.
This fixes the Issue#723