### PR TITLE
chore(springBoot): Temporarily disables management endpoint security …

### DIFF
--- a/config/spinnaker.yml
+++ b/config/spinnaker.yml
@@ -380,3 +380,5 @@ providers:
       gitHttpsUsername: ${SPINNAKER_APPENGINE_GIT_HTTPS_USERNAME:}
       gitHttpsPassword: ${SPINNAKER_APPENGINE_GIT_HTTPS_PASSWORD:}
       githubOAuthAccessToken: ${SPINNAKER_APPENGINE_GITHUB_OAUTH_ACCESS_TOKEN:}
+
+management.security.enabled: false


### PR DESCRIPTION
…for trial runs of citest.

Merging this into the `boot-upgrade` branch.

@ewiseblatt FYI
