### PR TITLE
feat(build): Build spinnaker distribution to validate with citest.

### DIFF
--- a/dev/annotate_source.py
+++ b/dev/annotate_source.py
@@ -118,7 +118,7 @@ class GitTagMissingException(Exception):
     self.message = message
 
 
-class Annotator(Refresher):
+class Annotator(object):
   """Provides semantic version tagging for Spinnaker repositories.
 
   Each Spinnaker repository has tags that denote releases. These tags follow
@@ -148,7 +148,6 @@ class Annotator(Refresher):
     self.__tags_to_delete = []
     self.__filtered_tags = []
     self.__current_version = None
-    super(Annotator, self).__init__(options)
 
   @property
   def build_number(self):
@@ -359,7 +358,7 @@ class Annotator(Refresher):
   @classmethod
   def init_argument_parser(cls, parser):
     """Initialize command-line arguments."""
-    parser.add_argument('--build_number', default='',
+    parser.add_argument('--build_number', default=os.environ.get('BUILD_NUMBER'),
                         help='The build number to append to the semantic version tag.')
     parser.add_argument('--initial_branch', default='master',
                         help='Initial branch to create the stable release branch from.')
@@ -371,7 +370,6 @@ class Annotator(Refresher):
                         help='Name of the stable release branch to create.')
     parser.add_argument('--force_rebuild', default=False, action='store_true',
                         help='Force a rebuild even if there is a git tag at HEAD.')
-    super(Annotator, cls).init_argument_parser(parser)
 
   @classmethod
   def main(cls):

--- a/dev/build_prevalidation.py
+++ b/dev/build_prevalidation.py
@@ -1,0 +1,70 @@
+#!/usr/bin/python
+#
+# Copyright 2017 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import os
+import sys
+
+from annotate_source import Annotator
+from build_release import Builder
+from generate_bom import BomGenerator
+from refresh_source import Refresher
+
+
+def __annotate_component(annotator, component):
+  """Annotate the component's source but don't include it in the BOM.
+  """
+  annotator.path = component
+  annotator.parse_git_tree()
+  annotator.tag_head()
+  annotator.delete_unwanted_tags()
+
+def init_argument_parser(parser):
+  # Don't need to init args for Annotator since BomGenerator extends it.
+  BomGenerator.init_argument_parser(parser)
+  Builder.init_argument_parser(parser)
+
+def main():
+  """Build a Spinnaker release to be validated by Citest.
+  """
+  parser = argparse.ArgumentParser()
+  init_argument_parser(parser)
+  options = parser.parse_args()
+
+  annotator = Annotator(options)
+  __annotate_component(annotator, 'spinnaker')
+  __annotate_component(annotator, 'halyard')
+  __annotate_component(annotator, 'spinnaker-monitoring')
+
+  bom_generator = BomGenerator(options)
+  bom_generator.determine_and_tag_versions()
+  if options.container_builder == 'gcb':
+    bom_generator.write_container_builder_gcr_config()
+  elif options.container_builder == 'docker':
+    bom_generator.write_docker_version_files()
+  else:
+    raise NotImplementedError('container_builder="{0}"'
+                              .format(options.container_builder))
+  Builder.do_build(options, options.build_number, options.container_builder)
+  # Load version information into memory and write BOM to disk. Don't publish yet.
+  bom_generator.write_bom()
+  bom_generator.publish_microservice_configs()
+  bom_generator.publish_boms()
+  bom_generator.generate_changelog()
+
+
+if __name__ == '__main__':
+  sys.exit(main())


### PR DESCRIPTION
This refactors our Jenkins build script (*GithubToBintray) out into a python script that
* Encapsulates a few release operations into one container.
* Runs the primitive operations in an order that won't leave the public BOM bucket or artifact repositories in an inconsistent state, i.e. we never publish a BOM that contains a non-existent package.
* Refactors the primitive classes to separate the logic slightly better.