### PR TITLE
Use noninteractive when performing dist-upgrade on startup.

### DIFF
--- a/dev/build_google_image.packer
+++ b/dev/build_google_image.packer
@@ -44,7 +44,7 @@
     "type": "shell",
     "inline": [
         "dpkg --list | grep linux-image | awk '{ print $2 }' | sort -V | sed -n '/'`uname -r`'/q;p' | xargs sudo apt-get -y purge",
-        "if [ '{{user `update_os`}}' = 'true' ]; then apt-get update -y; apt-get -y dist-upgrade; sed -i 's/start_rpc: false/start_rpc: true/' /etc/cassandra/cassandra.yaml; fi",
+        "if [ '{{user `update_os`}}' = 'true' ]; then apt-get update -y; DEBIAN_FRONTEND=noninteractive apt-get -y dist-upgrade; sed -i 's/start_rpc: false/start_rpc: true/' /etc/cassandra/cassandra.yaml; fi",
         "apt-get autoremove -y"
      ]
   }

--- a/install/first_google_boot.sh
+++ b/install/first_google_boot.sh
@@ -320,7 +320,7 @@ fi
 
 apt-mark hold $SPINNAKER_SUBSYSTEMS
 apt-get -y update
-apt-get -y dist-upgrade
+DEBIAN_FRONTEND=noninteractive apt-get -y dist-upgrade
 apt-mark unhold $SPINNAKER_SUBSYSTEMS
 sed -i "s/start_rpc: false/start_rpc: true/" /etc/cassandra/cassandra.yaml
 while ! $(nodetool enablethrift >& /dev/null); do


### PR DESCRIPTION
We encountered a package that was prompting for user input on upgrade.