### PR TITLE
Make the update_run_scripts in refresh_source.py default to True.

### DIFF
--- a/dev/refresh_source.py
+++ b/dev/refresh_source.py
@@ -538,9 +538,13 @@ bash -c "(npm start >> '$LOG_DIR/{name}.log') 2>&1\
                           help='Pull from this github user\'s repositories.'
                                ' If the user is "default" then use the'
                                ' authoritative (upstream) repository.')
-      parser.add_argument('--update_run_scripts', default=False,
+
+      parser.add_argument('--update_run_scripts', default=True,
                           action='store_true',
                           help='Update the run script for each component.')
+      parser.add_argument('--noupdate_run_scripts', 
+                          dest='update_run_scripts',
+                          action='store_false')
 
   @classmethod
   def main(cls):


### PR DESCRIPTION
And added `--noupdate_run_scripts` to allow for disabling it.

This fixes an issue observed yesterday where refresh_source no longer updates the run scripts by default, which broke the "Setting Up Spinnaker for Development" instructions in the spinnaker/README.

FYI @jtk54 