### PR TITLE
(gcr) adjust search for gcr email to work on GCE VMs

### DIFF
--- a/install/first_google_boot.sh
+++ b/install/first_google_boot.sh
@@ -267,7 +267,9 @@ function extract_spinnaker_gcr_credentials() {
     echo "GCR enabled"
 
     if [ -z "$gcr_account" ]; then
-      gcr_account=$(gcloud iam service-accounts list --filter="displayName:'Compute Engine default service account'" --format="value(email)")
+      # the @developer address is reserved for the project's special service
+      # compute engine default service account.
+      gcr_account=$(gcloud iam service-accounts list --format='value(email)' | grep developer -m 1)
       clear_instance_metadata "gcr_account"
     fi
 


### PR DESCRIPTION
getopts on the GCE vms parses `"` as a token, rather than the start/end of a string causing the filter command to gcloud to fail. This is a workaround. @ewiseblatt @jtk54 PTAL