### PR TITLE
fix(bake): Fixes bake of consul & vault servers

### DIFF
--- a/dev/halyard_install_component.sh
+++ b/dev/halyard_install_component.sh
@@ -64,7 +64,7 @@ function process_args() {
   done
 }
 
-EXTERNAL_ARTIFACTS=(vault consul redis)
+EXTERNAL_ARTIFACTS=(vault-server consul-server)
 
 function contains() {
   local e


### PR DESCRIPTION
The problem was the we were baking images based on the `artifact` alone, when it should have been the `service`. However, the `artifact` needs to be known to name & version the baked image, so I put both `artifact`s & `service`s into an associative array.