### PR TITLE
fix(component_image): Don't leave residual images in build project.

### DIFF
--- a/dev/build_google_image_functions.sh
+++ b/dev/build_google_image_functions.sh
@@ -106,13 +106,30 @@ function image_from_prototype_disk() {
 }
 
 
+function delete_disk_if_exists() {
+  local target_disk="$1"
+
+  echo "gcloud compute disks describe $target_disk --project $PROJECT --account $ACCOUNT --zone $ZONE"
+  if gcloud compute disks describe $target_disk \
+        --project $PROJECT \
+        --account $ACCOUNT \
+        --zone $ZONE &> /dev/null; then
+    echo "`date`: Deleting preexisting disk '$target_disk' in '$PROJECT'"
+    gcloud compute disks delete $target_disk \
+           --project $PROJECT \
+           --account $ACCOUNT \
+           --zone $ZONE
+  fi
+}
+
+
 function delete_image_if_exists() {
   local target_image="$1"
 
   if gcloud compute images describe $target_image \
       --project $PROJECT \
       --account $ACCOUNT &> /dev/null; then
-    echo "`date`: Deleting preexisting '$target_image' in '$PROJECT'"
+    echo "`date`: Deleting preexisting image '$target_image' in '$PROJECT'"
     gcloud compute images delete $target_image \
       --project $PROJECT \
       --account $ACCOUNT \

--- a/google/dev/publish_gce_release.sh
+++ b/google/dev/publish_gce_release.sh
@@ -29,6 +29,7 @@
 
 set -e
 set -u
+set -o pipefail
 
 SERVICE_ACCOUNT=${SERVICE_ACCOUNT:-""}
 ORIGINAL_ARTIFACT_REPO_PATH=${ORIGINAL_ARTIFACT_REPO_PATH:-""}
@@ -57,7 +58,7 @@ function validate_args() {
   die_if_empty "$ORIGINAL_PROJECT_ID" "--original_project_id"
   die_if_empty "$ZONE" "--zone"
 
-  
+
   if [[ "$PUBLISH_ARTIFACT_REPO_PATH" && ! "$ORIGINAL_ARTIFACT_REPO_PATH" ]] \
       || [[ ! "$PUBLISH_ARTIFACT_REPO_PATH" \
            && "$ORIGINAL_ARTIFACT_REPO_PATH" ]]; then
@@ -178,7 +179,7 @@ gcloud compute disks delete "$PUBLISH_IMAGE" $GCLOUD_ACCOUNT_ARG\
 if [[ "$PUBLISH_ARTIFACT_REPO_PATH" ]]; then
   echo "Copying artifact repository"
   copy_artifact_repository \
-      "$ORIGINAL_ARTIFACT_REPO_PATH" "$PUBLISH_ARTIFACT_REPO_PATH" 
+      "$ORIGINAL_ARTIFACT_REPO_PATH" "$PUBLISH_ARTIFACT_REPO_PATH"
 fi
 
 echo "Published $PUBLISH_IMAGE to $PUBLISH_PROJECT_ID."


### PR DESCRIPTION
…ect. This also deletes images in the publish project if we are recreating them. Additionally, I changed how we wait for the subprocesses so that errors in any subprocess should be surfaced now.