### PR TITLE
cassandra.enabled: true (by default)

### DIFF
--- a/config/front50.yml
+++ b/config/front50.yml
@@ -3,6 +3,7 @@ server:
   address: ${services.front50.host:localhost}
 
 cassandra:
+  enabled: ${services.cassandra.enabled:true}
   embedded: ${services.cassandra.embedded:false}
   host: ${services.cassandra.host:localhost}
 

--- a/config/spinnaker.yml
+++ b/config/spinnaker.yml
@@ -167,6 +167,7 @@ services:
     connection: redis://${services.redis.host}:${services.redis.port}
 
   cassandra:
+    enabled: true
     host: ${services.default.host}
     port: 9042
     embedded: false


### PR DESCRIPTION
The default value for `cassandra.enabled` (in Front50) was changed from `true` to `false`.

I believe that `false` is the correct code-level default but that yml configuration should be explicitly enabled.

PTAL @jtk54 

Relates to spinnaker/front50#92
