### PR TITLE
Can't nest ${..${}} in config

### DIFF
--- a/config/spinnaker.yml
+++ b/config/spinnaker.yml
@@ -231,8 +231,8 @@ services:
 
   stackdriver:
     enabled: ${SPINNAKER_STACKDRIVER_ENABLED:false}
-    projectName: ${SPINNAKER_STACKDRIVER_PROJECT_NAME:${providers.google.primaryCredentials.project}}
-    credentialsPath: ${SPINNAKER_STACKDRIVER_CREDENTIALS_PATH:${providers.google.primaryCredentials.jsonPath}}   
+    projectName: ${providers.google.primaryCredentials.project}
+    credentialsPath: ${providers.google.primaryCredentials.jsonPath} 
 
 
 providers:


### PR DESCRIPTION
This won't fail to parse, but it won't resolve the nested ${} expression. I'm dropping the env reference, since it's more likely that `primaryCredentials` is correctly defined. We can talk about a better way to resolve which project handles stack driver, but I figure we should leave this in an intermediate, working state.

There is another fix to kork incoming separate from this that is actually causing everything on kork 1.77 to fail that has stackdriver enabled (so far clouddriver, echo & front50).

@ewiseblatt, @duftler PTAL