### PR TITLE
feat(testing): add basic smoke tests for DC/OS

### DIFF
--- a/config/settings.js
+++ b/config/settings.js
@@ -37,6 +37,7 @@
 // var openstackPrimaryAccount = ${providers.openstack.primaryCredentials.name};
 // var openstackDefaultRegion = ${providers.openstack.defaultRegion};
 // var appenginePrimaryAccount = ${providers.appengine.primaryCredentials.name};
+// var dcosPrimaryAccount = ${providers.docs.primaryCredentials.name};
 
 // END reconfigure_spinnaker
 /**
@@ -101,6 +102,11 @@ window.spinnakerSettings = {
       defaults: {
         account: appenginePrimaryAccount,
         editLoadBalancerStageEnabled: false,
+      }
+    },
+    dcos: {
+      defaults: {
+        account: dcosPrimaryAccount
       }
     },
   },

--- a/testing/citest/Dockerfile
+++ b/testing/citest/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:2.7
+
+WORKDIR /usr/src/app
+
+RUN git clone https://github.com/google/citest.git && cd citest && pip install -r requirements.txt
+
+ADD requirements.txt .
+RUN pip install -r requirements.txt
+
+ADD https://downloads.dcos.io/binaries/cli/linux/x86-64/dcos-1.8/dcos /usr/src/app/bin/dcos
+RUN chmod +x /usr/src/app/bin/dcos
+
+ENV PYTHONPATH=.:spinnaker
+ENV PATH="${PATH}:/usr/src/app/bin"
+
+ENTRYPOINT ["python"]

--- a/testing/citest/README.md
+++ b/testing/citest/README.md
@@ -63,6 +63,7 @@ Amazon Web Services | awscli | ```sudo apt-get install -y awscli```
 Microsoft Azure | az | [See instructions](https://docs.microsoft.com/cli/azure/install-azure-cli)
 Google Cloud Platform | gcloud | ```curl https://sdk.cloud.google.com | bash```
 Kubernetes | kubectl | [See instructions](http://kubernetes.io/docs/user-guide/prereqs/)
+DC/OS | dcos | [See instructions](https://dcos.io/docs/1.9/cli/install/)
 OpenStack | openstack | [See instructions](https://docs.openstack.org/user-guide/common/cli-install-openstack-command-line-clients.html)
 
 
@@ -209,7 +210,8 @@ spinnaker_kubernetes_credentials |  The name of the Spinnaker [clouddriver] acco
 spinnaker_aws_credentials |  The name of the Spinnaker [clouddriver] account that you wish to use for Amazon Web Services operations. If not specified, this will use the configured primary account.
 spinnaker_os_account | The name of the Spinnaker [clouddriver] account that you wish to use for OpenStack operations. If not specified, this will use the configured primary account.
 spinnaker_azure_account | The name of the Spinnaker [clouddriver] account that you wish to use for the Azure operations. If not specified, this will use the configured primary account.
-
+spinnaker_dcos_account | The name of the Spinnaker [clouddriver] account that you wish to use for DC/OS operations. If not specified, this will use the configured primary account.
+spinnaker_dcos_cluster | The name of the DC/OS cluster associated to spinnaker_dcos_account to use for DC/OS operations.
 
 ## Standard Parameters For Configuring Observers
 Flag | Description

--- a/testing/citest/citest_contrib/dcos_testing/__init__.py
+++ b/testing/citest/citest_contrib/dcos_testing/__init__.py
@@ -1,0 +1,2 @@
+from dcoscli_agent import DcosCliAgent
+from dcos_contract import DcosContractBuilder

--- a/testing/citest/citest_contrib/dcos_testing/dcos_contract.py
+++ b/testing/citest/citest_contrib/dcos_testing/dcos_contract.py
@@ -1,0 +1,148 @@
+# Copyright 2017 Cerner Corporation All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Provides a means for specifying and verifying expectations of DC/OS."""
+
+# Standard python modules.
+import json
+import logging
+import traceback
+
+# Our modules.
+import citest.json_predicate as jp
+import citest.json_contract as jc
+from citest.service_testing import cli_agent
+
+class DcosObjectObserver(jc.ObjectObserver):
+  """Observe DC/OS resources."""
+
+  def __init__(self, dcoscli, args, filter=None):
+    """Construct observer.
+
+    Args:
+      dcoscli: DcosCliAgent instance to use.
+      args: Command-line argument list to execute.
+    """
+    super(DcosObjectObserver, self).__init__(filter)
+    self.__dcoscli = dcoscli
+    self.__args = args
+
+  def export_to_json_snapshot(self, snapshot, entity):
+    """Implements JsonSnapshotableEntity interface."""
+    snapshot.edge_builder.make_control(entity, 'Args', self.__args)
+    super(DcosObjectObserver, self).export_to_json_snapshot(snapshot, entity)
+
+  def __str__(self):
+    return 'DcosObjectObserver({0})'.format(self.__args)
+
+  def collect_observation(self, context, observation, trace=True):
+    args = context.eval(self.__args)
+    dcos_response = self.__dcoscli.run(args, trace=trace)
+    if not dcos_response.ok():
+      observation.add_error(
+          cli_agent.CliAgentRunError(self.__dcoscli, dcos_response))
+      return []
+
+    decoder = json.JSONDecoder()
+    try:
+      doc = decoder.decode(dcos_response.output)
+      if not isinstance(doc, list):
+        doc = [doc]
+      self.filter_all_objects_to_observation(context, doc, observation)
+    except ValueError as vex:
+      error = 'Invalid JSON in response: %s' % str(dcos_response)
+      logging.getLogger(__name__).info('%s\n%s\n----------------\n',
+                                       error, traceback.format_exc())
+      observation.add_error(jp.JsonError(error, vex))
+      return []
+
+    return observation.objects
+
+
+class DcosObjectFactory(object):
+  # pylint: disable=too-few-public-methods
+
+  def __init__(self, dcoscli):
+    self.__dcoscli = dcoscli
+
+  def new_get_marathon_resources(self, type, action, extra_args=None):
+    """Specify a resource list to be returned later.
+
+    Args:
+      type: dcos's name for the DC/OS resource type.
+
+    Returns:
+      A jc.ObjectObserver to return the specified resource list when called.
+    """
+    if extra_args is None:
+      extra_args = []
+
+    cmd = self.__dcoscli.build_dcoscli_command_args(
+        subcommand='marathon', resource=type, action=action, args=['--json'] + extra_args)
+    return DcosObjectObserver(self.__dcoscli, cmd)
+
+
+class DcosClauseBuilder(jc.ContractClauseBuilder):
+  """A ContractClause that facilitates observing DC/OS state."""
+
+  def __init__(self, title, dcoscli, retryable_for_secs=0, strict=False):
+    """Construct new clause.
+
+    Args:
+      title: The string title for the clause is only for reporting purposes.
+      dcoscli: The DcosCliAgent to make the observation for the clause to
+         verify.
+      retryable_for_secs: Number of seconds that observations can be retried
+         if their verification initially fails.
+      strict: DEPRECATED flag indicating whether the clauses (added later)
+         must be true for all objects (strict) or at least one (not strict).
+         See ValueObservationVerifierBuilder for more information.
+         This is deprecated because in the future this should be on a per
+         constraint basis.
+    """
+    super(DcosClauseBuilder, self).__init__(
+        title=title, retryable_for_secs=retryable_for_secs)
+    self.__factory = DcosObjectFactory(dcoscli)
+    self.__strict = strict
+
+  def get_marathon_resources(self, type, extra_args=None):
+    """Observe resources of a particular type.
+
+    This ultimately calls a "dcos marathon |type| |extra_args|"
+
+    """
+    self.observer = self.__factory.new_get_marathon_resources(
+        type, action='list', extra_args=extra_args)
+
+    get_builder = jc.ValueObservationVerifierBuilder(
+        'Get {0} {1}'.format(type, extra_args), strict=self.__strict)
+    self.verifier_builder.append_verifier_builder(get_builder)
+
+    return get_builder
+
+
+class DcosContractBuilder(jc.ContractBuilder):
+  """Specialized contract that facilitates observing DC/OS."""
+
+  def __init__(self, dcoscli):
+    """Constructs a new contract.
+
+    Args:
+      kubectl: The DcosCliAgent to use for communicating with DC/OS.
+    """
+    super(DcosContractBuilder, self).__init__(
+        lambda title, retryable_for_secs=0, strict=False:
+        DcosClauseBuilder(
+            title, dcoscli=dcoscli,
+            retryable_for_secs=retryable_for_secs, strict=strict))

--- a/testing/citest/citest_contrib/dcos_testing/dcoscli_agent.py
+++ b/testing/citest/citest_contrib/dcos_testing/dcoscli_agent.py
@@ -1,0 +1,49 @@
+# Copyright 2017 Cerner Corporation All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Standard python modules.
+import logging
+
+# Our modules.
+from citest.service_testing import cli_agent
+from citest.base.json_scrubber import JsonScrubber
+
+class DcosCliAgent(cli_agent.CliAgent):
+  """Agent that uses the DC/OS CLI (dcos) program to interact with DC/OS."""
+
+  def __init__(self, trace=True):
+    """Construct instance.
+
+    Args:
+      trace: Whether to trace all the calls by default for debugging.
+    """
+    super(DcosCliAgent, self).__init__(
+        'dcos', output_scrubber=JsonScrubber())
+    self.trace = trace
+    self.logger = logging.getLogger(__name__)
+
+  @staticmethod
+  def build_dcoscli_command_args(subcommand, resource=None, action=None, args=None):
+    """Build commandline for an action.
+ 
+    Args:
+      subcommand: The dcos subcommand to execute
+      resource: The dcos resource we are going to operate on (if applicable).
+      action: The action to take on the resource (if applicable).
+      args: The arguments following [gcloud_module, gce_type].
+ 
+    Returns:
+      list of complete command line arguments following implied 'dcos'
+    """
+    return [subcommand] + ([resource] if resource else []) + ([action] if action else []) + (args if args else [])

--- a/testing/citest/spinnaker_testing/dcos_scenario_support.py
+++ b/testing/citest/spinnaker_testing/dcos_scenario_support.py
@@ -1,0 +1,74 @@
+# Copyright 2017 Cerner Corporation All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""DC/OS platform and test support for SpinnakerTestScenario."""
+
+import citest_contrib.dcos_testing as dcos
+from spinnaker_testing.base_scenario_support import BaseScenarioPlatformSupport
+
+
+class DcosScenarioSupport(BaseScenarioPlatformSupport):
+  """Provides SpinnakerScenarioSupport for DC/OS."""
+
+  @classmethod
+  def add_commandline_parameters(cls, scenario_class, builder, defaults):
+    """Implements BaseScenarioPlatformSupport interface.
+
+    Args:
+      scenario_class: [class spinnaker_testing.SpinnakerTestScenario]
+      builder: [citest.base.ConfigBindingsBuilder]
+      defaults: [dict] Default binding value overrides.
+         This is used to initialize the default commandline parameters.
+    """
+    #
+    # Operation Parameters
+    #
+    builder.add_argument(
+        '--spinnaker_dcos_account',
+        default=defaults.get('SPINNAKER_DCOS_ACCOUNT', None),
+        help='Spinnaker account name to use for test operations against'
+             ' DC/OS. Only used when managing jobs running on'
+             ' DC/OS.')
+
+    builder.add_argument(
+        '--spinnaker_dcos_cluster',
+        default=defaults.get('SPINNAKER_DCOS_CLUSTER', None),
+        help='The name of the DC/OS cluster to be used. This should be'
+             ' the name of a cluster defined in the Spinnaker account'
+             ' configuration for the account supplied with'
+             ' --spinnaker_dcos_account.')
+
+    builder.add_argument(
+        '--spinnaker_docker_account',
+        default=defaults.get('SPINNAKER_DOCKER_ACCOUNT', 'my-docker-registry-account'),
+        help='The name of the Spinnaker Docker registry account to use.')
+
+  def _make_observer(self):
+    """Implements BaseScenarioPlatformSupport interface."""
+    bindings = self.scenario.bindings
+    if not bindings.get('SPINNAKER_DCOS_ACCOUNT'):
+      raise ValueError('There is no "spinnaker_dcos_account"')
+
+    if not bindings.get('SPINNAKER_DCOS_CLUSTER'):
+      raise ValueError('There is no "spinnaker_dcos_cluster"')
+
+    return dcos.DcosCliAgent()
+
+  def __init__(self, scenario):
+    """Constructor.
+
+    Args:
+      scenario: [SpinnakerTestScenario] The scenario being supported.
+    """
+    super(DcosScenarioSupport, self).__init__("dcos", scenario)

--- a/testing/citest/spinnaker_testing/spinnaker_test_scenario.py
+++ b/testing/citest/spinnaker_testing/spinnaker_test_scenario.py
@@ -34,6 +34,7 @@ from spinnaker_testing import google_scenario_support
 from spinnaker_testing import kubernetes_scenario_support
 from spinnaker_testing import openstack_scenario_support
 from spinnaker_testing import azure_scenario_support
+from spinnaker_testing import dcos_scenario_support
 
 PLATFORM_SUPPORT_CLASSES = [
     aws_scenario_support.AwsScenarioSupport,
@@ -42,7 +43,8 @@ PLATFORM_SUPPORT_CLASSES = [
     appengine_scenario_support.AppEngineScenarioSupport,
     kubernetes_scenario_support.KubernetesScenarioSupport,
     openstack_scenario_support.OpenStackScenarioSupport,
-    azure_scenario_support.AzureScenarioSupport
+    azure_scenario_support.AzureScenarioSupport,
+    dcos_scenario_support.DcosScenarioSupport
 ]
 
 
@@ -237,6 +239,15 @@ class SpinnakerTestScenario(sk.AgentTestScenario):
       Exception if the observer is not available.
     """
     return self.__platform_support['azure'].observer
+
+  @property
+  def dcos_observer(self):
+    """The observer for inspecting DC/OS platform state."
+
+    Raises:
+      Exception if the observer is not available.
+    """
+    return self.__platform_support['dcos'].observer
 
   def __init__(self, bindings, agent=None):
     """Constructor

--- a/testing/citest/tests/dcos_smoke_test.py
+++ b/testing/citest/tests/dcos_smoke_test.py
@@ -1,0 +1,387 @@
+# Copyright 2017 Cerner Corporation All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Smoke test to see if Spinnaker can interoperate with DC/OS.
+
+See testable_service/integration_test.py and spinnaker_testing/spinnaker.py
+for more details.
+
+Sample Usage:
+  These tests expect the 'dcos' utility to be available and configured for the DC/OS cluster being tested against.
+
+  PYTHONPATH=$CITEST_ROOT:$CITEST_ROOT/spinnaker \
+    python $CITEST_ROOT/tests/dcos_smoke_test.py \
+    --native_hostname=$HOSTNAME \
+    --native_port=$PORT \
+    --spinnaker_dcos_account=$ACCOUNT \
+    --spinnaker_dcos_cluster=$SPINNAKER_DCOS_CLUSTER
+"""
+
+# Standard python modules.
+import sys
+
+# citest modules.
+import citest.json_contract as jc
+import citest.json_predicate as jp
+import citest.service_testing as st
+import citest_contrib.dcos_testing as dcos
+
+# Spinnaker modules.
+import spinnaker_testing as sk
+import spinnaker_testing.gate as gate
+import spinnaker_testing.frigga as frigga
+import citest.base
+
+
+class DcosSmokeTestScenario(sk.SpinnakerTestScenario):
+    """Defines the scenario for the smoke test.
+  
+    This scenario defines the different test operations.
+    We're going to:
+      Create a Spinnaker Application
+      Create a Spinnaker Server Group
+      Create a Pipeline with the following stages
+        - Deploy
+        - Resize
+      Delete each of the above (in reverse order)
+    """
+
+    @classmethod
+    def new_agent(cls, bindings):
+        """Implements citest.service_testing.AgentTestScenario.new_agent."""
+        agent = gate.new_agent(bindings)
+        agent.default_max_wait_secs = 180
+        return agent
+
+    def __init__(self, bindings, agent=None):
+        """Constructor.
+    
+        Args:
+          bindings: [dict] The data bindings to use to configure the scenario.
+          agent: [GateAgent] The agent for invoking the test operations on Gate.
+        """
+        super(DcosSmokeTestScenario, self).__init__(bindings, agent)
+        bindings = self.bindings
+
+        self.pipeline_id = None
+
+        # No detail because name length is restricted too much to afford one!
+        self.__lb_detail = ''
+        self.__lb_name = frigga.Naming.cluster(
+            app=bindings['TEST_APP'],
+            stack=bindings['TEST_STACK'])
+
+        # We'll call out the app name because it is widely used
+        # because it scopes the context of our activities.
+        # pylint: disable=invalid-name
+        self.TEST_APP = bindings['TEST_APP']
+
+    def create_app(self):
+        """Creates OperationContract that creates a new Spinnaker Application."""
+        contract = jc.Contract()
+        return st.OperationContract(
+            self.agent.make_create_app_operation(
+                bindings=self.bindings, application=self.TEST_APP,
+                account_name=self.bindings['SPINNAKER_DCOS_ACCOUNT']),
+            contract=contract)
+
+    def delete_app(self):
+        """Creates OperationContract that deletes a new Spinnaker Application."""
+        contract = jc.Contract()
+        return st.OperationContract(
+            self.agent.make_delete_app_operation(
+                application=self.TEST_APP,
+                account_name=self.bindings['SPINNAKER_DCOS_ACCOUNT']),
+            contract=contract)
+
+    def create_server_group(self):
+        """Creates OperationContract for createServerGroup.
+    
+        To verify the operation, we just check that the server group was created.
+        """
+        bindings = self.bindings
+
+        # Spinnaker determines the group name created,
+        # which will be the following:
+        group_name = frigga.Naming.server_group(
+            app=self.TEST_APP,
+            stack=bindings['TEST_STACK'],
+            version='v000')
+
+        payload = self.agent.make_json_payload_from_kwargs(
+            job=[{
+                'cloudProvider': 'dcos',
+                'application': self.TEST_APP,
+                'account': bindings['SPINNAKER_DCOS_ACCOUNT'],
+                'env': {},
+                'desiredCapacity': 1,
+                'cpus': 0.1,
+                'mem': 64,
+                'docker': {
+                    'image': {
+                        'repository': 'nginx',
+                        'tag': 'canary',
+                        'imageId': 'nginx',
+                        'registry': 'docker.io',
+                        'account': bindings['SPINNAKER_DOCKER_ACCOUNT']
+                    }
+                },
+                'networkType': 'BRIDGE',
+                'stack': bindings['TEST_STACK'],
+                'type': 'createServerGroup',
+                'region': bindings['SPINNAKER_DCOS_CLUSTER'],
+                'dcosCluster': bindings['SPINNAKER_DCOS_CLUSTER'],
+                'user': '[anonymous]'
+            }],
+            description='Create Server Group in ' + group_name,
+            application=self.TEST_APP)
+
+        builder = dcos.DcosContractBuilder(self.dcos_observer)
+        (builder.new_clause_builder('Marathon App Added', retryable_for_secs=240)
+         .get_marathon_resources('app'.format(bindings['SPINNAKER_DCOS_ACCOUNT']))
+         .contains_path_value('id',
+                              '/{0}/{1}'.format(bindings['SPINNAKER_DCOS_ACCOUNT'], group_name)))
+
+        return st.OperationContract(
+            self.new_post_operation(
+                title='create_server_group', data=payload, path='tasks'),
+            contract=builder.build())
+
+    def delete_server_group(self, version='v000'):
+        """Creates OperationContract for deleteServerGroup.
+    
+        To verify the operation, we just check that the DC/OS application
+        is no longer visible (or is in the process of terminating).
+        """
+        bindings = self.bindings
+        group_name = frigga.Naming.server_group(
+            app=self.TEST_APP, stack=bindings['TEST_STACK'], version=version)
+
+        payload = self.agent.make_json_payload_from_kwargs(
+            job=[{
+                'cloudProvider': 'dcos',
+                'type': 'destroyServerGroup',
+                'account': bindings['SPINNAKER_DCOS_ACCOUNT'],
+                'credentials': bindings['SPINNAKER_DCOS_ACCOUNT'],
+                'user': '[anonymous]',
+                'serverGroupName': group_name,
+                'asgName': group_name,
+                'regions': [bindings['SPINNAKER_DCOS_CLUSTER']],
+                'region': bindings['SPINNAKER_DCOS_CLUSTER'],
+                'dcosCluster': bindings['SPINNAKER_DCOS_CLUSTER'],
+                'zones': [bindings['SPINNAKER_DCOS_CLUSTER']]
+            }],
+            application=self.TEST_APP,
+            description='Destroy Server Group: ' + group_name)
+
+        builder = dcos.DcosContractBuilder(self.dcos_observer)
+        (builder.new_clause_builder('Marathon App Deleted', retryable_for_secs=240)
+         .get_marathon_resources('app'.format(bindings['SPINNAKER_DCOS_ACCOUNT']))
+         .excludes_path_value('id',
+                              '/{0}/{1}'.format(bindings['SPINNAKER_DCOS_ACCOUNT'], group_name)))
+
+        contract = jc.Contract()
+        return st.OperationContract(
+            self.new_post_operation(
+                title='delete_server_group', data=payload, path='tasks'),
+            contract=contract)
+
+    def make_deploy_stage(self, requisiteStages=[], **kwargs):
+        bindings = self.bindings
+        result = {
+            'requisiteStageRefIds': requisiteStages,
+            'refId': 'DEPLOY',
+            'type': 'deploy',
+            'name': 'Deploy server group',
+            'clusters': [
+                {
+                    'cloudProvider': 'dcos',
+                    'application': self.TEST_APP,
+                    'account': bindings['SPINNAKER_DCOS_ACCOUNT'],
+                    'env': {},
+                    'desiredCapacity': 1,
+                    'cpus': 0.1,
+                    'mem': 64,
+                    'docker': {
+                        'image': {
+                            'repository': 'nginx',
+                            'tag': 'canary',
+                            'imageId': 'nginx',
+                            'registry': 'docker.io',
+                            'account': bindings['SPINNAKER_DOCKER_ACCOUNT']
+                        }
+                    },
+                    'networkType': 'BRIDGE',
+                    'stack': bindings['TEST_STACK'],
+                    'region': bindings['SPINNAKER_DCOS_CLUSTER'],
+                    'dcosCluster': bindings['SPINNAKER_DCOS_CLUSTER'],
+                    'user': '[anonymous]'
+                }
+            ]
+        }
+
+        result.update(kwargs)
+        return result
+
+    def make_resize_stage(self, cluster, requisiteStages=[], **kwargs):
+        bindings = self.bindings
+
+        result = {
+            'action': 'scale_exact',
+            'capacity': {
+                'desired': 3
+            },
+            'cloudProvider': 'dcos',
+            'cloudProviderType': 'dcos',
+            'cluster': cluster,
+            'credentials': bindings['SPINNAKER_DCOS_ACCOUNT'],
+            'name': 'Resize Server Group',
+            'refId': 'RESIZE',
+            'regions': [
+                bindings['SPINNAKER_DCOS_CLUSTER']
+            ],
+            'requisiteStageRefIds': requisiteStages,
+            'resizeType': 'exact',
+            'target': 'current_asg_dynamic',
+            'type': 'resizeServerGroup'
+        }
+
+        result.update(kwargs)
+        return result
+
+    def create_deploy_pipeline(self):
+        name = 'deployServerPipeline'
+
+        cluster = frigga.Naming.cluster(
+            app=self.TEST_APP,
+            stack=self.bindings['TEST_STACK'])
+
+        self.pipeline_id = name
+        deploy_stage = self.make_deploy_stage(requisiteStages=[])
+        resize_stage = self.make_resize_stage(requisiteStages=['DEPLOY'], cluster=cluster)
+
+        pipeline_spec = dict(
+            name=name,
+            stages=[deploy_stage, resize_stage],
+            triggers=[],
+            application=self.TEST_APP,
+            stageCounter=2,
+            parallel=True,
+            limitConcurrent=True,
+            executionEngine='v2',
+            appConfig={},
+            index=0
+        )
+
+        payload = self.agent.make_json_payload_from_kwargs(**pipeline_spec)
+
+        builder = st.HttpContractBuilder(self.agent)
+        (builder.new_clause_builder('Has Pipeline',
+                                    retryable_for_secs=15)
+         .get_url_path(
+            'applications/{app}/pipelineConfigs'.format(app=self.TEST_APP))
+         .contains_path_value(None, pipeline_spec))
+
+        return st.OperationContract(
+            self.new_post_operation(
+                title='create_deploy_pipeline', data=payload, path='pipelines',
+                status_class=st.SynchronousHttpOperationStatus),
+            contract=builder.build())
+
+    def run_deploy_pipeline(self):
+        path = 'pipelines/{0}/{1}'.format(self.TEST_APP, self.pipeline_id)
+        bindings = self.bindings
+        group_name = frigga.Naming.server_group(
+            app=self.TEST_APP,
+            stack=bindings['TEST_STACK'],
+            version='v001')
+
+        payload = self.agent.make_json_payload_from_kwargs(
+            type='manual',
+            user='[anonymous]')
+
+        builder = dcos.DcosContractBuilder(self.dcos_observer)
+        (builder.new_clause_builder('Marathon App deployed via pipeline', retryable_for_secs=240)
+         .get_marathon_resources('app'.format(bindings['SPINNAKER_DCOS_ACCOUNT']))
+         .contains_path_value('id',
+                              '/{0}/{1}'.format(bindings['SPINNAKER_DCOS_ACCOUNT'], group_name)))
+
+        (builder.new_clause_builder('Marathon App has expected # instances', retryable_for_secs=240)
+         .get_marathon_resources('app'.format(bindings['SPINNAKER_DCOS_ACCOUNT']))
+         .contains_path_eq('instances', 3))
+
+        return st.OperationContract(
+            self.new_post_operation(
+                title='run_deploy_pipeline', data=payload, path=path),
+            builder.build())
+
+
+class DcosSmokeTest(st.AgentTestCase):
+    """The test fixture for the DcosSmokeTest.
+  
+    This is implemented using citest OperationContract instances that are
+    created by the DcosSmokeTestScenario.
+    """
+
+    # pylint: disable=missing-docstring
+
+    @property
+    def scenario(self):
+        return citest.base.TestRunner.global_runner().get_shared_data(
+            DcosSmokeTestScenario)
+
+    def test_a_create_app(self):
+        self.run_test_case(self.scenario.create_app())
+
+    def test_b_create_server_group(self):
+        self.run_test_case(self.scenario.create_server_group(),
+                           max_retries=1,
+                           timeout_ok=True)
+
+    def test_c_create_deploy_pipeline(self):
+        self.run_test_case(self.scenario.create_deploy_pipeline())
+
+    def test_d_run_deploy_pipeline(self):
+        self.run_test_case(self.scenario.run_deploy_pipeline())
+
+    def test_x_delete_server_group(self):
+        self.run_test_case(self.scenario.delete_server_group('v000'), max_retries=2)
+
+    def test_x2_delete_server_group(self):
+        self.run_test_case(self.scenario.delete_server_group('v001'), max_retries=2)
+
+    def test_z_delete_app(self):
+        # Give a total of a minute because it might also need
+        # an internal cache update
+        self.run_test_case(self.scenario.delete_app(),
+                           retry_interval_secs=8, max_retries=8)
+
+
+def main():
+    """Implements the main method running this smoke test."""
+
+    defaults = {
+        'TEST_STACK': 'tst',
+        'TEST_APP': 'dcossmok' + DcosSmokeTestScenario.DEFAULT_TEST_ID
+    }
+
+    return citest.base.TestRunner.main(
+        parser_inits=[DcosSmokeTestScenario.initArgumentParser],
+        default_binding_overrides=defaults,
+        test_case_list=[DcosSmokeTest])
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
We still need to get a DC/OS cluster that can run these but I wanted to at least get this out there to see if there are any other changes we'd need to make.

Instructions for setting up the account in clouddriver, either with clouddriver-local.yml or halyard: https://github.com/spinnaker/spinnaker.github.io/pull/315