### PR TITLE
When cloning a repository, default to 'master' branch if none was set.

### DIFF
--- a/dev/refresh_source.py
+++ b/dev/refresh_source.py
@@ -211,7 +211,7 @@ class Refresher(object):
       name = repository.name
       repository_dir = get_repository_dir(name)
       upstream_user = repository.owner
-      branch = self.pull_branch
+      branch = self.pull_branch or 'master'
       origin_url = self.get_github_repository_url(repository, owner=owner)
       upstream_url = 'https://github.com/{upstream_user}/{name}.git'.format(
               upstream_user=upstream_user, name=name)


### PR DESCRIPTION
  Fixes --pull_upstream when a repository is missing.

@skim1420 