### PR TITLE
Tweak developer install to turn off cassandra.

### DIFF
--- a/dev/bootstrap_dev.sh
+++ b/dev/bootstrap_dev.sh
@@ -190,6 +190,9 @@ if prompt_YN "Y" "Install (or update) Google Cloud Platform SDK?"; then
    pushd $HOME
    echo "*** BEGIN installing gcloud..."
    curl https://sdk.cloud.google.com | bash
+   echo "Adding kubectl..."
+   gcloud components install kubectl -q || true
+
    if [[ ! -f $HOME/.config/gcloud/credentials ]]; then
       echo "Running gcloud authentication..."
       gcloud auth login
@@ -207,7 +210,6 @@ fi
 if ! aws --version >& /dev/null && prompt_YN "Y" "Install AWS Platform SDK?"; then
     sudo apt-get install -y awscli
 fi
-
 
 # Setup source code
 if [[ "$CONFIRMED_GITHUB_REPOSITORY_OWNER" != "none" ]]; then
@@ -230,6 +232,34 @@ fi
 # Some dependencies of Deck rely on Bower to manage their dependencies. Bower
 # annoyingly prompts the user to collect some stats, so this disables that.
 echo "{\"interactive\":false}" > ~/.bowerrc
+
+
+if [[ -f $HOME/.spinnaker/spinnaker-local.yml ]]; then
+  echo "Forcing cassandra off."
+  ./spinnaker/install/change_cassandra.sh --echo=inMemory --front50=gcs --change_defaults=false --change_local=true
+else
+  echo "Adding a default spinnaker-local that disables cassandra."
+  mkdir -p $HOME/.spinnaker
+  project=$(curl -L -s -f -H "Metadata-Flavor: Google" \
+            http://169.254.169.254/computeMetadata/v1/project/project-id)
+  cat > $HOME/.spinnaker/spinnaker-local.yml <<EOF
+services:
+  echo:
+    cassandra:
+      enabled: false
+    inMemory:
+      enabled: true
+
+  front50:
+    storage_bucket: spinnaker-${project}
+    bucket_location: \${providers.google.defaultRegion}
+    cassandra:
+      enabled: false
+    gcs:
+      enabled: true
+EOF
+  chmod 600 $HOME/.spinnaker/spinnaker-local.yml
+fi
 
 
 # If this script was run in a different shell then we


### PR DESCRIPTION
@danielpeach this is a fix for the bug you filed recently.

@duftler FYI I dont know if there is a better way. With Halyard could be easier and more robust. Here I assume that your existing spinnaker-local is good and create one if you dont have one.

If you do have a spinnaker-local then the bucket might not be set up because normally spinnaker.yml
relies on an environment variable that wont be there. I could potentially put it there (create an /etc/default/spinnaker for a development build) but that starts getting tedious because I'd also have to configure it with stuff that InstallSpinnaker or first_google_boot does. Halyard could potentially make this easier though I havent been tracking the details of what lars is thinking.

Note with an existing file I force gcs rather than cassanra. This is ok at present but in general would be wrong if you had it configured for something else like s3 (or even cassandra) since it forces gcs. It's not worth the extra config complexity until this proves an issue (the support is there, just the UI requires extra steps that are currently superfluous so I omit them).