### PR TITLE
Change experimental/kubernetes/ha to remove launch args

### DIFF
--- a/experimental/kubernetes/ha/deck/rcs/spin-deck.yaml
+++ b/experimental/kubernetes/ha/deck/rcs/spin-deck.yaml
@@ -19,12 +19,8 @@ spec:
     spec:
       containers:
         - image: quay.io/spinnaker/deck:master
+          imagePullPolicy: Always
           name: deck
-          command:
-            - /bin/bash
-            - -c
-          args:
-            - "cp /opt/spinnaker/config/settings.js .; /opt/deck/docker/run-apache2.sh"
           env:
             - name: DECK_HOST
               value: 0.0.0.0

--- a/experimental/kubernetes/ha/deck/rcs/spin-deck.yaml
+++ b/experimental/kubernetes/ha/deck/rcs/spin-deck.yaml
@@ -24,7 +24,7 @@ spec:
             - /bin/bash
             - -c
           args:
-            - "cp /opt/spinnaker/config/settings.js .; npm start"
+            - "cp /opt/spinnaker/config/settings.js .; /opt/deck/docker/run-apache2.sh"
           env:
             - name: DECK_HOST
               value: 0.0.0.0


### PR DESCRIPTION
Deck used to launch npm, now moved to apache2. This change to the spin-deck.yaml brings it in line with how the containers are now configured.

