### PR TITLE
sync `../../../config/*.yml` from `startup-config.sh` in simple Kubernetes setup

### DIFF
--- a/experimental/kubernetes/simple/config/clouddriver.yml
+++ b/experimental/kubernetes/simple/config/clouddriver.yml
@@ -24,7 +24,7 @@ aws:
   # info on setting environment variables.
   enabled: ${providers.aws.enabled:false}
   defaults:
-    iamRole: ${provider.aws.defaultIAMRole:BaseIAMRole}
+    iamRole: ${providers.aws.defaultIAMRole:BaseIAMRole}
   defaultRegions:
     - name: ${providers.aws.defaultRegion:us-east-1}
   defaultFront50Template: ${services.front50.baseUrl}
@@ -47,6 +47,8 @@ google:
     - name: ${providers.google.primaryCredentials.name}
       project: ${providers.google.primaryCredentials.project}
       jsonPath: ${providers.google.primaryCredentials.jsonPath}
+      consul:
+        enabled: ${providers.google.primaryCredentials.consul.enabled:false}
 
 cf:
   enabled: ${providers.cf.enabled:false}
@@ -67,16 +69,58 @@ kubernetes:
       dockerRegistries:
         - accountName: ${providers.kubernetes.primaryCredentials.dockerRegistryAccount}
 
+openstack:
+  enabled: ${providers.openstack.enabled:false}
+  accounts:
+    - name: ${providers.openstack.primaryCredentials.name}
+      authUrl: ${providers.openstack.primaryCredentials.authUrl}
+      username: ${providers.openstack.primaryCredentials.username}
+      password: ${providers.openstack.primaryCredentials.password}
+      projectName: ${providers.openstack.primaryCredentials.projectName}
+      domainName: ${providers.openstack.primaryCredentials.domainName:Default}
+      regions: ${providers.openstack.primaryCredentials.regions}
+      insecure: ${providers.openstack.primaryCredentials.insecure:false}
+      userDataFile: ${providers.openstack.primaryCredentials.userDataFile:}
+
+      # The Openstack API requires that the load balancer be in an ACTIVE
+      # state for it to create associated relationships (i.e. listeners,
+      # pools, monitors). Each modification will cause the load balancer to
+      # go into a PENDING state and back to ACTIVE once the change has been
+      # made. Depending on your implementation, the timeout and polling
+      # intervals would need to be adjusted, especially if testing out
+      # Spinnaker with Devstack or another resource constrained enviroment
+      lbaas:
+        pollTimeout: 60
+        pollInterval: 5
+
 dockerRegistry:
   enabled: ${providers.dockerRegistry.enabled:false}
   accounts:
     - name: ${providers.dockerRegistry.primaryCredentials.name}
       address: ${providers.dockerRegistry.primaryCredentials.address}
       username: ${providers.dockerRegistry.primaryCredentials.username:}
-      passwordFile: ${providers.dockerRegistry.primaryCredentials.passwordFile:}
-      repositories: 
-        - ${providers.dockerRegistry.primaryCredentials.repository}
+      passwordFile: ${providers.dockerRegistry.primaryCredentials.passwordFile}
 
 credentials:
   primaryAccountTypes: ${providers.aws.primaryCredentials.name}, ${providers.google.primaryCredentials.name}, ${providers.cf.primaryCredentials.name}, ${providers.azure.primaryCredentials.name}
   challengeDestructiveActionsEnvironments: ${providers.aws.primaryCredentials.name}, ${providers.google.primaryCredentials.name}, ${providers.cf.primaryCredentials.name}, ${providers.azure.primaryCredentials.name}
+
+
+spectator:
+  applicationName: ${spring.application.name}
+  webEndpoint:
+    enabled: ${services.spectator.webEndpoint.enabled:false}
+    prototypeFilter:
+      path: ${services.spectator.webEndpoint.prototypeFilter.path:}
+
+  stackdriver:
+    enabled: ${services.stackdriver.enabled}
+    projectName: ${services.stackdriver.projectName}
+    credentialsPath: ${services.stackdriver.credentialsPath}
+
+stackdriver:
+  hints:
+    - name: controller.invocations
+      labels:
+      - account
+      - region

--- a/experimental/kubernetes/simple/config/echo.yml
+++ b/experimental/kubernetes/simple/config/echo.yml
@@ -3,16 +3,16 @@ server:
   address: ${services.echo.host:localhost}
 
 cassandra:
