### PR TITLE
Removed bakeryDefaults for AWS keys

### DIFF
--- a/config/rosco.yml
+++ b/config/rosco.yml
@@ -7,9 +7,6 @@ redis:
 
 aws:
   enabled: ${providers.aws.enabled:false}
-  bakeryDefaults:
-    awsAccessKey: ${providers.aws.primaryCredentials.access_key_id}
-    awsSecretKey: ${providers.aws.primaryCredentials.secret_key}
 
 docker:
   enabled: ${services.docker.enabled:false}


### PR DESCRIPTION
These were removed from spinnaker.yml because clouddriver never references them
so it doesnt make sense to have them here. AWS credentials are typically set in ~/.aws/credentials

@duftler 