### PR TITLE
feat(dev): Fixes to google image scripts.

### DIFF
--- a/dev/build_google_component_image.sh
+++ b/dev/build_google_component_image.sh
@@ -154,7 +154,7 @@ function create_component_prototype_disk() {
   sleep 120 # Wait for the startup scripts to complete.
 
   echo "`date`: Installing $component and spinnaker-monitoring onto '$BUILD_INSTANCE'"
-  sudo gcloud alpha compute ssh $BUILD_INSTANCE \
+  gcloud alpha compute ssh $BUILD_INSTANCE \
     --internal-ip \
     --project $BUILD_PROJECT \
     --account $ACCOUNT \
@@ -164,7 +164,7 @@ function create_component_prototype_disk() {
 
   if [[ "$UPDATE_OS" == "true" ]]; then
     echo "`date`: Updating distribution on '$BUILD_INSTANCE'"
-    sudo gcloud alpha compute ssh $BUILD_INSTANCE \
+    gcloud alpha compute ssh $BUILD_INSTANCE \
       --internal-ip \
       --project $BUILD_PROJECT \
       --account $ACCOUNT \

--- a/dev/build_google_image.sh
+++ b/dev/build_google_image.sh
@@ -228,7 +228,13 @@ function process_args() {
 
 
 function create_cleaner_instance() {
+  # see https://cloud.google.com/compute/docs/instances/adding-removing-ssh-keys#instance-only
+  local key=$(cat $HOME/.ssh/google_empty.pub)
+  if [[ $key == ssh-rsa* ]]; then
+      key="$LOGNAME:$key"
+  fi
   gcloud compute instances create ${CLEANER_INSTANCE} \
+      --metadata ssh-keys="$key" \
       --project $PROJECT \
       --account $ACCOUNT \
       --zone $ZONE \


### PR DESCRIPTION
@jtk54 
There were changes made in https://github.com/spinnaker/spinnaker/commit/7581ef48c05913013f656e091291005c251f8d0b that broke my builds. The errors are a week old and seem fundamentally broken so I'm not sure what's going on here. It could be because I'm building monolithic images and you are building component based ones and only the monolithic one is broken.

This build works for me in my project. I havent tried a jenkins build with it.
Note that in my project the gcloud compute copy files command will probably work. I tested it with that guard forced out and into the scp command, which is what jenkins would probably use