### PR TITLE
Fixed postInstall

### DIFF
--- a/install/first_google_boot.sh
+++ b/install/first_google_boot.sh
@@ -302,7 +302,7 @@ process_args
 # therefore we do not want it to become available until we've done so.
 # Otherwise it would be running with the wrong (old/default) configuration.
 echo "Stopping spinnaker while we configure it."
-stop spinnaker
+stop spinnaker || true
 
 echo "$STATUS_PREFIX  Configuring Default Values"
 write_default_value "SPINNAKER_GOOGLE_ENABLED" "true"

--- a/pkg_scripts/postInstall.sh
+++ b/pkg_scripts/postInstall.sh
@@ -26,6 +26,6 @@ service apache2 restart
 # We'll have spinnaker auto start, and start them as it does.
 for s in clouddriver orca front50 rosco echo gate igor; do
     if [ ! -e /etc/init/$s.override ]; then
-        echo -e "limit nofile 32768 32768\nmanual" | sudo tee /etc/init/$s.override;
+        /bin/echo -e "limit nofile 32768 32768\nmanual" | sudo tee /etc/init/$s.override;
     fi
 done


### PR DESCRIPTION
@duftler 
postInstall is running in bourne shell, with built-in echo that doesnt support -e.
This was causing the config files to be malformed (containing -e) and preventing spinnaker
from running via upstart.

Also make first_google_boot resilient for configuring in the case when spinnaker could not start.