### PR TITLE
fix(profile): Correctly package contents of tar archives

### DIFF
--- a/dev/generate_bom.py
+++ b/dev/generate_bom.py
@@ -294,7 +294,7 @@ class BomGenerator(Annotator):
         self.__hal_upload_profile(component, self.__bom_file, full_profile)
       elif os.path.isdir(full_profile):
         tar_path = '{0}.tar.gz'.format(full_profile)
-        result = run_quick('tar -cvf {0} {1}/*'.format(tar_path, full_profile))
+        result = run_quick('tar -cvf {0} -C {1} $(ls {1})'.format(tar_path, full_profile))
         if result.returncode != 0:
           print "Creating a tar archive of '{0}/*' failed with \n{1}\nexiting...".format(full_profile, result.stdout)
           exit(result.returncode)


### PR DESCRIPTION
Originally the full patch `rosco/halconfig/packer/*` was prepended to each entry in the the tar archive. Setting the relative path with -C fixes that - otherwise it would be impossible for Halyard to know how much of the prefix path was necessary to correctly mount the config files.

@jtk54 or @ewiseblatt PTAL