### PR TITLE
feat(testing): ValidateBom with kubernetes deployment.

### DIFF
--- a/dev/all_tests.yaml
+++ b/dev/all_tests.yaml
@@ -11,7 +11,6 @@ aliases:
     spinnaker_aws_account: $aws_account_name
     aws_profile: citest
 
-
 tests:
   bake_and_deploy_test:
     requires:
@@ -98,12 +97,14 @@ tests:
     args:
       alias: [standard_google_provider_params]
 
-  kubernetes_smoke_test:
+  kube_smoke_test:
     requires:
       configuration:
         k8s_account_enabled: true
       services: [clouddriver, front50, gate, orca]
     api: gate
+    args:
+      spinnaker_kubernetes_account: $k8s_account_name
 
   aws_kato_test:
     requires:

--- a/dev/validate_bom.sh
+++ b/dev/validate_bom.sh
@@ -21,4 +21,4 @@
 export PYTHONPATH=$(dirname $0)/../testing/citest
 export PYTHONPATH=${PYTHONPATH}:$(dirname $0)/../pylib
 
-python validate_bom__main.py "$@"
+python $(dirname $0)/validate_bom__main.py "$@"


### PR DESCRIPTION
@lwander 

Also fixes some aws configuration setup, but not enough to properly configure AWS.

On the k8s front, this basically adds a K8s and Docker configurator and changes the deployer into two roles -- hal and spinnaker. They are both the same implementation but the hal role is just for deploying and running hal, where the spinnaker role is for running spinnaker. Since hal deploys spinnaker, the main concern with the role here is to port forward into it to run the tests. So the port forwarding is on the spinnaker role, not the hal role.

The deployer class methods are such that they will mediate to the right role and it will bind the roles depending on the type of deployment you make.
