### PR TITLE
chore(bake): Spit out contents of log files after build completes

### DIFF
--- a/dev/build_google_component_image.sh
+++ b/dev/build_google_component_image.sh
@@ -282,4 +282,12 @@ done
 echo "Waiting on PIDs: ${PIDS[@]}..."
 wait ${PIDS[@]}
 
+for logfile in *-image.log; do
+  echo "---- start $logfile ----"
+  echo ""
+  cat $logfile
+  echo ""
+  echo "---- end $logfile ----"
+done
+
 echo "`date`: DONE"


### PR DESCRIPTION
This way we don't need to ssh into jenkins to see why the build failed.