### PR TITLE
fix(bake_and_deploy_test): Change jenkins trigger job name.

### DIFF
--- a/dev/all_tests.yaml
+++ b/dev/all_tests.yaml
@@ -29,11 +29,11 @@ tests:
       alias: [standard_google_provider_params]
       test_google: true
       jenkins_token: TRIGGER_TOKEN
-      jenkins_job: TestTriggerProject
+      jenkins_job: NoOpTrigger
       jenkins_url: $jenkins_master_address
       jenkins_master: $jenkins_master_name
       jenkins_master_user: $jenkins_master_user
-    
+
   google_front50_test:
     requires:
       configuration:

--- a/testing/citest/tests/bake_and_deploy_test.py
+++ b/testing/citest/tests/bake_and_deploy_test.py
@@ -141,7 +141,7 @@ class BakeAndDeployTestScenario(sk.SpinnakerTestScenario):
            ' The Spinnaker server may have permissions, but the citest machine'
            ' may not. Otherwise, this defaults to Spinnaker\'s binding.')
     parser.add_argument(
-      '--jenkins_job', default='TestTriggerProject',
+      '--jenkins_job', default='NoOpTrigger',
       help='The name of the jenkins job to trigger off.'
            ' You will need to add this to your --jenkins_master.')
     parser.add_argument(


### PR DESCRIPTION
@ewiseblatt FYI, I peeked in our test Jenkins server and didn't see the other job.