### PR TITLE
feat(google): Configure test applications for  platform health checks

### DIFF
--- a/testing/citest/spinnaker_testing/gate.py
+++ b/testing/citest/spinnaker_testing/gate.py
@@ -221,7 +221,8 @@ class GateAgent(sk.SpinnakerAgent):
             'application': {
                 'name': application,
                 'description': description or 'Gate Testing Application',
-                'email': email
+                'email': email,
+                'platformHealthOnly': True
             },
             'user': '[anonymous]'
         }],


### PR DESCRIPTION
@jtk54, @duftler 
Allow test applications platformHealthOnly and explicitly create an application for server group tests. It still isnt clear why this was suddenly a problem when run against old branches.
