### PR TITLE
fix(aws/init): Adding missing '/' in meta-data AZ url

### DIFF
--- a/packer/init.aws.region
+++ b/packer/init.aws.region
@@ -16,7 +16,7 @@ function get_aws_metadata_value() {
 
 
 function set_aws_defaults_from_environ() {
-  local zone=$(get_aws_metadata_value "/placement/availability-zone")
+  local zone=$(get_aws_metadata_value "/placement/availability-zone/")
   local region=${zone%?}
   local mac_addr=$(get_aws_metadata_value "/network/interfaces/macs/")
   local vpc_id=$(get_aws_metadata_value "/network/interfaces/macs/${mac_addr}vpc-id")


### PR DESCRIPTION
fix(aws/init): Adding missing '/' in meta-data AZ url

Availability zone meta-data endpoint will always return an empty response if the trailing / is missing.