### PR TITLE
Clean up default docker config

### DIFF
--- a/config/clouddriver.yml
+++ b/config/clouddriver.yml
@@ -110,7 +110,8 @@ dockerRegistry:
     - name: ${providers.dockerRegistry.primaryCredentials.name}
       address: ${providers.dockerRegistry.primaryCredentials.address}
       username: ${providers.dockerRegistry.primaryCredentials.username:}
-      passwordFile: ${providers.dockerRegistry.primaryCredentials.passwordFile}
+      passwordFile: ${providers.dockerRegistry.primaryCredentials.passwordFile:}
+      repositories: ${providers.dockerRegistry.primaryCredentials.repository:}
 
 credentials:
   primaryAccountTypes: ${providers.aws.primaryCredentials.name}, ${providers.google.primaryCredentials.name}, ${providers.cf.primaryCredentials.name}, ${providers.azure.primaryCredentials.name}

--- a/config/default-spinnaker-local.yml
+++ b/config/default-spinnaker-local.yml
@@ -126,10 +126,10 @@ providers:
     primaryCredentials:
       name: my-docker-registry
       address: ${SPINNAKER_DOCKER_REGISTRY:https://index.docker.io/}
-      repository: ${SPINNAKER_DOCKER_REPOSITORY:library/nginx}
-      username: ${SPINNAKER_DOCKER_USERNAME}
+      repository: ${SPINNAKER_DOCKER_REPOSITORY:}
+      username: ${SPINNAKER_DOCKER_USERNAME:}
       # A path to a plain text file containing the user's password
-      passwordFile: ${SPINNAKER_DOCKER_PASSWORD_FILE}
+      passwordFile: ${SPINNAKER_DOCKER_PASSWORD_FILE:}
 
   openstack:
     # For more information on configuring Openstack clusters, see

--- a/config/spinnaker.yml
+++ b/config/spinnaker.yml
@@ -332,10 +332,10 @@ providers:
     primaryCredentials:
       name: my-docker-registry-account
       address: ${SPINNAKER_DOCKER_REGISTRY:https://index.docker.io/}
-      repository: ${SPINNAKER_DOCKER_REPOSITORY:library/nginx}
-      username: ${SPINNAKER_DOCKER_USERNAME}
+      repository: ${SPINNAKER_DOCKER_REPOSITORY:}
+      username: ${SPINNAKER_DOCKER_USERNAME:}
       # A path to a plain text file containing the user's password
-      passwordFile: ${SPINNAKER_DOCKER_PASSWORD_FILE}
+      passwordFile: ${SPINNAKER_DOCKER_PASSWORD_FILE:}
 
   openstack:
     # This default configuration uses the same environment variable names set in


### PR DESCRIPTION
‘repository’ should be ‘repositories’ based on DockerRegistryConfigurationProperties (I kept getting 401 Unauthorized and discovered it was because the repository wasn’t set right and it was trying to get the catalog for the ENTIRE registry at ‘index.docker.io’)

Add ‘:’ to the username and passwordFile environment vars so that they default to null (and thus you can connect to public repos). Otherwise it was using the literal string “${SPINNAKER_DOCKER_USERNAME}” as my username