### PR TITLE
(google) bump node version for bootstrap_dev

### DIFF
--- a/dev/bootstrap_dev.sh
+++ b/dev/bootstrap_dev.sh
@@ -151,7 +151,7 @@ EOF
 # Start script
 
 # Install node
-NODE_VERSION=0.12
+NODE_VERSION=4.4.1
 . /etc/profile.d/nvm.sh
 nvm install $NODE_VERSION
 nvm alias default $NODE_VERSION


### PR DESCRIPTION
@ewiseblatt or @ttomsu 

Deck has new build scripts that will not run with a node version <4. Deck's `build.gradle` and `Dockerfile` both use node 4.4.1.