### PR TITLE
Refactored to support multiple endpoints/replicas for a given service.

### DIFF
--- a/google/stackdriver_monitoring/command_processor.py
+++ b/google/stackdriver_monitoring/command_processor.py
@@ -106,7 +106,7 @@ class CommandHandler(object):
     query_list = ['{0}={1}'.format(key, value) for key, value in params.items()]
     return '?{0}'.format('&'.join(query_list)) if query_list else ''
 
-  def process_commandline_request(self, options):
+  def process_commandline_request(self, options, **kwargs):
     """Processes the command from a commandline request.
 
     Output (as opposed to logging) should be emitted using output()

--- a/google/stackdriver_monitoring/datadog_service.py
+++ b/google/stackdriver_monitoring/datadog_service.py
@@ -29,6 +29,7 @@ class DatadogMetricsService(object):
 
   @staticmethod
   def add_standard_parser_arguments(parser):
+    """Adds commandline arguments common to datadog commands."""
     parser.add_argument('--host', default='localhost')
 
 
@@ -74,7 +75,7 @@ class DatadogMetricsService(object):
 
     result.append({
         'metric': '{service}.{name}'.format(service=service, name=name),
-        'host': service_metadata['host'],
+        'host': service_metadata['__host'],
         'points': [(elem['t'] / 1000, elem['v'])
                    for elem in instance['values']],
         'tags': ['{0}:{1}'.format(tag['key'], tag['value']) for tag in tags]
@@ -87,7 +88,7 @@ class DatadogMetricsService(object):
         service_metrics, self.__append_timeseries_point, points)
 
     try:
-      response = self.api.Metric.send(points)
+      self.api.Metric.send(points)
     except IOError as ioerr:
       logging.error('Error sending to datadog: %s', ioerr)
       raise

--- a/google/stackdriver_monitoring/spinnaker_metric_tool.sh
+++ b/google/stackdriver_monitoring/spinnaker_metric_tool.sh
@@ -18,6 +18,6 @@ if [[ -f /etc/default/spinnaker ]]; then
   source /etc/default/spinnaker
 fi
 PYTHONPATH=$(dirname $0)/../../pylib \
-python $(dirname $0)/spinnaker_metric_tool.py $@
+python $(dirname $0)/spinnaker_metric_tool.py "$@"
 
 


### PR DESCRIPTION
This is currently configurable by command line parameters with fixed service
names so is restricted to the pre-existing service names (not HA names).
However except for that one function that converts the options toa list of
endpoints, that is the only place for that restriction. So in the interim
you can replace that method with a different mechanism if you need different
names (such as 'clouddriver-ro', etc) and it should work.

--service_hosts=<comma delimited list of IPs, defaulting to "localhost">
--<service>=<comma listed list of network locations> where <service> is
"clouddriver", etc and <network location> is <host[:port]> where the
standard port will be assumed if not provided. A host of "*" means
use all the hosts in --service_hosts.

If --service_hosts is empty then by default no services will be used.
If --<service>=<empty> then that service will be ignored. If non empty
it will override --service_hosts (unless it is "*" in which case it is
service_hosts).

By default each service specifies its endpoints as "*" so the net effect
is that it will look at the standard ports for localhost if you say nothing,
or the standard ports for --service_hosts if you just specify that.

@ttomsu  please review
@gardleopard  FYI
