### PR TITLE
Remove azure objectId from clouddriver.yml

### DIFF
--- a/config/clouddriver.yml
+++ b/config/clouddriver.yml
@@ -39,7 +39,6 @@ azure:
       appKey: ${providers.azure.primaryCredentials.appKey}
       tenantId: ${providers.azure.primaryCredentials.tenantId}
       subscriptionId: ${providers.azure.primaryCredentials.subscriptionId}
-      objectId: ${provider.azure.primaryCredentials.objectId}
       defaultResourceGroup: ${providers.azure.primaryCredentials.defaultResourceGroup}
       defaultKeyVault: ${providers.azure.primaryCredentials.defaultKeyVault}
 

--- a/experimental/kubernetes/simple/config/clouddriver.yml
+++ b/experimental/kubernetes/simple/config/clouddriver.yml
@@ -39,7 +39,6 @@ azure:
       appKey: ${providers.azure.primaryCredentials.appKey}
       tenantId: ${providers.azure.primaryCredentials.tenantId}
       subscriptionId: ${providers.azure.primaryCredentials.subscriptionId}
-      objectId: ${providers.azure.primaryCredentials.objectId}
 
 google:
   enabled: ${providers.google.enabled:false}


### PR DESCRIPTION
This property is only used in Rosco for baking Windows images, not clouddriver.