### PR TITLE
chore(build): Added Dockerfile for gradle cache container image.

### DIFF
--- a/google/release/gradle_cache_base_image.docker
+++ b/google/release/gradle_cache_base_image.docker
@@ -1,0 +1,7 @@
+# Provides a Docker image to start our Google Container Builder builds from.
+# Includes an updated Gradle cache in the produced image to decrease the traffic to Bintray.
+FROM java:8
+
+# Docker can only manipulate directories within the root it is invoked in,
+# so the gradle cache needs copied to the CWD before executing the Docker build.
+ADD .gradle /gradle_cache/.gradle


### PR DESCRIPTION
We can use this Dockerfile to maintain a base image to start our container builds from. This is particular to our builds, so I made a new Google-specific directory `release` directory.