### PR TITLE
Clean up replica sets during cleanup.

### DIFF
--- a/experimental/kubernetes/simple/scripts/cleanup-spinnaker.sh
+++ b/experimental/kubernetes/simple/scripts/cleanup-spinnaker.sh
@@ -1,1 +1,1 @@
-kubectl delete rc,svc -l app=spin --namespace=spinnaker
+kubectl delete rc,rs,svc -l app=spin --namespace=spinnaker


### PR DESCRIPTION
In commit 3338be8718c20a, the k8s install switched from using
replication controllers to using replication sets. This updates the
cleanup script to delete the replication sets too. Note that I left in
deleting replication controllers for older Spinnaker installs.