### PR TITLE
chore(build): Add support for RPM-based distros #1335

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,8 +40,6 @@ ospackage {
 
 // installer scripts
   preInstall = file('pkg_scripts/preInstall.sh')
-  postInstall = file('pkg_scripts/postInstall.sh')
-  postUninstall = file('pkg_scripts/postUninstall.sh')
 
 // files to put in the meta package
   from('pylib') {
@@ -74,13 +72,6 @@ ospackage {
   }
 
 
-  from('etc/apache2/sites-available/spinnaker.conf') {
-    into '/etc/apache2/sites-available'
-    user = 'root'
-    permissionGroup = 'root'    
-    fileMode = 0644
-  }
-
   from('etc/default/spinnaker') {
     into '/etc/default'
     user = 'root'
@@ -89,21 +80,13 @@ ospackage {
   }
 
   configurationFile('/etc/default/spinnaker\n')
-  configurationFile('/etc/apache2/sites-available/spinnaker.conf\n')
 
   File configDir
   FileCollection collection = files { configDir.listFiles() }
 
   configDir = file('config')
   collection.each { configurationFile(spinnakerHome + '/' + relativePath(it) + '\n') }
-}
 
-
-// Ubuntu
-buildDeb {
-  // requires('openjdk-8-jdk')
-  // requires('oracle-java8-installer')
-  requires('redis-server', '3.0.5', GREATER | EQUAL)
   requires('spinnaker-clouddriver')
   requires('spinnaker-deck')
   requires('spinnaker-echo')
@@ -113,15 +96,44 @@ buildDeb {
   requires('spinnaker-igor')
   requires('spinnaker-orca')
   requires('spinnaker-rosco')
-  requires('apache2')
-  
 }
 
 
-// TO DO 
+// Ubuntu
+buildDeb {
+  postInstall = file('pkg_scripts/postInstall.sh')
+  postUninstall = file('pkg_scripts/postUninstall.sh')
+
+  from('etc/apache2/sites-available/spinnaker.conf') {
+    into '/etc/apache2/sites-available'
+    user = 'root'
+    permissionGroup = 'root'
+    fileMode = 0644
+  }
+  configurationFile('/etc/apache2/sites-available/spinnaker.conf\n')
+
+  // requires('openjdk-8-jdk')
+  // requires('oracle-java8-installer')
+  requires('redis-server', '3.0.5', GREATER | EQUAL)
+  requires('apache2')
+}
+
 buildRpm {
   arch = NOARCH
   os = LINUX
+
+  postInstall = file('pkg_scripts/postInstallRpm.sh')
+  postUninstall = file('pkg_scripts/postUninstallRpm.sh')
+
+  from('etc/apache2/sites-available/spinnaker.conf') {
+    into '/etc/httpd/sites-available'
+    user = 'root'
+    permissionGroup = 'root'
+    fileMode = 0644
+  }
+  configurationFile('/etc/httpd/sites-available/spinnaker.conf\n')
+
+  requires('httpd')
 }
 
 task publishInstallSpinnaker {

--- a/etc/apache2/sites-available/spinnaker.conf
+++ b/etc/apache2/sites-available/spinnaker.conf
@@ -5,6 +5,8 @@
   ProxyPassReverse "/gate" "http://localhost:8084"
 
   <Directory "/opt/deck/html/">
+    # For apache < 2.4 (eg. httpd 2.2 which comes on Centos6), use "Allow from all" instead of "Require all granted".
     Require all granted
+
   </Directory>
 </VirtualHost>

--- a/pkg_scripts/postInstallRpm.sh
+++ b/pkg_scripts/postInstallRpm.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+if [ ! -f /opt/spinnaker/config/spinnaker-local.yml ]; then
+  # Create master config on original install, but leave in place on upgrades.
+  cp /opt/spinnaker/config/default-spinnaker-local.yml /opt/spinnaker/config/spinnaker-local.yml
+fi
+
+# deck settings
+/opt/spinnaker/bin/reconfigure_spinnaker.sh
+
+if ! grep -Fxq "Listen 127.0.0.1:9000" /etc/httpd/conf/httpd.conf
+then
+  echo "Listen 127.0.0.1:9000" >> /etc/httpd/conf/httpd.conf
+fi
+
+/opt/spinnaker/bin/enable_httpd_site.sh spinnaker
+service httpd restart

--- a/pkg_scripts/postUninstallRpm.sh
+++ b/pkg_scripts/postUninstallRpm.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+if grep -Fxq "Listen 127.0.0.1:9000" /etc/httpd/conf/httpd.conf
+then
+  sed -i "s/Listen 127.0.0.1:9000//" /etc/httpd/conf/httpd.conf
+fi
+
+/opt/spinnaker/bin/disable_httpd_site.sh spinnaker
+service httpd restart

--- a/pylib/spinnaker/spinnaker_runner.py
+++ b/pylib/spinnaker/spinnaker_runner.py
@@ -493,14 +493,25 @@ To fix this run the following:
 Proceeding anyway.
 """.format(script_dir=self.__installation.UTILITY_SCRIPT_DIR))
 
-
   def stop_deck(self):
-    print 'Stopping apache server while stopping Spinnaker.'
-    run_quick('service apache2 stop', echo=True)
+    apache = self.get_apache_service_name()
+    print 'Stopping %s server while stopping Spinnaker.' % apache
+    run_quick('service %s stop' % apache, echo=True)
 
   def start_deck(self):
-    print 'Starting apache server.'
-    run_quick('service apache2 start', echo=True)
+    apache = self.get_apache_service_name()
+    print 'Starting %s server.' % apache
+    run_quick('service %s start' % apache, echo=True)
+
+  def get_apache_service_name(self):
+      result = run_quick('service --status-all', echo=False)
+      if "apache2" in result.stdout:
+          return "apache2"
+      if "httpd" in result.stdout:
+          return "httpd"
+
+      print 'Unable to determine apache service name. Using apache2.'
+      return "apache2"
 
   def start_all(self, options):
     self.check_configuration(options)

--- a/runtime/disable_httpd_site.sh
+++ b/runtime/disable_httpd_site.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Disable an httpd site, by remove the symbolic link from /etc/httpd/sites-enabled/{site}.conf
+
+if [ "$#" != "1" ]; then
+        echo "Please specify one site name to disable."
+        exit 1
+fi
+
+if [ "$#" == "1" ]; then
+  site=/etc/httpd/sites-enabled/$1.conf
+
+  if test -e $site; then
+    unlink $site
+    echo "Successfuly disabled $site. Restart Apache server."
+  else
+    echo "Site $site could not be found."
+  fi
+fi

--- a/runtime/enable_httpd_site.sh
+++ b/runtime/enable_httpd_site.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Enable an httpd site, by creating a symbolic link from /etc/httpd/sites-available/{site}.conf to
+# /etc/httpd/sites-enabled
+
+if [ "$#" != "1" ]; then
+  echo "Please specify one site name to enable."
+  exit 1
+fi
+
+if test ! -d /etc/httpd/sites-available || test ! -d /etc/httpd/sites-enabled  ; then
+  mkdir -p /etc/httpd/sites-available
+  mkdir -p /etc/httpd/sites-enabled
+fi
+
+if ! grep -Fxq "Include sites-available/*.conf" /etc/httpd/conf/httpd.conf
+then
+  echo "Include sites-available/*.conf" >> /etc/httpd/conf/httpd.conf
+fi
+
+if [ "$#" == "1" ]; then
+  site=/etc/httpd/sites-available/$1.conf
+  enabled=/etc/httpd/sites-enabled/
+
+  if test -e $enabled/$1.conf; then
+    echo "$site is already enabled"
+    exit 0
+  fi
+
+  if test -e $site; then
+    sudo ln -s $site $enabled
+  else
+    echo "Site $site could not be found."
+    exit 1
+  fi
+
+  if test -e $enabled/$1.conf; then
+    echo "Successfuly enabled $site. Restart Apache server."
+  else
+    echo "Could not enable virtual site $site."
+    exit 1
+  fi
+fi


### PR DESCRIPTION
This adds support for building the RPM.
Apache service is named httpd on Red Hat and apache2 on Ubuntu. This change makes it possible to deal with both service names. Since we don't have the a2ensite/a2enmod on Red Hat, we have to manually create the logic to enable the spinnaker.conf site.
Tested on Centos6 with success.

We prefer small, well tested pull requests.

Please refer to [Contributing to Spinnaker](https://spinnaker.io/community/contributing/).

When filling out a pull request, please consider the following:

* Follow the commit message conventions [found here](http://www.spinnaker.io/v1.0/docs/how-to-submit-a-patch).
* Provide a descriptive summary for your changes.
* If it fixes a bug or resolves a feature request, be sure to link to that issue.
* Add inline code comments to changes that might not be obvious.
* Squash your commits as you keep adding changes.
* Add a comment to @spinnaker/reviewers for review if your issue has been outstanding for more than 3 days.

Note that we are unlikely to accept pull requests that add features without prior discussion. The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.
