### PR TITLE
Make it possible to shut off cassandra.

### DIFF
--- a/config/default-spinnaker-local.yml
+++ b/config/default-spinnaker-local.yml
@@ -222,13 +222,19 @@ services:
     # To use a cloud storage bucket on Amazon S3 or Google Cloud Storage instead
     # of cassandra, set the storage_bucket, disable cassandra, and enable one of
     # the service providers.
-    storage_bucket:
+    storage_bucket: ${SPINNAKER_DEFAULT_STORAGE_BUCKET:}
     gcs:
       enabled: false
     s3:
       enabled: false
 
   echo:
+    # Persistence mechanism to use
+    cassandra:
+      enabled: true
+    inMemory:
+      enabled: false
+
     cron:
       # Allow pipeline triggers to run periodically via cron expressions.
       enabled: true

--- a/config/echo.yml
+++ b/config/echo.yml
@@ -3,11 +3,16 @@ server:
   address: ${services.echo.host:localhost}
 
 cassandra:
+  enabled: ${services.echo.cassandra.enabled:true}
   embedded: ${services.cassandra.embedded:false}
   host: ${services.cassandra.host:localhost}
 
 spinnaker:
   baseUrl: ${services.deck.baseUrl}
+  cassandra:
+     enabled: ${services.echo.cassandra.enabled:true}
+  inMemory:
+     enabled: ${services.echo.inMemory.enabled:false}
 
 front50:
   baseUrl: ${services.front50.baseUrl:http://localhost:8080}

--- a/config/front50.yml
+++ b/config/front50.yml
@@ -3,7 +3,7 @@ server:
   address: ${services.front50.host:localhost}
 
 cassandra:
-  enabled: ${services.cassandra.enabled:true}
+  enabled: ${services.front50.cassandra.enabled:true}
   embedded: ${services.cassandra.embedded:false}
   host: ${services.cassandra.host:localhost}
 

--- a/config/spinnaker.yml
+++ b/config/spinnaker.yml
@@ -40,6 +40,13 @@ services:
     host: ${services.default.host}
     port: 8089
     baseUrl: ${services.default.protocol}://${services.echo.host}:${services.echo.port}
+
+    # Persistence mechanism to use
+    cassandra:
+      enabled: true
+    inMemory:
+      enabled: false
+
     cron:
       # Allow pipeline triggers to run periodically via cron expressions.
       enabled: true
@@ -176,7 +183,10 @@ services:
     connection: redis://${services.redis.host}:${services.redis.port}
 
   cassandra:
-    enabled: true
+    # cassandra.enabled is no longer used
+    # cassandra is enabled or disabled on a per-service basis
+    # where the alternative persistence mechanism for that service
+    # can be enabled.
     host: ${services.default.host}
     port: 9042
     embedded: false


### PR DESCRIPTION
@duftler These changes should allow you to manually configure out spinnaker with standard configs and have things run

@lwander When you add redis to echo, you need to add similar enabled entries for the forthcoming scripts to allow you to chose that, at least for the time being.