### PR TITLE
docker & kubernetes: Update install scripts & config locations

### DIFF
--- a/config/clouddriver.yml
+++ b/config/clouddriver.yml
@@ -71,6 +71,8 @@ dockerRegistry:
   accounts:
     - name: ${providers.dockerRegistry.primaryCredentials.name}
       address: ${providers.dockerRegistry.primaryCredentials.address}
+      username: ${providers.dockerRegistry.primaryCredentials.username}
+      passwordFile: ${providers.dockerRegistry.primaryCredentials.passwordFile}
       repositories: 
         - ${providers.dockerRegistry.primaryCredentials.repository}
 

--- a/config/default-spinnaker-local.yml
+++ b/config/default-spinnaker-local.yml
@@ -96,12 +96,11 @@ providers:
       # These credentials use authentication information at ~/.kube/config
       # by default.
       name: my-kubernetes-account
-      namespace: default
       dockerRegistryAccount: ${providers.dockerRegistry.primaryCredentials.name}
 
   dockerRegistry:
-    # If you want to deploy containers to a container management solution,
-    # you must specifiy where these container images exist first.
+    # For more information on configuring Docker registries, see
+    # http://www.spinnaker.io/v1.0/docs/target-deployment-configuration#section-docker-registry
 
     # NOTE: Enabling dockerRegistry is independent of other providers.
     # However, for convienience, we tie docker and kubernetes together
@@ -110,9 +109,12 @@ providers:
     enabled: ${SPINNAKER_KUBERNETES_ENABLED:false}
 
     primaryCredentials:
-      name: my-docker-registry-account
-      address: https://index.docker.io/
-      repository: library/nginx
+      name: my-docker-registry
+      address: ${SPINNAKER_DOCKER_REGISTRY:https://index.docker.io/}
+      repository: ${SPINNAKER_DOCKER_REPOSITORY:library/nginx}
+      username: ${SPINNAKER_DOCKER_USERNAME}
+      # A path to a plain text file containing the user's password
+      passwordFile: ${SPINNAKER_DOCKER_PASSWORD_FILE} 
 
 services:
   default:

--- a/config/igor.yml
+++ b/config/igor.yml
@@ -18,6 +18,9 @@ travis:
       address: ${services.travis.defaultMaster.address}
       githubToken: ${services.travis.defaultMaster.githubToken}
 
+dockerRegistry:
+  enabled: ${SPINNAKER_KUBERNETES_ENABLED:false}
+
 redis:
   connection: ${services.redis.connection:redis://localhost:6379}
 


### PR DESCRIPTION
@duftler @ewiseblatt PTAL

If the user provides the contents of a service account json file for the GCP project containing their registry, and the name of a repository in that registry, the values

`SPINNAKER_DOCKER_REPOSITORY`
`SPINNAKER_DOCKER_REGISTRY`
`SPINNAKER_DOCKER_USERNAME`
`SPINNAKER_DOCKER_PASSWORD_FILE`

will be populated with the correct values to be loaded by `spinnaker-local.yml` for configuring GCR with Kubernetes.