### PR TITLE
Add environment variable references to spinnaker.yml

### DIFF
--- a/config/default-spinnaker-local.yml
+++ b/config/default-spinnaker-local.yml
@@ -281,15 +281,3 @@ services:
         enabled: false
         token: # the API token for the bot
         botName: # the username of the bot
-
-spectator:
-  applicationName: ${spring.application.name}
-  endpoint:
-    enabled: false
-    prototypeFilter:
-      path:
- 
-  stackdriver:
-    projectName: ${providers.google.primaryCredentials.project}
-    credentialsPath: ${providers.google.primaryCredentials.jsonPath}
-    enabled: false

--- a/config/spinnaker.yml
+++ b/config/spinnaker.yml
@@ -231,9 +231,10 @@ providers:
     # For more information on configuring Amazon Web Services (aws), see
     # http://www.spinnaker.io/v1.0/docs/target-deployment-setup#section-amazon-web-services-setup
 
-    enabled: false
+    enabled: ${SPINNAKER_AWS_ENABLED:false}
     simpleDBEnabled: false
-    defaultRegion: us-east-1
+    defaultRegion: ${SPINNAKER_AWS_DEFAULT_REGION:us-west-2}
+    defaultIAMRole: BaseIAMRole
     defaultSimpleDBDomain: CLOUD_APPLICATIONS
     primaryCredentials:
       name: default
@@ -251,18 +252,19 @@ providers:
     # For more information on configuring Google Cloud Platform (google), see
     # http://www.spinnaker.io/v1.0/docs/target-deployment-setup#section-google-cloud-platform-setup
 
-    enabled: false
-    defaultRegion: us-central1
-    defaultZone: us-central1-f
+    enabled: ${SPINNAKER_GOOGLE_ENABLED:false}
+    defaultRegion: ${SPINNAKER_GOOGLE_DEFAULT_REGION:us-central1}
+    defaultZone: ${SPINNAKER_GOOGLE_DEFAULT_ZONE:us-central1-f}
+
     primaryCredentials:
       name: my-account-name
       # The project is the Google Project ID for the project to manage with
       # Spinnaker. The jsonPath is a path to the JSON service credentials
       # downloaded from the Google Developer's Console.
-      project:
-      jsonPath:
+      project: ${SPINNAKER_GOOGLE_PROJECT_ID:}
+      jsonPath: ${SPINNAKER_GOOGLE_PROJECT_CREDENTIALS_PATH:}
       consul:
-        enabled: false
+        enabled: ${SPINNAKER_GOOGLE_CONSUL_ENABLED:false}
 
   cf:
     # For more information on configuring Cloud Foundry (cf) support, see
@@ -281,8 +283,8 @@ providers:
     # For more information on configuring Microsoft Azure (azure), see
     # http://www.spinnaker.io/v1.0/docs/target-deployment-setup#section-azure-cloud-platform-setup
 
-    enabled: false
-    defaultRegion: westus
+    enabled: ${SPINNAKER_AZURE_ENABLED:false}
+    defaultRegion: ${SPINNAKER_AZURE_DEFAULT_REGION:westus}
     primaryCredentials:
       name: my-azure-account
 
@@ -307,7 +309,7 @@ providers:
     # http://www.spinnaker.io/v1.0/docs/target-deployment-setup#section-kubernetes-cluster-setup
 
     # NOTE: enabling kubernetes also requires enabling dockerRegistry.
-    enabled: false
+    enabled: ${SPINNAKER_KUBERNETES_ENABLED:false}
     primaryCredentials:
       name: my-kubernetes-account
       namespace: default
@@ -316,11 +318,15 @@ providers:
   dockerRegistry:
     # If you want to use a container based provider, you need to configure and
     # enable this provider to cache images.
-    enabled: false
+    enabled: ${SPINNAKER_KUBERNETES_ENABLED:false}
+
     primaryCredentials:
       name: my-docker-registry-account
