### PR TITLE
Avoid breaking existing infrastructure dependent on igor polling.

### DIFF
--- a/config/default-spinnaker-local.yml
+++ b/config/default-spinnaker-local.yml
@@ -107,7 +107,7 @@ services:
     #
     # Note that jenkins is not installed with Spinnaker so you must obtain this
     # on your own if you are interested.
-    enabled: false
+    enabled: ${services.igor.enabled:false}
     defaultMaster:
       name: Jenkins # The display name for this server
       baseUrl:

--- a/config/spinnaker.yml
+++ b/config/spinnaker.yml
@@ -143,7 +143,7 @@ services:
     #
     # Note that jenkins is not installed with Spinnaker so you must obtain this
     # on your own if you are interested.
-    enabled: false
+    enabled: ${services.igor.enabled:false}
     defaultMaster:
       name: Jenkins
       baseUrl:   # Expected in spinnaker-local.yml


### PR DESCRIPTION
@ewiseblatt 

I'm making the assumption that the user has configured their local file to set `igor.enabled:  true`. If none of `dockerRegistry` or `jenkins` are enabled, then Igor can't start polling and will fail to start. By making Jenkins dependent on Igor, we won't break existing Igor installations.