### PR TITLE
Install Google Cloud Logging and Monitoring when installing on GCE.

### DIFF
--- a/dev/build_google_image.packer
+++ b/dev/build_google_image.packer
@@ -8,7 +8,9 @@
     "zone": "us-central1-f",
     "source_image": null,
     "base_srcdir": null,
-    "target_image": "{{env `USER`}}-spinnaker-{{timestamp}}"
+    "target_image": "{{env `USER`}}-spinnaker-{{timestamp}}",
+    "google_cloud_logging": "true",
+    "google_cloud_monitoring": "true"
  },
 
  "builders": [{
@@ -27,38 +29,13 @@
     "destination": "/tmp/install_spinnaker.sh"
   },
   {
-    "type": "file",
-    "source": "{{user `base_srcdir`}}/google/google_cloud_logging/spinnaker.conf",
-    "destination": "/tmp/spinnaker_cloud_logging.conf"
-  },
-  {
     "type": "shell",
     "inline": [
-      "cd /tmp",
-      "mkdir -p /etc/google-fluentd/config.d",
-      "mv spinnaker_cloud_logging.conf /etc/google-fluentd/config.d/spinnaker.conf",
-      "curl -s -O https://dl.google.com/cloudagents/install-logging-agent.sh",
-      "bash ./install-logging-agent.sh",
-      "rm ./install-logging-agent.sh",
-      "service google-fluentd stop"
-    ]
-  },
-  {
-    "type": "shell",
-    "inline": [
-      "cd /tmp",
-      "CODENAME=$(lsb_release -sc)",
-      "curl -s -S -f -o /etc/apt/sources.list.d/stackdriver.list https://repo.stackdriver.com/$CODENAME.list",
-      "curl -s -f https://app.stackdriver.com/RPM-GPG-KEY-stackdriver | apt-key add -",
-      "apt-get -q update",
-      "DEBIAN_FRONTEND=noninteractive apt-get -y -q install stackdriver-agent"
-    ]
-  },
-  {
-    "type": "shell",
-    "inline": [
+        "flags=\"--cloud_provider google --google_region us-central1 --quiet\"",
+        "if \"{{ user `google_cloud_logging` }}\" == \"true\"; then flags=\"$flags --google_cloud_logging\"; fi",
+        "if \"{{ user `google_cloud_monitoring` }}\" == \"true\"; then flags=\"$flags --google_cloud_monitoring\"; fi",
         "chmod +x /tmp/install_spinnaker.sh",
-        "/tmp/install_spinnaker.sh --repository {{user `debian_repo`}} --cloud_provider google --google_region us-central1 --quiet",
+        "/tmp/install_spinnaker.sh --repository {{user `debian_repo`}} $flags",
         "service spinnaker stop"
      ]
   },

--- a/dev/build_google_image.sh
+++ b/dev/build_google_image.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-CURRENT_IMAGE=$(gcloud compute images list 2>1 | grep ubuntu-1404 | tail -1 | awk '{print $1}')
+CURRENT_IMAGE=$(gcloud compute images list 2>&1 | grep ubuntu-1404 | tail -1 | awk '{print $1}')
 
 VARS="-var 'install_path=$(dirname $0)/../InstallSpinnaker.sh'"
 VARS="$VARS -var 'source_image=$CURRENT_IMAGE'"

--- a/google/google_cloud_logging/add_google_cloud_logging.sh
+++ b/google/google_cloud_logging/add_google_cloud_logging.sh
@@ -22,15 +22,17 @@ GOOGLE_METADATA_URL="http://metadata.google.internal/computeMetadata/v1"
 
 scopes=$(curl -s -L -H "Metadata-Flavor:Google" "$GOOGLE_METADATA_URL/instance/service-accounts/default/scopes")
 if [[ $? -eq 0 ]] && [[ $scopes != *"logging.write"* ]]; then
-  echo "ERROR - missing scope 'https://www.googleapis.com/auth/logging.write'"
+  echo "WARNING - missing scope 'https://www.googleapis.com/auth/logging.write'"
   echo "---------------------------------------------------------------------"
   echo "Have scopes:"
   echo "$scopes"
   echo ""
-  echo "You will need to create a new VM that adds the scope for"
-  echo "   https://www.googleapis.com/auth/logging.write"
-  echo "then try this script again (in the new instance!)."
-  exit -1
+  echo "You will not be able to upload logging data to Google Cloud Logging"
+  echo "unless you add https://www.googleapis.com/auth/logging.write"
+  echo "as an Authorization Scope when creating your VM."
+  echo ""
+  # Proceed anyway. Note that packer will not have this scope, but that is
+  # ok since only the instance from the image packer creates needs it.
 fi
 
 sudo mkdir -p /etc/google-fluentd/config.d
@@ -42,7 +44,7 @@ else
   # Otherwise, download the config file from github.
   SPINNAKER_CONF_URL="https://raw.githubusercontent.com/spinnaker/spinnaker/master/google/google_cloud_logging/spinnaker.conf"
   cd /etc/google-fluentd/config.d
-  sudo sudo curl -s -O "$SPINNAKER_CONF_URL"
+  sudo curl -s -O "$SPINNAKER_CONF_URL"
 fi
 
 cd /tmp


### PR DESCRIPTION
@lwander 

This has to be explicitly requested with arguments to InstallSpinnaker.

The build_google_image script builds both these in by default, but an explicit
install (calling InstallSpinnaker.sh directly) would not include these by default even on GCE.