### PR TITLE
deploy/kubernetes: Avoid recreating failed pods

### DIFF
--- a/experimental/kubernetes/jobs/data-cassandra-keys.yaml
+++ b/experimental/kubernetes/jobs/data-cassandra-keys.yaml
@@ -16,4 +16,4 @@ spec:
       containers:
       - name: cassandra-keys
         image: gcr.io/kubernetes-spinnaker/cassandra-keys:v2
-      restartPolicy: Never
+      restartPolicy: OnFailure


### PR DESCRIPTION
@duftler FYI
See more details on [`restartPolicy](http://kubernetes.io/docs/user-guide/jobs/#handling-pod-and-container-failures).