### PR TITLE
Fix argparse Namespace handling in options.

### DIFF
--- a/dev/annotate_source.py
+++ b/dev/annotate_source.py
@@ -139,15 +139,15 @@ class Annotator(Refresher):
   TAG_MATCHER = re.compile('^version-[0-9]+\.[0-9]+\.[0-9]+-[0-9]$')
 
   def __init__(self, options):
-    self.__next_tag = options.get('next_tag', None)
-    self.__path = options.get('path', '.')
-    self.__initial_branch = options.get('initial_branch', '')
-    self.__stable_branch = options.get('stable_branch', '')
-    self.__build_number = options.get('build_number', '') or os.environ['BUILD_NUMBER']
+    self.__next_tag = options.next_tag
+    self.__path = options.path
+    self.__initial_branch = options.initial_branch
+    self.__stable_branch = options.stable_branch
+    self.__build_number = options.build_number or os.environ.get('BUILD_NUMBER', '')
     self.__tags_to_delete = []
     self.__filtered_tags = []
     self.__partition_tags_on_pattern()
-    super(Annotator, self).__init__(options or {})
+    super(Annotator, self).__init__(options)
 
   def __partition_tags_on_pattern(self):
     """Partitions the tags into two lists based on TAG_MATCHER.

--- a/dev/refresh_source.py
+++ b/dev/refresh_source.py
@@ -138,7 +138,7 @@ class Refresher(object):
   def __init__(self, options):
       self.__options = options
       self.__extra_repositories = self.__OPTIONAL_REPOSITORIES
-      if options.get('extra_repos', None):
+      if options.extra_repos:
         for extra in options.extra_repos.split(','):
           pair = extra.split('=')
           if len(pair) != 2:

--- a/unittest/source_annotator_test.py
+++ b/unittest/source_annotator_test.py
@@ -14,9 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import argparse
 import unittest
 
 from annotate_source import Annotator, CommitTag, VersionBump
+
+global OPTIONS # argparse Namespace
 
 class SourceAnnotatorTest(unittest.TestCase):
 
@@ -24,7 +27,7 @@ class SourceAnnotatorTest(unittest.TestCase):
 
   def test_patch_version(self):
     expect = VersionBump('version-1.0.1', patch=True)
-    annotator = Annotator({})
+    annotator = Annotator(OPTIONS)
     commit_hashes = [
       'a',
       'z'
@@ -38,7 +41,7 @@ class SourceAnnotatorTest(unittest.TestCase):
 
   def test_minor_version(self):
     expect = VersionBump('version-1.1.0', minor=True)
-    annotator = Annotator({})
+    annotator = Annotator(OPTIONS)
     commit_hashes = [
       'a',
       'b',
@@ -54,7 +57,7 @@ class SourceAnnotatorTest(unittest.TestCase):
 
   def test_minor_two_digit_version(self):
     expect = VersionBump('version-1.10.0', minor=True)
-    annotator = Annotator({})
+    annotator = Annotator(OPTIONS)
     commit_hashes = [
       'a',
       'b',
@@ -71,7 +74,7 @@ class SourceAnnotatorTest(unittest.TestCase):
 
   def test_minor_reset_patch(self):
     expect = VersionBump('version-1.10.0', minor=True)
-    annotator = Annotator({})
+    annotator = Annotator(OPTIONS)
     commit_hashes = [
       'a',
       'b',
@@ -88,7 +91,7 @@ class SourceAnnotatorTest(unittest.TestCase):
 
   def test_major_version(self):
     expect = VersionBump('version-2.0.0', major=True)
-    annotator = Annotator({})
+    annotator = Annotator(OPTIONS)
     commit_hashes = [
       'a',
       'b',
@@ -104,7 +107,7 @@ class SourceAnnotatorTest(unittest.TestCase):
 
   def test_major_reset_version(self):
     expect = VersionBump('version-2.0.0', major=True)
-    annotator = Annotator({})
+    annotator = Annotator(OPTIONS)
     commit_hashes = [
       'a',
       'b',
@@ -121,7 +124,7 @@ class SourceAnnotatorTest(unittest.TestCase):
 
   def test_major_reset_version(self):
     expect = VersionBump('version-2.0.0', major=True)
-    annotator = Annotator({})
+    annotator = Annotator(OPTIONS)
     commit_hashes = [
       'a',
       'b',
@@ -138,7 +141,7 @@ class SourceAnnotatorTest(unittest.TestCase):
 
   def test_default_msgs(self):
     expect = VersionBump('version-1.0.1', patch=True)
-    annotator = Annotator({})
+    annotator = Annotator(OPTIONS)
     commit_hashes = [
       'a',
       'z'
@@ -151,6 +154,11 @@ class SourceAnnotatorTest(unittest.TestCase):
     self.assertEqual(expect, result)
 
 if __name__ == '__main__':
+  parser = argparse.ArgumentParser()
+  Annotator.init_argument_parser(parser)
+  Annotator.init_extra_argument_parser(parser)
+  OPTIONS = parser.parse_args()
+
   loader = unittest.TestLoader()
   suite = loader.loadTestsFromTestCase(SourceAnnotatorTest)
   unittest.TextTestRunner(verbosity=2).run(suite)


### PR DESCRIPTION
#1376 broke how the `argparse` options were handled in `annotate_source` and `refresh_source`. I also had to fix the test to initialize the options before the test in the tests `main()`.