### PR TITLE
notifications: spinnaker.baseUrl should default to services.deck.base…

### DIFF
--- a/config/echo.yml
+++ b/config/echo.yml
@@ -6,6 +6,9 @@ cassandra:
   embedded: ${services.cassandra.embedded:false}
   host: ${services.cassandra.host:localhost}
 
+spinnaker:
+  baseUrl: ${services.deck.baseUrl}
+
 front50:
   baseUrl: ${services.front50.baseUrl:http://localhost:8080}
 


### PR DESCRIPTION
Echo relies on this url when constructing links to send in notifications.