### PR TITLE
fix(tests): Fixed native test startup / configuration

### DIFF
--- a/testing/citest/spinnaker_testing/spinnaker.py
+++ b/testing/citest/spinnaker_testing/spinnaker.py
@@ -256,7 +256,10 @@ class SpinnakerAgent(service_testing.HttpAgent):
       elif bindings['NATIVE_HOSTNAME']:
         host_platform = 'native'
       else:
-        raise ValueError('No --native_hostname nor --gce_project')
+        bindings['NATIVE_HOSTNAME'] = 'localhost'
+        logging.getLogger(__name__).info('Assuming --native_hostname=localhost')
+        host_platform = 'native'
+
     return host_platform
 
   @classmethod
@@ -371,7 +374,7 @@ class SpinnakerAgent(service_testing.HttpAgent):
       return None
 
     logger.info('%s is available at %s', name, base_url)
-    env_url = os.path.join(base_url, 'env')
+    env_url = os.path.join(base_url, 'resolvedEnv')
     deployed_config = scrape_spring_config(env_url)
     spinnaker_agent = cls(base_url, status_factory)
     spinnaker_agent.__deployed_config = deployed_config

--- a/testing/citest/spinnaker_testing/spinnaker_test_scenario.py
+++ b/testing/citest/spinnaker_testing/spinnaker_test_scenario.py
@@ -21,6 +21,7 @@ to make appropriate observations.
 """
 
 import logging
+import traceback
 
 from citest.base import JournalLogger
 
@@ -253,7 +254,9 @@ class SpinnakerTestScenario(sk.AgentTestScenario):
         self.__platform_support[support.platform_name] = support
       except:
         logger = logging.getLogger(__name__)
-        logger.exception('Failed to initialize support class %s', str(klas))
+        
+        logger.exception('Failed to initialize support class %s:\n%s',
+                         str(klas), traceback.format_exc())
 
     try:
       self._do_init_bindings()


### PR DESCRIPTION
Get configuration parameters from the "resolveEnv" endpoint.
Show exception information if agent fails
If not given a location, assume localhost

The net effect is that if you are on the same machine as spinnaker,
and the tests primary microservice is on its standard port, then
you can run a typical test without any command-line parameters provided
it can get whatever configuration it needs from the server.

@jtk54  
@rguthriemsft