### PR TITLE
feat(halyard_release): Implement support for Halyard release tracks.

### DIFF
--- a/dev/annotate_source.py
+++ b/dev/annotate_source.py
@@ -241,11 +241,11 @@ class Annotator(object):
     This is so that gradle will use the latest resolved semantic version from
     our tag pattern when it builds the package.
     """
+    print ('Deleting {0} unwanted git tags locally from {1}'
+           .format(len(self.__tags_to_delete), self.path))
     for bad_hash_tag in self.__tags_to_delete:
-      # NOTE: The following command prints output to STDOUT, so we don't
-      # explicitly log anything.
       run_quick('git -C {path} tag -d {tag}'
-                .format(path=self.path, tag=bad_hash_tag.tag))
+                .format(path=self.path, tag=bad_hash_tag.tag), echo=False)
 
   def checkout_branch(self):
     """Checks out a branch.
@@ -253,16 +253,22 @@ class Annotator(object):
     run_quick('git -C {path} checkout {branch}'.format(path=self.path,
                                                        branch=self.branch))
 
+  def get_head_commit(self):
+    """Retrieves the head commit hash.
+    """
+    head_commit_res = run_quick('git -C {path} rev-parse HEAD'
+                                .format(path=self.path),
+                                echo=False)
+    return head_commit_res.stdout.strip()
+
+
   def __is_head_current(self):
     """Checks if the current version is at HEAD.
 
     Returns:
       [Boolean]: True if the current version tag is on HEAD, else False.
     """
-    head_commit_res = run_quick('git -C {path} rev-parse HEAD'
-                                    .format(path=self.path),
-                                echo=False)
-    head_commit = head_commit_res.stdout.strip()
+    head_commit = self.get_head_commit()
     return self.__current_version.hash == head_commit
 
   def __determine_current_version(self):

--- a/dev/build_prevalidation.py
+++ b/dev/build_prevalidation.py
@@ -23,16 +23,53 @@ from build_release import Builder
 from generate_bom import BomGenerator
 from refresh_source import Refresher
 
+from spinnaker.run import check_run_quick
+
 
 def __annotate_component(annotator, component):
   """Annotate the component's source but don't include it in the BOM.
+
+  Returns:
+    Tuple of ([VersionBump] Halyard version bump, [string] head commit hash)
   """
   annotator.path = component
   annotator.parse_git_tree()
-  annotator.tag_head()
+  version_bump = annotator.tag_head()
+  head_hash = annotator.get_head_commit()
   annotator.delete_unwanted_tags()
+  return (version_bump, head_hash)
+
+def __record_halyard_nightly_version(version_bump, head_hash, options):
+  """Record the version and commit hash at which Halyard was built in a bucket.
+
+  Assumes that gsutil is installed on the machine this script is run from.
+
+  This function uses `gsutil rsync` to read the GCS file, changes it in-place,
+  and then uses `gsutil rsync` to write the file again. `rsync` is eventually
+  consistent, so running this script (or manually manipulating the GCS file)
+  concurrently could likely result in file corruption. Don't parallelize this.
+  """
+  bucket_uri = options.hal_nightly_bucket_uri
+  build_number = options.build_number
+  local_bucket_name = os.path.basename(bucket_uri)
+  # Copy all the bucket contents to local (-r) and get rid of extra stuff (-d).
+  if not os.path.exists(local_bucket_name):
+    os.mkdir(local_bucket_name)
+  check_run_quick('gsutil rsync -r -d {remote_uri} {local_bucket}'
+                  .format(remote_uri=bucket_uri, local_bucket=local_bucket_name))
+  hal_version = version_bump.version_str.replace('version-', '')
+  new_hal_nightly_entry = ('{version}-{build}: {commit}'
+                           .format(version=hal_version, build=build_number, commit=head_hash))
+  nightly_entry_file = '{0}/nightly-version-commits.yml'.format(local_bucket_name)
+  with open(nightly_entry_file, 'a') as nef:
+    nef.write('{0}\n'.format(new_hal_nightly_entry))
+  # Now sync the local dir with the bucket again after the update.
+  check_run_quick('gsutil rsync -r -d {local_bucket} {remote_uri}'
+                  .format(remote_uri=bucket_uri, local_bucket=local_bucket_name))
 
 def init_argument_parser(parser):
+  parser.add_argument('--hal_nightly_bucket_uri', default='',
+                      help='The URI of the bucket to record the version and commit at which we built Halyard.')
   # Don't need to init args for Annotator since BomGenerator extends it.
   BomGenerator.init_argument_parser(parser)
   Builder.init_argument_parser(parser)
@@ -45,7 +82,7 @@ def main():
   options = parser.parse_args()
 
   annotator = Annotator(options)
-  __annotate_component(annotator, 'halyard')
+  halyard_bump, halyard_head_hash = __annotate_component(annotator, 'halyard')
 
   bom_generator = BomGenerator(options)
   bom_generator.determine_and_tag_versions()
@@ -61,6 +98,7 @@ def main():
   # Load version information into memory and write BOM to disk. Don't publish yet.
   bom_generator.write_bom()
   bom_generator.publish_microservice_configs()
+  __record_halyard_nightly_version(halyard_bump, halyard_head_hash, options)
   bom_generator.publish_boms()
   bom_generator.generate_changelog()
 

--- a/dev/build_release.py
+++ b/dev/build_release.py
@@ -201,6 +201,8 @@ class Builder(object):
 
     if name == 'deck' and not 'CHROME_BIN' in os.environ:
       extra_args.append('-PskipTests')
+    elif name == 'halyard':
+      extra_args.append('-PbintrayPackageDebDistribution=trusty-nightly')
 
     # Currently spinnaker is in a separate location
     gradle_root = self.determine_gradle_root(name)


### PR DESCRIPTION
This makes the change to publish Halyard to the 'trusty-nightly' distribution rather than just 'trusty'. We record the version built during the nightly release and a commit hash in a GCS file so we can promote Halyard by re-building it later from the same commit hash.

I'll implement the second part (promoting Halyard) next.