### PR TITLE
fix(echo): Add Slack botName to echo configs

### DIFF
--- a/config/echo.yml
+++ b/config/echo.yml
@@ -25,6 +25,7 @@ endpoints.health.sensitive: false
 slack:
   enabled: ${services.echo.notifications.slack.enabled:false}
   token: ${services.echo.notifications.slack.token}
+  botName: ${services.echo.notifications.slack.botName}
 
 spring:
   mail:


### PR DESCRIPTION
An extremely small fix. The Spinnaker [config docs] (http://www.spinnaker.io/docs/target-deployment-configuration) imply that all configs will get pulled over from the spinnaker.yml or spinnaker-local.yml. This is not the case with the Slack notifications. The botName configuration needs to be pulled into the echo.yml in order for notifications to actually trigger. 