### PR TITLE
fix(docker-compose): Remove empty AWS variables

### DIFF
--- a/experimental/docker-compose/docker-compose.yml
+++ b/experimental/docker-compose/docker-compose.yml
@@ -2,8 +2,6 @@ clouddriver:
   container_name: clouddriver
   env_file: ./compose.env
   environment:
-    - AWS_ACCESS_KEY_ID
-    - AWS_SECRET_ACCESS_KEY
     - "SERVICES_FRONT50_BASEURL=http://$DOCKER_IP:8080"
   image: quay.io/spinnaker/clouddriver:master
   links:


### PR DESCRIPTION
Removing the AWS environment variables. Ran into an issue where the
variables were also defined in the ``compose.env`` file and were being
overridden by the `docker-compose.yml` and ended up being empty. This is
confusing for new folks trying to use Spinnaker with Compose as it _acts_
like the variables aren't being set if they're defined in the env file.