### PR TITLE
(front50) Added default hystrix timeout

### DIFF
--- a/config/front50.yml
+++ b/config/front50.yml
@@ -2,6 +2,10 @@ server:
   port: ${services.front50.port:8080}
   address: ${services.front50.host:localhost}
 
+hystrix:
+  command:
+    default.execution.isolation.thread.timeoutInMilliseconds: 15000
+
 cassandra:
   enabled: ${services.front50.cassandra.enabled:true}
   embedded: ${services.cassandra.embedded:false}


### PR DESCRIPTION
Latest `front50` has introduced hystrix around one of the S3 operations ... this PR increases the default timeout from 1s to 15s.
