### PR TITLE
update document for deploying on mac os

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -55,6 +55,7 @@ brew cask install java
 cd $SPINNAKER_HOME
 mkdir build
 cd build
+mkdir deck
 ../spinnaker/dev/refresh_source.sh --pull_origin --use_ssh --github_user default
 ----
 


### PR DESCRIPTION
in dev/dev_runner.py:276:
``` python
  if not os.path.exists('deck'):
     sys.stderr.write('This script needs to be run from the root of'
                      ' your build directory.\n')
     sys.exit(-1)
```
the script checks the existence of deck folder, but README doesn't tell me to create that folder