### PR TITLE
Fix wrong(?) key name on default front50.yml file

### DIFF
--- a/config/front50.yml
+++ b/config/front50.yml
@@ -32,7 +32,7 @@ spinnaker:
     project: ${providers.google.primaryCredentials.project}
     jsonPath: ${providers.google.primaryCredentials.jsonPath}
 
-  aws:
+  s3:
     enabled: ${services.front50.s3.enabled:false}
     bucket: ${services.front50.storage_bucket:}
     rootFolder: ${services.front50.bucket_root:front50}


### PR DESCRIPTION
Hi, I come with this and took few hours debugging how to have `front50` backed with `s3` as storage persistence layer.

Looks like the latest AMI for the regions `eu-west-1` have a wrong key name on the default `front50.yml` file.

After this change I got `spinnaker` working and configured just in one place: `spinnaker-local.yml`

Is that right?

btw, great project! 👍 