### PR TITLE
fix(docker-compose): Fixing typo in docker-compose.yml

### DIFF
--- a/experimental/docker-compose/docker-compose.yml
+++ b/experimental/docker-compose/docker-compose.yml
@@ -111,8 +111,8 @@ fiat:
   container_name: fiat
   env_file: ./compose.env
   environment:
-    - SERVICES_CLOUDDRIVER_HOST=clouddriver
-    - SERVICES_FRONT50_HOST=front50
+    - SERVICES_CLOUDDRIVER_BASEURL=clouddriver
+    - SERVICES_FRONT50_BASEURL=front50
   image: quay.io/spinnaker/fiat:master
   links:
     - redis


### PR DESCRIPTION
As far as I am aware, these are the correct environment variable names for the Fiat service.  I have tested and only been able to get the app functioning with the variables set in this way.  Please let me know if I am missing something.