### PR TITLE
Fix typos in shell scripts and yml config files.

### DIFF
--- a/InstallSpinnaker.sh
+++ b/InstallSpinnaker.sh
@@ -377,7 +377,7 @@ function install_apache2() {
 
 function install_cassandra() {
   # "service cassandra status" is currently broken in Ubuntu grep in the script is grepping for things that do not exist
-  # Cassandra 2.x can ship with RPC disabeld to enable run "nodetool enablethrift"
+  # Cassandra 2.x can ship with RPC disabled to enable run "nodetool enablethrift"
 
   local package_url="http://debian.datastax.com/community/pool"
 

--- a/config/clouddriver.yml
+++ b/config/clouddriver.yml
@@ -28,8 +28,8 @@ aws:
   # info on setting environment variables.
   #
   # TODO(ewiseblatt):
-  # This only works for root credentials, which you arent supposed to use.
-  # I havent been able to figure out how to get normal user accounts to work.
+  # This only works for root credentials, which you aren't supposed to use.
+  # I haven't been able to figure out how to get normal user accounts to work.
   # I'm leaving this broken for now hoping that once this gets mainlined some
   # body else will be able to fix it.
 

--- a/config/default-spinnaker-local.yml
+++ b/config/default-spinnaker-local.yml
@@ -49,7 +49,7 @@ services:
   default:
     # These defaults can be modified to change all the spinnaker subsystems
     # (clouddriver, gate, etc) at once, but not external systems (jenkins, etc).
-    # Individual systems can still be overriden using their own section entry
+    # Individual systems can still be overridden using their own section entry
     # directly under 'services'.
     protocol: http    # Assume all spinnaker subsystems are using http
     host: localhost   # Assume all spinnaker subsystems are on localhost
@@ -76,7 +76,7 @@ services:
   jenkins:
     # If you are integrating Jenkins, set its location here using the baseUrl
     # field and provide the username/password credentials.
-    # You must also enable the "igor" service listed seperately.
+    # You must also enable the "igor" service listed separately.
     #
     # If you have multiple jenkins servers, you will need to list
     # them in an igor-local.yml. See jenkins.masters in config/igor.yml.

--- a/config/spinnaker.yml
+++ b/config/spinnaker.yml
@@ -15,11 +15,11 @@ services:
   default:
     # These defaults can be modified to change all the spinnaker subsystems
     # (clouddriver, gate, etc) at once, but not external systems (jenkins, etc).
-    # Individual systems can still be overriden using their own section entry
+    # Individual systems can still be overridden using their own section entry
     # directly under 'services'.
     host: localhost
     protocol: http
-    primaryAccountName: service-default-primaryAcountName-not-defined
+    primaryAccountName: service-default-primaryAccountName-not-defined
 
   clouddriver:
     host: ${services.default.host}

--- a/experimental/kubernetes/spinnaker-local.yml
+++ b/experimental/kubernetes/spinnaker-local.yml
@@ -24,7 +24,7 @@ services:
   default:
     # These defaults can be modified to change all the spinnaker subsystems
     # (clouddriver, gate, etc) at once, but not external systems (jenkins, etc).
-    # Individual systems can still be overriden using their own section entry
+    # Individual systems can still be overridden using their own section entry
     # directly under 'services'.
     protocol: http    # Assume all spinnaker subsystems are using http
     host: localhost   # Assume all spinnaker subsystems are on localhost
@@ -51,7 +51,7 @@ services:
   jenkins:
     # If you are integrating Jenkins, set its location here using the baseUrl
     # field and provide the username/password credentials.
-    # You must also enable the "igor" service listed seperately.
+    # You must also enable the "igor" service listed separately.
     #
     # If you have multiple jenkins servers, you will need to list
     # them in an igor-local.yml. See jenkins.masters in config/igor.yml.

--- a/experimental/packer/configure.sh
+++ b/experimental/packer/configure.sh
@@ -330,7 +330,7 @@ services:
   default:
     # These defaults can be modified to change all the spinnaker subsystems
     # (clouddriver, gate, etc) at once, but not external systems (jenkins, etc).
-    # Individual systems can still be overriden using their own section entry
+    # Individual systems can still be overridden using their own section entry
     # directly under 'services'.
     protocol: http    # Assume all spinnaker subsystems are using http
     host: localhost   # Assume all spinnaker subsystems are on localhost
@@ -362,7 +362,7 @@ services:
     # Optional, but expected in spinnaker-local.yml if specified.
 
     # You'll need to provide it a Spinnaker account to use.
-    # Here we are assuming the default primary acccount.
+    # Here we are assuming the default primary account.
     #
     # If you have multiple accounts using docker then you will need to
     # provide a rush-local.yml.
@@ -378,7 +378,7 @@ services:
   jenkins:
     # If you are integrating Jenkins, set its location here using the baseUrl
     # field and provide the username/password credentials.
-    # You must also enable the "igor" service listed seperately.
+    # You must also enable the "igor" service listed separately.
     #
     # If you have multiple jenkins servers, you will need to list
     # them in an igor-local.yml. See jenkins.masters in config/igor.yml.
@@ -399,7 +399,7 @@ services:
   rush:
     # Spinnaker's "rush" subsystem is used by the "rosco" bakery.
     # You'll need to provide it a Spinnaker account to use.
-    # Here we are assuming the default primary acccount.
+    # Here we are assuming the default primary account.
     primaryAccount: \${services.default.primaryAccountName}
 EOT
 

--- a/experimental/packer/install.sh
+++ b/experimental/packer/install.sh
@@ -47,7 +47,7 @@ echo 'deb https://dl.bintray.com/kenzanlabs/spinnaker trusty spinnaker' > /etc/a
 
 ## Install software
 # "service cassandra status" is currently broken in Ubuntu grep in the script is grepping for things that do not exist
-# Cassandra 2.x can ship with RPC disabeld to enable run "nodetool enablethrift"
+# Cassandra 2.x can ship with RPC disabled to enable run "nodetool enablethrift"
 
 apt-get update
 apt-get install -y oracle-java8-installer

--- a/install/first_google_boot.sh
+++ b/install/first_google_boot.sh
@@ -28,7 +28,7 @@ LOCAL_CONFIG_DIR=$SPINNAKER_INSTALL_DIR/config
 
 # This status prefix provides a hook to inject output signals with status
 # messages for consumers like the Google Deployment Manager Coordinator.
-# Normally this isnt needed. Callers will populate it as they need
+# Normally this isn't needed. Callers will populate it as they need
 # using --status_prefix.
 STATUS_PREFIX="*"
 
@@ -149,7 +149,7 @@ function extract_spinnaker_google_credentials() {
   mkdir -p $(dirname $json_path)
   if clear_metadata_to_file "managed_project_credentials" $json_path; then
     # This is a workaround for difficulties using the Google Deployment Manager
-    # to express no value. We'll use the value "None". But we dont want
+    # to express no value. We'll use the value "None". But we don't want
     # to officially support this, so we'll just strip it out of this first
     # time boot if we happen to see it, and assume the Google Deployment Manager
     # got in the way.
@@ -182,7 +182,7 @@ function extract_spinnaker_aws_credentials() {
   mkdir -p $(dirname $credentials_path)
   if clear_metadata_to_file "aws_credentials" $credentials_path; then
     # This is a workaround for difficulties using the Google Deployment Manager
-    # to express no value. We'll use the value "None". But we dont want
+    # to express no value. We'll use the value "None". But we don't want
     # to officially support this, so we'll just strip it out of this first
     # time boot if we happen to see it, and assume the Google Deployment Manager
     # got in the way.


### PR DESCRIPTION
All typos except the following one are in comments.
```
-    primaryAccountName: service-default-primaryAcountName-not-defined
+    primaryAccountName: service-default-primaryAccountName-not-defined
```
It's a just sample value of config file.