### PR TITLE
Install scripts for monitoring support.

### DIFF
--- a/config/default-spinnaker-local.yml
+++ b/config/default-spinnaker-local.yml
@@ -231,7 +231,7 @@ services:
 
   spectator:
     webEndpoint:
-      enabled: false
+      enabled: true
 
   stackdriver:
     enabled: false

--- a/config/spinnaker.yml
+++ b/config/spinnaker.yml
@@ -238,7 +238,7 @@ services:
 
   spectator:
     webEndpoint:
-      enabled: false
+      enabled: true
 
   stackdriver:
     enabled: ${SPINNAKER_STACKDRIVER_ENABLED:false}

--- a/google/stackdriver_monitoring/config/datadog/KitchenSinkTimeboard.json
+++ b/google/stackdriver_monitoring/config/datadog/KitchenSinkTimeboard.json
@@ -314,6 +314,36 @@
         "viz": "timeseries", 
         "requests": [
           {
+            "q": "diff(sum:clouddriver.operations_count{success:true} by {operationtype})", 
+            "aggregator": "avg", 
+            "conditional_formats": [], 
+            "type": "bars"
+          }
+        ], 
+        "autoscale": true
+      }, 
+      "title": "Successful Operations (per minute)"
+    }, 
+    {
+      "definition": {
+        "viz": "timeseries", 
+        "requests": [
+          {
+            "q": "diff(sum:clouddriver.operations_count{success:false} by {operationtype})", 
+            "aggregator": "avg", 
+            "conditional_formats": [], 
+            "type": "bars"
+          }
+        ], 
+        "autoscale": true
+      }, 
+      "title": "Failed Operations (per minute)"
+    }, 
+    {
+      "definition": {
+        "viz": "timeseries", 
+        "requests": [
+          {
             "q": "per_second(sum:front50.controller.invocations_count{*} by {method})", 
             "aggregator": "avg", 
             "conditional_formats": [], 
@@ -422,28 +452,99 @@
         "viz": "timeseries", 
         "requests": [
           {
-            "q": "sum:orca.threadpool.activeCount{*}", 
+            "q": "diff(sum:orca.task.invocations{executiontype:orchestration,status:running} by {taskname})", 
             "aggregator": "avg", 
             "conditional_formats": [], 
-            "type": "line"
+            "type": "bars"
           }
-        ]
+        ], 
+        "autoscale": true
       }, 
-      "title": "Active Orca Threads (per minute)"
+      "title": "Active Orchestrations (orca)"
     }, 
     {
       "definition": {
         "viz": "timeseries", 
         "requests": [
           {
-            "q": "per_minute(sum:igor.controller.invocations_totalTime{*} by {method}) / 1000000 / per_minute(avg:igor.controller.invocations_count{*} by {method})", 
+            "q": "diff(sum:orca.task.invocations{executiontype:orchestration,status:succeeded} by {taskname})", 
             "aggregator": "avg", 
             "conditional_formats": [], 
-            "type": "line"
+            "type": "bars", 
+            "style": {
+              "palette": "cool"
+            }
+          }, 
+          {
+            "q": "- diff(sum:orca.task.invocations{executiontype:orchestration,status:terminal} by {taskname})", 
+            "aggregator": "avg", 
+            "conditional_formats": [], 
+            "type": "bars", 
+            "style": {
+              "palette": "warm"
+            }
           }
-        ]
+        ], 
+        "autoscale": true
       }, 
-      "title": "Igor Controller Invocation Time (ms per minute)"
+      "title": "Completed Orchestrations (orca)"
+    }, 
+    {
+      "definition": {
+        "viz": "timeseries", 
+        "requests": [
+          {
+            "q": "diff(sum:orca.task.invocations{status:running,executiontype:pipeline} by {taskname})", 
+            "aggregator": "avg", 
+            "conditional_formats": [], 
+            "type": "bars"
+          }
+        ], 
+        "autoscale": true
+      }, 
+      "title": "Active Pipelines (orca)"
+    }, 
+    {
+      "definition": {
+        "viz": "timeseries", 
+        "requests": [
+          {
+            "q": "diff(sum:orca.task.invocations{status:succeeded,executiontype:pipeline} by {taskname})", 
+            "aggregator": "avg", 
+            "conditional_formats": [], 
+            "type": "bars", 
+            "style": {
+              "palette": "cool"
+            }
+          }, 
+          {
+            "q": "- diff(sum:orca.task.invocations{status:terminal,executiontype:pipeline} by {taskname})", 
+            "aggregator": "avg", 
+            "conditional_formats": [], 
+            "type": "bars", 
+            "style": {
+              "palette": "warm"
+            }
+          }
+        ], 
+        "autoscale": true
+      }, 
+      "title": "Completed Pipelines (orca)"
+    }, 
+    {
+      "definition": {
+        "viz": "timeseries", 
+        "requests": [
+          {
+            "q": "sum:orca.threadpool.activeCount{*} by {id}", 
+            "aggregator": "avg", 
+            "conditional_formats": [], 
+            "type": "bars"
+          }
+        ], 
+        "autoscale": true
+      }, 
+      "title": "Active Orca Threads (per minute)"
     }, 
     {
       "definition": {
@@ -459,6 +560,20 @@
         "precision": "0"
       }, 
       "title": "Last known Orca Active Threads"
+    }, 
+    {
+      "definition": {
+        "viz": "timeseries", 
+        "requests": [
+          {
+            "q": "per_minute(sum:igor.controller.invocations_totalTime{*} by {method}) / 1000000 / per_minute(avg:igor.controller.invocations_count{*} by {method})", 
+            "aggregator": "avg", 
+            "conditional_formats": [], 
+            "type": "line"
+          }
+        ]
+      }, 
+      "title": "Igor Controller Invocation Time (ms per minute)"
     }, 
     {
       "definition": {
@@ -545,24 +660,31 @@
         "viz": "timeseries", 
         "requests": [
           {
-            "q": "per_minute(sum:rosco.bakes{*} by {success})", 
+            "q": "diff(sum:rosco.bakesActive{*})", 
             "aggregator": "avg", 
-            "style": {
-              "palette": "cool"
-            }, 
-            "type": "bars", 
-            "conditional_formats": []
+            "conditional_formats": [], 
+            "type": "line"
           }, 
           {
-            "q": "per_minute(sum:rosco.bakes.local{*} by {active})", 
+            "q": "diff(sum:rosco.bakesRequested{*} by {flavor})", 
+            "conditional_formats": [], 
+            "type": "bars", 
+            "style": {
+              "palette": "cool"
+            }
+          }, 
+          {
+            "q": "diff(sum:rosco.bakesCompleted_count{success:false} by {region})", 
+            "conditional_formats": [], 
+            "type": "bars", 
             "style": {
               "palette": "warm"
-            }, 
-            "type": "bars"
+            }
           }
-        ]
+        ], 
+        "autoscale": true
       }, 
-      "title": "Rosco Bakes (local warm, per minute)"
+      "title": "Rosco Bake Activity"
     }, 
     {
       "definition": {
@@ -817,7 +939,7 @@
         "viz": "timeseries", 
         "requests": [
           {
-            "q": " - diff(sum:clouddriver.google.api_count{success:false} by {api,scope}.as_rate()), diff(sum:clouddriver.google.api_count{success:true} by {api,scope}.as_rate())", 
+            "q": "- diff(sum:clouddriver.google.api_count{success:false} by {api,scope}.as_rate()), diff(sum:clouddriver.google.api_count{success:true} by {api,scope}.as_rate())", 
             "aggregator": "avg", 
             "style": {
               "palette": "dog_classic"
@@ -828,7 +950,7 @@
         ], 
         "autoscale": true
       }, 
-      "title": "Google API Call Rate (per minute, lines by scope, bars by api)"
+      "title": "Google API Call Rate"
     }, 
     {
       "definition": {
@@ -856,7 +978,7 @@
             "q": "per_minute(sum:clouddriver.google.api_totalTime{*} by {api,scope}) / 1000000 / per_minute(sum:clouddriver.google.api_count{*} by {api,scope}.as_count())", 
             "aggregator": "avg", 
             "conditional_formats": [], 
-            "type": "bars"
+            "type": "line"
           }
         ], 
         "autoscale": true
@@ -868,20 +990,58 @@
         "viz": "timeseries", 
         "requests": [
           {
-            "q": "diff(sum:clouddriver.google.operationWaits_count{*} by {basephase})", 
+            "q": "per_minute(sum:clouddriver.google.batchExecute_count{*} by {context})", 
+            "aggregator": "avg", 
+            "conditional_formats": [], 
+            "type": "line"
+          }
+        ], 
+        "autoscale": true
+      }, 
+      "title": "Google Batch Count (per minute)"
+    }, 
+    {
+      "definition": {
+        "viz": "timeseries", 
+        "requests": [
+          {
+            "q": "per_minute(sum:clouddriver.google.batchExecute_totalTime{*} by {context}) / 1000000 / per_minute(sum:clouddriver.google.batchExecute_count{*} by {context})", 
+            "aggregator": "avg", 
+            "conditional_formats": [], 
+            "type": "line"
+          }
+        ], 
+        "autoscale": true
+      }, 
+      "title": "Batch Call Latency (ms per call minute)"
+    }, 
+    {
+      "definition": {
+        "viz": "timeseries", 
+        "requests": [
+          {
+            "q": "per_minute(sum:clouddriver.google.batchSize{*} by {context})", 
+            "aggregator": "avg", 
+            "conditional_formats": [], 
+            "type": "line"
+          }
+        ], 
+        "autoscale": true
+      }, 
+      "title": "Batch Call Size (per minute)"
+    }, 
+    {
+      "definition": {
+        "viz": "timeseries", 
+        "requests": [
+          {
+            "q": "diff(sum:clouddriver.google.operationWaits_count{status:done} by {basephase,scope})", 
             "aggregator": "avg", 
             "conditional_formats": [], 
             "type": "bars", 
             "style": {
-              "palette": "cool"
+              "palette": "dog_classic"
             }
-          }, 
-          {
-            "q": "diff(sum:clouddriver.google.operationWaits_count{*} by {scope})", 
-            "style": {
-              "palette": "warm"
-            }, 
-            "type": "line"
           }
         ], 
         "autoscale": true, 
@@ -891,7 +1051,53 @@
           }
         }
       }, 
-      "title": "Google Waiting Operations (diff, bars by phase, lines by scope)"
+      "title": "Successful Google Operations (clouddriver)"
+    }, 
+    {
+      "definition": {
+        "viz": "timeseries", 
+        "requests": [
+          {
+            "q": "diff(sum:clouddriver.google.operationWaits_count{!status:done} by {basephase,scope})", 
+            "aggregator": "avg", 
+            "conditional_formats": [], 
+            "type": "bars", 
+            "style": {
+              "palette": "dog_classic"
+            }
+          }
+        ], 
+        "autoscale": true, 
+        "yaxis": {
+          "filter": {
+            "below": 0.01
+          }
+        }
+      }, 
+      "title": "Failed Google Operations (clouddriver)"
+    }, 
+    {
+      "definition": {
+        "viz": "timeseries", 
+        "requests": [
+          {
+            "q": "diff(sum:clouddriver.google.operationWaitRequests{*} by {basephase,scope})", 
+            "aggregator": "avg", 
+            "conditional_formats": [], 
+            "type": "bars", 
+            "style": {
+              "palette": "dog_classic"
+            }
+          }
+        ], 
+        "autoscale": true, 
+        "yaxis": {
+          "filter": {
+            "below": 0.01
+          }
+        }
+      }, 
+      "title": "Google Operations Started (clouddriver)"
     }, 
     {
       "definition": {
@@ -933,36 +1139,6 @@
         "viz": "timeseries", 
         "requests": [
           {
-            "q": "per_minute(sum:clouddriver.onDemand_total_totalTime{*} by {ondemandtype}) / 1000000000 / per_minute(sum:clouddriver.onDemand_total_count{*} by {ondemandtype})", 
-            "aggregator": "avg", 
-            "conditional_formats": [], 
-            "type": "bars"
-          }
-        ], 
-        "autoscale": true
-      }, 
-      "title": "Clouddriver OnDemand Invocation Time (ms per call per minute)"
-    }, 
-    {
-      "definition": {
-        "viz": "timeseries", 
-        "requests": [
-          {
-            "q": "diff(sum:clouddriver.operations_count{*} by {operationtype})", 
-            "aggregator": "avg", 
-            "conditional_formats": [], 
-            "type": "bars"
-          }
-        ], 
-        "autoscale": true
-      }, 
-      "title": "Clouddriver Operations (type per minute)"
-    }, 
-    {
-      "definition": {
-        "viz": "timeseries", 
-        "requests": [
-          {
             "q": "avg:clouddriver.spectator.datapoints{*}, avg:echo.spectator.datapoints{*}, avg:fiat.spectator.datapoints{*}, avg:front50.spectator.datapoints{*}, avg:gate.spectator.datapoints{*}, avg:orca.spectator.datapoints{*}, avg:rosco.spectator.datapoints{*}", 
             "aggregator": "avg", 
             "conditional_formats": [], 
@@ -972,23 +1148,8 @@
         "autoscale": true
       }, 
       "title": "Spectator Time Series Streams"
-    }, 
-    {
-      "definition": {
-        "viz": "timeseries", 
-        "requests": [
-          {
-            "q": "diff(sum:clouddriver.google.batchExecute_count{*} by {context})", 
-            "aggregator": "avg", 
-            "conditional_formats": [], 
-            "type": "area"
-          }
-        ], 
-        "autoscale": true
-      }, 
-      "title": "Google Batch Execution Count"
     }
   ], 
   "description": "Contains graphs of various metrics within Spinnaker to illustrate what is available.", 
-  "title": "FullSpinnaker"
+  "title": "Spinnaker Kitchen Sink"
 }

--- a/google/stackdriver_monitoring/config/datadog/MinimalTimeboard.json
+++ b/google/stackdriver_monitoring/config/datadog/MinimalTimeboard.json
@@ -22,7 +22,7 @@
         ], 
         "autoscale": true
       }, 
-      "title": "Hystrix Short Circuited"
+      "title": "Hystrix Short Circuited (global)"
     }, 
     {
       "definition": {
@@ -35,8 +35,8 @@
             "type": "line"
           }, 
           {
-            "q": "diff(sum:igor.hystrix.countExceptionsThrown{*})", 
-            "type": "line"
+            "q": "diff(sum:igor.hystrix.countExceptionsThrown{*}.as_count())", 
+            "type": "bars"
           }, 
           {
             "q": "diff(sum:gate.hystrix.countExceptionsThrown{*})", 
@@ -45,7 +45,89 @@
         ], 
         "autoscale": true
       }, 
