### PR TITLE
fix(install): Inject YAML nodes to fix disabling cassandra.

### DIFF
--- a/dev/bootstrap_dev.sh
+++ b/dev/bootstrap_dev.sh
@@ -237,6 +237,16 @@ if [[ "$CONFIRMED_GITHUB_REPOSITORY_OWNER" != "none" ]]; then
       --github_user $CONFIRMED_GITHUB_REPOSITORY_OWNER
 fi
 
+# Prepare spinnaker-local.yml
+if [[ ! -f $HOME/.spinnaker/spinnaker-local.yml ]]; then
+    # This has a side effect in which it will produce a spinnaker-local if
+    # it did not already exist. Since there is no "bogus" microservice, this
+    # will not actually do anything other than produce the spinnaker-local.
+    # The default spinnaker-local will be configured for this machine as
+    # a better starting point than otherwise.
+    ./spinnaker/dev/stop_dev.sh bogus >& /dev/null || true
+fi
+
 # Some dependencies of Deck rely on Bower to manage their dependencies. Bower
 # annoyingly prompts the user to collect some stats, so this disables that.
 echo "{\"interactive\":false}" > ~/.bowerrc

--- a/dev/dev_runner.py
+++ b/dev/dev_runner.py
@@ -169,8 +169,9 @@ class DevRunner(spinnaker_runner.Runner):
     change_path = os.path.join(os.path.dirname(os.path.dirname(__file__)),
                                'install', 'change_cassandra.sh')
     got = run_quick(change_path
-              + ' --echo=inMemory --front50=gcs'
-              + ' --change_defaults=false --change_local=true')
+                    + ' --echo=inMemory --front50=gcs'
+                    + ' --change_defaults=false --change_local=true',
+                    echo=False)
 
   def __init__(self, installation_parameters=None):
     self.maybe_generate_clean_user_local()

--- a/pylib/spinnaker/change_cassandra.py
+++ b/pylib/spinnaker/change_cassandra.py
@@ -54,10 +54,14 @@ ECHO_CHOICES = ['cassandra', 'inMemory']
 
 FRONT50_CHOICES = ['cassandra', 's3', 'gcs', 'redis', 'azs']
 
-_ECHO_KEYS = ['echo.cassandra.enabled', 'echo.inMemory.enabled']
-_FRONT50_KEYS = ['front50.cassandra.enabled', 'front50.redis.enabled',
-                 'front50.s3.enabled', 'front50.gcs.enabled',
-                 'front50.storage_bucket', 'front50.azs.enabled']
+_ECHO_KEYS = ['services.echo.cassandra.enabled',
+              'services.echo.inMemory.enabled']
+_FRONT50_KEYS = ['services.front50.cassandra.enabled',
+                 'services.front50.redis.enabled',
+                 'services.front50.s3.enabled',
+                 'services.front50.gcs.enabled',
+                 'services.front50.storage_bucket',
+                 'services.front50.azs.enabled']
 
 SPINNAKER_INSTALLED_PATH = '/opt/spinnaker/cassandra/SPINNAKER_INSTALLED_CASSANDRA'
 SPINNAKER_DISABLED_PATH = '/opt/spinnaker/cassandra/SPINNAKER_DISABLED_CASSANDRA'
@@ -115,7 +119,7 @@ class CassandraChanger(object):
                          }}
     if options.bucket:
         config['front50']['storage_bucket'] = options.bucket
-    self.__bindings.import_dict(config)
+    self.__bindings.import_dict({'services': config})
 
   def disable_cassandra(self):
     if os.path.exists(SPINNAKER_INSTALLED_PATH):


### PR DESCRIPTION
Rewrote YAML mutator so it uses parse tree rather than regex searching
for more robustness.

@duftler 
This also generates the spinnaker-local on install.
I didnt explicitly test that in the bootstrap, but did so outside bootstrap.