### PR TITLE
Fix IAM policy for Spinnaker on Kubernetes in GCE.

### DIFF
--- a/experimental/kubernetes/simple/README.md
+++ b/experimental/kubernetes/simple/README.md
@@ -70,7 +70,7 @@ SA_EMAIL=$(gcloud iam service-accounts list \
 PROJECT=$(gcloud info --format='value(config.project)')
 
 gcloud projects add-iam-policy-binding $PROJECT \
-    --role roles/compute.storageAdmin --member serviceAccount:$SA_EMAIL
+    --role roles/storage.admin --member serviceAccount:$SA_EMAIL
 ```
 
 Download the key:


### PR DESCRIPTION
Spinnaker needs access to the `storage.admin` IAM role (GCS) rather than `compute.storageAdmin` role (Compute Engine Disks)