### PR TITLE
fix(dev): clean google tarball more

### DIFF
--- a/dev/clean_google_image.sh
+++ b/dev/clean_google_image.sh
@@ -29,13 +29,14 @@ disk_id=$1
 mkdir -p /mnt/disks/${disk_id}
 mount -o discard,defaults /dev/disk/by-id/google-${disk_id}-part1 /mnt/disks/${disk_id}
 cd /mnt/disks/${disk_id}
+echo "FYI, disk Usage is `df -kh .`"
 
 
 # Remove user information from etc/ and their home directories.
 # But leave spinnaker.
 etc_files="group gshadow passwd shadow subgid subuid"
 for user in $(ls home); do
-  if [[ "$user" != "spinnaker" ]]; then
+  if [[ "$user" != "spinnaker" && "$user" != "ubuntu" ]]; then
     for file in $etc_files; do
       sed /^$user:.*/d -i etc/${file} || true
       sed /^$user:.*/d -i etc/${file}- || true
@@ -53,3 +54,6 @@ fi
 # Remove tmp and log files
 rm -rf tmp/*
 find var/log -type f -exec rm {} \;
+
+cd /
+umount /mnt/disks/${disk_id}

--- a/dev/extract_disk_to_gcs.sh
+++ b/dev/extract_disk_to_gcs.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+#
+# Copyright 2017 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+set -x
+
+if [[ $# -ne 2 ]]; then
+  echo "Usage: $0 <disk-id to extract> <gcs path to write to>"
+  exit -1
+fi
+
+disk_id="$1"
+gcs_path="$2"
+if [[ "$gcs_path" != gs://*.tar.gz ]]; then
+  echo "'$gcs_path' is not a Google Cloud Storage URI to a tar.gz (gs://*)"
+  exit -1
+fi
+
+# This might need to literally be "disk.raw" inside tar file.
+echo "`date` Dumping disk $disk_id"
+sudo dd if=/dev/disk/by-id/google-${disk_id}-part1 of=./disk.raw bs=4096
+
+echo "`date` Creating tar file"
+sudo tar czf disk.raw.tz disk.raw
+
+echo "`date` Writing $gcs_path"
+gsutil -q cp disk.raw.tz ${gcs_path}
+
+echo "`date` Finished"
+
+
+


### PR DESCRIPTION
This cleans the google image tarballs.
To do so, I refactored the build_google_image script so that it
can preserve the disk and/or emit tarballs instead of or along with images.
This obsoletes the google/dev/build_google_tarball script, but am keeping
it around until other processes that use the script switch over.

@skim1420 
