### PR TITLE
Modified the K8 install to use a relative path vs hard path

### DIFF
--- a/experimental/kubernetes/simple/scripts/cleanup-all.sh
+++ b/experimental/kubernetes/simple/scripts/cleanup-all.sh
@@ -1,8 +1,9 @@
-kubectl delete -f namespaces/namespace.yaml
+export SPIN_SCRIPT_PATH=~/spinnaker/experimental/kubernetes/simple
+kubectl delete -f $SPIN_SCRIPT_PATH/namespaces/namespace.yaml
 
-kubectl get -f namespaces/namespace.yaml &> /dev/null
+kubectl get -f $SPIN_SCRIPT_PATH/namespaces/namespace.yaml &> /dev/null
 
 while [ $? -eq 0 ]; do
     sleep 1
-    kubectl get -f namespaces/namespace.yaml
+    kubectl get -f $SPIN_SCRIPT_PATH/namespaces/namespace.yaml
 done

--- a/experimental/kubernetes/simple/scripts/startup-all.sh
+++ b/experimental/kubernetes/simple/scripts/startup-all.sh
@@ -1,7 +1,8 @@
-bash scripts/startup-namespace.sh
+export SPIN_SCRIPT_PATH=~/spinnaker/experimental/kubernetes/simple
+bash $SPIN_SCRIPT_PATH/scripts/startup-namespace.sh
 
-bash scripts/startup-redis.sh
+bash $SPIN_SCRIPT_PATH/scripts/startup-redis.sh
 
-bash scripts/startup-config.sh
+bash $SPIN_SCRIPT_PATH/scripts/startup-config.sh
 
-bash scripts/startup-spinnaker.sh
+bash $SPIN_SCRIPT_PATH/scripts/startup-spinnaker.sh

--- a/experimental/kubernetes/simple/scripts/startup-cluster-redis.sh
+++ b/experimental/kubernetes/simple/scripts/startup-cluster-redis.sh
@@ -2,19 +2,19 @@ echo "Bootstrapping redis master..."
 echo
 
 # Create a bootstrap master
-kubectl create -f pods/data-redis-master.yaml
+kubectl create -f $SPIN_SCRIPT_PATH/pods/data-redis-master.yaml
 
 # Create a service to track the servers
-kubectl create -f svcs/data-redis-server.yaml
+kubectl create -f $SPIN_SCRIPT_PATH/svcs/data-redis-server.yaml
 
 # Create a service to track the sentinels
-kubectl create -f svcs/data-redis-sentinel.yaml
+kubectl create -f $SPIN_SCRIPT_PATH/svcs/data-redis-sentinel.yaml
 
 # Create a replica set for redis servers
-kubectl create -f rs/data-redis-server.yaml
+kubectl create -f $SPIN_SCRIPT_PATH/rs/data-redis-server.yaml
 
 # Create a replica set for redis sentinels
-kubectl create -f rs/data-redis-sentinel.yaml
+kubectl create -f $SPIN_SCRIPT_PATH/rs/data-redis-sentinel.yaml
 
 echo
 echo "Waiting a bit for all resources to be ready..."

--- a/experimental/kubernetes/simple/scripts/startup-namespace.sh
+++ b/experimental/kubernetes/simple/scripts/startup-namespace.sh
@@ -3,6 +3,5 @@ kubectl get namespace spinnaker &> /dev/null
 if [ $? -eq 0 ]; then
     echo "Namespace 'spinnaker' already exists."
 else
-    kubectl create -f namespaces/namespace.yaml
+    kubectl create -f $SPIN_SCRIPT_PATH/namespaces/namespace.yaml
 fi
-

--- a/experimental/kubernetes/simple/scripts/startup-redis.sh
+++ b/experimental/kubernetes/simple/scripts/startup-redis.sh
@@ -2,7 +2,7 @@ echo "Bootstrapping redis master..."
 echo
 
 # Create a service to track the servers
-kubectl create -f svcs/data-redis-server.yaml
+kubectl create -f $SPIN_SCRIPT_PATH/svcs/data-redis-server.yaml
 
 # Create a replica set for redis servers
-kubectl create -f rs/data-redis-master.yaml
+kubectl create -f $SPIN_SCRIPT_PATH/rs/data-redis-master.yaml

