### PR TITLE
fix(build_numbers): Use datetime for build numbers, not job numbers.

### DIFF
--- a/dev/annotate_source.py
+++ b/dev/annotate_source.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import argparse
+import datetime
 import logging
 import os
 import re
@@ -390,7 +391,8 @@ class Annotator(object):
   @classmethod
   def init_argument_parser(cls, parser):
     """Initialize command-line arguments."""
-    parser.add_argument('--build_number', default=os.environ.get('BUILD_NUMBER'),
+    parser.add_argument('--build_number',
+                        default='{:%Y%m%d%H%M%S}'.format(datetime.datetime.utcnow()),
                         help='The build number to append to the semantic version tag.')
     parser.add_argument('--branch', default='master',
                         help='Git branch to checkout.')

--- a/dev/build_release.py
+++ b/dev/build_release.py
@@ -150,7 +150,7 @@ class Builder(object):
       self.__background_processes = []
 
       os.environ['NODE_ENV'] = os.environ.get('NODE_ENV', 'dev')
-      self.__build_number = build_number or os.environ.get('BUILD_NUMBER') or '{:%Y-%m-%d}'.format(datetime.datetime.utcnow())
+      self.__build_number = build_number or os.environ.get('BUILD_NUMBER') or '{:%Y%m%d%H%M%S}'.format(datetime.datetime.utcnow())
       self.__gcb_service_account = options.gcb_service_account
       self.__options = options
       if (container_builder and container_builder not in ['gcb', 'docker', 'gcb-trigger']):
@@ -486,7 +486,7 @@ class Builder(object):
 
   @classmethod
   def __jar_build(cls, name, gradle_root):
-    version = run_quick('cat {name}-component-version.yml'.format(name=name), 
+    version = run_quick('cat {name}-component-version.yml'.format(name=name),
                         echo=False).stdout.strip()
     cmds = [
       './release/all.sh {version} nightly'.format(version=version),


### PR DESCRIPTION
Put this one off for a while, but here it is. With this PR, build numbers are monotonically increasing date strings of the form `%Y%m%d%H%M%S`. As an example: `20170801182548`.