### PR TITLE
fix(bake): Allow auto-delete flag to propagate

### DIFF
--- a/dev/build_google_component_image.sh
+++ b/dev/build_google_component_image.sh
@@ -173,13 +173,15 @@ function create_component_prototype_disk() {
       --command="sudo DEBIAN_FRONTEND=noninteractive apt-get -y dist-upgrade && sudo apt-get autoremove -y"
   fi
 
-  echo "`date`: Deleting '$BUILD_INSTANCE' but keeping disk"
+  echo "`date`: Setting auto-delete behavior '$BUILD_INSTANCE' disk to false"
   gcloud compute instances set-disk-auto-delete $BUILD_INSTANCE \
     --project $BUILD_PROJECT \
     --account $ACCOUNT \
     --zone $ZONE \
     --no-auto-delete \
     --disk $BUILD_INSTANCE
+
+  sleep 20
 
   # This will be on success too
   trap delete_prototype_disk EXIT


### PR DESCRIPTION
A race condition is my only guess as to why sometimes the `--no-auto-delete` behavior isn't preserved every now and then on one or two of our builds. PTAL @ewiseblatt 