### PR TITLE
Fix experimental docker-compose to be able to run reconfigure

### DIFF
--- a/experimental/docker-compose/docker-compose.override.yml
+++ b/experimental/docker-compose/docker-compose.override.yml
@@ -6,9 +6,12 @@ clouddriver:
 echo: 
   volumes: 
     - "../../config:/opt/spinnaker/config"
-#deck:
-#  volumes: 
-#    - "../../config/settings.js:/deck/settings.js"
+deck:
+  volumes: 
+    - "../../config:/opt/spinnaker/config"
+    - "../../config/settings.js:/opt/deck/html/settings.js"
+    - "../../runtime:/opt/spinnaker/runtime"
+    - "../../pylib:/opt/spinnaker/pylib"
 front50: 
   volumes: 
     - "../../config:/opt/spinnaker/config"


### PR DESCRIPTION
This is a workaround due to some changes made in the `deck` Dockerfile about 10 days ago.  The `settings.js` file is no longer automatically regenerated when you load deck for the first time.

So we need to allow a way to regenerate the `settings.js` file.  With these changes in place, if you run:

```
DOCKER_IP=`docker-machine ip` docker-compose run deck /opt/spinnaker/runtime/reconfigure_spinnaker.sh
```

Then you should end up with a working settings.js file.  I'm not sure where in the README this will fit in, and I know it won't work for remote docker machines.