### PR TITLE
Adds script for configuring nested igor properties for codelab.

### DIFF
--- a/pylib/spinnaker/codelab_config.py
+++ b/pylib/spinnaker/codelab_config.py
@@ -1,0 +1,39 @@
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from spinnaker.yaml_util import YamlBindings
+
+def configure_codelab_igor_jenkins():
+  """Configures Igor to be enabled and to point to the codelab jenkins instance.
+
+  """
+  YamlBindings.update_yml_source(
+    '/opt/spinnaker/config/spinnaker-local.yml',
+    {
+      'jenkins': {
+        'defaultMaster': {
+          'name': 'CodelabJenkins',
+          'baseUrl': 'http://localhost:9090',
+          'name': 'admin',
+          'password': 'admin'
+        }
+      },
+      'igor': {
+        'enabled': 'true'
+      }
+    }
+  )
+
+if __name__ == '__main__':
+  configure_codelab_igor_jenkins()

--- a/unittest/yaml_util_test.py
+++ b/unittest/yaml_util_test.py
@@ -249,7 +249,7 @@ unique:
 
      self.assertEqual(expect, bindings.transform_yaml_source(expect, 'bogus'))
      self.assertEqual(expect, got)
-                      
+
 
   def test_transform_fail(self):
      bindings = YamlBindings()
@@ -278,6 +278,49 @@ a:
      self.assertEqual([{'elem': True}, {'elem': True}, {'elem': False}, {'elem': False}],
                       bindings.get('root'))
      self.assertEqual(bindings.get('root'), bindings.get('copy'))
+
+  def test_update_yml_source(self):
+    yaml = """
+a: A
+b: 0
+c:
+  - A
+  - B
+d:
+  child:
+    grandchild: x
+e:
+"""
+    fd, temp_path = tempfile.mkstemp()
+    os.write(fd, yaml)
+    os.close(fd)
+
+    update_dict = {
+      'b': 'Z',
+      'd': {
+        'child': {
+          'grandchild': 'xy'
+        }
+      },
+      'e': 'AA'
+    }
+
+    expect = {'a': 'A',
+              'b': 'Z',
+              'c': ['A','B'],
+              'd': {
+                'child': {
+                  'grandchild': 'xy'
+                }
+              },
+              'e': 'AA'}
+
+    YamlBindings.update_yml_source(temp_path, update_dict)
+
+    comparison_bindings = YamlBindings()
+    comparison_bindings.import_path(temp_path)
+    self.assertEqual(expect, comparison_bindings.map)
+    os.remove(temp_path)
 
 if __name__ == '__main__':
   loader = unittest.TestLoader()


### PR DESCRIPTION
Adds script for configuring nested igor properties for codelab. @ewiseblatt PTAL. The full codelab provision script needs to run this script remotely (i.e. curl it from github). Hence I am committing this first and the full script will follow after testing.