-  enabled: ${services.echo.cassandra.enabled:true}
+  enabled: ${services.echo.cassandra.enabled:false}
   embedded: ${services.cassandra.embedded:false}
   host: ${services.cassandra.host:localhost}
 
 spinnaker:
   baseUrl: ${services.deck.baseUrl}
   cassandra:
-     enabled: ${services.echo.cassandra.enabled:true}
+     enabled: ${services.echo.cassandra.enabled:false}
   inMemory:
-     enabled: ${services.echo.inMemory.enabled:false}
+     enabled: ${services.echo.inMemory.enabled:true}
 
 front50:
   baseUrl: ${services.front50.baseUrl:http://localhost:8080}
@@ -56,3 +56,15 @@ scheduler:
     pollingIntervalMs: 30000
   cron:
     timezone: ${services.echo.cron.timezone}
+
+spectator:
+  applicationName: ${spring.application.name}
+  webEndpoint:
+    enabled: ${services.spectator.webEndpoint.enabled:false}
+    prototypeFilter:
+      path: ${services.spectator.webEndpoint.prototypeFilter.path:}
+
+  stackdriver:
+    enabled: ${services.stackdriver.enabled}
+    projectName: ${services.stackdriver.projectName}
+    credentialsPath: ${services.stackdriver.credentialsPath}

--- a/experimental/kubernetes/simple/config/fiat.yml
+++ b/experimental/kubernetes/simple/config/fiat.yml
@@ -5,6 +5,14 @@ server:
 redis:
   connection: ${services.redis.connection:redis://localhost:6379}
 
-auth:
-  getAll:
-    enabled: false
+spectator:
+  applicationName: ${spring.application.name}
+  webEndpoint:
+    enabled: ${services.spectator.webEndpoint.enabled:false}
+    prototypeFilter:
+      path: ${services.spectator.webEndpoint.prototypeFilter.path:}
+
+  stackdriver:
+    enabled: ${services.stackdriver.enabled}
+    projectName: ${services.stackdriver.projectName}
+    credentialsPath: ${services.stackdriver.credentialsPath}

--- a/experimental/kubernetes/simple/config/front50.yml
+++ b/experimental/kubernetes/simple/config/front50.yml
@@ -2,6 +2,10 @@ server:
   port: ${services.front50.port:8080}
   address: ${services.front50.host:localhost}
 
+hystrix:
+  command:
+    default.execution.isolation.thread.timeoutInMilliseconds: 15000
+
 cassandra:
   enabled: ${services.front50.cassandra.enabled:true}
   embedded: ${services.cassandra.embedded:false}
@@ -32,7 +36,34 @@ spinnaker:
     project: ${providers.google.primaryCredentials.project}
     jsonPath: ${providers.google.primaryCredentials.jsonPath}
 
-  aws:
+  s3:
     enabled: ${services.front50.s3.enabled:false}
     bucket: ${services.front50.storage_bucket:}
     rootFolder: ${services.front50.bucket_root:front50}
+
+spectator:
+  applicationName: ${spring.application.name}
+  webEndpoint:
+    enabled: ${services.spectator.webEndpoint.enabled:false}
+    prototypeFilter:
+      path: ${services.spectator.webEndpoint.prototypeFilter.path:}
+
+  stackdriver:
+    enabled: ${services.stackdriver.enabled}
+    projectName: ${services.stackdriver.projectName}
+    credentialsPath: ${services.stackdriver.credentialsPath}
+
+stackdriver:
+  hints:
+    - name: controller.invocations
+      labels:
+      - application
+      - cause
+    - name: aws.request.httpRequestTime
+      labels:
+      - status
+      - exception
+      - AWSErrorCode
+    - name: aws.request.requestSigningTime
+      labels:
+      - exception

--- a/experimental/kubernetes/simple/config/gate.yml
+++ b/experimental/kubernetes/simple/config/gate.yml
@@ -23,3 +23,22 @@ server:
 redis:
   connection: ${services.redis.connection}
 
+spectator:
+  applicationName: ${spring.application.name}
+  webEndpoint:
+    enabled: ${services.spectator.webEndpoint.enabled:false}
+    prototypeFilter:
+      path: ${services.spectator.webEndpoint.prototypeFilter.path:}
+
+  stackdriver:
+    enabled: ${services.stackdriver.enabled}
+    projectName: ${services.stackdriver.projectName}
+    credentialsPath: ${services.stackdriver.credentialsPath}
+
+stackdriver:
+  hints:
+    - name: EurekaOkClient_Request
+      labels:
+      - cause
+      - reason
+      - status

--- a/experimental/kubernetes/simple/config/igor.yml
+++ b/experimental/kubernetes/simple/config/igor.yml
@@ -19,7 +19,7 @@ travis:
       githubToken: ${services.travis.defaultMaster.githubToken}
 
 dockerRegistry:
-  enabled: ${SPINNAKER_KUBERNETES_ENABLED:false}
+  enabled: ${providers.dockerRegistry.enabled:false}
 
 redis:
   connection: ${services.redis.connection:redis://localhost:6379}
@@ -31,3 +31,21 @@ redis:
 #     baseUrl: ${services.clouddriver.baseUrl}
 #   echo:
 #     baseUrl: ${services.echo.baseUrl}
+
+spectator:
+  applicationName: ${spring.application.name}
+  webEndpoint:
+    enabled: ${services.spectator.webEndpoint.enabled:false}
+    prototypeFilter:
+      path: ${services.spectator.webEndpoint.prototypeFilter.path:}
+
+  stackdriver:
+    enabled: ${services.stackdriver.enabled}
+    projectName: ${services.stackdriver.projectName}
+    credentialsPath: ${services.stackdriver.credentialsPath}
+
+stackdriver:
+  hints:
+    - name: controller.invocations
+      labels:
+      - master

--- a/experimental/kubernetes/simple/config/orca.yml
+++ b/experimental/kubernetes/simple/config/orca.yml
@@ -13,7 +13,6 @@ kato:
 bakery:
     baseUrl: ${services.bakery.baseUrl:localhost:8087}
     extractBuildDetails: ${services.bakery.extractBuildDetails:true}
-    propagateCloudProviderType: ${services.bakery.propagateCloudProviderType:true}
     allowMissingPackageInstallation: ${services.bakery.allowMissingPackageInstallation:false}
 echo:
     enabled: ${services.echo.enabled:false}
@@ -39,3 +38,21 @@ redis:
 tasks:
   executionWindow:
     timezone: ${services.orca.timezone}
+
+spectator:
+  applicationName: ${spring.application.name}
+  webEndpoint:
+    enabled: ${services.spectator.webEndpoint.enabled:false}
+    prototypeFilter:
+      path: ${services.spectator.webEndpoint.prototypeFilter.path:}
+
+  stackdriver:
+    enabled: ${services.stackdriver.enabled}
+    projectName: ${services.stackdriver.projectName}
+    credentialsPath: ${services.stackdriver.credentialsPath}
+
+stackdriver:
+  hints:
+    - name: controller.invocations
+      labels:
+      - application

--- a/experimental/kubernetes/simple/config/rosco.yml
+++ b/experimental/kubernetes/simple/config/rosco.yml
@@ -25,3 +25,21 @@ google:
 
 rosco:
   configDir: ${services.rosco.configDir}
+
+spectator:
+  applicationName: ${spring.application.name}
+  webEndpoint:
+    enabled: ${services.spectator.webEndpoint.enabled:false}
+    prototypeFilter:
+      path: ${services.spectator.webEndpoint.prototypeFilter.path:}
+
+  stackdriver:
+    enabled: ${services.stackdriver.enabled}
+    projectName: ${services.stackdriver.projectName}
+    credentialsPath: ${services.stackdriver.credentialsPath}
+
+stackdriver:
+  hints:
+    - name: bakes
+      labels:
+      - success

--- a/experimental/kubernetes/simple/config/spinnaker.yml
+++ b/experimental/kubernetes/simple/config/spinnaker.yml
@@ -42,9 +42,9 @@ services:
 
     # Persistence mechanism to use
     cassandra:
-      enabled: true
-    inMemory:
       enabled: false
+    inMemory:
+      enabled: true
 
     cron:
       # Allow pipeline triggers to run periodically via cron expressions.
@@ -71,11 +71,16 @@ services:
         token: # twilio auth token
         from: # phone number by which sms messages are sent
       slack:
+        # See https://api.slack.com/bot-users for details about using bots
+        # and how to create your own bot user.
         enabled: false
         token: # the API token for the bot
         botName: # the username of the bot
 
   deck:
+    # Frontend configuration.
+    # If you are proxying Spinnaker behind a single host, you may want to
+    # override these values. Remember to run `reconfigure_spinnaker.sh` after.
     host: ${services.default.host}
     port: 9000
     baseUrl: ${services.default.protocol}://${services.deck.host}:${services.deck.port}
@@ -96,9 +101,10 @@ services:
     port: 8080
     baseUrl: ${services.default.protocol}://${services.front50.host}:${services.front50.port}
 
-    # If using storage bucket persistence (gcs or s3), specify the bucket here
-    # disable cassandra and enable the storage service below.
-    storage_bucket:
+    # To use a cloud storage bucket on Amazon S3 or Google Cloud Storage instead
+    # of cassandra, set the storage_bucket, disable cassandra, and enable one of
+    # the service providers.
+    storage_bucket: ${SPINNAKER_DEFAULT_STORAGE_BUCKET:}
     # (GCS Only) Location for bucket.
     bucket_location:
     bucket_root: front50
@@ -151,7 +157,8 @@ services:
     host: ${services.default.host}
     port: 8087
     baseUrl: ${services.default.protocol}://${services.rosco.host}:${services.rosco.port}
-    # You need to provide the fully-qualified path to the directory containing the packer templates.
+    # You need to provide the fully-qualified path to the directory containing
+    # the packer templates.
     # They typically live in rosco's config/packer directory.
     configDir: /opt/rosco/config/packer
 
@@ -160,7 +167,6 @@ services:
     port: ${services.rosco.port}
     baseUrl: ${services.rosco.baseUrl}
     extractBuildDetails: true
-    propagateCloudProviderType: true
     allowMissingPackageInstallation: false
 
   docker:
@@ -169,8 +175,11 @@ services:
     targetRepository: # Optional, but expected in spinnaker-local.yml if specified.
 
   jenkins:
+    # If you are integrating Jenkins, set its location here using the baseUrl
+    # field and provide the username/password credentials.
+    # You must also enable the "igor" service listed separately.
     # The "name" entry is used for the display name when selecting
-    # this server. You must set `enabled` to true when enabling igor.
+    # this server.
     #
     # If you have multiple jenkins servers, you will need to list
     # them in an igor-local.yml. See jenkins.masters in config/igor.yml.
@@ -199,14 +208,42 @@ services:
     embedded: false
     cluster: CASS_SPINNAKER
 
+  travis:
+    # If you are integrating Travis, set its location here using the baseUrl
+    # and adress fields and provide the githubToken for authentication.
+    # You must also enable the "igor" service listed separately.
+    #
+    # If you have multiple travis servers, you will need to list
+    # them in an igor-local.yml. See travis.masters in config/igor.yml.
+    #
+    # Note that travis is not installed with Spinnaker so you must obtain this
+    # on your own if you are interested.
+    enabled: false
+    defaultMaster:
+      name: ci # The display name for this server. Gets prefixed with "travis-"
+      baseUrl: https://travis-ci.com
+      address: https://api.travis-ci.org
+      githubToken: # GitHub scopes currently required by Travis is required.
+
+  spectator:
+    webEndpoint:
+      enabled: false
+
+  stackdriver:
+    enabled: ${SPINNAKER_STACKDRIVER_ENABLED:false}
+    projectName: ${SPINNAKER_STACKDRIVER_PROJECT_NAME:${providers.google.primaryCredentials.project}}
+    credentialsPath: ${SPINNAKER_STACKDRIVER_CREDENTIALS_PATH:${providers.google.primaryCredentials.jsonPath}}   
+
+
 providers:
   aws:
     # For more information on configuring Amazon Web Services (aws), see
     # http://www.spinnaker.io/v1.0/docs/target-deployment-setup#section-amazon-web-services-setup
 
-    enabled: false
+    enabled: ${SPINNAKER_AWS_ENABLED:false}
     simpleDBEnabled: false
-    defaultRegion: us-east-1
+    defaultRegion: ${SPINNAKER_AWS_DEFAULT_REGION:us-west-2}
+    defaultIAMRole: BaseIAMRole
     defaultSimpleDBDomain: CLOUD_APPLICATIONS
     primaryCredentials:
       name: default
@@ -224,16 +261,19 @@ providers:
     # For more information on configuring Google Cloud Platform (google), see
     # http://www.spinnaker.io/v1.0/docs/target-deployment-setup#section-google-cloud-platform-setup
 
-    enabled: false
-    defaultRegion: us-central1
-    defaultZone: us-central1-f
+    enabled: ${SPINNAKER_GOOGLE_ENABLED:false}
+    defaultRegion: ${SPINNAKER_GOOGLE_DEFAULT_REGION:us-central1}
+    defaultZone: ${SPINNAKER_GOOGLE_DEFAULT_ZONE:us-central1-f}
+
     primaryCredentials:
       name: my-account-name
       # The project is the Google Project ID for the project to manage with
       # Spinnaker. The jsonPath is a path to the JSON service credentials
       # downloaded from the Google Developer's Console.
-      project:
-      jsonPath:
+      project: ${SPINNAKER_GOOGLE_PROJECT_ID:}
+      jsonPath: ${SPINNAKER_GOOGLE_PROJECT_CREDENTIALS_PATH:}
+      consul:
+        enabled: ${SPINNAKER_GOOGLE_CONSUL_ENABLED:false}
 
   cf:
     # For more information on configuring Cloud Foundry (cf) support, see
@@ -252,8 +292,8 @@ providers:
     # For more information on configuring Microsoft Azure (azure), see
     # http://www.spinnaker.io/v1.0/docs/target-deployment-setup#section-azure-cloud-platform-setup
 
-    enabled: false
-    defaultRegion: westus
+    enabled: ${SPINNAKER_AZURE_ENABLED:false}
+    defaultRegion: ${SPINNAKER_AZURE_DEFAULT_REGION:westus}
     primaryCredentials:
       name: my-azure-account
 
@@ -278,7 +318,7 @@ providers:
     # http://www.spinnaker.io/v1.0/docs/target-deployment-setup#section-kubernetes-cluster-setup
 
     # NOTE: enabling kubernetes also requires enabling dockerRegistry.
-    enabled: false
+    enabled: ${SPINNAKER_KUBERNETES_ENABLED:false}
     primaryCredentials:
       name: my-kubernetes-account
       namespace: default
@@ -287,8 +327,28 @@ providers:
   dockerRegistry:
     # If you want to use a container based provider, you need to configure and
     # enable this provider to cache images.
-    enabled: false
+    enabled: ${SPINNAKER_KUBERNETES_ENABLED:false}
+
     primaryCredentials:
       name: my-docker-registry-account
-      address: https://index.docker.io/
-      repository: library/nginx
+      address: ${SPINNAKER_DOCKER_REGISTRY:https://index.docker.io/}
+      repository: ${SPINNAKER_DOCKER_REPOSITORY:library/nginx}
+      username: ${SPINNAKER_DOCKER_USERNAME}
+      # A path to a plain text file containing the user's password
+      passwordFile: ${SPINNAKER_DOCKER_PASSWORD_FILE}
+
+  openstack:
+    # This default configuration uses the same environment variable names set in
+    # the OpenStack RC file. See
+    # http://docs.openstack.org/user-guide/common/cli-set-environment-variables-using-openstack-rc.html
+    # for details on the OpenStack RC file.
+    enabled: false
+    primaryCredentials:
+      name: my-openstack-account
+      authUrl: ${OS_AUTH_URL}
+      username: ${OS_USERNAME}
+      password: ${OS_PASSWORD}
+      projectName: ${OS_PROJECT_NAME}
+      domainName: ${OS_USER_DOMAIN_NAME:Default}
+      regions: ${OS_REGION_NAME:RegionOne}
+      insecure: false


### PR DESCRIPTION
Hi, I've been trying to setup spinnaker with the simple Kubernetes setup, and have been finding in the position of needing to clean up the setup scripts a bit. Hope contributions like this are accepted.

`startup-config.sh` contains a step to copy all the configuration files from `config/` to the simple Kubernetes setup directory. Since there's been updates to the files in the root config directory, it produces unclean git state after `startup-config.sh` or `startup-all.sh` is run.

This PR commits the results from running `startup-config.sh`. Note that because all ReplicationController specs in https://github.com/spinnaker/spinnaker/tree/master/experimental/kubernetes/simple/rcs reference master images rather than locking to a version, there seems to be divergence of code and configuration compatibility. Particularly, whether we use the configurations in this branch or in master, not all spinnaker components will startup correctly. Particularly, `front50` produces error with both configuration files from master and this branch.

@lwander