-      "title": "Hystrix Exceptions"
+      "title": "Hystrix Exceptions (global)"
+    }, 
+    {
+      "definition": {
+        "viz": "timeseries", 
+        "requests": [
+          {
+            "q": "diff(sum:orca.task.invocations{executiontype:orchestration,status:running} by {taskname})", 
+            "aggregator": "avg", 
+            "conditional_formats": [], 
+            "type": "bars"
+          }
+        ], 
+        "autoscale": true
+      }, 
+      "title": "Active Orchestrations (orca)"
+    }, 
+    {
+      "definition": {
+        "viz": "timeseries", 
+        "requests": [
+          {
+            "q": "diff(sum:orca.task.invocations{executiontype:orchestration,status:succeeded} by {taskname})", 
+            "aggregator": "avg", 
+            "conditional_formats": [], 
+            "type": "bars", 
+            "style": {
+              "palette": "cool"
+            }
+          }, 
+          {
+            "q": "- diff(sum:orca.task.invocations{executiontype:orchestration,status:terminal} by {taskname})", 
+            "aggregator": "avg", 
+            "conditional_formats": [], 
+            "type": "bars", 
+            "style": {
+              "palette": "warm"
+            }
+          }
+        ], 
+        "autoscale": true
+      }, 
+      "title": "Completed Orchestrations (orca)"
+    }, 
+    {
+      "definition": {
+        "viz": "timeseries", 
+        "requests": [
+          {
+            "q": "diff(sum:orca.task.invocations{status:running,executiontype:pipeline} by {taskname})", 
+            "aggregator": "avg", 
+            "conditional_formats": [], 
+            "type": "bars"
+          }
+        ], 
+        "autoscale": true
+      }, 
+      "title": "Active Pipelines (orca)"
+    }, 
+    {
+      "definition": {
+        "viz": "timeseries", 
+        "requests": [
+          {
+            "q": "diff(sum:orca.task.invocations{status:succeeded,executiontype:pipeline} by {taskname})", 
+            "aggregator": "avg", 
+            "conditional_formats": [], 
+            "type": "bars", 
+            "style": {
+              "palette": "cool"
+            }
+          }, 
+          {
+            "q": " - diff(sum:orca.task.invocations{status:terminal,executiontype:pipeline} by {taskname})", 
+            "style": {
+              "palette": "warm"
+            }, 
+            "type": "bars"
+          }
+        ], 
+        "autoscale": true
+      }, 
+      "title": "Completed Pipelines (orca)"
     }, 
     {
       "definition": {
@@ -60,37 +142,7 @@
         ], 
         "autoscale": true
       }, 
-      "title": "Clouddriver Operations"
-    }, 
-    {
-      "definition": {
-        "viz": "timeseries", 
-        "requests": [
-          {
-            "q": "avg:system.load.1{*}", 
-            "aggregator": "avg", 
-            "conditional_formats": [], 
-            "type": "line"
-          }
-        ], 
-        "autoscale": true
-      }, 
-      "title": "This Slot Is Reserved For Future Use"
-    }, 
-    {
-      "definition": {
-        "viz": "timeseries", 
-        "requests": [
-          {
-            "q": "diff(sum:clouddriver.operations_count{success:true} by {operationtype}), - diff(sum:clouddriver.operations_count{!success:true} by {operationtype})", 
-            "aggregator": "avg", 
-            "conditional_formats": [], 
-            "type": "bars"
-          }
-        ], 
-        "autoscale": true
-      }, 
-      "title": "Active Orca Threads"
+      "title": "Active Threads (orca)"
     }, 
     {
       "definition": {
@@ -105,21 +157,38 @@
         ], 
         "autoscale": true
       }, 
-      "title": "Pipelines Triggered"
+      "title": "Pipelines Triggered (echo)"
     }, 
     {
       "definition": {
         "viz": "timeseries", 
         "requests": [
           {
-            "q": "sum:rosco.bakesActive{*}", 
+            "q": "diff(sum:rosco.bakesActive{*})", 
+            "aggregator": "avg", 
             "conditional_formats": [], 
             "type": "line"
+          }, 
+          {
+            "q": "diff(sum:rosco.bakesRequested{*} by {flavor})", 
+            "conditional_formats": [], 
+            "type": "bars", 
+            "style": {
+              "palette": "cool"
+            }
+          }, 
+          {
+            "q": "diff(sum:rosco.bakesCompleted_count{success:false} by {region})", 
+            "conditional_formats": [], 
+            "type": "bars", 
+            "style": {
+              "palette": "warm"
+            }
           }
         ], 
         "autoscale": true
       }, 
-      "title": "Bakes in Progress"
+      "title": "Bake Activity (rosco)"
     }, 
     {
       "definition": {
@@ -134,7 +203,37 @@
         ], 
         "autoscale": true
       }, 
-      "title": "Front50 Item Cache Sizes"
+      "title": "Item Cache Size (front50)"
+    }, 
+    {
+      "definition": {
+        "viz": "timeseries", 
+        "requests": [
+          {
+            "q": "diff(sum:clouddriver.operations_count{success:true} by {operationtype})", 
+            "aggregator": "avg", 
+            "conditional_formats": [], 
+            "type": "bars"
+          }
+        ], 
+        "autoscale": true
+      }, 
+      "title": "Successful Operations (clouddriver)"
+    }, 
+    {
+      "definition": {
+        "viz": "timeseries", 
+        "requests": [
+          {
+            "q": "diff(sum:clouddriver.operations_count{success:false} by {operationtype})", 
+            "aggregator": "avg", 
+            "conditional_formats": [], 
+            "type": "bars"
+          }
+        ], 
+        "autoscale": true
+      }, 
+      "title": "Failed Operations (clouddriver)"
     }, 
     {
       "definition": {
@@ -196,5 +295,5 @@
     }
   ], 
   "description": "A bare-bones dashboard for monitoring a Spinnaker deployment", 
-  "title": "MinimalSpinnaker"
+  "title": "Minimal Spinnaker"
 }

--- a/google/stackdriver_monitoring/config/datadog/SpecificApplicationTimeboard.json
+++ b/google/stackdriver_monitoring/config/datadog/SpecificApplicationTimeboard.json
@@ -1,0 +1,186 @@
+{
+  "read_only": false, 
+  "graphs": [
+    {
+      "definition": {
+        "viz": "timeseries", 
+        "requests": [
+          {
+            "q": "diff(sum:orca.task.invocations{$SourceApplication,executiontype:orchestration,status:running} by {taskname})", 
+            "aggregator": "avg", 
+            "conditional_formats": [], 
+            "type": "bars"
+          }
+        ], 
+        "autoscale": true
+      }, 
+      "title": "$SourceApplication Active Orchestrations (orca)"
+    }, 
+    {
+      "definition": {
+        "viz": "timeseries", 
+        "requests": [
+          {
+            "q": "diff(sum:orca.task.invocations{$SourceApplication,executiontype:orchestration,status:running} by {taskname})", 
+            "aggregator": "avg", 
+            "conditional_formats": [], 
+            "type": "bars"
+          }
+        ], 
+        "autoscale": true
+      }, 
+      "title": "$SourceApplication Active Orchestrations (orca)"
+    }, 
+    {
+      "definition": {
+        "viz": "timeseries", 
+        "requests": [
+          {
+            "q": "diff(sum:orca.task.invocations{$SourceApplication,status:running,executiontype:pipeline} by {taskname})", 
+            "aggregator": "avg", 
+            "conditional_formats": [], 
+            "type": "bars"
+          }
+        ], 
+        "autoscale": true
+      }, 
+      "title": "$SourceApplication Active Pipelines (orca)"
+    }, 
+    {
+      "definition": {
+        "viz": "timeseries", 
+        "requests": [
+          {
+            "q": "diff(sum:orca.task.invocations{$SourceApplication,status:succeeded,executiontype:pipeline} by {taskname})", 
+            "aggregator": "avg", 
+            "conditional_formats": [], 
+            "type": "bars", 
+            "style": {
+              "palette": "cool"
+            }
+          }, 
+          {
+            "q": "- diff(sum:orca.task.invocations{$SourceApplication,status:terminal,executiontype:pipeline} by {taskname})", 
+            "aggregator": "avg", 
+            "conditional_formats": [], 
+            "type": "bars", 
+            "style": {
+              "palette": "warm"
+            }
+          }
+        ], 
+        "autoscale": true
+      }, 
+      "title": "$SourceApplication Completed Pipelines (orca)"
+    }, 
+    {
+      "definition": {
+        "viz": "timeseries", 
+        "requests": [
+          {
+            "q": "diff(sum:echo.pipelines.triggered{$Application} by {name})", 
+            "aggregator": "avg", 
+            "conditional_formats": [], 
+            "type": "bars"
+          }
+        ], 
+        "autoscale": true
+      }, 
+      "title": "$Application Pipelines Triggered (echo)"
+    }, 
+    {
+      "definition": {
+        "viz": "timeseries", 
+        "requests": [
+          {
+            "q": "diff(sum:rosco.bakesActive{*})", 
+            "aggregator": "avg", 
+            "conditional_formats": [], 
+            "type": "line"
+          }, 
+          {
+            "q": "diff(sum:rosco.bakesRequested{*} by {flavor})", 
+            "conditional_formats": [], 
+            "type": "bars", 
+            "style": {
+              "palette": "cool"
+            }
+          }, 
+          {
+            "q": "diff(sum:rosco.bakesCompleted_count{success:false} by {region})", 
+            "conditional_formats": [], 
+            "type": "bars", 
+            "style": {
+              "palette": "warm"
+            }
+          }
+        ], 
+        "autoscale": true
+      }, 
+      "title": "Global Bake Activity (rosco)"
+    }, 
+    {
+      "definition": {
+        "viz": "timeseries", 
+        "requests": [
+          {
+            "q": "per_minute(sum:rosco.bakesCompleted_totalTime{*} by {region}) / 1000000000 / per_minute(sum:rosco.bakesCompleted_count{*} by {region}) / 60", 
+            "aggregator": "avg", 
+            "conditional_formats": [], 
+            "type": "area"
+          }
+        ], 
+        "autoscale": true
+      }, 
+      "title": "Global Bake Completion Time Minutes (rosco)"
+    }, 
+    {
+      "definition": {
+        "viz": "timeseries", 
+        "requests": [
+          {
+            "q": "diff(sum:gate.hystrix.rollingCountShortCircuited{*} by {metricgroup})", 
+            "aggregator": "avg", 
+            "conditional_formats": [], 
+            "type": "bars"
+          }, 
+          {
+            "q": "diff(sum:igor.hystrix.rollingCountShortCircuited{*} by {metricgroup})", 
+            "type": "bars"
+          }, 
+          {
+            "q": "diff(sum:front50.hystrix.rollingCountShortCircuited{*} by {metricgroup})", 
+            "type": "bars"
+          }
+        ], 
+        "autoscale": true
+      }, 
+      "title": "Hystrix Short Circuited (global)"
+    }, 
+    {
+      "definition": {
+        "viz": "timeseries", 
+        "requests": [
+          {
+            "q": "diff(sum:front50.hystrix.countExceptionsThrown{*})", 
+            "aggregator": "avg", 
+            "conditional_formats": [], 
+            "type": "line"
+          }, 
+          {
+            "q": "diff(sum:igor.hystrix.countExceptionsThrown{*}.as_count())", 
+            "type": "bars"
+          }, 
+          {
+            "q": "diff(sum:gate.hystrix.countExceptionsThrown{*})", 
+            "type": "line"
+          }
+        ], 
+        "autoscale": true
+      }, 
+      "title": "Hystrix Exceptions Thrown (global)"
+    }
+  ], 
+  "description": "Templated dashboard to show details for a specific Application", 
+  "title": "Specific Spinnaker Application"
+}

