### PR TITLE
Do not mistakenly iterate over None object

### DIFF
--- a/pylib/spinnaker/yaml_util.py
+++ b/pylib/spinnaker/yaml_util.py
@@ -58,7 +58,7 @@ class YamlBindings(object):
       return default
 
   def import_dict(self, d):
-    if dict is not None:
+    if d is not None:
       for name,value in d.items():
         self.__update_field(name, value, self.__map)
 


### PR DESCRIPTION
In the case that `spinnaker-local.yml` contains only comments, or is empty, you will get the following stacktrace:

```
Traceback (most recent call last):
  File "/opt/spinnaker/runtime/../pylib/spinnaker/reconfigure_spinnaker.py", line 25, in <module>
    configurator.update_deck_settings()
  File "/opt/spinnaker/pylib/spinnaker/configurator.py", line 173, in update_deck_settings
    settings = self.process_deck_settings(source)
  File "/opt/spinnaker/pylib/spinnaker/configurator.py", line 223, in process_deck_settings
    value = self.bindings.replace(match.group(2))
  File "/opt/spinnaker/pylib/spinnaker/configurator.py", line 80, in bindings
    self.installation_config_dir, self.user_config_dir)
  File "/opt/spinnaker/pylib/spinnaker/yaml_util.py", line 256, in load_bindings
    bindings.import_path(install_local_yml_path)
  File "/opt/spinnaker/pylib/spinnaker/yaml_util.py", line 70, in import_path
    self.import_dict(yaml.load(f, Loader=yaml.Loader))
  File "/opt/spinnaker/pylib/spinnaker/yaml_util.py", line 62, in import_dict
    for name,value in d.items():
AttributeError: 'NoneType' object has no attribute 'items'
```

I think `dict` was mistakenly used here where `d` was intended, since `dict is not None` is always `True`.