### PR TITLE
fix(google_kato_test): Default to bindings for spinnaker account.

### DIFF
--- a/dev/hal_k8s_run.sh
+++ b/dev/hal_k8s_run.sh
@@ -59,8 +59,8 @@ sed "s/^start halyard/exit 0/" -i InstallHalyard.sh
 
 sudo bash InstallHalyard.sh -y
 echo "Starting Halyard..."
-exec sudo /opt/halyard/bin/halyard 2>&1 /var/log/spinnaker/halyard/halyard.log &
-sleep 25
+sudo /opt/halyard/bin/halyard 2>&1 /var/log/spinnaker/halyard/halyard.log &
+sleep 60
 
 echo "Configuring k8s..."
 echo $KUBE_CONF
@@ -86,7 +86,7 @@ hal config provider google account add my-gce-account \
     --json-path /supporting_data/build.json --project $BUILD_PROJECT
 hal config storage edit --account-name my-gce-account
 
-hal config deploy edit --type flotilla --account-name my-k8s-account
+hal config deploy edit --type distributed --account-name my-k8s-account
 hal deploy run
 
 cat ~/.hal/default/install.sh

--- a/testing/citest/tests/google_kato_test.py
+++ b/testing/citest/tests/google_kato_test.py
@@ -579,8 +579,7 @@ class GoogleKatoTestScenario(sk.SpinnakerTestScenario):
 
       # Produce the list of images that we expect to receive from spinnaker
       # (visible to the primary service account).
-      spinnaker_account = self.agent.deployed_config.get(
-          'providers.google.primaryCredentials.name')
+      spinnaker_account = self.bindings['SPINNAKER_GOOGLE_ACCOUNT']
 
       logger.debug('Configured with Spinnaker account "%s"', spinnaker_account)
       expect_images = [{'account': spinnaker_account, 'imageName': image['name']}


### PR DESCRIPTION
Also waits a bit longer for Halyard to start and updates the change from flotilla -> distributed.