### PR TITLE
Configuration file portion of enabling azure in InstallSpinnaker.sh

### DIFF
--- a/config/clouddriver.yml
+++ b/config/clouddriver.yml
@@ -33,6 +33,16 @@ aws:
   # See providers.aws.primaryCredentials in spinnaker.yml for more
   # info on setting environment variables.
 
+azure:
+  enabled: ${providers.azure.enabled:false}
+
+  accounts:
+    - name: ${providers.azure.primaryCredentials.name}
+      clientId: ${providers.azure.primaryCredentials.clientId}
+      appKey: ${providers.azure.primaryCredentials.appKey}
+      tenantId: ${providers.azure.primaryCredentials.tenantId}
+      subscriptionId: ${providers.azure.primaryCredentials.subscriptionId}
+
 google:
   enabled: ${providers.google.enabled:false}
 
@@ -69,5 +79,5 @@ dockerRegistry:
         - ${providers.dockerRegistry.primaryCredentials.repository}
 
 credentials:
-  primaryAccountTypes: ${providers.aws.primaryCredentials.name}, ${providers.google.primaryCredentials.name}, ${providers.cf.primaryCredentials.name}
-  challengeDestructiveActionsEnvironments: ${providers.aws.primaryCredentials.name}, ${providers.google.primaryCredentials.name}, ${providers.cf.primaryCredentials.name}
+  primaryAccountTypes: ${providers.aws.primaryCredentials.name}, ${providers.google.primaryCredentials.name}, ${providers.cf.primaryCredentials.name}, ${providers.azure.primaryCredentials.name}
+  challengeDestructiveActionsEnvironments: ${providers.aws.primaryCredentials.name}, ${providers.google.primaryCredentials.name}, ${providers.cf.primaryCredentials.name}, ${providers.azure.primaryCredentials.name}

--- a/config/default-spinnaker-local.yml
+++ b/config/default-spinnaker-local.yml
@@ -15,6 +15,19 @@ providers:
       # Store actual credentials in $HOME/.aws/credentials. See spinnaker.yml for
       # more information, including alternatives.
 
+  azure:
+    # If you want to deploy some services to Microsoft Azure (azure),
+    # set enabled and provide primary credentials for deploying.
+    # Enabling azure is independent of other providers.
+    enabled: ${SPINNAKER_AZURE_ENABLED:false}
+    defaultRegion: ${SPINNAKER_AZURE_DEFAULT_REGION}
+    primaryCredentials:
+      name: my-azure-account
+      clientId:
+      appKey:
+      tenantId:
+      subscriptionId:
+    # To set azure credentials, enter values in spinnaker-local.yml 
   google:
     # If you want to deploy some services to Google Cloud Platform (google),
     # set enabled and provide primary credentials for deploying.

--- a/config/spinnaker.yml
+++ b/config/spinnaker.yml
@@ -212,9 +212,14 @@ providers:
     # set enabled and provide primary credentials for deploying.
     # Enabling azure is independent of other providers.
     enabled: false
-    defaultRegion: West US
+    defaultRegion: westus
     primaryCredentials:
       name: my-azure-account
+      clientId:
+      appKey:
+      tenantId:
+      subscriptionId:
+    # To set azure credentials, enter values for: clientId, appKey, tenantId, subscriptionId.  See spinnaker documentation - cloud provider setup for instructions on how to retrieve these values.
   titan:
     # If you want to deploy some services to titan,
     # set enabled and provide primary credentials for deploying.

--- a/etc/default/spinnaker
+++ b/etc/default/spinnaker
@@ -18,3 +18,10 @@ SPINNAKER_GOOGLE_DEFAULT_REGION=us-central1
 # Default zone you desire to operate in
 SPINNAKER_GOOGLE_DEFAULT_ZONE=us-central1-f
 
+## Azure
+
+# If you plan on using Azure set this to true
+SPINNAKER_AZURE_ENABLED=false
+# Default region you desire to operate in
+SPINNAKER_AZURE_DEFAULT_REGION=westus
+


### PR DESCRIPTION
submitting configuration file portion for getting Azure into InstallSpinnaker.sh. We are planning to move credentials into file based credentials similar to google approach in near future but for now will set in yaml.