### PR TITLE
fix(release): Halyard not being published with correct distribution

### DIFF
--- a/dev/build_release.py
+++ b/dev/build_release.py
@@ -240,7 +240,8 @@ class Builder(object):
     if (not self.__options.run_unit_tests or 
             (name == 'deck' and not 'CHROME_BIN' in os.environ)):
       extra_args.append('-x test')
-    elif name == 'halyard':
+      
+    if name == 'halyard':
       extra_args.append('-PbintrayPackageDebDistribution=trusty-nightly')
 
     # Currently spinnaker is in a separate location


### PR DESCRIPTION
My change to the test options caused builds w/o unit tests to fail to publish halyard under the "nightly" distribution.