### PR TITLE
fix(build): Revert change to build numbers.

### DIFF
--- a/dev/annotate_source.py
+++ b/dev/annotate_source.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 
 import argparse
-import datetime
 import logging
 import os
 import re
@@ -380,8 +379,7 @@ class Annotator(object):
   @classmethod
   def init_argument_parser(cls, parser):
     """Initialize command-line arguments."""
-    parser.add_argument('--build_number',
-                        default='{:%Y_%m_%d_%H_%M_%S}'.format(datetime.datetime.utcnow()),
+    parser.add_argument('--build_number', default=os.environ.get('BUILD_NUMBER'),
                         help='The build number to append to the semantic version tag.')
     parser.add_argument('--branch', default='master',
                         help='Git branch to checkout.')


### PR DESCRIPTION
@spinnaker/google-reviewers Reverting change to ISO instants. Our builds are broken until this is merged. We need to rethink what we want this to be, since apparently the Nebula Gods require more sacrifice before they are placated.

TLDR: The date-underscore format is not accepted by Nebula, which then defaults to 0.0.0 for all components.