### PR TITLE
Rename azure storage to azs

### DIFF
--- a/config/default-spinnaker-local.yml
+++ b/config/default-spinnaker-local.yml
@@ -264,8 +264,8 @@ services:
       enabled: false
 
     # To use an Azure storage account instead of Cassandra:
-    # Disable Cassandra above, enable Azure, and set the storage account name and key
-    azure:
+    # Disable Cassandra above, enable azs, and set the storage account name and key
+    azs:
       enabled: false
       storageAccountName:
       storageAccountKey:

--- a/config/front50.yml
+++ b/config/front50.yml
@@ -48,12 +48,12 @@ spinnaker:
     bucket: ${services.front50.storage_bucket:}
     rootFolder: ${services.front50.bucket_root:front50}
 
-  azure:
-    enabled: ${services.front50.azure.enabled:false}
-    storageAccountName: ${services.front50.azure.storageAccountName}
-    storageAccountKey: ${services.front50.azure.storageAccountKey}
-    storageContainerName: ${services.front50.azure.storageContainerName:spinnaker}
-    rootFolder: ${services.front50.azure.rootFolder:front50}
+  azs:
+    enabled: ${services.front50.azs.enabled:false}
+    storageAccountName: ${services.front50.azs.storageAccountName}
+    storageAccountKey: ${services.front50.azs.storageAccountKey}
+    storageContainerName: ${services.front50.azs.storageContainerName:spinnaker}
+    rootFolder: ${services.front50.azs.rootFolder:front50}
 
 spectator:
   applicationName: ${spring.application.name}

--- a/config/spinnaker.yml
+++ b/config/spinnaker.yml
@@ -119,8 +119,8 @@ services:
       enabled: false
 
     # To use an Azure storage account instead of Cassandra:
-    # Disable Cassandra above, enable Azure, and set the storage account name and key
-    azure:
+    # Disable Cassandra above, enable azs, and set the storage account name and key
+    azs:
       enabled: false
       storageAccountName:
       storageAccountKey:

--- a/pylib/spinnaker/change_cassandra.py
+++ b/pylib/spinnaker/change_cassandra.py
@@ -31,7 +31,7 @@ instance, or you have a providers.google.primaryCredentials.jsonPath configured
 with service account credentials.
 
 Usage:
-   --echo=(cassandra|inMemory)  --front50=(cassandra|gcs|s3|azure)
+   --echo=(cassandra|inMemory)  --front50=(cassandra|gcs|s3|azs)
    [--bucket=<storage_bucket_name>]
    [--change_local=(true|false)]
    [--change_defaults=(true|false)]
@@ -52,12 +52,12 @@ from configurator import Configurator
 
 ECHO_CHOICES = ['cassandra', 'inMemory']
 
-FRONT50_CHOICES = ['cassandra', 's3', 'gcs', 'redis', 'azure']
+FRONT50_CHOICES = ['cassandra', 's3', 'gcs', 'redis', 'azs']
 
 _ECHO_KEYS = ['echo.cassandra.enabled', 'echo.inMemory.enabled']
 _FRONT50_KEYS = ['front50.cassandra.enabled', 'front50.redis.enabled',
                  'front50.s3.enabled', 'front50.gcs.enabled',
-                 'front50.storage_bucket', 'front50.azure.enabled']
+                 'front50.storage_bucket', 'front50.azs.enabled']
 
 SPINNAKER_INSTALLED_PATH = '/opt/spinnaker/cassandra/SPINNAKER_INSTALLED_CASSANDRA'
 SPINNAKER_DISABLED_PATH = '/opt/spinnaker/cassandra/SPINNAKER_DISABLED_CASSANDRA'
@@ -111,7 +111,7 @@ class CassandraChanger(object):
                           'redis': {'enabled': options.front50 == 'redis'},
                           's3': {'enabled': options.front50 == 's3'},
                           'gcs': {'enabled': options.front50 == 'gcs'},
-                          'azure': {'enabled': options.front50 == 'azure'}
+                          'azs': {'enabled': options.front50 == 'azs'}
                          }}
     if options.bucket:
         config['front50']['storage_bucket'] = options.bucket


### PR DESCRIPTION
'spinnaker.azure.enabled' conflicted with the environment variable used for the Azure cloudprovider config. Since azure storage can be used with other providers (like Kubernetes) we want the names to be independent.