### PR TITLE
fix(installation): make it clear that the current Ubuntu LTS is not supported

### DIFF
--- a/InstallSpinnaker.sh
+++ b/InstallSpinnaker.sh
@@ -59,14 +59,14 @@ fi
 # If not Ubuntu 14.xx.x or higher
 
 if [[ "$DISTRO" == "Ubuntu" ]]; then
-  if [[ "${DISTRIB_RELEASE%%.*}" -lt 14 ]]; then
+  if [[ "${DISTRIB_RELEASE%%.*}" -ne 14 ]]; then
     echo "Not a supported version of Ubuntu"
-    echo "Version is $DISTRIB_RELEASE we require 14.04 or higher"
+    echo "Version is $DISTRIB_RELEASE we require 14.04.x LTS"
     exit 1
   fi
 else
   echo "Not a supported operating system"
-  echo "Recommend you use Ubuntu 14.04 or higher"
+  echo "Only Ubuntu 14.04.x LTS is supported"
   exit 1
 fi
 


### PR DESCRIPTION
Most of the documentation refers to Ubuntu 14.04 LTS. The new LTS version 16.04 does not work with Spinnaker. Version 15.04 was not an LTS and it has reached its EOL

Fixed Issue #1544 
