### PR TITLE
Typo while stopping the spinnaker.

### DIFF
--- a/pylib/spinnaker/spinnaker_runner.py
+++ b/pylib/spinnaker/spinnaker_runner.py
@@ -512,7 +512,7 @@ Proceeding anyway.
 
 
   def stop_deck(self):
-    print 'Stopping apache server while starting Spinnaker.'
+    print 'Stopping apache server while stopping Spinnaker.'
     run_quick('service apache2 stop', echo=True)
 
   def start_deck(self):


### PR DESCRIPTION
Output was : `Stopping apache server while starting Spinnaker.` changed
to `Stopping apache server while stopping Spinnaker.`