### PR TITLE
Moved keyspace creation into install script.

### DIFF
--- a/InstallSpinnaker.sh
+++ b/InstallSpinnaker.sh
@@ -680,6 +680,8 @@ install_spinnaker
 
 # Touch a file to tell other scripts we installed Cassandra.
 touch /opt/spinnaker/cassandra/SPINNAKER_INSTALLED_CASSANDRA
+cqlsh -f "/opt/spinnaker/cassandra/create_echo_keyspace.cql"
+cqlsh -f "/opt/spinnaker/cassandra/create_front50_keyspace.cql"
 
 # Write values to /etc/default/spinnaker.
 if [[ $AWS_ENABLED || $AZURE_ENABLED || $GOOGLE_ENABLED ]] ; then

--- a/pkg_scripts/postInstall.sh
+++ b/pkg_scripts/postInstall.sh
@@ -22,13 +22,6 @@ fi
 /usr/sbin/a2enmod proxy_http
 service apache2 restart
 
-# Install cassandra keyspaces if we installed Cassandra
-if [ -f /opt/spinnaker/cassandra/SPINNAKER_INSTALLED_CASSANDRA ]; then
-  cqlsh -f "/opt/spinnaker/cassandra/create_echo_keyspace.cql"
-  cqlsh -f "/opt/spinnaker/cassandra/create_front50_keyspace.cql"
-fi
-
-
 # Disable auto upstart of the services.
 # We'll have spinnaker auto start, and start them as it does.
 for s in clouddriver orca front50 rosco echo gate igor; do


### PR DESCRIPTION
We should create keyspaces only if we install Cassandra, and because we only install Cassandra in InstallSpinnaker, we can move the keyspace creation. There is no guarantee that postInstall will run after InstallSpinnaker. @lwander PTAL, @ewiseblatt @danielpeach FYI.