### PR TITLE
fix(hal_k8s_run): Remove kubeconfig logging.

### DIFF
--- a/dev/hal_k8s_run.sh
+++ b/dev/hal_k8s_run.sh
@@ -71,7 +71,6 @@ sudo /opt/halyard/bin/halyard 2>&1 /var/log/spinnaker/halyard/halyard.log &
 sleep 60
 
 echo "Configuring k8s..."
-echo $KUBE_CONF
 mkdir ~/.kube
 echo $KUBE_CONF >> ~/.kube/config
 


### PR DESCRIPTION
I rebuilt and pushed this container to dockerhub, so this change is ready for our Jenkins jobs.