### PR TITLE
fix(build): Dont buffer log output

### DIFF
--- a/dev/all_tests.yaml
+++ b/dev/all_tests.yaml
@@ -190,6 +190,7 @@ tests:
       services: [clouddriver, front50, gate, orca]
     quota:
       appengine_deployment: 1
+    path: citest/tests/appengine_smoke_test.py
     api: gate
     args:
       alias: [standard_appengine_provider_params]
@@ -204,6 +205,7 @@ tests:
       services: [clouddriver, front50, gate, orca]
     quota:
       appengine_deployment: 1
+    path: citest/tests/appengine_smoke_test.py
     api: gate
     args:
       alias: [standard_appengine_provider_params]

--- a/dev/build_release.py
+++ b/dev/build_release.py
@@ -84,7 +84,7 @@ class BackgroundProcess(
     sp = None
     log = None
     if logfile:
-      log = open(logfile, 'w')
+      log = open(logfile, 'w', 0) # Unbuffered
       sp = subprocess.Popen(args, shell=True, close_fds=True,
                             stdout=log, stderr=log)
     else:


### PR DESCRIPTION
@ttomsu 
This is to ensure access to all the log information available in the event of a deadlock