### PR TITLE
Install Google Cloud Logging from the Web.

### DIFF
--- a/google/google_cloud_logging/add_google_cloud_logging.sh
+++ b/google/google_cloud_logging/add_google_cloud_logging.sh
@@ -1,24 +1,24 @@
 #!/bin/bash
 # This should install Google Cloud Logging to the current instance
-# and add a custom Spinnaker configuration to it in addition to the standard ones.
+# and add a custom Spinnaker configuration to it in addition to the
+# standard ones.
 #
 # This requires that the current instance have scope for
 #    https://www.googleapis.com/auth/logging.write.
 #
-# If you do not then you are hosed and need to create a new instance because scopes
-# are only introduced at construction time.
+# If you do not then you are hosed and need to create a new instance because
+# scopes are only introduced at construction time.
 #
 # If you are very much tied to this instance, you can detatch the disk, destroy
-# the instance, turn the disk into a new image, then create a new instance off that
-# image. Otherwise, just create a new instance.
+# the instance, turn the disk into a new image, then create a new instance off
+# that image. Otherwise, just create a new instance.
 #
-# Since logging.write is added by default, you might have created this instance using
-# an older C2D or spinnaker/dev/create_google_dev_vm.sh. Each of these has been updated
-# to add logging-write so you can use the same procedure as before, but with the
-# current versions.
+# Since logging.write is added by default, you might have created this
+# instance using an older C2D or spinnaker/dev/create_google_dev_vm.sh.
+# Each of these has been updated to add logging-write so you can use the
+# same procedure as before, but with the current versions.
 
 GOOGLE_METADATA_URL="http://metadata.google.internal/computeMetadata/v1"
-SPINNAKER_CONF_PATH=$(readlink -f "$(dirname $0)/spinnaker.conf")
 
 scopes=$(curl -s -L -H "Metadata-Flavor:Google" "$GOOGLE_METADATA_URL/instance/service-accounts/default/scopes")
 if [[ $? -eq 0 ]] && [[ $scopes != *"logging.write"* ]]; then
@@ -33,10 +33,19 @@ if [[ $? -eq 0 ]] && [[ $scopes != *"logging.write"* ]]; then
   exit -1
 fi
 
-cd /tmp
-mkdir -p /etc/google-fluentd/config.d
-sudo cp "$SPINNAKER_CONF_PATH" /etc/google-fluentd/config.d/spinnaker.conf
+sudo mkdir -p /etc/google-fluentd/config.d
+SPINNAKER_CONF_PATH=$(readlink -f "$(dirname $0)/spinnaker.conf")
+if [[ -f "$SPINNAKER_CONF_PATH" ]]; then
+  # If we're running locally (e.g. from the git repository), then copy the file
+  sudo cp "$SPINNAKER_CONF_PATH" /etc/google-fluentd/config.d/spinnaker.conf
+else
+  # Otherwise, download the config file from github.
+  SPINNAKER_CONF_URL="https://raw.githubusercontent.com/spinnaker/spinnaker/master/google/google_cloud_logging/spinnaker.conf"
+  cd /etc/google-fluentd/config.d
+  sudo sudo curl -s -O "$SPINNAKER_CONF_URL"
+fi
 
+cd /tmp
 curl -s -O https://dl.google.com/cloudagents/install-logging-agent.sh
 chmod +x ./install-logging-agent.sh
 sudo ./install-logging-agent.sh


### PR DESCRIPTION
@duftler 
I think this command could be used (once submitted) to install google cloud logging from the web.

curl -s -q https://raw.githubusercontent.com/spinnakerspinnaker/google_cloud_logging/google/google_cloud_logging/add_google_cloud_logging.sh | bash

That will add google cloud logging to any spinnaker instance, not just those in GCE baked images
(i.e. for those that install spinnaker directly, have existing deployments, or are somewhere other than GCE).


