### PR TITLE
Get bindings from scenario, not runner.

### DIFF
--- a/testing/citest/tests/bake_and_deploy_test.py
+++ b/testing/citest/tests/bake_and_deploy_test.py
@@ -535,7 +535,7 @@ class BakeAndDeployTestScenario(sk.SpinnakerTestScenario):
   def delete_baked_image(self, execution_context):
     status = execution_context.get('OperationStatus', None)
     if status is None:
-      self.log.info(
+      self.logger.info(
           'Operation could not be performed so there is no image to delete.')
       return;
 
@@ -567,7 +567,7 @@ class BakeAndDeployTest(st.AgentTestCase):
     if not scenario.test_google:
       return
 
-    managed_region = runner.bindings['TEST_GCE_REGION']
+    managed_region = scenario.bindings['TEST_GCE_REGION']
     title = 'Check Quota for {0}'.format(scenario.__class__.__name__)
 
     verify_results = gcp.verify_quota(

--- a/testing/citest/tests/google_http_lb_upsert_test.py
+++ b/testing/citest/tests/google_http_lb_upsert_test.py
@@ -75,14 +75,12 @@ class GoogleHttpLoadBalancerTest(st.AgentTestCase):
   @classmethod
   def setUpClass(cls):
     runner = citest.base.TestRunner.global_runner()
-    bindings = runner.bindings
+    scenario = runner.get_shared_data(GoogleHttpLoadBalancerTestScenario)
+    bindings = scenario.bindings
     cls.FIRST_CERT = 'first-cert-%s' % (bindings['TEST_APP'])
     cls.SECOND_CERT = 'second-cert-%s'  % (bindings['TEST_APP'])
     cls.UPDATED_HC = 'updated-%s' % (bindings['TEST_APP'])
-    runner = citest.base.TestRunner.global_runner()
-    bindings = runner.bindings
-    scenario = runner.get_shared_data(GoogleHttpLoadBalancerTestScenario)
-    managed_region = runner.bindings['TEST_GCE_REGION']
+    managed_region = bindings['TEST_GCE_REGION']
     title = 'Check Quota for {0}'.format(scenario.__class__.__name__)
 
     verify_results = gcp.verify_quota(
@@ -116,7 +114,8 @@ class GoogleHttpLoadBalancerTest(st.AgentTestCase):
   @classmethod
   def tearDownClass(cls):
     runner = citest.base.TestRunner.global_runner()
-    bindings = runner.bindings
+    scenario = runner.get_shared_data(GoogleHttpLoadBalancerTestScenario)
+    bindings = scenario.bindings
     context = ExecutionContext()
     compute_agent = (
       gcp.GcpComputeAgent

--- a/testing/citest/tests/google_server_group_test.py
+++ b/testing/citest/tests/google_server_group_test.py
@@ -356,7 +356,7 @@ class GoogleServerGroupTest(st.AgentTestCase):
   def setUpClass():
     runner = citest.base.TestRunner.global_runner()
     scenario = runner.get_shared_data(GoogleServerGroupTestScenario)
-    managed_region = runner.bindings['TEST_GCE_REGION']
+    managed_region = scenario.bindings['TEST_GCE_REGION']
     title = 'Check Quota for {0}'.format(scenario.__class__.__name__)
 
     verify_results = gcp.verify_quota(

--- a/testing/citest/tests/google_smoke_test.py
+++ b/testing/citest/tests/google_smoke_test.py
@@ -353,7 +353,7 @@ class GoogleSmokeTest(st.AgentTestCase):
   def setUpClass():
     runner = citest.base.TestRunner.global_runner()
     scenario = runner.get_shared_data(GoogleSmokeTestScenario)
-    managed_region = runner.bindings['TEST_GCE_REGION']
+    managed_region = scenario.bindings['TEST_GCE_REGION']
     title = 'Check Quota for {0}'.format(scenario.__class__.__name__)
 
     verify_results = gcp.verify_quota(


### PR DESCRIPTION
@jtk54 
This is a nop change at present, but I'm about to change how bindings are created and the intent here is to use the scenario's bindings, not the runners.
