### PR TITLE
feat(release): Deploy built spinnaker version to k8s.

### DIFF
--- a/dev/hal_install_spin.docker
+++ b/dev/hal_install_spin.docker
@@ -1,0 +1,26 @@
+FROM ubuntu:14.04
+
+# This is assumed to run in spinnaker/dev.
+# The container already has a '/dev' so we name it something different.
+COPY . runscript
+
+RUN apt-get install -y curl software-properties-common apt-transport-https wget
+
+# The container expects the following environment variables to be set.
+# These should be handled by creating k8s secrets and specifying
+# environment variables in the pod spec using those secrets.
+# ---
+# Parameters of the GCP project Spinnaker is maintaining.
+# BUILD_PROJECT
+# BUILD_KEY # json keyfile contents
+#
+# Parameters to configure the Docker registry.
+# DOCKER_KEY # json keyfile contents
+#
+# Kubernetes config in json format so we can pass it to the
+# container an an env variable.
+# KUBE_CONF
+
+WORKDIR runscript
+
+CMD /runscript/hal_k8s_run.sh

--- a/dev/hal_k8s_run.sh
+++ b/dev/hal_k8s_run.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+# Copyright 2017 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The purpose of this script is to install Halyard at the latest released
+# version (output from our build process, not a Github release) and use
+# Halyard to deploy Spinnaker to Kubernetes at the versions specified in
+# the latest nightly version. After Spinnaker is instantiated on Kubernetes,
+# a Citest suite will run against it. This is outside the scope of this script.
+
+# It is assumed that this script will run in a container with the proper
+# environment variables and files present.
+#
+# The container expects the following environment variables to be set.
+# These should be handled by creating k8s secrets and specifying
+# environment variables in the pod spec using those secrets.
+# ---
+# Parameters of the GCP project Spinnaker is maintaining.
+# BUILD_PROJECT
+# BUILD_KEY # json keyfile contents
+#
+# Parameters to configure the Docker registry.
+# DOCKER_KEY # json keyfile contents
+#
+# Kubernetes config in json format so we can pass it to the
+# container an an env variable.
+# KUBE_CONF
+
+set -e
+export TERMINFO=/usr/lib/terminfo
+export TERM=xterm
+
+mkdir /supporting_data
+echo $BUILD_KEY >> /supporting_data/build.json
+echo $DOCKER_KEY >> /supporting_data/docker.json
+
+curl -O https://storage.googleapis.com/kubernetes-release/release/v1.5.4/bin/linux/amd64/kubectl
+chmod +x kubectl
+mv kubectl /usr/local/bin/kubectl
+
+echo "Downloading Halyard..."
+wget https://raw.githubusercontent.com/spinnaker/halyard/master/InstallHalyard.sh
+
+# We need to make changes to the Halyard install script so it can run in a container.
+sed "s/^printf/echo/" -i InstallHalyard.sh
+sed "s/^start halyard/exit 0/" -i InstallHalyard.sh
+
+sudo bash InstallHalyard.sh -y
+echo "Starting Halyard..."
+exec sudo /opt/halyard/bin/halyard 2>&1 /var/log/spinnaker/halyard/halyard.log &
+sleep 25
+
+echo "Configuring k8s..."
+echo $KUBE_CONF
+mkdir ~/.kube
+echo $KUBE_CONF >> ~/.kube/config
+
+echo "Running Halyard commands to deploy spinnaker."
+cat /supporting_data/build.json
+cat /supporting_data/docker.json
+hal config version edit --version nightly
+
+hal config provider docker-registry enable
+hal config provider docker-registry account add my-gcr-account \
+    --password-file /supporting_data/docker.json --username _json_key \
+    --address gcr.io
+
+hal config provider kubernetes enable
+hal config provider kubernetes account add my-k8s-account \
+    --docker-registries my-gcr-account
+
+hal config provider google enable
+hal config provider google account add my-gce-account \
+    --json-path /supporting_data/build.json --project $BUILD_PROJECT
+hal config storage edit --account-name my-gce-account
+
+hal config deploy edit --type flotilla --account-name my-k8s-account
+hal deploy run
+
+cat ~/.hal/default/install.sh


### PR DESCRIPTION
This installs Halyard on an ubuntu:14.04 container and subsequently deploys Spinnaker on the same k8s cluster using Halyard. Once Spinnaker is running on k8s, we can tunnel using `kubectl` to run a citest suite.

The container is built using something like:
```
docker build --build-arg BUILD_PROJECT="${project}" \
   --build-arg  BUILD_ACCOUNT="${builder account}" \
   --build-arg BUILD_KEY="$(cat build.json)" \
   --build-arg DOCKER_PROJECT="${docker project}" \
   --build-arg DOCKER_ACCOUNT="${docker project account}" \
   --build-arg DOCKER_KEY="$(cat docker.json)" \
   --build-arg CLUSTER_NAME="halyard-cluster" \
   --build-arg KUBE_CONF="$(python -c 'import sys, yaml, json; json.dump(yaml.load(sys.stdin), sys.stdout, indent=4)' < ~/.kube/config)" \
   -t ${tag name} -f hal_install_spin.docker .
```

and subsequently run with `kubectl create -f ${pod spec}.yml` after the building and pushing the container.