### PR TITLE
adding redis connection property for igor

### DIFF
--- a/config/igor.yml
+++ b/config/igor.yml
@@ -9,6 +9,9 @@ jenkins:
       username: ${services.jenkins.defaultMaster.username}
       password: ${services.jenkins.defaultMaster.password}
 
+redis:
+  connection: ${services.redis.connection:redis://localhost:6379}
+
 # This is recursive
 #services:
 #  echo:


### PR DESCRIPTION
Looks like igor is unable to find redis or connect to it without this added configuration. We had a similar commit recently to the rosco config.