### PR TITLE
Edited references to $HOME/.spinnaker

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -77,16 +77,23 @@ so is performed here.
 
 == Configure Spinnaker
 
-We will create a directory for Spinnaker configuration overrides, copy the
-default configuration template there, and edit to select the appropriate cloud
-provider(s).
+We will create a directory for Spinnaker configuration overrides and
+create an override to select the appropriate cloud provider(s).
 
 [source,bash]
 ----
 cd $SPINNAKER_HOME
 mkdir -p $HOME/.spinnaker
-cp spinnaker/config/default-spinnaker-local.yml $HOME/.spinnaker/spinnaker-local.yml
+touch $HOME/.spinnaker/spinnaker-local.yml
 chmod 600 $HOME/.spinnaker/spinnaker-local.yml
+
+# Ideally you only need to add the properties you want to override.
+# However if you are not comfortable editing yml, you can copy the
+# entire file. The difference is that you may be overriding future
+# changes to default values that you otherwise would not care about.
+cp spinnaker/config/spinnaker.yml $HOME/spinnaker/spinnaker-local.yml
+
+$EDITOR $HOME/.emacs/spinnaker-local.yml
 ----
 
 If you are deployed onto a supported cloud provider (e.g., AWS or Google) and

--- a/config/default-spinnaker-local.yml
+++ b/config/default-spinnaker-local.yml
@@ -3,7 +3,13 @@
 # configuration parameters to be changed.
 #
 # In order for Spinnaker to discover it, it must be copied to a file named
-# "spinnaker-local.yml" and placed in the $HOME/.spinnaker directory.
+# "spinnaker-local.yml" and placed in /opt/spinnaker/config
+# (or when running from source code, in the $HOME/.spinnaker directory.)
+#
+# A better practice could be to create the spinnaker-local.yml file by
+# hand with only the particular attributes that you want to override
+# and use the spinnaker.yml file as your guide since it is spinnaker.yml
+# that we are overriding here in the first place.
 
 global:
   spinnaker:

--- a/dev/dev_runner.py
+++ b/dev/dev_runner.py
@@ -95,7 +95,7 @@ class DevInstallationParameters(InstallationParameters):
   out of this repository rather than a standard system installation.
 
   Also, custom configuration parameters come from the $HOME/.spinnaker
-  rather than the normal installation location.
+  rather than the normal installation location of /opt/spinnaker/config.
   """
   DEV_SCRIPT_DIR = os.path.abspath(os.path.dirname(__file__))
   SUBSYSTEM_ROOT_DIR = os.getcwd()

--- a/google/README.txt
+++ b/google/README.txt
@@ -66,7 +66,7 @@ To stop spinnaker in a development environment:
 
 
 To reconfigure spinnaker in a development environment:
-   (1) Edit the $HOME/.spinnaker/spinnaker_config.cfg file
+   (1) Edit the $HOME/.spinnaker/spinnaker-local.yml file
    (2) ../spinnaker/google/dev/stop_dev.sh
    (3) ../spinnaker/google/dev/run_dev.sh
       The environment is always reconfigured within run_dev.sh.


### PR DESCRIPTION
@ttomsu 
I went on a hunt to erradicate $HOME/.spinnaker/spinnaker-local references from production deployments but turned up empty handed. There are a few references not visible in this PR but they are strictly and explicitly when running from source, and that is still intentional.

These are other related cleanups I made during that expedition.

- eric