### PR TITLE
fix a bug with upstart where override files are overwritten, these fi…

### DIFF
--- a/pkg_scripts/postInstall.sh
+++ b/pkg_scripts/postInstall.sh
@@ -25,5 +25,7 @@ service apache2 restart
 # Disable auto upstart of the services.
 # We'll have spinnaker auto start, and start them as it does.
 for s in clouddriver orca front50 rosco echo gate igor; do
-    echo manual | sudo tee /etc/init/$s.override
+    if [ ! -e /etc/init/$s.override ]; then
+        echo -e "limit nofile 32768 32768\nmanual" | sudo tee /etc/init/$s.override;
+    fi
 done


### PR DESCRIPTION
…les should be sticky and not be overwritten once created. Add sane defaults for open file descriptors. For the recommended instance types, this is a better default. igor coughs out errors about open file descriptors with the upstart defaults. Our spinnaker instance is only 10 applications, so afaict others get this error too