### PR TITLE
Remove rootFolder from AZS config

### DIFF
--- a/config/default-spinnaker-local.yml
+++ b/config/default-spinnaker-local.yml
@@ -291,8 +291,7 @@ services:
       enabled: false
       storageAccountName:
       storageAccountKey:
-      storageContainerName: spinnaker
-      rootFolder: front50
+      storageContainerName: front50
 
   echo:
     # Persistence mechanism to use

--- a/config/front50.yml
+++ b/config/front50.yml
@@ -52,8 +52,7 @@ spinnaker:
     enabled: ${services.front50.azs.enabled:false}
     storageAccountName: ${services.front50.azs.storageAccountName}
     storageAccountKey: ${services.front50.azs.storageAccountKey}
-    storageContainerName: ${services.front50.azs.storageContainerName:spinnaker}
-    rootFolder: ${services.front50.azs.rootFolder:front50}
+    storageContainerName: ${services.front50.azs.storageContainerName:front50}
 
 spectator:
   applicationName: ${spring.application.name}

--- a/config/spinnaker.yml
+++ b/config/spinnaker.yml
@@ -126,8 +126,7 @@ services:
       enabled: false
       storageAccountName:
       storageAccountKey:
-      storageContainerName: spinnaker
-      rootFolder: front50
+      storageContainerName: front50
 
   gate:
     host: ${services.default.host}


### PR DESCRIPTION
For a few reasons:
1. Simplify the config
2. Match the folder structure for other providers, which are only 2 levels deep not 3 (in front50.yml, s3.bucket == azs.storageAccountName and s3.rootFolder == azs.storageContainerName)
3. Fix a bug where the 'last_modified' files were stored at the container level and everything else was stored at the (now removed) rootFolder level. Now everything is at the container level.