--- a/experimental/kubernetes/simple/scripts/startup-spinnaker.sh
+++ b/experimental/kubernetes/simple/scripts/startup-spinnaker.sh
@@ -1,22 +1,22 @@
 echo "Starting all services..."
 echo
 
-kubectl create -f svcs/spin-clouddriver.yaml
-kubectl create -f svcs/spin-deck.yaml
-kubectl create -f svcs/spin-echo.yaml
-kubectl create -f svcs/spin-front50.yaml
-kubectl create -f svcs/spin-gate.yaml
-kubectl create -f svcs/spin-igor.yaml
-kubectl create -f svcs/spin-orca.yaml
+kubectl create -f $SPIN_SCRIPT_PATH/svcs/spin-clouddriver.yaml
+kubectl create -f $SPIN_SCRIPT_PATH/svcs/spin-deck.yaml
+kubectl create -f $SPIN_SCRIPT_PATH/svcs/spin-echo.yaml
+kubectl create -f $SPIN_SCRIPT_PATH/svcs/spin-front50.yaml
+kubectl create -f $SPIN_SCRIPT_PATH/svcs/spin-gate.yaml
+kubectl create -f $SPIN_SCRIPT_PATH/svcs/spin-igor.yaml
+kubectl create -f $SPIN_SCRIPT_PATH/svcs/spin-orca.yaml
 
 echo
 echo "Starting all replica sets..."
 echo
 
-kubectl create -f rs/spin-clouddriver.yaml
-kubectl create -f rs/spin-deck.yaml
-kubectl create -f rs/spin-echo.yaml
-kubectl create -f rs/spin-front50.yaml
-kubectl create -f rs/spin-gate.yaml
-kubectl create -f rs/spin-igor.yaml
-kubectl create -f rs/spin-orca.yaml
+kubectl create -f $SPIN_SCRIPT_PATH/rs/spin-clouddriver.yaml
+kubectl create -f $SPIN_SCRIPT_PATH/rs/spin-deck.yaml
+kubectl create -f $SPIN_SCRIPT_PATH/rs/spin-echo.yaml
+kubectl create -f $SPIN_SCRIPT_PATH/rs/spin-front50.yaml
+kubectl create -f $SPIN_SCRIPT_PATH/rs/spin-gate.yaml
+kubectl create -f $SPIN_SCRIPT_PATH/rs/spin-igor.yaml
+kubectl create -f $SPIN_SCRIPT_PATH/rs/spin-orca.yaml

--- a/experimental/kubernetes/simple/scripts/update-component.sh
+++ b/experimental/kubernetes/simple/scripts/update-component.sh
@@ -1,3 +1,3 @@
 kubectl delete rs -l stack=$1 --namespace=spinnaker
 
-kubectl create -f rs/spin-$1.yaml
+kubectl create -f $SPIN_SCRIPT_PATH/rs/spin-$1.yaml

--- a/experimental/kubernetes/simple/scripts/update-config.sh
+++ b/experimental/kubernetes/simple/scripts/update-config.sh
@@ -1,2 +1,2 @@
-bash scripts/cleanup-config.sh
-bash scripts/startup-config.sh
+bash $SPIN_SCRIPT_PATH/scripts/cleanup-config.sh
+bash $SPIN_SCRIPT_PATH/scripts/startup-config.sh

--- a/experimental/kubernetes/simple/scripts/update-spinnaker.sh
+++ b/experimental/kubernetes/simple/scripts/update-spinnaker.sh
@@ -1,3 +1,3 @@
-bash scripts/cleanup-spinnaker.sh
+bash $SPIN_SCRIPT_PATH/scripts/cleanup-spinnaker.sh
 sleep 31 # graceful termination period is 30s
-bash scripts/startup-spinnaker.sh
+bash $SPIN_SCRIPT_PATH/scripts/startup-spinnaker.sh


### PR DESCRIPTION
* Provide a descriptive title for your changes.
- I had a lot of issues with script pathing when trying to use the 'startup-all.sh' and 'cleanup-all.sh' and noticed there was lots of hardcoding. I've modified the scripts to set an environment variable for the spinnaker pathing and added that to the directory paths.
The hope is to allow for the install from any directory within the spinnaker main path.

* If it fixes a bug or resolves a feature request, be sure to link to that issue.
- kind of a bug imo

* Add a comment to @spinnaker/reviewers for review if your issue has been outstanding for more than 3 days. 
