### PR TITLE
Support external storage bucket configuration from spinnaker-local.yml

### DIFF
--- a/config/default-spinnaker-local.yml
+++ b/config/default-spinnaker-local.yml
@@ -213,6 +213,21 @@ services:
     # They typically live in rosco's config/packer directory.
     configDir: /opt/rosco/config/packer
 
+  front50:
+    cassandra:
+      enabled: true
+    redis:
+      enabled: false
+
+    # To use a cloud storage bucket on Amazon S3 or Google Cloud Storage instead
+    # of cassandra, set the storage_bucket, disable cassandra, and enable one of
+    # the service providers.
+    storage_bucket:
+    gcs:
+      enabled: false
+    s3:
+      enabled: false
+
   echo:
     cron:
       # Allow pipeline triggers to run periodically via cron expressions.

--- a/config/front50.yml
+++ b/config/front50.yml
@@ -13,9 +13,24 @@ aws:
 
 spinnaker:
   cassandra:
-    enabled: true
+    enabled: ${services.front50.cassandra.enabled:true}
     host: ${services.cassandra.host:localhost}
     port: ${services.cassandra.port:9042}
     cluster: ${services.cassandra.cluster:CASS_SPINNAKER}
     keyspace: front50
     name: global
+
+  redis:
+    enabled: ${services.front50.redis.enabled:false}
+
+  gcs:
+    enabled: ${services.front50.gcs.enabled:false}
+    bucket: ${services.front50.storage_bucket:}
+    rootFolder: ${services.front50.bucket_root:front50}
+    project: ${providers.google.primaryCredentials.project}
+    jsonPath: ${providers.google.primaryCredentials.jsonPath}
+
+  aws:
+    enabled: ${services.front50.s3.enabled:false}
+    bucket: ${services.front50.storage_bucket:}
+    rootFolder: ${services.front50.bucket_root:front50}

--- a/config/spinnaker.yml
+++ b/config/spinnaker.yml
@@ -84,6 +84,20 @@ services:
     port: 8080
     baseUrl: ${services.default.protocol}://${services.front50.host}:${services.front50.port}
 
+    # If using storage bucket persistence (gcs or s3), specify the bucket here
+    # disable cassandra and enable the storage service below.
+    storage_bucket:
+    bucket_root: front50
+
+    cassandra:
+      enabled: true
+    redis:
+      enabled: false
+    gcs:
+      enabled: false
+    s3:
+      enabled: false
+
   gate:
     host: ${services.default.host}
     port: 8084


### PR DESCRIPTION
@ajordens I'm sharing the config attributes for S3 and Google Cloud Storage and just having different enable flags. Front50 still uses explicit attributes for each of the services. Since they are disjoint, I thought you didnt need the different config parameters in spinnaker-local so thought this might make sense. Feel free to object.