### PR TITLE
Fixed run_dev startup

### DIFF
--- a/pylib/spinnaker/spinnaker_runner.py
+++ b/pylib/spinnaker/spinnaker_runner.py
@@ -274,10 +274,11 @@ class Runner(object):
     environ = dict(os.environ)
     # Set AWS environment variables for credentials if not already there.
     key_id = self.__bindings.get(
-    'providers.aws.primaryCredentials.access_key_id')
+        'providers.aws.primaryCredentials.access_key_id', None)
     secret_key = self.__bindings.get(
-      'providers.aws.primaryCredentials.secret_key')
-    if key_id:
+        'providers.aws.primaryCredentials.secret_key', None)
+
+    if key_id is not None:
       environ['AWS_ACCESS_KEY_ID'] = environ.get('AWS_ACCESS_KEY_ID', key_id)
 
       # TODO(ewiseblatt): 20151030
@@ -286,7 +287,7 @@ class Runner(object):
       # to work (when running from gradle). Instead the key needs to be
       # AWS_ACCESS_KEY, so we will set both for now.
       environ['AWS_ACCESS_KEY'] = environ.get('AWS_ACCESS_KEY', key_id)
-    if secret_key:
+    if secret_key is not None:
       environ['AWS_SECRET_KEY'] = environ.get('AWS_SECRET_KEY', secret_key)
 
     return environ

--- a/pylib/spinnaker/yaml_util.py
+++ b/pylib/spinnaker/yaml_util.py
@@ -27,8 +27,14 @@ class YamlBindings(object):
   def __init__(self):
     self.__map = {}
 
-  def get(self, field):
+  def __getitem__(self, field):
     return self.__get_field_value(field, [], original=field)
+    
+  def get(self, field, default=None):
+    try:
+      return self.__get_field_value(field, [], original=field)
+    except KeyError:
+      return default
 
   def import_dict(self, d):
     for name,value in d.items():
@@ -139,7 +145,7 @@ class YamlBindings(object):
       Transformed source with value of key replaced to match the bindings.
     """
     try:
-      value = self.get(key)
+      value = self[key]
     except KeyError:
       return source
 

--- a/unittest/yaml_util_test.py
+++ b/unittest/yaml_util_test.py
@@ -167,13 +167,16 @@ e:
     bindings.import_dict({'field': '${injected.value}', 'found': 'FOUND'})
     bindings.import_dict({'injected': {'value': '${found}'}})
     self.assertEqual('FOUND', bindings.get('field'))
+    self.assertEqual('FOUND', bindings['field'])
+    self.assertEqual('FOUND', bindings.get('field', None))
 
   def test_load_key_not_found(self):
     bindings = YamlBindings()
     bindings.import_dict({'field': '${injected.value}', 'injected': {}})
 
     with self.assertRaises(KeyError):
-      bindings.get('unknown')
+      bindings['unknown']
+    self.assertEqual(None, bindings.get('unknown', None))
 
   def test_cyclic_reference(self):
     bindings = YamlBindings()


### PR DESCRIPTION
I introduced a bug into developer run_dev earlier today when I took out
AWS credentials from the spinnaker.yml. This fixes that.

@duftler