### PR TITLE
added retry logic to build google tarball script

### DIFF
--- a/google/dev/build_google_tarball.py
+++ b/google/dev/build_google_tarball.py
@@ -134,8 +134,12 @@ class Builder(object):
                .format(uri=uri))
       raise ValueError(error)
 
-    result = run_quick('gsutil ls {uri}'.format(uri=uri), echo=False)
-    if not result.returncode:
+    retry_count = 3
+    for i in range(0, retry_count):
+      result = run_quick('gsutil ls {uri}'.format(uri=uri), echo=False)
+      if result.returncode:
+        break
+    else:
       error = 'tarball "{uri}" already exists.'.format(uri=uri)
       raise ValueError(error)
 


### PR DESCRIPTION
`gsutil ls` will sometimes list a file that has just been deleted, which has caused the build to fail a few times. I was able to reproduce this locally and I don't think a sleep is necessary here.

@ewiseblatt or @jtk54 please review.