### PR TITLE
(google) first boot & codelab image installs apt fix

### DIFF
--- a/google/codelab/provision_spinnaker_codelab_image.sh
+++ b/google/codelab/provision_spinnaker_codelab_image.sh
@@ -35,9 +35,14 @@ service apache2 stop
 
 set -e
 
+# this allows us to skip any interactive post-install configuration,
+# specifically around keeping defaults for files that were modified.
+export DEBIAN_FRONTEND=noninteractive
+
 # update apt
 apt-get update
-apt-get -y upgrade
+# temporary workaround for where DEBIAN_FRONTEND=noninteractive isn't enough
+apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y upgrade
 
 # acquire and configure jenkins
 apt-get install -y git

--- a/install/first_google_boot.sh
+++ b/install/first_google_boot.sh
@@ -419,7 +419,6 @@ fi
 
 apt-mark hold $SPINNAKER_SUBSYSTEMS
 apt-get -y update
-apt-get -y dist-upgrade
 DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y dist-upgrade
 apt-mark unhold $SPINNAKER_SUBSYSTEMS
 


### PR DESCRIPTION
There was a duplicate apt upgrade in first_google_boot, and we have to set noninteractive mode for the codelab setup otherwise we might get stuck during the update process.