### PR TITLE
Add spinnaker user to sudoers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,15 +72,22 @@ ospackage {
   from('etc/apache2/sites-available/spinnaker.conf') {
     into '/etc/apache2/sites-available'
     user = 'root'
-    permissionGroup = 'root'    
+    permissionGroup = 'root'
     fileMode = 0644
   }
 
   from('etc/default/spinnaker') {
     into '/etc/default'
     user = 'root'
-    permissionGroup = 'root'    
+    permissionGroup = 'root'
     fileMode = 0644
+  }
+
+  from('etc/sudoers.d/spinnaker') {
+    into '/etc/sudoers.d'
+    user = 'root'
+    permissionGroup = 'root'
+    fileMode = 0440
   }
 
   configurationFile('/etc/default/spinnaker\n')

--- a/etc/sudoers.d/spinnaker
+++ b/etc/sudoers.d/spinnaker
@@ -1,0 +1,2 @@
+# User rules for spinnaker
+spinnaker ALL=(ALL) NOPASSWD: /usr/bin/packer

--- a/etc/sudoers.d/spinnaker
+++ b/etc/sudoers.d/spinnaker
@@ -1,2 +1,5 @@
+# An entry in /etc/sudoers.d is needed to grant spinnaker sudo rights for packer.
+# This is a security risk that can be exploited.
+# Uncomment the last line if you are using a template needing root in rosco.
 # User rules for spinnaker
-spinnaker ALL=(ALL) NOPASSWD: /usr/bin/packer
+# spinnaker ALL=(ALL) NOPASSWD: /usr/bin/packer


### PR DESCRIPTION
This is to support the aws-chroot builder that requires sudo.

Related to https://github.com/spinnaker/rosco/pull/79

