### PR TITLE
generate secret from whole directory since all config files are needed in simple Kubernetes setup

### DIFF
--- a/experimental/kubernetes/simple/scripts/startup-config.sh
+++ b/experimental/kubernetes/simple/scripts/startup-config.sh
@@ -2,21 +2,7 @@ cp ../../../config/*.yml config
 rm config/default-spinnaker-local.yml
 
 kubectl create secret generic spinnaker-config \
-    --from-file=./config/clouddriver.yml \
-    --from-file=./config/clouddriver-local.yml \
-    --from-file=./config/echo.yml \
-    --from-file=./config/echo-local.yml \
-    --from-file=./config/front50.yml \
-    --from-file=./config/front50-local.yml \
-    --from-file=./config/gate.yml \
-    --from-file=./config/gate-local.yml \
-    --from-file=./config/igor.yml \
-    --from-file=./config/igor-local.yml \
-    --from-file=./config/orca.yml \
-    --from-file=./config/orca-local.yml \
-    --from-file=./config/settings.js \
-    --from-file=./config/spinnaker.yml \
-    --from-file=./config/spinnaker-local.yml \
+    --from-file=./config/. \
     --namespace=spinnaker
 
 GENERIC_CREDS="--from-file=$HOME/.kube/config"


### PR DESCRIPTION
Hi, I've been trying to setup spinnaker with the simple Kubernetes setup, and have been finding in the position of needing to clean up the setup scripts a bit. Hope contributions like this are accepted.

Since almost all configuration files are needed in the directory, it probably make more sense to generate secret from all the files in case any is missed when new files are added.

@lwander