### PR TITLE
chore(changelog): Extend changelog keywords.

### DIFF
--- a/.clog.toml
+++ b/.clog.toml
@@ -1,0 +1,5 @@
+[clog]
+
+[sections]
+"Breaking Changes" = ["bc"]
+"Configuration Changes" = ["config", "conf"]


### PR DESCRIPTION
Adds a few new changelog keywords: `bc` for breaking change and `config` or `conf` for configuration changes.