-      address: https://index.docker.io/
-      repository: library/nginx
+      address: ${SPINNAKER_DOCKER_REGISTRY:https://index.docker.io/}
+      repository: ${SPINNAKER_DOCKER_REPOSITORY:library/nginx}
+      username: ${SPINNAKER_DOCKER_USERNAME}
+      # A path to a plain text file containing the user's password
+      passwordFile: ${SPINNAKER_DOCKER_PASSWORD_FILE}
 
 openstack:
     # This default configuration uses the same environment variable names set in
@@ -339,13 +345,13 @@ openstack:
       insecure: false
 
 spectator:
+  applicationName: ${spring.application.name}
   webEndpoint:
     enabled: false
     prototypeFilter:
       path:
 
   stackdriver:
-    projectName: ${providers.google.primaryCredentials.project}
-    credentialsPath: ${providers.google.primaryCredentials.jsonPath}
-    defaultRegistry: false
-    enabled: false
+    enabled: ${SPINNAKER_STACKDRIVER_ENABLED:false}
+    projectName: ${SPINNAKER_STACKDRIVER_PROJECT_NAME:${providers.google.primaryCredentials.project}}
+    credentialsPath: ${SPINNAKER_STACKDRIVER_CREDENTIALS_PATH:${providers.google.primaryCredentials.jsonPath}}

--- a/install/first_google_boot.sh
+++ b/install/first_google_boot.sh
@@ -150,6 +150,7 @@ function extract_spinnaker_google_credentials() {
     else
        rm $json_path
     fi
+    write_default_value "SPINNAKER_GOOGLE_PROJECT_CREDENTIALS_PATH" "$json_path"
   else
     clear_instance_metadata "managed_project_credentials"
     json_path=""
@@ -319,8 +320,7 @@ process_args
 echo "Stopping spinnaker while we configure it."
 stop spinnaker || true
 
-# Update gcloud to chosen version, piping stdout to /dev/null since it's noisy
-echo y | gcloud components update --version $GCLOUD_VERSION > /dev/null 
+gcloud -q components update --version $GCLOUD_VERSION --no-user-output-enabled
 
 echo "$STATUS_PREFIX  Configuring Default Values"
 write_default_value "SPINNAKER_GOOGLE_ENABLED" "true"
@@ -329,6 +329,11 @@ write_default_value "SPINNAKER_GOOGLE_DEFAULT_ZONE" "$MY_ZONE"
 write_default_value "SPINNAKER_GOOGLE_DEFAULT_REGION" "${MY_ZONE%-*}"
 write_default_value "SPINNAKER_DEFAULT_STORAGE_BUCKET" "spinnaker-${MY_PROJECT}"
 write_default_value "SPINNAKER_GOOGLE_CONSUL_ENABLED" "false"
+
+# Use local project for stackdriver credentials, not the managed one.
+write_default_value "SPINNAKER_STACKDRIVER_PROJECT_NAME" "${MY_PROJECT}"
+write_default_value "SPINNAKER_STACKDRIVER_CREDENTIALS_PATH" ""
+
 echo "$STATUS_PREFIX  Extracting Configuration Info"
 extract_spinnaker_local_yaml
 


### PR DESCRIPTION
@lwander can you test this against kubernetes? I forgot to do that and woudnt hurt for an independent test.

@danielpeach 

I'm pretty sure this fixes the breakage. 

This is a pretty big PR for a conceptually small fix because I tried to be comprehensive and fix the issue on multiple levels. There are many different deployment scenarios.

default-spinnaker-local added a number of environment variables for provider configuration.
These are set in /etc/default/spinnaker. When we dont use a spinnaker-local, these dont get
picked up (from spinnaker.yml) so are ignored. Here we introduce the default environment
variable bindings in the spinnaker.yml itself.

I write out some other variables, like the json path that was written.
I threw in some additional stackdriver changes while here. These arent used yet, but will likely be tomorrow.
