### PR TITLE
provider/consul: Start creating consul install path

### DIFF
--- a/consul/install/install.sh
+++ b/consul/install/install.sh
@@ -1,0 +1,14 @@
+#! /bin/bash
+
+CONSUL_VERSION=0.6.4
+CONSUL_ARCH=linux_amd64
+
+wget https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_${CONSUL_ARCH}.zip
+
+apt-get update
+apt-get install unzip
+
+unzip consul_${CONSUL_VERSION}_${CONSUL_ARCH}.zip
+rm consul_${CONSUL_VERSION}_${CONSUL_ARCH}.zip
+
+mv consul /usr/bin


### PR DESCRIPTION
The idea is that this is run once to create a base VM image with consul installed. Since it's not in any apt repository (AFAIK), this is the easiest install path.

@duftler  PTAL