### PR TITLE
(front50) Increase size of DefaultNotificationDAO and DefaultPipeline…

### DIFF
--- a/config/front50.yml
+++ b/config/front50.yml
@@ -5,6 +5,13 @@ server:
 hystrix:
   command:
     default.execution.isolation.thread.timeoutInMilliseconds: 15000
+  threadpool:
+    DefaultNotificationDAO:
+      coreSize: 25
+      maxQueueSize: 100
+    DefaultPipelineDAO:
+      coreSize: 25
+      maxQueueSize: 100
 
 cassandra:
   enabled: ${services.front50.cassandra.enabled:true}


### PR DESCRIPTION
Several users reported failures related to exhaustion of these threadpools.