### PR TITLE
chore(dev): Expose Chaos Monkey configuration. 

### DIFF
--- a/config/default-spinnaker-local.yml
+++ b/config/default-spinnaker-local.yml
@@ -270,6 +270,9 @@ services:
   fiat:
     enabled: false
 
+  chaos:
+    enabled: false
+
   front50:
     cassandra:
       enabled: true

--- a/config/settings.js
+++ b/config/settings.js
@@ -33,6 +33,7 @@
 // var slackEnabled = ${services.echo.notifications.slack.enabled};
 // var slackBotName = ${services.echo.notifications.slack.botName};
 // var fiatEnabled = ${services.fiat.enabled};
+// var chaosEnabled = ${services.chaos.enabled};
 // var openstackPrimaryAccount = ${providers.openstack.primaryCredentials.name};
 // var openstackDefaultRegion = ${providers.openstack.defaultRegion};
 // var appenginePrimaryAccount = ${providers.appengine.primaryCredentials.name};
@@ -128,5 +129,6 @@ window.spinnakerSettings = {
     roscoMode: true,
     netflixMode: false,
     fiatEnabled: fiatEnabled,
+    chaosMonkey: chaosEnabled,
   },
 };


### PR DESCRIPTION
Adding chaosEnabled and chaosMonkey flags to config/settings.js and a chaos service to default_spinnaker_local.yml.