### PR TITLE
(Azure Windows) Add 'object_id' as a configuration parameter as it's required by packer when baking Windows images

### DIFF
--- a/config/clouddriver.yml
+++ b/config/clouddriver.yml
@@ -39,6 +39,7 @@ azure:
       appKey: ${providers.azure.primaryCredentials.appKey}
       tenantId: ${providers.azure.primaryCredentials.tenantId}
       subscriptionId: ${providers.azure.primaryCredentials.subscriptionId}
+      objectId: ${provider.azure.primaryCredentials.objectId}
       defaultResourceGroup: ${providers.azure.primaryCredentials.defaultResourceGroup}
       defaultKeyVault: ${providers.azure.primaryCredentials.defaultKeyVault}
 

--- a/config/default-spinnaker-local.yml
+++ b/config/default-spinnaker-local.yml
@@ -54,11 +54,12 @@ providers:
       name: my-azure-account
 
       # To set Azure credentials, enter your Azure supscription values for:
-      # clientId, appKey, tenantId, and subscriptionId.
+      # clientId, appKey, tenantId, subscriptionId, and objectId.
       clientId:
       appKey:
       tenantId:
       subscriptionId:
+      objectId:
       packerResourceGroup:
       packerStorageAccount:
       defaultResourceGroup:

--- a/config/rosco.yml
+++ b/config/rosco.yml
@@ -16,6 +16,7 @@ azure:
       appKey: ${providers.azure.primaryCredentials.appKey}
       tenantId: ${providers.azure.primaryCredentials.tenantId}
       subscriptionId: ${providers.azure.primaryCredentials.subscriptionId}
+      objectId: ${provider.azure.primaryCredentials.objectId}
       packerResourceGroup: ${providers.azure.primaryCredentials.packerResourceGroup}
       packerStorageAccount: ${providers.azure.primaryCredentials.packerStorageAccount}
 

--- a/config/spinnaker.yml
+++ b/config/spinnaker.yml
@@ -297,12 +297,13 @@ providers:
     primaryCredentials:
       name: my-azure-account
 
-      # To set Azure credentials, enter your Azure supscription values for:
-      # clientId, appKey, tenantId, and subscriptionId.
+      # To set Azure credentials, enter your Azure subscription values for:
+      # clientId, appKey, tenantId, subscriptionId, and objectId.
       clientId:
       appKey:
       tenantId:
       subscriptionId:
+      objectId:
 
   titan:
     # If you want to deploy some services to titan,

--- a/experimental/kubernetes/ha/config/spinnaker.yaml
+++ b/experimental/kubernetes/ha/config/spinnaker.yaml
@@ -283,11 +283,12 @@ providers:
       name: my-azure-account
 
       # To set Azure credentials, enter your Azure supscription values for:
-      # clientId, appKey, tenantId, and subscriptionId.
+      # clientId, appKey, tenantId, subscriptionId, and objectId.
       clientId:
       appKey:
       tenantId:
       subscriptionId:
+      objectId:
 
   titan:
     # If you want to deploy some services to titan,

--- a/experimental/kubernetes/simple/config/clouddriver.yml
+++ b/experimental/kubernetes/simple/config/clouddriver.yml
@@ -39,6 +39,7 @@ azure:
       appKey: ${providers.azure.primaryCredentials.appKey}
       tenantId: ${providers.azure.primaryCredentials.tenantId}
       subscriptionId: ${providers.azure.primaryCredentials.subscriptionId}
+      objectId: ${providers.azure.primaryCredentials.objectId}
 
 google:
   enabled: ${providers.google.enabled:false}

--- a/experimental/kubernetes/simple/config/spinnaker.yml
+++ b/experimental/kubernetes/simple/config/spinnaker.yml
@@ -258,11 +258,12 @@ providers:
       name: my-azure-account
 
       # To set Azure credentials, enter your Azure supscription values for:
-      # clientId, appKey, tenantId, and subscriptionId.
+      # clientId, appKey, tenantId, subscriptionId, and objectId.
       clientId:
       appKey:
       tenantId:
       subscriptionId:
+      objectId:
 
   titan:
     # If you want to deploy some services to titan,


### PR DESCRIPTION
Related PR [#1146](https://github.com/spinnaker/orca/pull/1146) has been opened in Ocra. Another related PR will be opened in Rosco that requires this change
