### PR TITLE
feat(testing): Test appengine from gcs bucket

### DIFF
--- a/dev/all_tests.yaml
+++ b/dev/all_tests.yaml
@@ -183,16 +183,33 @@ tests:
     args:
       alias: [standard_azure_provider_params]
 
-  appengine_smoke_test:
+  appengine_smoke_test_git:
     requires:
       configuration:
         appengine_account_enabled: true
       services: [clouddriver, front50, gate, orca]
+    quota:
+      appengine_deployment: 1
     api: gate
     args:
       alias: [standard_appengine_provider_params]
-      source_repo_url: https://github.com/GoogleCloudPlatform/python-docs-samples.git
+      git_repo_url: https://github.com/GoogleCloudPlatform/python-docs-samples.git
       app_directory_root: appengine/standard/hello_world
+      branch: master
+
+  appengine_smoke_test_gcs:
+    requires:
+      configuration:
+        appengine_account_enabled: true
+      services: [clouddriver, front50, gate, orca]
+    quota:
+      appengine_deployment: 1
+    api: gate
+    args:
+      alias: [standard_appengine_provider_params]
+      git_repo_url: https://github.com/GoogleCloudPlatform/python-docs-samples.git
+      app_directory_root: appengine/standard/hello_world
+      test_gcs_bucket: $storage_gcs_bucket
       branch: master
 
   

--- a/dev/validate_bom__test.py
+++ b/dev/validate_bom__test.py
@@ -357,7 +357,10 @@ class ValidateBomTestController(object):
     options = deployer.options
     quota_spec = {parts[0]: int(parts[1])
                   for parts in [entry.split('=')
-                                for entry in options.test_quota.split(',')]}
+                                for entry in options.test_default_quota.split(',')]}
+    quota_spec.update({parts[0]: int(parts[1])
+                  for parts in [entry.split('=')
+                                for entry in options.test_quota.split(',')]})
     self.__quota_tracker = QuotaTracker(quota_spec)
     self.__deployer = deployer
     self.__lock = threading.Lock()
@@ -882,10 +885,13 @@ def init_argument_parser(parser):
       help='Limits how many tests to run at a time. Default is unbounded')
 
   parser.add_argument(
-      '--test_quota',
-      default='google_backend_services=3,google_forwarding_rules=3,google_ssl_certificates=2,google_cpu=20',
+      '--test_default_quota',
+      default='google_backend_services=3,google_forwarding_rules=3,google_ssl_certificates=2,google_cpu=20,appengine_deployment=1',
       help='Comma-delimited name=value list of quota limits. This is used'
            ' to rate-limit tests based on their profiled quota specifications.')
+  parser.add_argument(
+      '--test_quota', default='',
+      help='Comma-delimited name=value list of --test_default_quota overrides.')
 
   parser.add_argument(
       '--test_disable', default=False, action='store_true',

--- a/testing/citest/requirements.txt
+++ b/testing/citest/requirements.txt
@@ -5,6 +5,11 @@
 # and run pip install -r requirements.txt on its requirements file
 citest
 
+# This is to make gsutil compatible with virtualenv
+# it isnt directly used by any tests, only tests that
+# use gsutil.
+google_compute_engine
+
 # This is needed by the google_http_lb_tests
 pyopenssl
 


### PR DESCRIPTION
@danielpeach 
Can invoke appengine test with a test_gcs_bucket to test the GCS source.
It is a separate process to keep it simple, though it might be better to put them together.
You can followup a change if you want.