### PR TITLE
chore(remove_http_logging): Remove http logging.

### DIFF
--- a/dev/build_release.py
+++ b/dev/build_release.py
@@ -372,7 +372,7 @@ class Builder(object):
       # Tell rmtree to delete the directory even if it's non-empty.
       shutil.rmtree(gradle_cache)
     cmds = [
-      ('gcloud container builds submit --log-http'
+      ('gcloud container builds submit'
        ' --account={account} --project={project} --config="../{name}-gcb.yml" .'
        .format(name=name, account=gcb_service_account, project=gcb_project))
     ]


### PR DESCRIPTION
Remove http logging within build scripts that is currently polluting our logs with every http binary body we send to gcs since the bodies are now strings.