### PR TITLE
adds confdef/confold flags to dist-upgrade

### DIFF
--- a/install/first_google_boot.sh
+++ b/install/first_google_boot.sh
@@ -417,10 +417,10 @@ fi
 # This can take several minutes so we are performing it at the end after
 # spinnaker has already started and is available.
 
-export DEBIAN_FRONTEND=noninteractive
 apt-mark hold $SPINNAKER_SUBSYSTEMS
 apt-get -y update
 apt-get -y dist-upgrade
+DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y dist-upgrade
 apt-mark unhold $SPINNAKER_SUBSYSTEMS
 
 if [[ -f /opt/spinnaker/cassandra/SPINNAKER_INSTALLED_CASSANDRA ]]; then


### PR DESCRIPTION
@duftler @ewiseblatt 
Per http://askubuntu.com/questions/104899/make-apt-get-or-aptitude-run-with-y-but-not-prompt-for-replacement-of-configu it seems we need to force the update while leaving conf files as is. We've also filed a bug with Canonical, and our upcoming change to our guest daemon should address this more long-term. In the meanwhile adding these flags only helps.