### PR TITLE
fix(google_kato_test): Temporarily remove image list test.

### DIFF
--- a/testing/citest/tests/google_kato_test.py
+++ b/testing/citest/tests/google_kato_test.py
@@ -657,7 +657,7 @@ class GoogleKatoIntegrationTest(st.AgentTestCase):
     # with the defaults here.
     self.run_test_case(self.scenario.delete_load_balancer(), max_retries=5)
 
-  def test_available_images(self):
+  def Xtest_available_images(self):
     self.run_test_case(self.scenario.list_available_images())
 
 


### PR DESCRIPTION
We currently manipulate the global project images concurrently with the tests in our nightly build process. This PR removes the problematic image list test while we figure out an appropriate workaround.