### PR TITLE
fix(publish/halyard): Ensure docs are always unique

### DIFF
--- a/dev/publish_halyard.py
+++ b/dev/publish_halyard.py
@@ -31,6 +31,7 @@
 # If you are running this script on Jenkins, you can configure Jenkins to handle SSH credentials.
 
 import argparse
+import datetime
 import os
 import sys
 import yaml
@@ -189,7 +190,11 @@ class HalyardPublisher(object):
           '  nav: reference',
           '---',
           '',
-          ''
+          'Published: {}'.format(datetime
+              .datetime
+              .now()
+              .strftime('%Y-%m-%d %H:%M:%S')),
+          '',
         ])
         target.write(header + source.read())
 


### PR DESCRIPTION
Many Halyard stable publishes have failed because the docs don't supply
anything unique to be commited - adding the date ensures the process of
generating & publishing that docs commit won't fail for that reason.