### PR TITLE
fix(google): Fixed codelab image construction

### DIFF
--- a/google/codelab/codelab_config.py
+++ b/google/codelab/codelab_config.py
@@ -37,18 +37,6 @@ def configure_codelab_igor_jenkins(password):
     }
   )
 
-def disable_destructive_action_challenge():
-  """Disables destructive action challenge for codelab.
-
-  """
-  with open('/opt/spinnaker/config/clouddriver-local.yml', 'w') as fd:
-    fd.write("""
-'credentials': {
-   'challengeDestructiveActionsEnvironments': ''
-}
-"""
-
 
 if __name__ == '__main__':
   configure_codelab_igor_jenkins('admin')
-  disable_destructive_action_challenge()

--- a/google/codelab/first_codelab_boot.sh
+++ b/google/codelab/first_codelab_boot.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Copyright 2017 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+PYTHONPATH=/opt/spinnaker/pylib python /opt/spinnaker/install/codelab_config.py
+echo "debianRepository: http://$(hostname):9999/ trusty main" \
+    > /opt/spinnaker/config/rosco-local.yml
+chown spinnaker:spinnaker /opt/spinnaker/config/rosco-local.yml
+
+cat <<EOF > /opt/spinnaker/config/clouddriver-local.yml
+credentials:
+  challengeDestructiveActionsEnvironments:
+EOF
+chown spinnaker:spinnaker /opt/spinnaker/config/clouddriver-local.yml
+
+/opt/spinnaker/install/first_google_boot.sh


### PR DESCRIPTION
Moved codelab configuration script from pylib/spinnaker to google/codelab
since it isnt really part of the runtime.

Reintroduced first_codelab_boot because there are deployment-time
configurations needed.

@jtk54 