### PR TITLE
Proxy gate and rosco through Apache alongside deck

### DIFF
--- a/config/default-spinnaker-local.yml
+++ b/config/default-spinnaker-local.yml
@@ -96,6 +96,11 @@ services:
 
   deck:
     # Frontend configuration.
+    # If you are proxying Spinnaker behind a single host, you may want to
+    # override these values. Remember to run `reconfigure_spinnaker.sh` after.
+    #baseUrl: http://spinnaker.mydomain.com
+    #gateUrl: ${services.deck.baseUrl}/gate
+    #bakeryUrl: ${services.deck.baseUrl}/rosco
     timezone: 'America/Los_Angeles' # See: http://momentjs.com/timezone/docs/#/data-utilities/
     auth:
       enabled: false

--- a/config/settings.js
+++ b/config/settings.js
@@ -9,8 +9,8 @@
  */
 // BEGIN reconfigure_spinnaker
 
-// var gateUrl = ${services.gate.baseUrl};
-// var bakeryBaseUrl = ${services.bakery.baseUrl};
+// var gateUrl = ${services.deck.gateUrl};
+// var bakeryUrl = ${services.deck.bakeryUrl};
 // var authEnabled = ${services.deck.auth.enabled};
 // var defaultTimeZone = ${services.deck.timezone};
 // var awsDefaultRegion = ${providers.aws.defaultRegion};
@@ -36,7 +36,7 @@
 
 window.spinnakerSettings = {
   gateUrl: gateUrl,
-  bakeryDetailUrl: bakeryBaseUrl + '/api/v1/global/logs/{{context.status.id}}?html=true',
+  bakeryDetailUrl: bakeryUrl + '/api/v1/global/logs/{{context.status.id}}?html=true',
   authEndpoint: gateUrl + '/auth/info',
   pollSchedule: 30000,
   defaultTimeZone: defaultTimeZone, // see http://momentjs.com/timezone/docs/#/data-utilities/

--- a/config/settings.js
+++ b/config/settings.js
@@ -10,7 +10,7 @@
 // BEGIN reconfigure_spinnaker
 
 // var gateUrl = ${services.deck.gateUrl};
-// var bakeryUrl = ${services.deck.bakeryUrl};
+// var bakeryBaseUrl = ${services.deck.bakeryUrl};
 // var authEnabled = ${services.deck.auth.enabled};
 // var defaultTimeZone = ${services.deck.timezone};
 // var awsDefaultRegion = ${providers.aws.defaultRegion};
@@ -36,7 +36,7 @@
 
 window.spinnakerSettings = {
   gateUrl: gateUrl,
-  bakeryDetailUrl: bakeryUrl + '/api/v1/global/logs/{{context.status.id}}?html=true',
+  bakeryDetailUrl: bakeryBaseUrl + '/api/v1/global/logs/{{context.status.id}}?html=true',
   authEndpoint: gateUrl + '/auth/info',
   pollSchedule: 30000,
   defaultTimeZone: defaultTimeZone, // see http://momentjs.com/timezone/docs/#/data-utilities/

--- a/config/spinnaker.yml
+++ b/config/spinnaker.yml
@@ -54,6 +54,11 @@ services:
         token: # the part after http://hooks.slack.com/services/
 
   deck:
+    host: ${services.default.host}
+    port: 9000
+    baseUrl: ${services.default.protocol}://${services.deck.host}:${services.deck.port}
+    gateUrl: ${services.gate.baseUrl}
+    bakeryUrl: ${services.bakery.baseUrl}
     timezone: 'America/Los_Angeles'
     auth:
       enabled: false

--- a/etc/apache2/sites-available/spinnaker.conf
+++ b/etc/apache2/sites-available/spinnaker.conf
@@ -1,6 +1,12 @@
 <VirtualHost 127.0.0.1:9000>
   DocumentRoot /opt/deck/html
-  
+
+  ProxyPass "/gate" "http://localhost:8084"
+  ProxyPassReverse "/gate" "http://localhost:8084"
+
+  ProxyPass "/rosco" "http://localhost:8087"
+  ProxyPassReverse "/rosco" "http://localhost:8087"
+
   <Directory "/opt/deck/html/">
     Require all granted
   </Directory>

--- a/etc/apache2/sites-available/spinnaker.conf
+++ b/etc/apache2/sites-available/spinnaker.conf
@@ -1,10 +1,10 @@
 <VirtualHost 127.0.0.1:9000>
   DocumentRoot /opt/deck/html
 
-  ProxyPass "/gate" "http://localhost:8084"
+  ProxyPass "/gate" "http://localhost:8084" retry=0
   ProxyPassReverse "/gate" "http://localhost:8084"
 
-  ProxyPass "/rosco" "http://localhost:8087"
+  ProxyPass "/rosco" "http://localhost:8087" retry=0
   ProxyPassReverse "/rosco" "http://localhost:8087"
 
   <Directory "/opt/deck/html/">

--- a/pkg_scripts/postInstall.sh
+++ b/pkg_scripts/postInstall.sh
@@ -20,7 +20,8 @@ fi
 # vhosts
 rm -rf /etc/apache2/sites-enabled/*.conf
 
-ln -s /etc/apache2/sites-available/spinnaker.conf /etc/apache2/sites-enabled/spinnaker.conf
+/usr/sbin/a2ensite spinnaker
+/usr/sbin/a2enmod proxy_http
 
 sed -i "s/Listen\ 80/Listen 127.0.0.1:9000/" /etc/apache2/ports.conf
 


### PR DESCRIPTION
cc @vjames-bmc 

Configures Apache to proxy gate and rosco on the same <VirtualHost> as deck.

Adds instructions for setting custom deck.{baseUrl,gateUrl,bakeryUrl} 