--- a/google/stackdriver_monitoring/config/datadog/install.sh
+++ b/google/stackdriver_monitoring/config/datadog/install.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Copyright 2017 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+SOURCE_DIR=$(dirname $0)
+HAVE_KEYS=0
+
+function prompt_if_unset() {
+  local name=$1
+  local tmp
+  while [[ "${!name}" == "" ]]; do
+      read -e -p "ENTER $name: " tmp
+      eval ${name}=$tmp
+  done
+}
+
+prompt_if_unset DATADOG_API_KEY
+prompt_if_unset DATADOG_APP_KEY
+
+environ_file=$(readlink -f "${SOURCE_DIR}/../../environ")
+echo "Storing keys into $environ_file"
+if [[ ! -f "${environ_file}" ]]; then
+  sudo touch "${environ_file}"
+fi
+sudo chmod 600 "${environ_file}"
+sudo cat >> "$environ_file" <<EOF
+DATADOG_API_KEY=$DATADOG_API_KEY
+DATADOG_APP_KEY=$DATADOG_APP_KEY
+EOF
+
+
+echo "Installing Datadog Agent"
+DD_API_KEY=$DATADOG_API_KEY bash -c "$(curl -L https://raw.githubusercontent.com/DataDog/dd-agent/master/packaging/datadog-agent/source/install_agent.sh)"
+
+for dashboard in ${SOURCE_DIR}/*Timeboard.json; do
+  echo "Installing $(basename $dashboard)"
+  curl -X POST -H "Content-type: application/json" \
+       -d "@${dasboard}"
+      "https://app.datadoghq.com/api/v1/dash?api_key=${DATADOG_API_KEY}&application_key=${DATADOG_APP_KEY}"
+done
+

--- a/google/stackdriver_monitoring/config/prometheus/KitchenSinkDashboard.json
+++ b/google/stackdriver_monitoring/config/prometheus/KitchenSinkDashboard.json
@@ -165,7 +165,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "delta(front50:hystrix:countExceptionsThrown[1m])",
+              "expr": "sum(idelta(front50:hystrix:countExceptionsThrown[$SamplePeriod])) by (metricType, metricGroup)",
               "intervalFactor": 2,
               "legendFormat": "front50/{{metricType}}({{metricGroup}})",
               "metric": "front50:hystrix:countExceptionsThrown",
@@ -173,7 +173,7 @@
               "step": 10
             },
             {
-              "expr": "delta(gate:hystrix:countExceptionsThrown[1m])",
+              "expr": "sum(idelta(gate:hystrix:countExceptionsThrown[$SamplePeriod])) by (metricType, metricGroup)",
               "intervalFactor": 2,
               "legendFormat": "gate/{{metricType}}({{metricGroup}})",
               "metric": "gate:hystrix:countExceptionsThrown",
@@ -181,7 +181,7 @@
               "step": 10
             },
             {
-              "expr": "delta(igor:hystrix:countExceptionsThrown[1m])",
+              "expr": "sum(idelta(igor:hystrix:countExceptionsThrown[$SamplePeriod])) by (metricType, metricGroup)",
               "intervalFactor": 2,
               "legendFormat": "igor/{{metricType}}({{metricGroup}})",
               "metric": "igor:hystrix:countExceptionsThrown",
@@ -211,7 +211,7 @@
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             },
             {
@@ -219,7 +219,7 @@
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             }
           ]
@@ -359,7 +359,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "label_replace(sum(delta(clouddriver:controller:invocations__count[1m])) by (controller, method), \"controller\", \"$1\", \"controller\", \"(.*)Controller\")",
+              "expr": "label_replace(sum(idelta(clouddriver:controller:invocations__count[$SamplePeriod])) by (controller, method), \"controller\", \"$1\", \"controller\", \"(.*)Controller\")",
               "hide": false,
               "intervalFactor": 2,
               "legendFormat": "{{controller}}({{method}})",
@@ -389,7 +389,7 @@
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             },
             {
@@ -397,7 +397,7 @@
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             }
           ]
@@ -433,7 +433,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "label_replace(sum(rate(clouddriver:controller:invocations__totalTime[1m])) by (controller, method) / 1000000 / sum(rate(clouddriver:controller:invocations__count[1m])) by (controller, method), \"controller\", \"$1\", \"controller\", \"(.*)Controller\")",
+              "expr": "label_replace(sum(rate(clouddriver:controller:invocations__totalTime[$SamplePeriod])) by (controller, method) / 1000000 / sum(rate(clouddriver:controller:invocations__count[$SamplePeriod])) by (controller, method), \"controller\", \"$1\", \"controller\", \"(.*)Controller\")",
               "hide": false,
               "intervalFactor": 2,
               "legendFormat": "{{controller}}({{method}})",
@@ -519,7 +519,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "label_replace(sum(idelta(clouddriver:operations__count{success=\"true\"}[1m])) by (OperationType), \"OperationType\", \"$1\", \"OperationType\", \"(.*)AtomicOperation\")",
+              "expr": "label_replace(sum(idelta(clouddriver:operations__count{success=\"true\"}[$SamplePeriod])) by (OperationType), \"OperationType\", \"$1\", \"OperationType\", \"(.*)AtomicOperation\")",
               "hide": false,
               "intervalFactor": 2,
               "legendFormat": "{{OperationType}}",
@@ -530,7 +530,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Successful Operations",
+          "title": "Successful Operations (clouddriver)",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -549,7 +549,7 @@
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             },
             {
@@ -557,7 +557,7 @@
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             }
           ]
@@ -593,7 +593,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "label_replace(label_replace(sum(idelta(clouddriver:operations__count{success=\"false\"}[1m])) by (OperationType, cause), \"OperationType\", \"$1\", \"OperationType\", \"(.*)AtomicOperation\"), \"cause\", \"$1\", \"cause\", \"(.*)Exception\")",
+              "expr": "label_replace(label_replace(sum(idelta(clouddriver:operations__count{success=\"false\"}[$SamplePeriod])) by (OperationType, cause), \"OperationType\", \"$1\", \"OperationType\", \"(.*)AtomicOperation\"), \"cause\", \"$1\", \"cause\", \"(.*)Exception\")",
               "intervalFactor": 2,
               "legendFormat": "{{OperationType}}/{{cause}}",
               "refId": "A",
@@ -603,7 +603,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Failed Operations",
+          "title": "Failed Operations (clouddriver)",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -622,7 +622,7 @@
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             },
             {
@@ -630,7 +630,7 @@
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             }
           ]
@@ -645,7 +645,7 @@
     },
     {
       "collapse": false,
-      "height": 264,
+      "height": 276,
       "panels": [
         {
           "aliasColors": {},
@@ -673,17 +673,17 @@
           "points": false,
           "renderer": "flot",
           "seriesOverrides": [],
-          "span": 2,
+          "span": 3,
           "stack": false,
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(delta(echo:controller:invocations__count[1m])) by (controller, method)",
+              "expr": "sum(idelta(echo:controller:invocations__count[$SamplePeriod])) by (controller, method)",
               "hide": false,
               "intervalFactor": 2,
               "legendFormat": "{{controller}}({{method}})",
               "refId": "C",
-              "step": 30
+              "step": 20
             }
           ],
           "thresholds": [],
@@ -708,7 +708,7 @@
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             },
             {
@@ -716,7 +716,7 @@
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             }
           ]
@@ -747,17 +747,17 @@
           "points": false,
           "renderer": "flot",
           "seriesOverrides": [],
-          "span": 2,
+          "span": 3,
           "stack": false,
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(echo:controller:invocations__totalTime[1m])) by (controller, method) / 1000000 / sum(rate(echo:controller:invocations__count[1m])) by (controller, method)",
+              "expr": "sum(rate(echo:controller:invocations__totalTime[$SamplePeriod])) by (controller, method) / 1000000 / sum(rate(echo:controller:invocations__count[$SamplePeriod])) by (controller, method)",
               "hide": false,
               "intervalFactor": 2,
               "legendFormat": "{{controller}}({{method}})",
               "refId": "C",
-              "step": 30
+              "step": 20
             }
           ],
           "thresholds": [],
@@ -804,6 +804,8 @@
           "legend": {
             "avg": false,
             "current": false,
+            "hideEmpty": true,
+            "hideZero": true,
             "max": false,
             "min": false,
             "show": true,
@@ -819,15 +821,15 @@
           "points": false,
           "renderer": "flot",
           "seriesOverrides": [],
-          "span": 8,
+          "span": 6,
           "stack": false,
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(delta(echo:pipelines:triggered[1m])) by (application, name)",
+              "expr": "sum(idelta(echo:pipelines:triggered[$SamplePeriod])) by (name)",
               "hide": false,
               "intervalFactor": 2,
-              "legendFormat": "{{name}}({{application}})",
+              "legendFormat": "{{name}}",
               "metric": "echo:pipelines:triggered",
               "refId": "A",
               "step": 10
@@ -836,7 +838,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Pipelines Triggered",
+          "title": "Pipelines Triggered (echo)",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -855,7 +857,7 @@
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             },
             {
@@ -863,7 +865,7 @@
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             }
           ]
@@ -911,7 +913,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "label_replace(sum(delta(gate:controller:invocations__count[1m])) by (controller, method), \"controller\", \"$1\", \"controller\", \"(.*)Controller\")",
+              "expr": "label_replace(sum(idelta(gate:controller:invocations__count[$SamplePeriod])) by (controller, method), \"controller\", \"$1\", \"controller\", \"(.*)Controller\")",
               "intervalFactor": 2,
               "legendFormat": "{{controller}}({{method}})",
               "refId": "A",
@@ -940,7 +942,7 @@
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             },
             {
@@ -948,7 +950,7 @@
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             }
           ]
@@ -983,7 +985,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "label_replace(sum(rate(gate:controller:invocations__totalTime[1m])) by (controller, method) / 1000000 / sum(rate(gate:controller:invocations__count[1m])) by (controller, method), \"controller\", \"$1\", \"controller\", \"(.*)Controller\")",
+              "expr": "label_replace(sum(rate(gate:controller:invocations__totalTime[$SamplePeriod])) by (controller, method) / 1000000 / sum(rate(gate:controller:invocations__count[$SamplePeriod])) by (controller, method), \"controller\", \"$1\", \"controller\", \"(.*)Controller\")",
               "intervalFactor": 2,
               "legendFormat": "{{controller}}({{method}})",
               "refId": "A",
@@ -1068,7 +1070,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "label_replace(sum(delta(igor:controller:invocations__count[1m])) by (controller, method), \"controller\", \"$1\", \"controller\", \"(.*)Controller\")",
+              "expr": "label_replace(sum(idelta(igor:controller:invocations__count[$SamplePeriod])) by (controller, method), \"controller\", \"$1\", \"controller\", \"(.*)Controller\")",
               "intervalFactor": 2,
               "legendFormat": "{{controller}}({{method}})",
               "refId": "A",
@@ -1097,7 +1099,7 @@
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             },
             {
@@ -1105,7 +1107,7 @@
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             }
           ]
@@ -1140,7 +1142,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "label_replace(sum(rate(igor:controller:invocations__totalTime[1m])) by (controller, method) / 1000000 / sum(rate(igor:controller:invocations__count[1m])) by (controller, method), \"controller\", \"$1\", \"controller\", \"(.*)Controller\")",
+              "expr": "label_replace(sum(rate(igor:controller:invocations__totalTime[$SamplePeriod])) by (controller, method) / 1000000 / sum(rate(igor:controller:invocations__count[$SamplePeriod])) by (controller, method), \"controller\", \"$1\", \"controller\", \"(.*)Controller\")",
               "intervalFactor": 2,
               "legendFormat": "{{controller}}({{method}})",
               "refId": "A",
@@ -1225,7 +1227,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "label_replace(sum(delta(orca:controller:invocations__count[1m])) by (controller, method), \"controller\", \"$1\", \"controller\", \"(.*)Controller\")",
+              "expr": "label_replace(sum(idelta(orca:controller:invocations__count[$SamplePeriod])) by (controller, method), \"controller\", \"$1\", \"controller\", \"(.*)Controller\")",
               "intervalFactor": 2,
               "legendFormat": "{{controller}}({{method}})",
               "refId": "A",
@@ -1254,7 +1256,7 @@
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             },
             {
@@ -1262,7 +1264,7 @@
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             }
           ]
@@ -1295,7 +1297,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "label_replace(sum(rate(orca:controller:invocations__totalTime[1m])) by (controller, method) / 1000000 / sum(rate(orca:controller:invocations__count[1m])) by (controller, method), \"controller\", \"$1\", \"controller\", \"(.*)Controller\")",
+              "expr": "label_replace(sum(rate(orca:controller:invocations__totalTime[$SamplePeriod])) by (controller, method) / 1000000 / sum(rate(orca:controller:invocations__count[$SamplePeriod])) by (controller, method), \"controller\", \"$1\", \"controller\", \"(.*)Controller\")",
               "intervalFactor": 2,
               "legendFormat": "{{controller}}({{method}})",
               "refId": "A",
@@ -1377,7 +1379,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Orca Active Threads",
+          "title": "Active Threads (orca)",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -1419,6 +1421,338 @@
     },
     {
       "collapse": false,
+      "height": 250,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "${DS_SPINNAKER}",
+          "fill": 1,
+          "id": 55,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 3,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(idelta(orca:task:invocations{executionType=\"Orchestration\", isComplete=\"false\"}[$SamplePeriod])) by (taskName)",
+              "hide": false,
+              "intervalFactor": 2,
+              "legendFormat": "{{taskName}}",
+              "metric": "",
+              "refId": "B",
+              "step": 20
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Active Orchestrations (orca)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "${DS_SPINNAKER}",
+          "fill": 1,
+          "id": 56,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 3,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(idelta(orca:task:invocations{executionType=\"Orchestration\",isComplete=\"true\", status=\"SUCCEEDED\"}[$SamplePeriod])) by (taskName)",
+              "hide": false,
+              "intervalFactor": 2,
+              "legendFormat": "{{taskName}}",
+              "metric": "orca:task:invocations",
+              "refId": "C",
+              "step": 20
+            },
+            {
+              "expr": "-1 * sum(idelta(orca:task:invocations{executionType=\"Orchestration\",isComplete=\"true\", status!=\"SUCCEEDED\"}[$SamplePeriod])) by (taskName)",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "ERR {{taskName}}",
+              "metric": "orca:task:invocations",
+              "refId": "D",
+              "step": 20
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Orchestrations Completed (orca)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "${DS_SPINNAKER}",
+          "fill": 1,
+          "id": 58,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 3,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(idelta(orca:task:invocations{executionType=\"Pipeline\", isComplete=\"false\"}[$SamplePeriod])) by (taskName)",
+              "hide": false,
+              "intervalFactor": 2,
+              "legendFormat": "{{taskName}}",
+              "metric": "",
+              "refId": "B",
+              "step": 20
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Active Pipelines (orca)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "${DS_SPINNAKER}",
+          "fill": 1,
+          "id": 59,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 3,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(idelta(orca:task:invocations{executionType=\"Pipeline\",isComplete=\"true\", status=\"SUCCEEDED\"}[$SamplePeriod])) by (taskName)",
+              "hide": false,
+              "intervalFactor": 2,
+              "legendFormat": "{{taskName}}",
+              "metric": "orca:task:invocations",
+              "refId": "C",
+              "step": 20
+            },
+            {
+              "expr": "-1 * sum(idelta(orca:task:invocations{executionType=\"Pipeline\",isComplete=\"true\", status!=\"SUCCEEDED\"}[$SamplePeriod])) by (taskName)",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "ERR {{taskName}}",
+              "metric": "orca:task:invocations",
+              "refId": "D",
+              "step": 20
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Pipelines Completed (orca)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Orca Pipelines",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
       "height": 221,
       "panels": [
         {
@@ -1450,7 +1784,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "label_replace(sum(delta(rosco:controller:invocations__count[1m])) by (controller, method), \"controller\", \"$1\", \"controller\", \"(.*)Controller\")",
+              "expr": "label_replace(sum(idelta(rosco:controller:invocations__count[$SamplePeriod])) by (controller, method), \"controller\", \"$1\", \"controller\", \"(.*)Controller\")",
               "intervalFactor": 2,
               "legendFormat": "{{controller}}({{method}})",
               "refId": "A",
@@ -1479,7 +1813,7 @@
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             },
             {
@@ -1487,7 +1821,7 @@
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             }
           ]
@@ -1520,7 +1854,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "label_replace(sum(rate(rosco:controller:invocations__totalTime[1m])) by (controller, method) / 1000000 / sum(rate(rosco:controller:invocations__count[1m])) by (controller, method), \"controller\", \"$1\", \"controller\", \"(.*)Controller\")",
+              "expr": "label_replace(sum(rate(rosco:controller:invocations__totalTime[$SamplePeriod])) by (controller, method) / 1000000 / sum(rate(rosco:controller:invocations__count[$SamplePeriod])) by (controller, method), \"controller\", \"$1\", \"controller\", \"(.*)Controller\")",
               "intervalFactor": 2,
               "legendFormat": "{{controller}}({{method}})",
               "refId": "A",
@@ -1605,7 +1939,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(rosco:bakesCompleted__totalTime[1m]) / 1000000000) by (region) / sum(rate(rosco:bakesCompleted__count[1m])) by (region)",
+              "expr": "sum(rate(rosco:bakesCompleted__totalTime[$SamplePeriod]) / 1000000000) by (region) / sum(rate(rosco:bakesCompleted__count[$SamplePeriod])) by (region)",
               "hide": false,
               "intervalFactor": 2,
               "legendFormat": "{{region}}",
@@ -1617,7 +1951,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Bakes Completed",
+          "title": "Bakes Completed (rosco)",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -1689,18 +2023,20 @@
               "step": 10
             },
             {
-              "expr": "sum(idelta(rosco:bakeRequests[1m])) by (flavor)",
+              "expr": "sum(idelta(rosco:bakesRequested[$SamplePeriod])) by (flavor)",
               "hide": false,
               "intervalFactor": 2,
               "legendFormat": "Request({{flavor}})",
-              "metric": "rosco:bakeRequests",
+              "metric": "rosco:bakes",
               "refId": "B",
               "step": 10
             },
             {
-              "expr": "-1 * sum(idelta(rosco:bakesCompleted{success=\"false\"}[1m])) by (region)",
+              "expr": "-1 * sum(idelta(rosco:bakesCompleted__count{success=\"false\"}[$SamplePeriod])) by (region)",
+              "hide": false,
               "intervalFactor": 2,
               "legendFormat": "Failed {{region}}",
+              "metric": "bakesC",
               "refId": "C",
               "step": 10
             }
@@ -1708,7 +2044,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Bake Requests",
+          "title": "Bake Requests and Failures  (rosco)",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -1783,7 +2119,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(delta(front50:controller:invocations__count[1m])) by (controller, method)",
+              "expr": "sum(idelta(front50:controller:invocations__count[$SamplePeriod])) by (controller, method)",
               "intervalFactor": 2,
               "legendFormat": "{{controller}}({{method}})",
               "refId": "A",
@@ -1812,7 +2148,7 @@
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             },
             {
@@ -1820,7 +2156,7 @@
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             }
           ]
@@ -1855,7 +2191,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "label_replace(sum(rate(front50:controller:invocations__totalTime[1m])) by (controller, method) / 1000000 / sum(rate(front50:controller:invocations__count[1m])) by (controller, method), \"controller\", \"$1\", \"controller\", \"(.*)Controller\")",
+              "expr": "label_replace(sum(rate(front50:controller:invocations__totalTime[$SamplePeriod])) by (controller, method) / 1000000 / sum(rate(front50:controller:invocations__count[$SamplePeriod])) by (controller, method), \"controller\", \"$1\", \"controller\", \"(.*)Controller\")",
               "intervalFactor": 2,
               "legendFormat": "{{controller}}({{method}})",
               "refId": "A",
@@ -1952,7 +2288,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Item Cache Size",
+          "title": "Item Cache Size (front50)",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -2024,7 +2360,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(delta(front50:storageServiceSupport:numAdded[1m])) by (objectType)",
+              "expr": "sum(idelta(front50:storageServiceSupport:numAdded[$SamplePeriod])) by (objectType)",
               "intervalFactor": 2,
               "legendFormat": "add {{objectType}}",
               "metric": "front50:storageServiceSupport:numAdded",
@@ -2032,7 +2368,7 @@
               "step": 20
             },
             {
-              "expr": "-1 * sum(delta(front50:storageServiceSupport:numRemoved[1m])) by (objectType)",
+              "expr": "-1 * sum(idelta(front50:storageServiceSupport:numRemoved[$SamplePeriod])) by (objectType)",
               "intervalFactor": 2,
               "legendFormat": "del {{objectType}}",
               "refId": "B",
@@ -2042,7 +2378,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Item Cache Adds (+) and Removes (-)",
+          "title": "Item Cache Adds (+) and Removes (-) (front50)",
           "tooltip": {
             "shared": false,
             "sort": 0,
@@ -2107,7 +2443,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(delta(front50:storageServiceSupport:numUpdated[1m])) by (objectType)",
+              "expr": "sum(idelta(front50:storageServiceSupport:numUpdated[$SamplePeriod])) by (objectType)",
               "intervalFactor": 2,
               "legendFormat": "{{objectType}}",
               "metric": "front50:storageServiceSupport:numUpdated",
@@ -2118,7 +2454,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Item Cache Updates",
+          "title": "Item Cache Updates (front50)",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -2137,7 +2473,7 @@
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             },
             {
@@ -2145,7 +2481,7 @@
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             }
           ]
@@ -2193,25 +2529,17 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(front50:storageServiceSupport:cacheSize) by (objectType)",
-              "intervalFactor": 2,
-              "legendFormat": "{{objectType}}",
-              "metric": "front50:storageServiceSupport:cacheSize",
-              "refId": "A",
-              "step": 10
-            },
-            {
               "expr": "drop_common_labels(front50:storageServiceSupport:cacheAge) / 1000",
               "intervalFactor": 2,
               "legendFormat": "{{objectType}}",
-              "refId": "B",
+              "refId": "A",
               "step": 10
             }
           ],
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Front50 Item Cache Age",
+          "title": "Item Cache Age (front50)",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -2283,7 +2611,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(delta(front50:storageServiceSupport:autoRefreshTime__count[1m])) by (objectType)",
+              "expr": "sum(idelta(front50:storageServiceSupport:autoRefreshTime__count[$SamplePeriod])) by (objectType)",
               "hide": false,
               "intervalFactor": 2,
               "legendFormat": "force/{{objectType}}",
@@ -2292,7 +2620,7 @@
               "step": 10
             },
             {
-              "expr": "-1 * (sum(delta(front50:storageServiceSupport:scheduledRefreshTime__count[1m])) by (objectType))",
+              "expr": "-1 * (sum(idelta(front50:storageServiceSupport:scheduledRefreshTime__count[$SamplePeriod])) by (objectType))",
               "hide": false,
               "intervalFactor": 2,
               "legendFormat": "{{objectType}}",
@@ -2303,7 +2631,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Front50 Cache Refreshes / Minute  (negative are scheduled)",
+          "title": "Cache Refreshes / Minute  (negative are scheduled) (front50)",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -2378,7 +2706,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(delta(front50:google:storage:invocation__count[1m])) by (method)",
+              "expr": "sum(idelta(front50:google:storage:invocation__count[$SamplePeriod])) by (method)",
               "intervalFactor": 2,
               "legendFormat": "{{method}}",
               "refId": "A",
@@ -2388,7 +2716,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Front50 Google Storage Service Invocations",
+          "title": "Google Storage Service Invocations (front50)",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -2407,7 +2735,7 @@
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             },
             {
@@ -2415,7 +2743,7 @@
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             }
           ]
@@ -2450,7 +2778,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(front50:google:storage:invocation__totalTime[1m])) by (method) / 1000000 / sum(rate(front50:google:storage:invocation__count[1m])) by (method)",
+              "expr": "sum(rate(front50:google:storage:invocation__totalTime[$SamplePeriod])) by (method) / 1000000 / sum(rate(front50:google:storage:invocation__count[$SamplePeriod])) by (method)",
               "intervalFactor": 2,
               "legendFormat": "{{method}}",
               "refId": "A",
@@ -2460,7 +2788,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Front50 Google Storage Service Invocation Latency",
+          "title": "Google Storage Service Invocation Latency (front50)",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -2533,7 +2861,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "drop_common_labels(clouddriver:jvm:memory:used{memtype=\"HEAP\"}) / (1024 * 1024)",
+              "expr": "sum(clouddriver:jvm:memory:used{memtype=\"HEAP\"}) by (id, memtype)",
               "intervalFactor": 2,
               "legendFormat": "Clouddriver({{id}}/{{memtype}})",
               "metric": "clouddriver:jvm:memory:used",
@@ -2541,7 +2869,7 @@
               "step": 4
             },
             {
-              "expr": "echo:jvm:memory:used{memtype=\"HEAP\"} / (1024 * 1024)",
+              "expr": "sum(echo:jvm:memory:used{memtype=\"HEAP\"}) by (id, memtype)",
               "intervalFactor": 2,
               "legendFormat": "Echo({{id}}/{{memtype}})",
               "metric": "echo:jvm:memory:used",
@@ -2549,7 +2877,7 @@
               "step": 4
             },
             {
-              "expr": "fiat:jvm:memory:used{memtype=\"HEAP\"} / (1024 * 1024)",
+              "expr": "sum(fiat:jvm:memory:used{memtype=\"HEAP\"}) by (id, memtype)",
               "intervalFactor": 2,
               "legendFormat": "Fiat({{id}}/{{memtype}})",
               "metric": "fiat:jvm:memory:used",
@@ -2557,7 +2885,7 @@
               "step": 4
             },
             {
-              "expr": "front50:jvm:memory:used{memtype=\"HEAP\"} / (1024 * 1024)",
+              "expr": "sum(front50:jvm:memory:used{memtype=\"HEAP\"}) by (id, memtype)",
               "intervalFactor": 2,
               "legendFormat": "Front50({{id}}/{{memtype}})",
               "metric": "front50:jvm:memory:used",
@@ -2565,7 +2893,7 @@
               "step": 4
             },
             {
-              "expr": "gate:jvm:memory:used{memtype=\"HEAP\"} / (1024 * 1024)",
+              "expr": "sum(gate:jvm:memory:used{memtype=\"HEAP\"}) by (id, memtype)",
               "intervalFactor": 2,
               "legendFormat": "Gate({{id}}/{{memtype}})",
               "metric": "gate:jvm:memory:used",
@@ -2573,7 +2901,7 @@
               "step": 4
             },
             {
-              "expr": "igor:jvm:memory:used{memtype=\"HEAP\"} / (1024 * 1024)",
+              "expr": "sum(igor:jvm:memory:used{memtype=\"HEAP\"}) by (id, memtype)",
               "intervalFactor": 2,
               "legendFormat": "Igor({{id}}/{{memtype}})",
               "metric": "igor:jvm:memory:used",
@@ -2581,7 +2909,7 @@
               "step": 4
             },
             {
-              "expr": "orca:jvm:memory:used{memtype=\"HEAP\"} / (1024 * 1024)",
+              "expr": "sum(orca:jvm:memory:used{memtype=\"HEAP\"}) by (id, memtype)",
               "intervalFactor": 2,
               "legendFormat": "Orca({{id}}/{{memtype}})",
               "metric": "orca:jvm:memory:used",
@@ -2589,7 +2917,7 @@
               "step": 4
             },
             {
-              "expr": "rosco:jvm:memory:used{memtype=\"HEAP\"} / (1024 * 1024)",
+              "expr": "sum(rosco:jvm:memory:used{memtype=\"HEAP\"}) by (id, memtype)",
               "intervalFactor": 2,
               "legendFormat": "Rosco({{id}}/{{memtype}})",
               "metric": "rosco:jvm:memory:used",
@@ -2600,7 +2928,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "JVM Memory Usage (Megabytes)",
+          "title": "JVM Memory Usage",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -2615,7 +2943,7 @@
           },
           "yaxes": [
             {
-              "format": "short",
+              "format": "decbytes",
               "label": null,
               "logBase": 1,
               "max": null,
@@ -2623,7 +2951,7 @@
               "show": true
             },
             {
-              "format": "short",
+              "format": "decbytes",
               "label": null,
               "logBase": 1,
               "max": null,
@@ -2684,7 +3012,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "AWS Delay (not sure of units)",
+          "title": "AWS Delay (clouddriver)",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -2747,7 +3075,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "label_replace(sum(delta(clouddriver:aws:request:httpRequestTime__count{error=\"true\"}[1m])) by (requestType, serviceName, statusCode, AWSErrorCode), \"requestType\", \"$1\", \"requestType\", \"(.*)Request(.*)\")",
+              "expr": "label_replace(sum(idelta(clouddriver:aws:request:httpRequestTime__count{error=\"true\"}[$SamplePeriod])) by (requestType, serviceName, statusCode, AWSErrorCode), \"requestType\", \"$1\", \"requestType\", \"(.*)Request(.*)\")",
               "intervalFactor": 2,
               "legendFormat": "{{statusCode}}/{{requestType}}({{serviceName}})->{{AWSErrorCode}}",
               "metric": "clouddriver:aws:request:httpRequestTime__count",
@@ -2758,7 +3086,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "AWS Errors",
+          "title": "AWS Errors (clouddriver)",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -2777,7 +3105,7 @@
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             },
             {
@@ -2785,7 +3113,7 @@
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             }
           ]
@@ -2833,7 +3161,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "label_replace(sum(delta(clouddriver:aws:request:httpRequestTime__count{serviceName=\"AmazonEC2\", error=\"false\"}[1m])) by (requestType, serviceName), \"requestType\", \"$1\", \"requestType\", \"(.*)Request\")",
+              "expr": "label_replace(sum(idelta(clouddriver:aws:request:httpRequestTime__count{serviceName=\"AmazonEC2\", error=\"false\"}[$SamplePeriod])) by (requestType, serviceName), \"requestType\", \"$1\", \"requestType\", \"(.*)Request\")",
               "intervalFactor": 2,
               "legendFormat": "{{requestType}}",
               "metric": "clouddriver:aws:request:httpRequestTime__count",
@@ -2844,7 +3172,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "AWS EC2 Requests",
+          "title": "AWS EC2 Requests (clouddriver)",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -2863,7 +3191,7 @@
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             },
             {
@@ -2871,7 +3199,7 @@
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             }
           ]
@@ -2907,7 +3235,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(delta(clouddriver:aws:request:httpRequestTime__count{serviceName!=\"AmazonEC2\", error=\"false\"}[1m])) by (requestType, serviceName)",
+              "expr": "sum(idelta(clouddriver:aws:request:httpRequestTime__count{serviceName!=\"AmazonEC2\", error=\"false\"}[$SamplePeriod])) by (requestType, serviceName)",
               "intervalFactor": 2,
               "legendFormat": "{{requestType}}({{serviceName}})",
               "metric": "clouddriver:aws:request:httpRequestTime__count",
@@ -2918,7 +3246,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "AWS Requests (non EC2)",
+          "title": "AWS Requests (non EC2) (clouddrier)",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -2937,7 +3265,7 @@
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             },
             {
@@ -2945,7 +3273,7 @@
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             }
           ]
@@ -2993,7 +3321,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(delta(clouddriver:aws:request:httpRequestTime__totalTime{serviceName=\"AmazonEC2\"}[1m])) by (requestType, serviceName) / 1000000 / sum(delta(clouddriver:aws:request:httpRequestTime__count{serviceName=\"AmazonEC2\", error=\"false\"}[1m])) by (requestType, serviceName)",
+              "expr": "sum(rate(clouddriver:aws:request:httpRequestTime__totalTime{serviceName=\"AmazonEC2\"}[$SamplePeriod])) by (requestType, serviceName) / 1000000 / sum(rate(clouddriver:aws:request:httpRequestTime__count{serviceName=\"AmazonEC2\", error=\"false\"}[$SamplePeriod])) by (requestType, serviceName)",
               "intervalFactor": 2,
               "legendFormat": "{{requestType}}",
               "metric": "",
@@ -3004,7 +3332,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "AWS EC2 Request Latency",
+          "title": "AWS EC2 Request Latency (clouddriver)",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -3067,7 +3395,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "label_replace(sum(delta(clouddriver:aws:request:httpRequestTime__totalTime{serviceName!=\"AmazonEC2\"}[1m])) by (requestType, serviceName) / 1000000 / sum(delta(clouddriver:aws:request:httpRequestTime__count{serviceName!=\"AmazonEC2\", error=\"false\"}[1m])) by (requestType, serviceName), \"requestType\", \"$1\", \"requestType\", \"(.*)Request\")",
+              "expr": "label_replace(sum(rate(clouddriver:aws:request:httpRequestTime__totalTime{serviceName!=\"AmazonEC2\"}[$SamplePeriod])) by (requestType, serviceName) / 1000000 / sum(rate(clouddriver:aws:request:httpRequestTime__count{serviceName!=\"AmazonEC2\", error=\"false\"}[$SamplePeriod])) by (requestType, serviceName), \"requestType\", \"$1\", \"requestType\", \"(.*)Request\")",
               "intervalFactor": 2,
               "legendFormat": "{{requestType}}",
               "metric": "",
@@ -3078,7 +3406,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "AWS Non-EC2 Request Latency",
+          "title": "AWS Non-EC2 Request Latency (clouddriver)",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -3153,7 +3481,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(delta(clouddriver:google:operationWaits__count{status=\"DONE\"}[30s])) by (basePhase)",
+              "expr": "sum(idelta(clouddriver:google:operationWaits__count{status=\"DONE\"}[$SamplePeriod])) by (basePhase)",
               "hide": false,
               "intervalFactor": 2,
               "legendFormat": "{{basePhase}}",
@@ -3165,7 +3493,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Successful Google Operations",
+          "title": "Successful Google Operations (clouddriver)",
           "tooltip": {
             "shared": false,
             "sort": 0,
@@ -3186,7 +3514,7 @@
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             },
             {
@@ -3194,7 +3522,7 @@
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             }
           ]
@@ -3230,7 +3558,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(idelta(clouddriver:google:operationWaits__count{status!=\"DONE\"}[1m])) by (basePhase, scope) ",
+              "expr": "sum(idelta(clouddriver:google:operationWaits__count{status!=\"DONE\"}[$SamplePeriod])) by (basePhase, scope) ",
               "intervalFactor": 2,
               "legendFormat": "{{scope}}/{{basePhase}}",
               "metric": "",
@@ -3241,7 +3569,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Failed Google Operations",
+          "title": "Failed Google Operations (clouddriver)",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -3260,7 +3588,7 @@
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             },
             {
@@ -3268,7 +3596,7 @@
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             }
           ]
@@ -3316,7 +3644,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(idelta(clouddriver:google:operationWaitRequests[1m])) by (basePhase, scope)",
+              "expr": "sum(idelta(clouddriver:google:operationWaitRequests[$SamplePeriod])) by (basePhase, scope)",
               "intervalFactor": 2,
               "legendFormat": "{{scope}}/{{basePhase}}",
               "metric": "clouddriver:google:operationWaitRequests",
@@ -3327,7 +3655,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Google Operations Started",
+          "title": "Google Operations Started (clouddriver)",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -3346,7 +3674,7 @@
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             },
             {
@@ -3354,7 +3682,7 @@
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             }
           ]
@@ -3390,7 +3718,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(clouddriver:google:operationWaits__totalTime[1m])) by (basePhase, scope) / 1000000000 / sum(rate(clouddriver:google:operationWaits__count[1m])) by (basePhase, scope) ",
+              "expr": "sum(rate(clouddriver:google:operationWaits__totalTime[$SamplePeriod])) by (basePhase, scope) / 1000000000 / sum(rate(clouddriver:google:operationWaits__count[$SamplePeriod])) by (basePhase, scope) ",
               "hide": false,
               "intervalFactor": 2,
               "legendFormat": "{{scope}}/{{basePhase}}",
@@ -3420,7 +3748,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Google Operation Wait Until Done Time",
+          "title": "Google Operation Wait Until Done Time (clouddriver)",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -3495,7 +3823,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "label_replace(sum(delta(clouddriver:google:api__count[1m])) by (api), \"api\", \"$1\", \"api\", \"compute.(.*)\")",
+              "expr": "label_replace(sum(idelta(clouddriver:google:api__count[$SamplePeriod])) by (api), \"api\", \"$1\", \"api\", \"compute.(.*)\")",
               "hide": false,
               "intervalFactor": 2,
               "legendFormat": "{{api}}",
@@ -3507,7 +3835,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Google API Call Count",
+          "title": "Google API Call Count (clouddriver)",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -3527,7 +3855,7 @@
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             },
             {
@@ -3535,7 +3863,7 @@
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             }
           ]
@@ -3571,7 +3899,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "label_replace(sum(rate(clouddriver:google:api__totalTime{success=\"true\"}[1m])) by (api) / 1000000 / sum(rate(clouddriver:google:api__count{success=\"true\"}[1m])) by (api), \"api\", \"$1\", \"api\", \"compute.(.*)\")",
+              "expr": "label_replace(sum(rate(clouddriver:google:api__totalTime{success=\"true\"}[$SamplePeriod])) by (api) / 1000000 / sum(rate(clouddriver:google:api__count{success=\"true\"}[$SamplePeriod])) by (api), \"api\", \"$1\", \"api\", \"compute.(.*)\")",
               "intervalFactor": 2,
               "legendFormat": "{{api}}",
               "metric": "clouddriver:google:api__count",
@@ -3582,7 +3910,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Google API Call Latency",
+          "title": "Google API Call Latency (clouddriver)",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -3645,7 +3973,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "label_replace(sum(idelta(clouddriver:google:api__count{success=\"false\"}[1m])) by (api), \"api\", \"$1\", \"api\", \"compute.(.*)\")",
+              "expr": "label_replace(sum(idelta(clouddriver:google:api__count{success=\"false\"}[$SamplePeriod])) by (api), \"api\", \"$1\", \"api\", \"compute.(.*)\")",
               "intervalFactor": 2,
               "legendFormat": "{{api}}",
               "metric": "clouddriver:google:api__count",
@@ -3656,7 +3984,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Google API Failures",
+          "title": "Google API Failures (clouddriver)",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -3675,7 +4003,7 @@
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             },
             {
@@ -3683,7 +4011,7 @@
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             }
           ]
@@ -3731,7 +4059,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "label_replace(sum(idelta(clouddriver:google:batchSize[1m])) by (context), \"context\", \"$1$2\", \"context\", \"(.*)Caching(.*)\")",
+              "expr": "label_replace(sum(idelta(clouddriver:google:batchSize[$SamplePeriod])) by (context), \"context\", \"$1$2\", \"context\", \"(.*)Caching(.*)\")",
               "intervalFactor": 2,
               "legendFormat": "{{context}}",
               "metric": "clouddriver:google:batchSize",
@@ -3742,7 +4070,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Clouddriver Google API Batch Size",
+          "title": "Google API Batch Size (clouddriver)",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -3761,7 +4089,7 @@
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             },
             {
@@ -3769,7 +4097,7 @@
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             }
           ]
@@ -3805,7 +4133,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "label_replace(sum(delta(clouddriver:google:batchExecute__count[1m])) by (context), \"context\", \"$1$2\", \"context\", \"(.*)Caching(.*)\")",
+              "expr": "label_replace(sum(idelta(clouddriver:google:batchExecute__count[$SamplePeriod])) by (context), \"context\", \"$1$2\", \"context\", \"(.*)Caching(.*)\")",
               "intervalFactor": 2,
               "legendFormat": "{{context}}",
               "metric": "clouddriver:google:batchExecute__count",
@@ -3816,7 +4144,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Clouddriver Google API Batch Count",
+          "title": "Google API Batch Count (clouddriver)",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -3835,7 +4163,7 @@
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             },
             {
@@ -3843,7 +4171,7 @@
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             }
           ]
@@ -3879,7 +4207,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "label_replace(rate(clouddriver:google:batchExecute__totalTime[1m]) / 1000000 / rate(clouddriver:google:batchExecute__count[1m]), \"context\", \"$1$2\", \"context\", \"(.*)Caching(.*)\")",
+              "expr": "label_replace(rate(clouddriver:google:batchExecute__totalTime[$SamplePeriod]) / 1000000 / rate(clouddriver:google:batchExecute__count[$SamplePeriod]), \"context\", \"$1$2\", \"context\", \"(.*)Caching(.*)\")",
               "intervalFactor": 2,
               "legendFormat": "{{context}}",
               "metric": "",
@@ -3890,7 +4218,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Clouddriver Google API Batch Latency",
+          "title": "Google API Batch Latency (clouddriver)",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -3965,7 +4293,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "delta(clouddriver:google:safeRetry__count[1m])",
+              "expr": "idelta(clouddriver:google:safeRetry__count[$SamplePeriod])",
               "hide": false,
               "intervalFactor": 2,
               "legendFormat": "{{operation}}({{phase}})",
@@ -3977,7 +4305,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Google API Safe Retries",
+          "title": "Google API Safe Retries (clouddriver)",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -3996,7 +4324,7 @@
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             },
             {
@@ -4004,7 +4332,7 @@
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             }
           ]
@@ -4040,7 +4368,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(clouddriver:google:safeRetry__totalTime[1m])) by (operation, phase) / 100000000000000 / sum(rate(clouddriver:google:safeRetry__count[1m])) by (operation, phase)",
+              "expr": "sum(rate(clouddriver:google:safeRetry__totalTime[$SamplePeriod])) by (operation, phase) / 1000000 / sum(rate(clouddriver:google:safeRetry__count[$SamplePeriod])) by (operation, phase)",
               "intervalFactor": 2,
               "legendFormat": "{{operation}}({{phase}})",
               "metric": "clouddriver:google:safeRetry__count",
@@ -4051,7 +4379,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Google API Safe Retry Latency",
+          "title": "Google API Safe Retry Latency (clouddriver)",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -4090,24 +4418,56 @@
       "showTitle": false,
       "title": "Google Safe Retry",
       "titleSize": "h6"
-    },
-    {
-      "collapse": false,
-      "height": 250,
-      "panels": [],
-      "repeat": null,
-      "repeatIteration": null,
-      "repeatRowId": null,
-      "showTitle": false,
-      "title": "Dashboard Row",
-      "titleSize": "h6"
     }
   ],
   "schemaVersion": 14,
   "style": "dark",
   "tags": [],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "auto": false,
+        "auto_count": 30,
+        "auto_min": "10s",
+        "current": {
+          "text": "1m",
+          "value": "1m"
+        },
+        "hide": 0,
+        "label": "Sample Period",
+        "name": "SamplePeriod",
+        "options": [
+          {
+            "selected": true,
+            "text": "1m",
+            "value": "1m"
+          },
+          {
+            "selected": false,
+            "text": "5m",
+            "value": "5m"
+          },
+          {
+            "selected": false,
+            "text": "10m",
+            "value": "10m"
+          },
+          {
+            "selected": false,
+            "text": "15m",
+            "value": "15m"
+          },
+          {
+            "selected": false,
+            "text": "30m",
+            "value": "30m"
+          }
+        ],
+        "query": "1m,5m,10m,15m,30m",
+        "refresh": 2,
+        "type": "interval"
+      }
+    ]
   },
   "time": {
     "from": "now-1h",
@@ -4139,6 +4499,6 @@
     ]
   },
   "timezone": "browser",
-  "title": "Spinnaker",
-  "version": 9
+  "title": "Spinnaker Kitchen Sink",
+  "version": 1
 }

--- a/google/stackdriver_monitoring/config/prometheus/MachineDashboard.json
+++ b/google/stackdriver_monitoring/config/prometheus/MachineDashboard.json
@@ -1,0 +1,585 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_SPINNAKER",
+      "label": "Spinnaker",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "4.1.1"
+    },
+    {
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph",
+      "version": ""
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    }
+  ],
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "hideControls": false,
+  "id": null,
+  "links": [],
+  "rows": [
+    {
+      "collapse": false,
+      "height": 254,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "${DS_SPINNAKER}",
+          "fill": 1,
+          "id": 1,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [
+            {
+              "alias": "cpu0",
+              "yaxis": 1
+            },
+            {
+              "alias": "All",
+              "yaxis": 2
+            }
+          ],
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(rate(node_cpu{mode!=\"idle\"}[$SamplePeriod])) / sum(rate(node_cpu[$SamplePeriod])) ",
+              "hide": false,
+              "intervalFactor": 2,
+              "legendFormat": "All",
+              "metric": "",
+              "refId": "A",
+              "step": 30
+            },
+            {
+              "expr": "sum(rate(node_cpu{mode!=\"idle\"}[$SamplePeriod])) by (cpu)",
+              "hide": false,
+              "intervalFactor": 2,
+              "legendFormat": "{{cpu}}",
+              "metric": "node_cpu",
+              "refId": "B",
+              "step": 30
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "CPU Utilization",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "percentunit",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "percentunit",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "${DS_SPINNAKER}",
+          "fill": 1,
+          "id": 3,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [
+            {
+              "alias": "Dirty",
+              "yaxis": 2
+            }
+          ],
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "node_memory_MemFree ",
+              "hide": false,
+              "intervalFactor": 2,
+              "legendFormat": "Free",
+              "metric": "",
+              "refId": "B",
+              "step": 30
+            },
+            {
+              "expr": "(node_memory_MemTotal - node_memory_Committed_AS) ",
+              "hide": false,
+              "intervalFactor": 2,
+              "legendFormat": "Uncommitted",
+              "metric": "node_memory_Committed_AS",
+              "refId": "G",
+              "step": 30
+            },
+            {
+              "expr": "node_memory_Dirty",
+              "hide": false,
+              "intervalFactor": 2,
+              "legendFormat": "Dirty",
+              "metric": "",
+              "refId": "F",
+              "step": 30
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "System Memory Available",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "decbytes",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "decbytes",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Dashboard Row",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 255,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "${DS_SPINNAKER}",
+          "fill": 1,
+          "id": 4,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [
+            {
+              "alias": "cpu0",
+              "yaxis": 1
+            }
+          ],
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(node_netstat_Ip_InReceives[$SamplePeriod]) ",
+              "hide": false,
+              "intervalFactor": 2,
+              "legendFormat": "In Packets",
+              "metric": "",
+              "refId": "A",
+              "step": 120
+            },
+            {
+              "expr": "rate(node_netstat_Ip_OutRequests[$SamplePeriod])",
+              "hide": false,
+              "intervalFactor": 2,
+              "legendFormat": "Out Packets",
+              "metric": "",
+              "refId": "B",
+              "step": 120
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Networking",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "${DS_SPINNAKER}",
+          "fill": 1,
+          "id": 2,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [
+            {
+              "alias": "READ",
+              "yaxis": 2
+            }
+          ],
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "delta(node_disk_bytes_written[$SamplePeriod])",
+              "intervalFactor": 2,
+              "legendFormat": "WRITE",
+              "metric": "node_disk_bytes_written",
+              "refId": "A",
+              "step": 60
+            },
+            {
+              "expr": "delta(node_disk_bytes_read[$SamplePeriod])",
+              "intervalFactor": 2,
+              "legendFormat": "READ",
+              "metric": "node_disk_bytes_read",
+              "refId": "B",
+              "step": 60
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Disk IO",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "decbytes",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "decbytes",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "${DS_SPINNAKER}",
+          "fill": 1,
+          "id": 5,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [
+            {
+              "alias": "READ",
+              "yaxis": 2
+            }
+          ],
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "node_filesystem_free{mountpoint!~\"/run.*\"}",
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "{{mountpoint}}",
+              "metric": "",
+              "refId": "B",
+              "step": 60
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Disk Available",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "decbytes",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "decbytes",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Dashboard Row",
+      "titleSize": "h6"
+    }
+  ],
+  "schemaVersion": 14,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "auto": false,
+        "auto_count": 30,
+        "auto_min": "10s",
+        "current": {
+          "text": "1m",
+          "value": "1m"
+        },
+        "hide": 0,
+        "label": "Sample Period",
+        "name": "SamplePeriod",
+        "options": [
+          {
+            "selected": true,
+            "text": "1m",
+            "value": "1m"
+          },
+          {
+            "selected": false,
+            "text": "5m",
+            "value": "5m"
+          },
+          {
+            "selected": false,
+            "text": "10m",
+            "value": "10m"
+          },
+          {
+            "selected": false,
+            "text": "15m",
+            "value": "15m"
+          },
+          {
+            "selected": false,
+            "text": "30m",
+            "value": "30m"
+          }
+        ],
+        "query": "1m,5m,10m,15m,30m",
+        "refresh": 2,
+        "type": "interval"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "browser",
+  "title": "Machine Stats",
+  "version": 1
+}

--- a/google/stackdriver_monitoring/config/prometheus/MinimalDashboard.json
+++ b/google/stackdriver_monitoring/config/prometheus/MinimalDashboard.json
@@ -165,7 +165,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "delta(front50:hystrix:countExceptionsThrown[1m])",
+              "expr": "idelta(front50:hystrix:countExceptionsThrown[1m])",
               "intervalFactor": 2,
               "legendFormat": "front50/{{metricType}}({{metricGroup}})",
               "metric": "front50:hystrix:countExceptionsThrown",
@@ -173,7 +173,7 @@
               "step": 10
             },
             {
-              "expr": "delta(gate:hystrix:countExceptionsThrown[1m])",
+              "expr": "idelta(gate:hystrix:countExceptionsThrown[1m])",
               "intervalFactor": 2,
               "legendFormat": "gate/{{metricType}}({{metricGroup}})",
               "metric": "gate:hystrix:countExceptionsThrown",
@@ -181,7 +181,7 @@
               "step": 10
             },
             {
-              "expr": "delta(igor:hystrix:countExceptionsThrown[1m])",
+              "expr": "idelta(igor:hystrix:countExceptionsThrown[1m])",
               "intervalFactor": 2,
               "legendFormat": "igor/{{metricType}}({{metricGroup}})",
               "metric": "igor:hystrix:countExceptionsThrown",
@@ -211,7 +211,7 @@
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             },
             {
@@ -219,7 +219,7 @@
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             }
           ]
@@ -234,14 +234,14 @@
     },
     {
       "collapse": false,
-      "height": 282,
+      "height": 262,
       "panels": [
         {
           "aliasColors": {},
           "bars": false,
           "datasource": "${DS_SPINNAKER}",
           "fill": 1,
-          "id": 1,
+          "id": 55,
           "legend": {
             "avg": false,
             "current": false,
@@ -249,7 +249,6 @@
             "hideZero": true,
             "max": false,
             "min": false,
-            "rightSide": false,
             "show": true,
             "total": false,
             "values": false
@@ -268,18 +267,19 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "label_replace(sum(increase(clouddriver:operations__count{success=\"true\"}[1m])) by (OperationType), \"OperationType\", \"$1\", \"OperationType\", \"(.*)AtomicOperation\")",
+              "expr": "sum(idelta(orca:task:invocations{executionType=\"Orchestration\", isComplete=\"false\"}[1m])) by (taskName)",
               "hide": false,
               "intervalFactor": 2,
-              "legendFormat": "{{OperationType}}",
-              "refId": "A",
+              "legendFormat": "{{taskName}}",
+              "metric": "",
+              "refId": "B",
               "step": 10
             }
           ],
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Successful Operations",
+          "title": "Active Orchestrations (orca)",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -298,7 +298,7 @@
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             },
             {
@@ -306,7 +306,7 @@
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             }
           ]
@@ -316,7 +316,7 @@
           "bars": false,
           "datasource": "${DS_SPINNAKER}",
           "fill": 1,
-          "id": 42,
+          "id": 58,
           "legend": {
             "avg": false,
             "current": false,
@@ -324,7 +324,6 @@
             "hideZero": true,
             "max": false,
             "min": false,
-            "rightSide": false,
             "show": true,
             "total": false,
             "values": false
@@ -343,18 +342,19 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "label_replace(sum(increase(clouddriver:operations__count{success!=\"true\"}[1m])) by (OperationType), \"OperationType\", \"$1\", \"OperationType\", \"(.*)AtomicOperation\")",
+              "expr": "sum(idelta(orca:task:invocations{executionType=\"Pipeline\", isComplete=\"false\"}[1m])) by (taskName)",
               "hide": false,
               "intervalFactor": 2,
-              "legendFormat": "{{OperationType}}",
-              "refId": "A",
+              "legendFormat": "{{taskName}}",
+              "metric": "",
+              "refId": "B",
               "step": 10
             }
           ],
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Failed Operations",
+          "title": "Active Pipelines (orca)",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -373,7 +373,7 @@
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             },
             {
@@ -381,7 +381,7 @@
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             }
           ]
@@ -391,7 +391,189 @@
       "repeatIteration": null,
       "repeatRowId": null,
       "showTitle": false,
-      "title": "Operations",
+      "title": "Orca Active",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 250,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "${DS_SPINNAKER}",
+          "fill": 1,
+          "id": 56,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(idelta(orca:task:invocations{executionType=\"Orchestration\",isComplete=\"true\", status=\"SUCCEEDED\"}[1m])) by (taskName)",
+              "hide": false,
+              "intervalFactor": 2,
+              "legendFormat": "{{taskName}}",
+              "metric": "orca:task:invocations",
+              "refId": "C",
+              "step": 10
+            },
+            {
+              "expr": "-1 * sum(idelta(orca:task:invocations{executionType=\"Orchestration\",isComplete=\"true\", status!=\"SUCCEEDED\"}[1m])) by (taskName)",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "ERR {{taskName}}",
+              "metric": "orca:task:invocations",
+              "refId": "D",
+              "step": 10
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Orchestrations Completed (orca)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "${DS_SPINNAKER}",
+          "fill": 1,
+          "id": 59,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(idelta(orca:task:invocations{executionType=\"Pipeline\",isComplete=\"true\", status=\"SUCCEEDED\"}[1m])) by (taskName)",
+              "hide": false,
+              "intervalFactor": 2,
+              "legendFormat": "{{taskName}}",
+              "metric": "orca:task:invocations",
+              "refId": "C",
+              "step": 10
+            },
+            {
+              "expr": "-1 * sum(idelta(orca:task:invocations{executionType=\"Pipeline\",isComplete=\"true\", status!=\"SUCCEEDED\"}[1m])) by (taskName)",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "ERR {{taskName}}",
+              "metric": "orca:task:invocations",
+              "refId": "D",
+              "step": 10
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Pipelines Completed (orca)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Orca Completed",
       "titleSize": "h6"
     },
     {
@@ -438,7 +620,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Orca Active Threads",
+          "title": "Active Threads (orca)",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -499,26 +681,18 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(delta(echo:pipelines:triggered[1m])) by (application, name)",
+              "expr": "sum(idelta(echo:pipelines:triggered[1m])) by (application, name)",
               "intervalFactor": 2,
               "legendFormat": "{{name}}({{application}})",
               "metric": "echo:pipelines:triggered",
               "refId": "A",
-              "step": 10
-            },
-            {
-              "expr": "sum(delta(echo:pipelines:triggered[1m])) by (application, name)",
-              "intervalFactor": 2,
-              "legendFormat": "{{name}}({{application}})",
-              "metric": "echo:pipelines:triggered",
-              "refId": "B",
               "step": 10
             }
           ],
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Pipelines Triggered",
+          "title": "Pipelines Triggered (echo)",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -537,7 +711,7 @@
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             },
             {
@@ -545,7 +719,7 @@
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             }
           ]
@@ -602,18 +776,20 @@
               "step": 10
             },
             {
-              "expr": "sum(idelta(rosco:bakeRequests[1m])) by (flavor)",
+              "expr": "sum(idelta(rosco:bakesRequested[1m])) by (flavor)",
               "hide": false,
               "intervalFactor": 2,
               "legendFormat": "Request({{flavor}})",
-              "metric": "rosco:bakeRequests",
+              "metric": "rosco:bakes",
               "refId": "B",
               "step": 10
             },
             {
-              "expr": "-1 * sum(idelta(rosco:bakesCompleted{success=\"false\"}[1m])) by (region)",
+              "expr": "-1 * sum(idelta(rosco:bakesCompleted__count{success=\"false\"}[1m])) by (region)",
+              "hide": false,
               "intervalFactor": 2,
               "legendFormat": "Failed {{region}}",
+              "metric": "bakesC",
               "refId": "C",
               "step": 10
             }
@@ -621,7 +797,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Bake Requests",
+          "title": "Bake Activity (rosco)",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -640,7 +816,7 @@
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "-5",
               "show": true
             },
             {
@@ -648,7 +824,7 @@
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "-5",
               "show": true
             }
           ]
@@ -696,7 +872,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Item Cache Size",
+          "title": "Item Cache Size (front50)",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -734,6 +910,168 @@
       "repeatRowId": null,
       "showTitle": false,
       "title": "Bakes and Items",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 282,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "${DS_SPINNAKER}",
+          "fill": 1,
+          "id": 1,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "label_replace(sum(idelta(clouddriver:operations__count{success=\"true\"}[1m])) by (OperationType), \"OperationType\", \"$1\", \"OperationType\", \"(.*)AtomicOperation\")",
+              "hide": false,
+              "intervalFactor": 2,
+              "legendFormat": "{{OperationType}}",
+              "refId": "A",
+              "step": 10
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Successful Operations (clouddriver)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "${DS_SPINNAKER}",
+          "fill": 1,
+          "id": 42,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "label_replace(sum(idelta(clouddriver:operations__count{success!=\"true\"}[1m])) by (OperationType), \"OperationType\", \"$1\", \"OperationType\", \"(.*)AtomicOperation\")",
+              "hide": false,
+              "intervalFactor": 2,
+              "legendFormat": "{{OperationType}}",
+              "refId": "A",
+              "step": 10
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Failed Operations (clouddriver)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Operations",
       "titleSize": "h6"
     },
     {
@@ -913,6 +1251,6 @@
     ]
   },
   "timezone": "browser",
-  "title": "Minimal Spinnaker",
-  "version": 3
+  "title": "Spinnaker Minimalist",
+  "version": 1
 }

--- a/google/stackdriver_monitoring/config/prometheus/SpecificApplicationDashboard.json
+++ b/google/stackdriver_monitoring/config/prometheus/SpecificApplicationDashboard.json
@@ -1,0 +1,1031 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_SPINNAKER",
+      "label": "Spinnaker",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "4.1.1"
+    },
+    {
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph",
+      "version": ""
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    }
+  ],
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "hideControls": false,
+  "id": null,
+  "links": [],
+  "refresh": false,
+  "rows": [
+    {
+      "collapse": false,
+      "height": 276,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "${DS_SPINNAKER}",
+          "fill": 1,
+          "id": 55,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(idelta(orca:task:invocations{sourceApplication=~\"$Application\", executionType=\"Orchestration\", isComplete=\"false\"}[$SamplePeriod])) by (taskName)",
+              "hide": false,
+              "intervalFactor": 2,
+              "legendFormat": "{{taskName}}",
+              "metric": "",
+              "refId": "B",
+              "step": 10
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "$Application Active Orchestrations (orca)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "${DS_SPINNAKER}",
+          "fill": 1,
+          "id": 56,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(idelta(orca:task:invocations{sourceApplication=~\"$Application\", executionType=\"Orchestration\",isComplete=\"true\", status=\"SUCCEEDED\"}[$SamplePeriod])) by (taskName)",
+              "hide": false,
+              "intervalFactor": 2,
+              "legendFormat": "{{taskName}}",
+              "metric": "orca:task:invocations",
+              "refId": "C",
+              "step": 10
+            },
+            {
+              "expr": "-1 * sum(idelta(orca:task:invocations{sourceApplication=~\"$Application\", executionType=\"Orchestration\",isComplete=\"true\", status!=\"SUCCEEDED\"}[$SamplePeriod])) by (taskName)",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "ERR {{taskName}}",
+              "metric": "orca:task:invocations",
+              "refId": "D",
+              "step": 10
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "$Application Orchestrations Completed (orca)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Echo",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 217,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "${DS_SPINNAKER}",
+          "fill": 1,
+          "id": 58,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(idelta(orca:task:invocations{sourceApplication=~\"$Application\", executionType=\"Pipeline\", isComplete=\"false\"}[$SamplePeriod])) by (taskName)",
+              "hide": false,
+              "intervalFactor": 2,
+              "legendFormat": "{{taskName}}",
+              "metric": "",
+              "refId": "B",
+              "step": 10
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "$Application Active Pipelines (orca)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "${DS_SPINNAKER}",
+          "fill": 1,
+          "id": 59,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(idelta(orca:task:invocations{sourceApplication=~\"$Application\", executionType=\"Pipeline\",isComplete=\"true\", status=\"SUCCEEDED\"}[$SamplePeriod])) by (taskName)",
+              "hide": false,
+              "intervalFactor": 2,
+              "legendFormat": "{{taskName}}",
+              "metric": "orca:task:invocations",
+              "refId": "C",
+              "step": 10
+            },
+            {
+              "expr": "-1 * sum(idelta(orca:task:invocations{sourceApplication=~\"$Application\", executionType=\"Pipeline\",isComplete=\"true\", status!=\"SUCCEEDED\"}[$SamplePeriod])) by (taskName)",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "ERR {{taskName}}",
+              "metric": "orca:task:invocations",
+              "refId": "D",
+              "step": 10
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "$Application Pipelines Completed (orca)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Orca Pipelines",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 235,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "${DS_SPINNAKER}",
+          "fill": 1,
+          "id": 38,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(idelta(echo:pipelines:triggered{application=~\"$Application\"}[$SamplePeriod])) by (name, application)",
+              "hide": false,
+              "intervalFactor": 2,
+              "legendFormat": "{{name}}({{application}})",
+              "metric": "echo:pipelines:triggered",
+              "refId": "A",
+              "step": 10
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "$Application Pipelines Triggered (echo)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "${DS_SPINNAKER}",
+          "fill": 1,
+          "id": 41,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 5,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(rosco:bakesActive)",
+              "hide": false,
+              "intervalFactor": 2,
+              "legendFormat": "Active",
+              "metric": "rosco:bakesActive",
+              "refId": "A",
+              "step": 20
+            },
+            {
+              "expr": "sum(idelta(rosco:bakesRequested[$SamplePeriod])) by (flavor)",
+              "hide": false,
+              "intervalFactor": 2,
+              "legendFormat": "Request({{flavor}})",
+              "metric": "rosco:bakes",
+              "refId": "B",
+              "step": 20
+            },
+            {
+              "expr": "-1 * sum(idelta(rosco:bakesCompleted__count{success=\"false\"}[$SamplePeriod])) by (region)",
+              "hide": false,
+              "intervalFactor": 2,
+              "legendFormat": "Failed {{region}}",
+              "metric": "bakesC",
+              "refId": "C",
+              "step": 20
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Bake Requests and Failures (global)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "${DS_SPINNAKER}",
+          "fill": 1,
+          "id": 14,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": true,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 3,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(rate(rosco:bakesCompleted__totalTime[$SamplePeriod]) / 1000000000) by (region) / sum(rate(rosco:bakesCompleted__count[$SamplePeriod])) by (region)",
+              "hide": false,
+              "intervalFactor": 2,
+              "legendFormat": "{{region}}",
+              "metric": "",
+              "refId": "A",
+              "step": 20
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Bakes Completed (global)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "s",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "s",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Bakes",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 217,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": true,
+          "datasource": "${DS_SPINNAKER}",
+          "fill": 1,
+          "id": 11,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 4,
+          "stack": true,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(front50:hystrix:countShortCircuited) by (metricGroup, metricType)",
+              "intervalFactor": 2,
+              "legendFormat": "front50/{{metricGroup}}({{metricType}})",
+              "metric": "",
+              "refId": "A",
+              "step": 20
+            },
+            {
+              "expr": "sum(gate:hystrix:countShortCircuited) by (metricGroup, metricType)",
+              "intervalFactor": 2,
+              "legendFormat": "gate/{{metricGroup}}({{metricType}})",
+              "metric": "",
+              "refId": "B",
+              "step": 20
+            },
+            {
+              "expr": "sum(igor:hystrix:countShortCircuited) by (metricGroup, metricType)",
+              "intervalFactor": 2,
+              "legendFormat": "igor/{{metricGroup}}({{metricType}})",
+              "metric": "",
+              "refId": "C",
+              "step": 20
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Hystrix Short Circuited (global)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "${DS_SPINNAKER}",
+          "fill": 1,
+          "id": 37,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 5,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "idelta(front50:hystrix:countExceptionsThrown[$SamplePeriod])",
+              "intervalFactor": 2,
+              "legendFormat": "front50/{{metricType}}({{metricGroup}})",
+              "metric": "front50:hystrix:countExceptionsThrown",
+              "refId": "A",
+              "step": 10
+            },
+            {
+              "expr": "idelta(gate:hystrix:countExceptionsThrown[$SamplePeriod])",
+              "intervalFactor": 2,
+              "legendFormat": "gate/{{metricType}}({{metricGroup}})",
+              "metric": "gate:hystrix:countExceptionsThrown",
+              "refId": "B",
+              "step": 10
+            },
+            {
+              "expr": "idelta(igor:hystrix:countExceptionsThrown[$SamplePeriod])",
+              "intervalFactor": 2,
+              "legendFormat": "igor/{{metricType}}({{metricGroup}})",
+              "metric": "igor:hystrix:countExceptionsThrown",
+              "refId": "C",
+              "step": 10
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Hystrix Exceptions Thrown (global)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": true,
+          "datasource": "${DS_SPINNAKER}",
+          "fill": 1,
+          "id": 12,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 3,
+          "stack": true,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(front50:hystrix:rollingCountFailure) by (metricGroup, metricType)",
+              "hide": true,
+              "intervalFactor": 2,
+              "legendFormat": "front50({{metricGroup}}/{{metricType}})",
+              "metric": "",
+              "refId": "A",
+              "step": 2
+            },
+            {
+              "expr": "sum(gate:hystrix:rollingCountFailure) by (metricGroup, metricType)",
+              "hide": true,
+              "intervalFactor": 2,
+              "legendFormat": "gate({{metricGroup}}/{{metricType}})",
+              "metric": "",
+              "refId": "B",
+              "step": 2
+            },
+            {
+              "expr": "sum(igor:hystrix:rollingCountFailure) by (metricGroup, metricType)",
+              "hide": true,
+              "intervalFactor": 2,
+              "legendFormat": "igor({{metricGroup}}/{{metricType}})",
+              "metric": "",
+              "refId": "C",
+              "step": 2
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Hystrix Rolling Count Failure (global)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Hystrix Error Signals",
+      "titleSize": "h6"
+    }
+  ],
+  "schemaVersion": 14,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "auto": false,
+        "auto_count": 30,
+        "auto_min": "10s",
+        "current": {
+          "text": "1m",
+          "value": "1m"
+        },
+        "hide": 0,
+        "label": "Sample Period",
+        "name": "SamplePeriod",
+        "options": [
+          {
+            "selected": true,
+            "text": "1m",
+            "value": "1m"
+          },
+          {
+            "selected": false,
+            "text": "5m",
+            "value": "5m"
+          },
+          {
+            "selected": false,
+            "text": "10m",
+            "value": "10m"
+          },
+          {
+            "selected": false,
+            "text": "15m",
+            "value": "15m"
+          },
+          {
+            "selected": false,
+            "text": "30m",
+            "value": "30m"
+          }
+        ],
+        "query": "1m,5m,10m,15m,30m",
+        "refresh": 2,
+        "type": "interval"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "tags": [],
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": "Spinnaker",
+        "hide": 0,
+        "includeAll": true,
+        "label": null,
+        "multi": false,
+        "name": "Application",
+        "options": [],
+        "query": "orca:task:invocations",
+        "refresh": 1,
+        "regex": "/sourceApplication=\"([^\"]+)/",
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "browser",
+  "title": "Specific Spinnaker Application Details",
+  "version": 1
+}

--- a/google/stackdriver_monitoring/config/prometheus/install.sh
+++ b/google/stackdriver_monitoring/config/prometheus/install.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Copyright 2017 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+PROMETHEUS_VERSION=prometheus-1.5.0.linux-amd64
+PROMETHEUS_PORT=9090
+GRAFANA_PORT=3000
+CONFIG_DIR=$(readlink -f `dirname $0`)
+cd /opt
+
+# Install Prometheus
+curl -L -o /tmp/prometheus.gz \
+     https://github.com/prometheus/prometheus/releases/download/v1.5.0/prometheus-1.5.0.linux-amd64.tar.gz
+sudo tar xzf /tmp/prometheus.gz -C /opt
+rm /tmp/prometheus.gz
+
+curl -L -o /tmp/node_exporter.gz \
+     https://github.com/prometheus/node_exporter/releases/download/v0.13.0/node_exporter-0.13.0.linux-amd64.tar.gz
+sudo tar xzf /tmp/node_exporter.gz -C /opt/prometheus-1.5.0.linux-amd64
+sudo ln -s /opt/prometheus-1.5.0.linux-amd64/node_exporter-0.13.0.linux-amd64/node_exporter /usr/bin/node_exporter
+rm /tmp/node_exporter.gz
+
+sudo cp $CONFIG_DIR/spinnaker-prometheus.yml prometheus-1.5.0.linux-amd64
+sudo cp $CONFIG_DIR/prometheus.conf /etc/init/prometheus.conf
+sudo cp $CONFIG_DIR/node_exporter.conf /etc/init/node_exporter.conf
+
+
+# Install Grafana
+cd /tmp
+wget https://grafanarel.s3.amazonaws.com/builds/grafana_4.1.1-1484211277_amd64.deb
+sudo apt-get install -y adduser libfontconfig
+sudo dpkg -i grafana_4.1.1-1484211277_amd64.deb
+sudo update-rc.d grafana-server defaults
+rm grafana_4.1.1-1484211277_amd64.deb
+
+
+# Startup
+echo "Starting Prometheus"
+sudo service node_exporter start
+sudo service prometheus start
+sudo service grafana-server start
+
+TRIES=0
+until nc -z localhost $GRAFANA_PORT || [[ $TRIES -gt 5 ]]; do
+  sleep 1
+  let TRIES+=1
+done
+
+echo "Adding datasource"
+PAYLOAD="{'name':'Spinnaker','type':'prometheus','url':'http://localhost:${PROMETHEUS_PORT}','access':'direct','isDefault':true}"
+curl -u admin:admin http://localhost:${GRAFANA_PORT}/api/datasources \
+     -H "Content-Type: application/json" \
+     -X POST \
+     -d "${PAYLOAD//\'/\"}"
+
+for dashboard in ${CONFIG_DIR}/*Dashboard.json; do
+  echo "Installing $(basename $dashboard)"
+  x=$(sed -e "/\"__inputs\"/,/],/d" \
+          -e "/\"__requires\"/,/],/d" \
+          -e "s/\${DS_SPINNAKER\}/Spinnaker/g" < "$dashboard")
+  temp_file=$(mktemp)
+  echo "{ \"dashboard\": $x }" > $temp_file
+  curl -u admin:admin http://localhost:${GRAFANA_PORT}/api/dashboards/import \
+       -H "Content-Type: application/json" \
+       -X POST \
+       -d @${temp_file}
+  rm -f $temp_file
+done

--- a/google/stackdriver_monitoring/config/prometheus/node_exporter.conf
+++ b/google/stackdriver_monitoring/config/prometheus/node_exporter.conf
@@ -1,0 +1,2 @@
+start on filesystem or runlevel [2345]
+exec /usr/bin/node_exporter

--- a/google/stackdriver_monitoring/config/prometheus/prometheus.conf
+++ b/google/stackdriver_monitoring/config/prometheus/prometheus.conf
@@ -1,0 +1,6 @@
+start on filesystem or runlevel [2345]
+
+exec /opt/prometheus-1.5.0.linux-amd64/prometheus \
+  -config.file /opt/prometheus-1.5.0.linux-amd64/spinnaker-prometheus.yml \
+  -storage.local.path /opt/prometheus-1.5.0.linux-amd64/data \
+  > /var/log/prometheus.log 2>&1

--- a/google/stackdriver_monitoring/config/prometheus/spinnaker-prometheus.yml
+++ b/google/stackdriver_monitoring/config/prometheus/spinnaker-prometheus.yml
@@ -1,0 +1,33 @@
+# my global config
+global:
+  scrape_interval:     15s
+  evaluation_interval: 15s
+  # scrape_timeout is set to the global default (10s).
+
+  # Attach these labels to any time series or alerts when communicating with
+  # external systems (federation, remote storage, Alertmanager).
+  external_labels:
+      monitor: 'codelab-monitor'
+
+# Load rules once and periodically evaluate them according to the global 'evaluation_interval'.
+rule_files:
+  # - "first.rules"
+  # - "second.rules"
+
+# A scrape configuration containing exactly one endpoint to scrape:
+# Here it's Prometheus itself.
+scrape_configs:
+  - job_name: 'spinnaker'
+    static_configs:
+      - targets: ['localhost:8008']
+    metrics_path: '/prometheus_metrics'
+    honor_labels: true
+
+  - job_name: 'node'
+    static_configs:
+      - targets: ['localhost:9100']
+
+#  - job_name: 'prometheus'
+#    static_configs:
+#      - targets: ['localhost:9090']
+

--- a/google/stackdriver_monitoring/config/stackdriver/MinimalDashboard.json
+++ b/google/stackdriver_monitoring/config/stackdriver/MinimalDashboard.json
@@ -1,0 +1,324 @@
+{
+  "displayName": "Minimal Spinnaker Dashboard",
+  "version": 14,
+  "root": {
+    "gridLayout": {
+      "widgets": [
+        {
+          "title": "Hystrix Short Circuited (global)",
+          "xyChart": {
+            "dataSets": [
+              {
+                "timeSeriesFilter": {
+                  "filter": "metric.type=\"custom.googleapis.com/spinnaker/front50/hystrix.countShortCircuited\"",
+                  "perSeriesAligner": "ALIGN_DELTA"
+                }
+              },
+              {
+                "timeSeriesFilter": {
+                  "filter": "metric.type=\"custom.googleapis.com/spinnaker/gate/hystrix.countShortCircuited\"",
+                  "perSeriesAligner": "ALIGN_DELTA"
+                }
+              },
+              {
+                "timeSeriesFilter": {
+                  "filter": "metric.type=\"custom.googleapis.com/spinnaker/igor/hystrix.countShortCircuited\"",
+                  "perSeriesAligner": "ALIGN_DELTA"
+                }
+              }
+            ],
+            "constantLines": [
+              {}
+            ],
+            "options": {},
+            "y1Axis": {},
+            "xAxis": {}
+          }
+        },
+        {
+          "title": "Hystrix Exceptions Thrown (global)",
+          "xyChart": {
+            "dataSets": [
+              {
+                "timeSeriesFilter": {
+                  "filter": "metric.type=\"custom.googleapis.com/spinnaker/front50/hystrix.countExceptionsThrown\"",
+                  "perSeriesAligner": "ALIGN_DELTA"
+                }
+              },
+              {
+                "timeSeriesFilter": {
+                  "filter": "metric.type=\"custom.googleapis.com/spinnaker/gate/hystrix.countExceptionsThrown\"",
+                  "perSeriesAligner": "ALIGN_DELTA"
+                }
+              },
+              {
+                "timeSeriesFilter": {
+                  "filter": "metric.type=\"custom.googleapis.com/spinnaker/igor/hystrix.countExceptionsThrown\"",
+                  "perSeriesAligner": "ALIGN_DELTA"
+                }
+              }
+            ],
+            "constantLines": [
+              {}
+            ],
+            "options": {},
+            "y1Axis": {},
+            "xAxis": {}
+          }
+        },
+        {
+          "title": "Active Orchestrations (orca)",
+          "xyChart": {
+            "dataSets": [
+              {
+                "timeSeriesFilter": {
+                  "filter": "metric.type=\"custom.googleapis.com/spinnaker/orca/task.invocations\" AND metric.label.isComplete=\"false\" AND metric.label.executionType=\"Orchestration\"",
+                  "perSeriesAligner": "ALIGN_DELTA"
+                }
+              }
+            ],
+            "constantLines": [
+              {}
+            ],
+            "options": {},
+            "y1Axis": {},
+            "xAxis": {}
+          }
+        },
+        {
+          "title": "Active Pipelines (orca)",
+          "xyChart": {
+            "dataSets": [
+              {
+                "timeSeriesFilter": {
+                  "filter": "metric.type=\"custom.googleapis.com/spinnaker/orca/task.invocations\" AND metric.label.isComplete=\"false\" AND metric.label.executionType=\"Pipeline\"",
+                  "perSeriesAligner": "ALIGN_DELTA"
+                }
+              }
+            ],
+            "constantLines": [
+              {}
+            ],
+            "options": {},
+            "y1Axis": {},
+            "xAxis": {}
+          }
+        },
+        {
+          "title": "Completed Orchestrations (orca)",
+          "xyChart": {
+            "dataSets": [
+              {
+                "timeSeriesFilter": {
+                  "filter": "metric.type=\"custom.googleapis.com/spinnaker/orca/task.invocations\" AND metric.label.status=\"SUCCEEDED\" AND metric.label.executionType=\"Orchestration\"",
+                  "perSeriesAligner": "ALIGN_DELTA"
+                }
+              },
+              {
+                "timeSeriesFilter": {
+                  "filter": "metric.type=\"custom.googleapis.com/spinnaker/orca/task.invocations\" AND metric.label.status!=\"SUCCEEDED\" AND metric.label.executionType=\"Orchestration\"",
+                  "perSeriesAligner": "ALIGN_DELTA"
+                }
+              }
+            ],
+            "constantLines": [
+              {}
+            ],
+            "options": {},
+            "y1Axis": {},
+            "xAxis": {}
+          }
+        },
+        {
+          "title": "Completed Pipelines (orca)",
+          "xyChart": {
+            "dataSets": [
+              {
+                "timeSeriesFilter": {
+                  "filter": "metric.type=\"custom.googleapis.com/spinnaker/orca/task.invocations\" AND metric.label.status=\"SUCCEEDED\" AND metric.label.executionType=\"Pipeline\"",
+                  "perSeriesAligner": "ALIGN_DELTA"
+                }
+              },
+              {
+                "timeSeriesFilter": {
+                  "filter": "metric.type=\"custom.googleapis.com/spinnaker/orca/task.invocations\" AND metric.label.status!=\"SUCCEEDED\" AND metric.label.executionType=\"Pipeline\"",
+                  "perSeriesAligner": "ALIGN_DELTA"
+                }
+              }
+            ],
+            "constantLines": [
+              {}
+            ],
+            "options": {},
+            "y1Axis": {},
+            "xAxis": {}
+          }
+        },
+        {
+          "title": "Active Threads (orca)",
+          "xyChart": {
+            "dataSets": [
+              {
+                "timeSeriesFilter": {
+                  "filter": "metric.type=\"custom.googleapis.com/spinnaker/orca/threadpool.activeCount\""
+                }
+              }
+            ],
+            "constantLines": [
+              {}
+            ],
+            "options": {},
+            "y1Axis": {},
+            "xAxis": {}
+          }
+        },
+        {
+          "title": "Pipelines Triggered (echo)",
+          "xyChart": {
+            "dataSets": [
+              {
+                "timeSeriesFilter": {
+                  "filter": "metric.type=\"custom.googleapis.com/spinnaker/echo/pipelines.triggered\"",
+                  "perSeriesAligner": "ALIGN_DELTA"
+                }
+              }
+            ],
+            "constantLines": [
+              {}
+            ],
+            "options": {},
+            "y1Axis": {},
+            "xAxis": {}
+          }
+        },
+        {
+          "title": "Bake Activity (rosco)",
+          "xyChart": {
+            "dataSets": [
+              {
+                "timeSeriesFilter": {
+                  "filter": "metric.type=\"custom.googleapis.com/spinnaker/rosco/bakesActive\""
+                }
+              }
+            ],
+            "constantLines": [
+              {}
+            ],
+            "options": {},
+            "y1Axis": {},
+            "xAxis": {}
+          }
+        },
+        {
+          "title": "Cached Items (front50)",
+          "xyChart": {
+            "dataSets": [
+              {
+                "timeSeriesFilter": {
+                  "filter": "metric.type=\"custom.googleapis.com/spinnaker/front50/storageServiceSupport.cacheSize\""
+                }
+              }
+            ],
+            "constantLines": [
+              {}
+            ],
+            "options": {},
+            "y1Axis": {},
+            "xAxis": {}
+          }
+        },
+        {
+          "title": "Successful Operations (clouddriver)",
+          "xyChart": {
+            "dataSets": [
+              {
+                "timeSeriesFilter": {
+                  "filter": "metric.type=\"custom.googleapis.com/spinnaker/clouddriver/operations__count\" AND metric.label.success=\"true\"",
+                  "perSeriesAligner": "ALIGN_DELTA"
+                }
+              }
+            ],
+            "constantLines": [
+              {}
+            ],
+            "options": {},
+            "y1Axis": {},
+            "xAxis": {}
+          }
+        },
+        {
+          "title": "Failed Operations (clouddriver)",
+          "xyChart": {
+            "dataSets": [
+              {
+                "timeSeriesFilter": {
+                  "filter": "metric.type=\"custom.googleapis.com/spinnaker/clouddriver/operations__count\" AND metric.label.success=\"false\"",
+                  "perSeriesAligner": "ALIGN_DELTA"
+                }
+              }
+            ],
+            "constantLines": [
+              {}
+            ],
+            "options": {},
+            "y1Axis": {},
+            "xAxis": {}
+          }
+        },
+        {
+          "title": "JVM Memory (global)",
+          "xyChart": {
+            "dataSets": [
+              {
+                "timeSeriesFilter": {
+                  "filter": "metric.type=\"custom.googleapis.com/spinnaker/clouddriver/jvm.memory.used\" AND metric.label.memtype=\"HEAP\""
+                }
+              },
+              {
+                "timeSeriesFilter": {
+                  "filter": "metric.type=\"custom.googleapis.com/spinnaker/echo/jvm.memory.used\" AND metric.label.memtype=\"HEAP\""
+                }
+              },
+              {
+                "timeSeriesFilter": {
+                  "filter": "metric.type=\"custom.googleapis.com/spinnaker/fiat/jvm.memory.used\" AND metric.label.memtype=\"HEAP\""
+                }
+              },
+              {
+                "timeSeriesFilter": {
+                  "filter": "metric.type=\"custom.googleapis.com/spinnaker/front50/jvm.memory.used\" AND metric.label.memtype=\"HEAP\""
+                }
+              },
+              {
+                "timeSeriesFilter": {
+                  "filter": "metric.type=\"custom.googleapis.com/spinnaker/gate/jvm.memory.used\" AND metric.label.memtype=\"HEAP\""
+                }
+              },
+              {
+                "timeSeriesFilter": {
+                  "filter": "metric.type=\"custom.googleapis.com/spinnaker/igor/jvm.memory.used\" AND metric.label.memtype=\"HEAP\""
+                }
+              },
+              {
+                "timeSeriesFilter": {
+                  "filter": "metric.type=\"custom.googleapis.com/spinnaker/orca/jvm.memory.used\" AND metric.label.memtype=\"HEAP\""
+                }
+              },
+              {
+                "timeSeriesFilter": {
+                  "filter": "metric.type=\"custom.googleapis.com/spinnaker/rosco/jvm.memory.used\" AND metric.label.memtype=\"HEAP\""
+                }
+              }
+            ],
+            "constantLines": [
+              {}
+            ],
+            "options": {},
+            "y1Axis": {},
+            "xAxis": {}
+          }
+        }
+      ]
+    }
+  }
+}

--- a/google/stackdriver_monitoring/config/stackdriver/install.sh
+++ b/google/stackdriver_monitoring/config/stackdriver/install.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Copyright 2017 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+echo "See https://cloud.google.com/monitoring/agent/install-agent"
+echo "The agent is optional (and only available on GCP and AWS)"
+
+if [[ -z $STACKDRIVER_API_KEY ]]; then
+    # Remove this once API is no longer whitelisted.
+    echo "You need a STACKDRIVER_API_KEY to use this installer."
+    exit -1
+fi
+
+for dashboard in *Dashboard.json; do
+  google/stackdriver_monitoring/spinnaker_metric_tool.sh \
+      upload_stackdriver_dashboard --dashboard ${dashboard} \
+      "$@"
+done
+--credentials_path=$HOME/.spinnaker/google-credentials.json --dashboard xyz --update

--- a/google/stackdriver_monitoring/create_install_tar.sh
+++ b/google/stackdriver_monitoring/create_install_tar.sh
@@ -30,37 +30,36 @@ function make_spinnaker_monitor_zip() {
   local zip_file="$TEMP_DIR/monitor_spinnaker.zip"
 
   cd "$SOURCE_DIR"
-  zip -r "$zip_file" `ls *.py | grep -v _test.py`
+  zip -qr "$zip_file" `ls *.py | grep -v _test.py`
 
   cp spinnaker_metric_tool.py $TEMP_DIR/__main__.py
   cd $TEMP_DIR
-  zip $zip_file __main__.py
+  zip -q $zip_file __main__.py
   rm -f __main__.py
 
   cd "$BUILD_DIR/spinnaker"
-  zip -r $zip_file pylib
-
-  cd "$BUILD_DIR/citest"
-  zip -r $zip_file citest
+  zip -qr $zip_file pylib
 }
 
 function make_install_tar() {
-  local tar_file="$TEMP_DIR/install.tz"
+  local tar_file="$1"
   local staging_dir="$TEMP_DIR/monitor_spinnaker"
   mkdir $staging_dir
 
   cd "$SOURCE_DIR"
-  cp *.json README.md $TEMP_DIR/monitor_spinnaker.zip $staging_dir
+  cp -pr install_monitoring.sh config README.md $TEMP_DIR/monitor_spinnaker.zip $staging_dir
   cat requirements.txt | grep -v mock > $staging_dir/requirements.txt
 
   cd $TEMP_DIR
-  tar czf $tar_file monitor_spinnaker
+  if [[ "$tar_file" == *.tz || "$tar_file" == *.tar.gz ]]; then
+    tar czf $tar_file monitor_spinnaker
+  else
+    tar cf $tar_file monitor_spinnaker
+  fi
 }
 
 make_spinnaker_monitor_zip
-make_install_tar
+make_install_tar "$TARGET_PATH"
 
-cp "$TEMP_DIR/install.tz" "$TARGET_PATH"
-rm -rf $TEMP_DIR
 
 echo "WROTE $TARGET_PATH"

--- a/google/stackdriver_monitoring/install_monitoring.sh
+++ b/google/stackdriver_monitoring/install_monitoring.sh
@@ -1,0 +1,204 @@
+#!/bin/bash
+# Copyright 2017 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+SOURCE_DIR=$(readlink -f `dirname $0`)
+COMMAND_LINE_FLAGS=("$@")
+USE_DATADOG=false
+USE_PROMETHEUS=false
+USE_STACKDRIVER=false
+PROVIDERS=""
+EXTRA_ARGS=""
+
+function print_usage() {
+  cat <<-EOF
+	`basename $0`: <provider_switch>+ \
+	               <monitor_options>* \
+	               <service_options>* \
+	               <provider_options>*
+
+	<provider_switch> is one or more of:
+	   --datadog
+	        Install and configure a Datadog agent.
+	        Spinnaker's metric monitoring tool will publish metrics to Datadog.
+	        You will be prompted for your API and APP keys unless you define
+	        environment variables DATADOG_APP_KEY and DATADOG_API_KEY.
+
+	   --prometheus
+	        Install and configure Prometheus and Grafana Dashboard.
+	        Spinnaker's metric monitoring tool will publish metrics to Prometheus.
+
+	   --stackdriver
+	        Spinnaker's metric monitoring tool will publish metrics to Stackdriver.
+	        You may also need --credentials_path=<path>
+
+
+	<monitor_options> zero or more of:
+	   --port=8008
+	        The port number to use for the embedded HTTP server within the monitor.
+
+	   --period=60
+	        Number of seconds between pollings of microservices.
+
+	   --service_hosts <ip>+
+	        A comma-delimited list of hostnames (or IPs) to poll by default.
+	        The default is localhost.
+	        Make this empty "" to not poll any services by default.
+
+
+	<service_options> are in the form --<service>=<netloc>* where:
+	    <service> is one of clouddriver, echo, fiat, front50, gate, igor, rosco
+	    <netloc> is a comma-delimited list of either a <host> or <host>:<port>
+	    If only a <host> is provided, then the dfeault port will be used.
+
+	    An empty <netloc> list will disable polling on the service entirely.
+	    A value of "*" refers to all the --service_hosts.
+	    The default <netloc> for each of the services is "*".
+	   
+
+	<provider_options> are zero or more of:
+	    --credentials_path=<path>
+	        If using --stackdriver, the path for the Google Credentials to use.
+	        The default will be the application default credentials.
+EOF
+}
+
+
+function process_args() {
+  while [[ $# > 0 ]]
+  do
+      local key="$1"
+      shift
+      case $key in
+          --datadog)
+              USE_DATADOG=true
+              PROVIDERS="$PROVIDERS --datadog"
+              ;;
+
+          --prometheus)
+              USE_PROMETHEUS=true
+              PROVIDERS="$PROVIDERS --prometheus"
+              ;;
+
+          --stackdriver)
+              USE_STACKDRIVER=true
+              PROVIDERS="$PROVIDERS --stackdriver"
+              ;;
+
+          --help|-h)
+              print_usage
+              exit 1
+              ;;
+
+          *)
+              ;;  # ignore
+
+      esac
+  done
+}
+
+
+function install_dependencies() {
+  apt-get update
+  apt-get install python-pip python-dev -y
+  pip install -r $SOURCE_DIR/requirements.txt
+}
+
+
+function install_metric_services() {
+  if [[ "$USE_DATADOG" == "true" ]]; then
+      $SOURCE_DIR/config/datadog/install.sh
+  fi
+  if [[ "$USE_PROMETHEUS" == "true" ]]; then
+      $SOURCE_DIR/config/prometheus/install.sh
+  fi
+  if [[ "$USE_STACKDRIVER" == "true" ]]; then
+      local credentials=""
+      for arg in ${COMMAND_LINE_FLAGS[@]}; do
+          if [[ $arg = --credentials_path=* ]]; then
+              credentials=$arg
+          fi
+      done
+      $SOURCE_DIR/config/stackdriver/install.sh $credentials
+  fi
+}
+
+
+function write_startup_script() {
+  cat <<-EOF > "$SOURCE_DIR/monitor_spinnaker.sh"
+	#!/bin/bash
+
+	set -o allexport
+	if [[ -f /etc/default/spinnaker ]]; then
+	  source /etc/default/spinnaker
+	fi
+	if [[ -f "$SOURCE_DIR/environ" ]]; then
+	  source "$SOURCE_DIR/environ"
+	fi
+	set +o allexport
+
+	PYTHONWARNINGS=once \
+	python "$SOURCE_DIR/monitor_spinnaker.zip" \
+	monitor $@ "\$@"
+EOF
+  chmod 755 "$SOURCE_DIR/monitor_spinnaker.sh"
+}
+
+
+function write_upstart_script() {
+  cat <<-EOF > /etc/init/monitor_spinnaker.conf
+	start on filesystem or runlevel [2345]
+
+	exec $SOURCE_DIR/monitor_spinnaker.sh > /var/log/monitor_spinnaker.log 2>&1
+EOF
+  chmod 644 /etc/init/monitor_spinnaker.conf
+}
+
+
+process_args "${COMMAND_LINE_FLAGS[@]}"
+if [[ "$PROVIDERS" == "" ]]; then
+  print_usage
+  echo ""
+  echo "ERROR: No <provider_switch> options were provided."
+  exit -1
+fi
+
+
+if [[ `/usr/bin/id -u` -ne 0 ]]; then
+  echo "$0 must be executed with root permissions; exiting"
+  exit 1
+fi
+
+install_dependencies
+install_metric_services
+write_startup_script "${COMMAND_LINE_FLAGS[@]}"
+write_upstart_script
+
+echo "Starting to monitor Spinnaker services..."
+service monitor_spinnaker start
+
+cat <<EOF
+
+
+Be sure that your spinnaker-local.yml has services.spectator.webEndpoint.enabled=true
+For more information, see:
+    http://www.spinnaker.io/docs/monitoring-a-spinnaker-deployment
+EOF
+
+
+
+
+
+

--- a/google/stackdriver_monitoring/stackdriver_service.py
+++ b/google/stackdriver_monitoring/stackdriver_service.py
@@ -74,6 +74,11 @@ class StackdriverMetricsService(object):
     return datetime.fromtimestamp(millis / 1000).isoformat('T') + 'Z'
 
   @property
+  def project(self):
+    """Returns the stackdriver project being used."""
+    return self.__project
+
+  @property
   def stub(self):
     """Returns the stackdriver client stub."""
     if self.__stub is None:
@@ -385,7 +390,15 @@ def make_service(options):
       credentials = GoogleCredentials.get_application_default()
 
     http = credentials.authorize(http)
-    return apiclient.discovery.build('monitoring', 'v3', http=http)
+    developerKey = os.environ.get('STACKDRIVER_API_KEY')
+    if developerKey:
+      url='https://monitoring.googleapis.com/$discovery/rest?labels=DASHBOARD_TRUSTED_TESTER&key='+developerKey
+      return apiclient.discovery.build(
+          'monitoring', 'v3', http=http,
+          discoveryServiceUrl=url)
+    else:
+      return apiclient.discovery.build('monitoring', 'v3', http=http)
+
 
   return StackdriverMetricsService(make_stub, options)
 

--- a/install/first_google_boot.sh
+++ b/install/first_google_boot.sh
@@ -320,6 +320,18 @@ function extract_spinnaker_gcr_credentials() {
   fi
 }
 
+function do_experimental_startup() {
+  local monitor_config=$(get_instance_metadata_attribute "monitor_spinnaker")
+  if [[ ! -z $monitor_config && \
+          -f /opt/spinnaker/install/install_monitor_spinnaker.tz ]]; then
+     echo "$STATUS_PREFIX  Install Monitoring with flags '$monitor_config' "
+     tar xzf /opt/spinnaker/install/install_monitor_spinnaker.tz \
+         -C /opt --no-same-owner
+     /opt/monitor_spinnaker/install_monitoring.sh $monitor_config
+     clear_instance_metadata "monitor_spinnaker"
+  fi
+}
+
 function process_args() {
   while [[ $# > 0 ]]
   do
@@ -381,6 +393,8 @@ extract_spinnaker_credentials
 
 echo "$STATUS_PREFIX  Configuring Spinnaker"
 $SPINNAKER_INSTALL_DIR/scripts/reconfigure_spinnaker.sh
+
+do_experimental_startup
 
 
 # Replace this first time boot with the normal startup script


### PR DESCRIPTION
@lwander 
Not that interesting. Just sending it to you to seed the back of your mind regarding installing optional components outside spinnaker. Not part of halyard's scope, but still part of the installation process picture.

@jtk54 
This is not automatically built or part of any release. For not you manually run a create script for the installer and it packages up a tar file that you copy untar and run the install from that. Ultimately we should build a spinnaker_monitoring debian package. Maybe that means this goes into a different project entirely. I'm still not sure what the final packaging is though. I still want to look at straight up collectd. For now this CL is about development convenience and making it easy to give to people to start trying out.
