### PR TITLE
Add redis configuration for front50 in kubernetes

### DIFF
--- a/experimental/kubernetes/ha/front50/config/front50.yaml
+++ b/experimental/kubernetes/ha/front50/config/front50.yaml
@@ -16,6 +16,8 @@ spinnaker:
 
   redis:
     enabled: false
+    host: ${services.redis.host}
+    port: ${services.redis.port}
 
   gcs:
     enabled: ${services.front50.gcs.enabled:false}

--- a/experimental/kubernetes/simple/config/front50-local.yml
+++ b/experimental/kubernetes/simple/config/front50-local.yml
@@ -14,6 +14,8 @@ spinnaker:
     enabled: false
   redis:
     enabled: false
+    host: ${services.redis.host}
+    port: ${services.redis.port}
   gcs:
     enabled: ${services.front50.gcs.enabled}
     project: ${services.front50.gcs.project}

--- a/experimental/kubernetes/simple/config/front50.yml
+++ b/experimental/kubernetes/simple/config/front50.yml
@@ -22,6 +22,8 @@ spinnaker:
 
   redis:
     enabled: ${services.front50.redis.enabled:false}
+    host: ${services.redis.host}
+    port: ${services.redis.port}
 
   gcs:
     enabled: ${services.front50.gcs.enabled:false}


### PR DESCRIPTION
Provided changes related to issue https://github.com/spinnaker/spinnaker/issues/1038, which was fixed by  PR https://github.com/spinnaker/front50/pull/149
Current PR fixes configuration for front50 services, running in Kubernetes pod