### PR TITLE
feat(buildtool): buildtool git and util modules

### DIFF
--- a/dev/buildtool/git.py
+++ b/dev/buildtool/git.py
@@ -1,0 +1,762 @@
+#!/usr/bin/python
+#
+# Copyright 2017 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Helper class for issuing git commands."""
+
+# pylint: disable=logging-format-interpolation
+
+import collections
+import logging
+import os
+import re
+import shutil
+import time
+
+from subprocess import CalledProcessError
+
+# pylint: disable=no-name-in-module
+# pylint: disable=import-error
+from distutils.version import LooseVersion
+import yaml
+
+from buildtool.util import (
+    check_subprocess,
+    check_subprocess_sequence,
+    ensure_dir_exists,
+    run_subprocess)
+
+
+class RemoteGitRepository(
+    collections.namedtuple(
+        'RemoteGitRepository', ['name', 'url', 'upstream_ref'])):
+  """A reference to a remote git repository and possibly it's upstream as well.
+
+  Attributes:
+    name: [string] The shorthand name of the repository
+    url: [string] The url to the repository isnt necessarily a URL, rather
+       this is simply the repository string passed to git clone, which is
+       typically a URL or directory name.
+    upstream_ref: [RemoteGitRepository] A reference to the upstream repository
+       that the url repository is derived from. This is for purposes of
+       informing update requests between the origin URL from its upstream URL.
+  """
+
+  @staticmethod
+  def make_from_url(url, upstream_ref=None):
+    """Create a new RemoteGitRepository from the specified URL.
+
+    The tail of the URL is assumed to be the repository name.
+    """
+    name = url[url.rfind('/') + 1:]
+    return RemoteGitRepository(name, url, upstream_ref)
+
+  @staticmethod
+  def merge_to_dict(*pos_args):
+    """For a upstream_repos parameter value from a list of mappings.
+
+    pos_args: [list of dict] where key is name of repository,
+        value is the RemoteGitRepository specification for that repository name.
+    """
+    result = {}
+    for some in pos_args:
+      result.update(some)
+    return result
+
+  @property
+  def upstream_url(self):
+    """The upstream repository URL or None if there is no upstream_ref."""
+    return None if self.upstream_ref is None else self.upstream_ref.url
+
+
+class SemanticVersion(
+    collections.namedtuple('SemanticVersion',
+                           ['series_name', 'major', 'minor', 'patch'])):
+  """Helper class for interacting with semantic version tags."""
+
+  SEMVER_MATCHER = re.compile(r'(.+)-(\d+)\.(\d+)\.(\d+)')
+  TAG_INDEX = 0
+  MAJOR_INDEX = 1
+  MINOR_INDEX = 2
+  PATCH_INDEX = 3
+
+  @staticmethod
+  def make(tag):
+    """Create a new SemanticVersion from the given tag instance.
+
+    Args:
+      tag: [string] in the form <series_name>-<major>.<minor>.<patch>
+    """
+    match = SemanticVersion.SEMVER_MATCHER.match(tag)
+    if match is None:
+      raise ValueError('Malformed tag "{tag}"'.format(tag=tag))
+
+    # Keep first group as a string, but use integers for the component parts
+    return SemanticVersion(match.group(1),
+                           *[int(num) for num in match.groups()[1:]])
+
+  def most_significant_diff_index(self, arg):
+    """Returns the *_INDEX for the most sigificant component differnce."""
+    if arg.series_name != self.series_name:
+      return self.TAG_INDEX
+    if arg.major != self.major:
+      return self.MAJOR_INDEX
+    if arg.minor != self.minor:
+      return self.MINOR_INDEX
+    if arg.patch != self.patch:
+      return self.PATCH_INDEX
+
+    return None
+
+  def to_version(self):
+    """Return string encoding of underlying version number."""
+    return '{major}.{minor}.{patch}'.format(
+        major=self.major, minor=self.minor, patch=self.patch)
+
+  def to_tag(self):
+    """Return string encoding of SemanticVersion tag."""
+    return '{series}-{major}.{minor}.{patch}'.format(
+        series=self.series_name,
+        major=self.major, minor=self.minor, patch=self.patch)
+
+  def next(self, at_index):
+    """Returns the next SemanticVersion from this when bumping up.
+
+    Args:
+       at_index: [int] The component *_INDEX to bump at.
+    """
+    if at_index is None:
+      raise ValueError('Invalid index={0}'.format(at_index))
+
+    major = self.major
+    minor = self.minor
+    patch = self.patch
+
+    if at_index == self.PATCH_INDEX:
+      patch += 1
+    else:
+      patch = 0
+      if at_index == self.MINOR_INDEX:
+        minor += 1
+      elif at_index == self.MAJOR_INDEX:
+        minor = 0
+        major += 1
+      else:
+        raise ValueError('Invalid index={0}'.format(at_index))
+
+    return SemanticVersion(self.series_name, major, minor, patch)
+
+
+class CommitTag(
+    collections.namedtuple('CommitTag', ['commit_id', 'tag', 'version'])):
+  """Denotes an individual result of git show-ref --tags."""
+
+  @staticmethod
+  def make(ref_line):
+    """Create a new instance from a response line.
+
+    Args:
+      ref_line: [string] Response from "git show-ref --tags"
+    """
+    # ref_line is in the form "$commit_id refs/tags/$tag"
+    tokens = ref_line.split(' ')
+    line_id = tokens[0]
+    tag_parts = tokens[1].split('/')
+    tag = tag_parts[len(tag_parts) - 1]
+    version = LooseVersion(tag)
+    return CommitTag(line_id, tag, version)
+
+  @staticmethod
+  def compare_tags(first, second):
+    """Comparator for instances compares the lexical order of the tags."""
+    return cmp(first.tag, second.tag)
+
+  # pylint: disable=multiple-statements
+  def __lt__(self, other): return self.tag.__lt__(other.tag)
+  def __le__(self, other): return self.tag.__le__(other.tag)
+  def __eq__(self, other): return self.tag.__eq__(other.tag)
+  def __ge__(self, other): return self.tag.__ge__(other.tag)
+  def __gt__(self, other): return self.tag.__gt__(other.tag)
+  def __ne__(self, other): return self.tag.__ne__(other.tag)
+
+
+class CommitMessage(
+    collections.namedtuple('CommitMessage',
+                           ['commit_id', 'author', 'date', 'message'])):
+  """Denotes an individual entry in 'git log --pretty'."""
+  _MEDIUM_PRETTY_COMMIT_MATCHER = re.compile(
+      '(.+)\nAuthor: *(.+)\nDate: *(.*)\n', re.MULTILINE)
+
+  _EMBEDDED_COMMIT_MATCHER = re.compile(
+      r'^( *)commit [a-f0-9]+\n'
+      r'^\s*Author: .+\n'
+      r'^\s*Date:   .+\n',
+      re.MULTILINE)
+
+  _EMBEDDED_SUMMARY_MATCHER = re.compile(
+      r'^\s*(?:\*\s*)?[a-z]+\(.+?\): .+',
+      re.MULTILINE)
+
+  # The vocabulary in the following list was taken looking at what's
+  # used in practice (right or wrong), for conforming log entries,
+  # using the following command over the various spinnaker repositories:
+  #
+  # git log --pretty=oneline \
+  #   | sed "s/^[a-f0-9]\+ //g" \
+  #   | egrep "^[^ \(]+\(" \
+  #   | sed "s/^\([^\(]\+\).*/\1/g" \
+  #   | sort | uniq
+  DEFAULT_PATCH_REGEXS = [
+      # Some tags indicate only a patch release.
+      re.compile(r'^\s*'
+                 r'(?:\*\s+)?'
+                 r'((?:fix|bug|docs?|test)[\(:].*)',
+                 re.MULTILINE)
+  ]
+  DEFAULT_MINOR_REGEXS = [
+      # Some tags indicate a minor release.
+      # These are features as well as hints to non-trivial
+      # implementation changes that suggest a higher level of risk.
+      re.compile(r'^\s*'
+                 r'(?:\*\s+)?'
+                 r'((?:feat|feature|chore|refactor|perf|config)[\(:].*)',
+                 re.MULTILINE)
+  ]
+  DEFAULT_MAJOR_REGEXS = [
+      # Breaking changes are explicitly marked as such.
+      re.compile(r'^\s*'
+                 r'(.*?BREAKING CHANGE.*)',
+                 re.MULTILINE)
+  ]
+
+  @staticmethod
+  def make_list_from_result(response_text):
+    """Returns a list of CommitMessage from the command response.
+
+    Args:
+      response_text: [string] result of "git log --pretty=medium"
+    """
+    all_entries = ('\n' + response_text.strip()).split('\ncommit ')[1:]
+    response = []
+    for entry in all_entries:
+      response.append(CommitMessage.make(entry))
+    return response
+
+  @staticmethod
+  def make(entry):
+    """Create a new CommitMessage from an individual entry"""
+    match = CommitMessage._MEDIUM_PRETTY_COMMIT_MATCHER.match(entry)
+
+    text = entry[match.end(3):]
+
+    # strip trailing spaces on each line
+    lines = [line.rstrip() for line in text.split('\n')]
+
+    # remove blank lines from beginning and end of text
+    while lines and not lines[0]:
+      del lines[0]
+    while lines and not lines[-1]:
+      del lines[-1]
+
+    # new string may have initial spacing but no leading/trailing blank lines.
+    text = '\n'.join(lines)
+
+    return CommitMessage(match.group(1), match.group(2), match.group(3), text)
+
+  @staticmethod
+  def normalize_message_list(msg_list):
+    """Transform a series of CommitMessage into one without compound messages.
+
+    A compound message is a single commit that is a merge of multiple commits
+    as indicated by a message that looks like multiple entires.
+    This will break apart those compound commits into individual ones for
+    the same commit id entry for easier processing.
+    """
+    msg_list = CommitMessage._unpack_embedded_commits(msg_list)
+    return CommitMessage._unpack_embedded_summaries(msg_list)
+
+  @staticmethod
+  def _unpack_embedded_commits(msg_list):
+    """Helper function looking for merged commits.
+
+    These are indicated by having an embedded commit within them.
+    If found, unnest the indentation and run through as if these
+    came directly from a git result to turn them into additional commits.
+    """
+    result = []
+    for commit_message in msg_list:
+      text = commit_message.message
+      found = CommitMessage._EMBEDDED_COMMIT_MATCHER.search(text)
+      if not found:
+        result.append(commit_message)
+        continue
+
+      text_before = text[:found.start(1)]
+      text_lines = text[found.start(1):].split('\n')
+      pruned_lines = []
+      offset = found.end(1) - found.start(1)
+      for line in text_lines:
+        if line.startswith(found.group(1)):
+          pruned_lines.append(line[offset:])
+        elif not line:
+          pruned_lines.append(line)
+        else:
+          logging.warning(
+              '"%s" looks like an composite commit, but not indented by %d.',
+              text, offset)
+          pruned_lines = []
+          result.append(commit_message)
+          break
+
+      if pruned_lines:
+        if text_before.strip():
+          logging.info('Dropping commit message "%s" in favor of "%s"',
+                       text_before, '\n'.join(pruned_lines))
+        result.extend(
+            CommitMessage.make_list_from_result('\n'.join(pruned_lines)))
+    return result
+
+  @staticmethod
+  def _unpack_embedded_summaries(msg_list):
+    """Helper function looking for embedded summaries.
+
+    An embedded summary is another top-line message block (e.g. fix(...): ...)
+    This is different from a merged commit in that it doesnt have the
+    commit/author/date fields. These types of entries are typically entered
+    manually to convey a single atomic commit contains multiple changes
+    as opposed to multiple commits becomming aggregated after the fact.
+
+    Note that embedded summaries all originated from an atomic commit, so
+    all the resulting CommitMessages will have the same underlying commit id.
+    """
+    result = []
+    for commit_message in msg_list:
+      commit_id = commit_message.commit_id
+      author = commit_message.author
+      date = commit_message.date
+
+      lines = commit_message.message.split('\n')
+      prev = -1
+      for index, line in enumerate(lines):
+        if CommitMessage._EMBEDDED_SUMMARY_MATCHER.match(line):
+          logging.debug('Found embedded commit at line "%s" prev=%d',
+                        line, prev)
+          if prev >= 0:
+            text = '\n'.join(lines[prev:index]).rstrip()
+            result.append(CommitMessage(commit_id, author, date, text))
+          prev = index
+      if prev < 0:
+        prev = 0
+      text = '\n'.join(lines[prev:]).rstrip()
+      result.append(CommitMessage(commit_id, author, date, text))
+
+    return result
+
+  @staticmethod
+  def determine_semver_implication_on_list(
+      msg_list, major_regexs=None, minor_regexs=None, patch_regexs=None,
+      default_semver_index=SemanticVersion.MINOR_INDEX):
+    """Determine the worst case semvar component that needs incremented."""
+    if not msg_list:
+      return None
+    msi = SemanticVersion.PATCH_INDEX + 1
+    for commit_message in msg_list:
+      msi = min(msi, commit_message.determine_semver_implication(
+          major_regexs=major_regexs,
+          minor_regexs=minor_regexs,
+          patch_regexs=patch_regexs,
+          default_semver_index=default_semver_index))
+    return msi
+
+  def determine_semver_implication(
+      self, major_regexs=None, minor_regexs=None, patch_regexs=None,
+      default_semver_index=SemanticVersion.MINOR_INDEX):
+    """Determine what effect this commit has on future semantic versioning.
+
+    Args:
+      major_regexs: [list of re] Regexes to look for indicating a MAJOR change
+      minor_regexs: [list of re] Regexes to look for indicating a MINOR change
+      patch_regexs: [list of re] Regexes to look for indicating a PATCH change
+      default_semver_index: SemanticVersion.*_INDEX for default change
+
+    Returns:
+      The SemanticVersion.*_INDEX of the affected idealized version component
+      that will need to be incremented to accomodate this change.
+    """
+    def is_compliant(spec):
+      """Determine if the commit message satisfies the specification."""
+      if not spec:
+        return None
+      if not isinstance(spec, list):
+        spec = [spec]
+
+      text = self.message.strip()
+      for matcher in spec:
+        match = matcher.search(text)
+        if match:
+          return match.groups()
+      return None
+
+    if major_regexs is None:
+      major_regexs = CommitMessage.DEFAULT_MAJOR_REGEXS
+    if minor_regexs is None:
+      minor_regexs = CommitMessage.DEFAULT_MINOR_REGEXS
+    if patch_regexs is None:
+      patch_regexs = CommitMessage.DEFAULT_PATCH_REGEXS
+
+    attempts = [('MAJOR', major_regexs, SemanticVersion.MAJOR_INDEX),
+                ('MINOR', minor_regexs, SemanticVersion.MINOR_INDEX),
+                ('PATCH', patch_regexs, SemanticVersion.PATCH_INDEX)]
+    for name, regexes, index in attempts:
+      reason = is_compliant(regexes)
+      if reason:
+        logging.debug('Commit is considered "%s" because it says "%s"',
+                      name, reason)
+        return index
+
+    logging.debug('Commit is considered #%d by DEFAULT: message was "%s"',
+                  default_semver_index, self.message)
+    return default_semver_index
+
+
+
+class RepositorySummary(collections.namedtuple(
+    'RepositorySummary',
+    ['commit_id', 'tag', 'version', 'commit_messages'])):
+  """Denotes information about a repository that a build-delta wants.
+
+  Attributes:
+    commit_id: [string] The HEAD commit id
+    tag: [string] The tag at the HEAD
+    version: [string] The Major.Minor.Patch version number
+    commit_messages: [list of CommitMessage] The commits since the last tag.
+       If this is empty then the tag and version already exists.
+       Otherwise the tag and version are proposed values.
+  """
+  def to_yaml(self, with_commit_messages=True):
+    """Convert the summary to a yaml string."""
+    data = dict(super(RepositorySummary, self).__dict__)
+    del data['commit_messages']
+
+    if with_commit_messages:
+      # Need data['commit_messages'] = [
+      #   message.to_dict() for message in self.commit_messages]
+      raise NotImplementedError('with_commit_messages not yet supported')
+
+    return yaml.dump(data, default_flow_style=False)
+
+
+class GitRunner(object):
+  """Helper class for interacting with Git"""
+
+  def query_local_repository_commits_to_existing_tag_from_id(
+      self, git_dir, commit_id, commit_tags):
+    """Returns the list of commit messages to the local repository."""
+    # pylint: disable=invalid-name
+
+    id_to_newest_tag = {}
+    for commit_tag in sorted(commit_tags):
+      id_to_newest_tag[commit_tag.commit_id] = commit_tag.tag
+    tag = id_to_newest_tag.get(commit_id)
+    if tag is not None:
+      return tag, []
+
+    result = check_subprocess(
+        'git -C "{dir}" log --pretty=oneline {id}'.format(
+            dir=git_dir, id=commit_id))
+
+    lines = result.split('\n')
+    count = 0
+    for line in lines:
+      line_id = line.split(' ', 1)[0]
+      tag = id_to_newest_tag.get(line_id)
+      if tag:
+        break
+      count += 1
+
+    if tag is None:
+      raise ValueError(
+          'There is no baseline tag for commit "{id}" in {dir}.'.format(
+              id=commit_id, dir=git_dir))
+
+    result = check_subprocess(
+        'git -C "{dir}" log -n {count} --pretty=medium {id}'.format(
+            dir=git_dir, count=count, id=commit_id))
+    messages = CommitMessage.make_list_from_result(result)
+    return tag, messages
+
+  def query_local_repository_commit_id(self, git_dir):
+    """Returns the current commit for the repository at git_dir."""
+    result = check_subprocess(
+        'git -C "{dir}" rev-parse HEAD'.format(dir=git_dir))
+    return result
+
+  def query_local_repository_branch(self, git_dir):
+    """Returns the branch for the repository at git_dir."""
+    returncode, stdout = run_subprocess(
+        'git -C "{dir}" rev-parse --abbrev-ref HEAD'.format(dir=git_dir))
+
+    if returncode:
+      error = 'Could not determine branch: ' + stdout
+      raise RuntimeError(error + ' in ' + git_dir)
+    return stdout
+
+  def push_branch_to_origin(self, git_dir, branch):
+    """Push the given local repository back up to the origin.
+
+    This has no effect if the repository is not in the given branch.
+    """
+    in_branch = self.query_local_repository_branch(git_dir)
+    if in_branch != branch:
+      logging.warning('Skipping push %s "%s" to origin because branch is "%s".',
+                      git_dir, branch, in_branch)
+      return
+    check_subprocess(
+        'git -C "{dir}" push origin {branch} --tags'.format(
+            dir=git_dir, branch=branch))
+
+  def refresh_local_repository(self, git_dir, remote_name, branch):
+    """Refreshes the given local repository from the remote one.
+
+    Args:
+      git_dir: [string] Which local repository to update.
+      remote_name: [remote_name] Which remote repository to pull from.
+      branch: [string] Which branch to pull.
+    """
+    repository_name = os.path.basename(git_dir)
+    # pylint: disable=unused-variable
+    retcode, stdout = run_subprocess(
+        'git -C "{dir}" remote -v | egrep "^{which}.*\\(fetch\\)$"'.format(
+            dir=git_dir, which=remote_name))
+    if not stdout:
+      logging.warning(
+          'Skipping pull {remote_name} {branch} in {repository} because'
+          ' it does not have a remote "{remote_name}"'
+          .format(remote_name=remote_name,
+                  branch=branch,
+                  repository=repository_name))
+      return
+
+    local_branch = self.query_local_repository_branch(git_dir)
+    if local_branch != branch:
+      logging.warning(
+          'Skipping pull {remote_name} {branch} in {repository} because'
+          ' its in branch={local_branch}'
+          .format(remote_name=remote_name,
+                  branch=branch,
+                  repository=repository_name,
+                  local_branch=local_branch))
+      return
+
+    try:
+      logging.debug('Refreshing %s from %s branch %s',
+                    git_dir, remote_name, branch)
+      command = 'git -C "{dir}" pull {remote_name} {branch} --tags'.format(
+          dir=git_dir, remote_name=remote_name, branch=branch)
+      result = check_subprocess(command)
+      logging.info('%s:\n%s', repository_name, result)
+    except RuntimeError:
+      result = check_subprocess(
+          'git -C "{dir}" branch -r'.format(dir=git_dir))
+      if result.find(
+          '{which}/{branch}\n'.format(which=remote_name, branch=branch)) >= 0:
+        raise
+      logging.warning(
+          'WARNING {name} branch={branch} is not known to {which}.\n'
+          .format(name=repository_name, branch=branch, which=remote_name))
+
+  def __check_clone_branch(self, origin_url, git_command, branches):
+    remaining_branches = list(branches)
+    while True:
+      branch = remaining_branches.pop(0)
+      cmd = '{git} -b {branch}'.format(git=git_command, branch=branch)
+      retcode, stdout = run_subprocess(cmd)
+      if not retcode:
+        return
+
+      not_found = stdout.find('Remote branch {branch} not found'
+                              .format(branch=branch)) >= 0
+      if not not_found:
+        raise CalledProcessError(cmd=cmd, returncode=retcode, output=stdout)
+
+      if remaining_branches:
+        logging.warning(
+            'Branch %s does not exist in %s. Retry with %s',
+            branch, origin_url, remaining_branches[0])
+        continue
+
+      lines = stdout.split('\n')
+      if len(lines) > 10:
+        lines = lines[-10:]
+      stdout = '\n   '.join(lines)
+      logging.error('%s failed with last %d lines:\n   %s',
+                    cmd, len(lines), stdout)
+      raise ValueError('Branches {0} do not exist in {1}.'
+                       .format(branches, origin_url))
+
+  def clone_repository_to_path(
+      self, origin_url, git_dir, upstream_url=None,
+      commit=None, branch=None, default_branch=None):
+    """Clone the remote repository at the given commit or branch.
+
+    If requesting a branch and it is not found, then settle for the default
+    branch, if one was explicitly specified.
+    """
+    # pylint: disable=too-many-arguments
+
+    if (commit != None) and (branch != None):
+      raise ValueError('At most one of commit or branch can be specified.')
+
+    logging.debug('Begin cloning %s', origin_url)
+    parent_dir = os.path.dirname(git_dir)
+    ensure_dir_exists(parent_dir)
+
+    git_command = 'git -C "{parent_dir}" clone {origin_url}'.format(
+        parent_dir=parent_dir, origin_url=origin_url)
+
+    if branch:
+      branches = [branch]
+      if default_branch:
+        branches.append(default_branch)
+      self.__check_clone_branch(origin_url, git_command, branches)
+    else:
+      check_subprocess(git_command)
+    logging.info('Cloned %s into %s', origin_url, parent_dir)
+
+    if commit:
+      check_subprocess(
+          'git -C "{dir}" checkout {commit} -q'.format(
+              dir=git_dir, commit=commit),
+          echo=True)
+
+    if upstream_url and upstream_url != origin_url:
+      logging.debug('Adding upstream %s with disabled push', upstream_url)
+      check_subprocess(
+          'git -C "{dir}" remote add upstream {upstream_url}'.format(
+              dir=git_dir, upstream_url=upstream_url))
+
+    which = ('upstream'
+             if upstream_url and upstream_url != origin_url
+             else 'origin')
+    check_subprocess(
+        'git -C "{dir}" remote set-url --push {which} disabled'.format(
+            dir=git_dir, which=which))
+    logging.debug('Finished cloning %s', origin_url)
+
+  def tag_head(self, git_dir, tag):
+    """Add tag to the local repository HEAD."""
+    check_subprocess('git -C "{dir}" tag {tag} HEAD'.format(
+        dir=git_dir, tag=tag))
+
+  def query_tag_commits(self, git_dir, tag_pattern):
+    """Collect the TagCommit for each tag matching the pattern.
+
+      Returns: list of CommitTag sorted most recent first.
+    """
+    tag_ref_result = check_subprocess(
+        'git -C "{dir}" show-ref --tags'.format(dir=git_dir))
+
+    ref_lines = tag_ref_result.split('\n')
+    commit_tags = [CommitTag.make(line) for line in ref_lines]
+    matcher = re.compile(tag_pattern)
+    filtered = [ct for ct in commit_tags if matcher.match(ct.tag)]
+    return sorted(filtered, reverse=True)
+
+  def determine_remote_git_repository(self, git_dir):
+    """Infter RemoteGitRepository from a local git repository."""
+    git_text = check_subprocess(
+        'git -C "{dir}" remote -v'.format(dir=git_dir))
+    remote_urls = {
+        match.group(1): match.group(2)
+        for match in re.finditer(r'(\w+)\s+(\S+)\s+\(fetch\)', git_text)
+    }
+    origin_url = remote_urls.get('origin')
+    if not origin_url:
+      raise ValueError('{0} has no remote "origin"'.format(git_dir))
+
+    upstream_url = remote_urls.get('upstream')
+    upstream = (RemoteGitRepository.make_from_url(upstream_url)
+                if upstream_url
+                else None)
+    return RemoteGitRepository.make_from_url(origin_url, upstream_ref=upstream)
+
+  def collect_repository_summary(self, git_dir):
+    """Collects RepsitorySummary from local repository directory."""
+    start_time = time.time()
+    logging.debug('Begin analyzing %s', git_dir)
+    all_tags = self.query_tag_commits(
+        git_dir, r'^version-[0-9]+\.[0-9]+\.[0-9]+$')
+    current_id = self.query_local_repository_commit_id(git_dir)
+    tag, msgs = self.query_local_repository_commits_to_existing_tag_from_id(
+        git_dir, current_id, all_tags)
+
+    current_semver = SemanticVersion.make(tag)
+    next_semver = None
+    if msgs:
+      semver_significance = CommitMessage.determine_semver_implication_on_list(
+          msgs)
+      next_semver = current_semver.next(semver_significance)
+      use_tag = next_semver.to_tag()
+      use_version = next_semver.to_version()
+    else:
+      use_tag = tag
+      use_version = current_semver.to_version()
+
+    total_ms = int((time.time() - start_time) * 1000)
+    logging.debug('Finished analyzing %s in %d ms', git_dir, total_ms)
+    return RepositorySummary(current_id, use_tag, use_version, msgs)
+
+  def reinit_local_repository_with_tag(
+      self, git_dir, git_tag, initial_commit_message):
+    """Recreate the given local repository using the current content.
+
+    The Netflix Nebula gradle plugin that spinnaker uses to build the sources
+    is hardcoded with some incompatible constraints which we are unable to
+    change (the owner is receptive but wont do it for us and we arent familiar
+    with how it works or exactly what needs changed). Therefore we'll wipe out
+    the old tags and just put the one tag we want in order to avoid ambiguity.
+    We'll detatch the old repository to avoid accidental pushes. It's much
+    faster to create a new repo than remove all the existing tags.
+
+    Args:
+      git_dir: [path]  The path to the local git repository.
+         If this has an existing .git directory it will be removed.
+         The directory will be re initialized as a new repository.
+      git_tag: [string] The tag to give the initial commit
+      initial_commit_message: [string] The initial commit message
+        when commiting the existing directory content to the new repo.
+    """
+    if git_tag is None:
+      git_tag = check_subprocess(
+          'git -C "{dir}" describe --tags --abbrev=0'.format(dir=git_dir))
+
+    escaped_commit_message = initial_commit_message.replace('"', '\\"')
+    logging.info('Removing old .git from %s and starting new at %s',
+                 git_dir, git_tag)
+    original_origin = self.determine_remote_git_repository(git_dir)
+
+    shutil.rmtree(os.path.join(git_dir, '.git'))
+
+    _git = 'git -C "{dir}" '.format(dir=git_dir)
+    check_subprocess_sequence([
+        _git + 'init',
+        _git + 'add .',
+        _git + 'remote add {name} {url}'.format(
+            name='origin', url=original_origin.url),
+        _git + 'remote set-url --push {name} disabled'.format(name='origin'),
+        _git + 'commit -q -a -m "{message}"'.format(
+            message=escaped_commit_message),
+        _git + 'tag {tag} HEAD'.format(tag=git_tag)
+    ])

--- a/dev/buildtool/requirements.txt
+++ b/dev/buildtool/requirements.txt
@@ -1,0 +1,8 @@
+PyYAML
+
+# This is for testing
+python-dateutil
+
+# This is to satisfy gsutil
+google_compute_engine
+

--- a/dev/buildtool/util.py
+++ b/dev/buildtool/util.py
@@ -1,0 +1,174 @@
+# Copyright 2017 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Common helper functions across buildtool modules."""
+
+import datetime
+import logging
+import os
+import shlex
+import subprocess
+import time
+import traceback
+
+
+def timestring(now=None):
+  """Returns timestamp as date time string."""
+  now = now or datetime.datetime.now()
+  return '{:%Y-%m-%d %H:%M:%S}'.format(now)
+
+
+def timedelta_string(delta):
+  """Returns a string indicating the time duration.
+
+  Args:
+    delta: [datetime.timedelta] The time difference
+  """
+  delta_secs = int(delta.total_seconds())
+  delta_mins = delta_secs / 60
+  delta_hours = (delta_mins / 60 % 24)
+  delta_days = delta.days
+
+  day_str = '' if not delta_days else ('days=%d + ' % delta_days)
+  delta_mins = delta_mins % 60
+  delta_secs = delta_secs % 60
+
+  if delta_hours or day_str:
+    return day_str + '%02d:%02d:%02d' % (delta_hours, delta_mins, delta_secs)
+  elif delta_mins:
+    return '%02d:%02d' % (delta_mins, delta_secs)
+  return '%d.%03d secs' % (delta_secs, delta.microseconds / 1000)
+
+
+def maybe_log_exception(where, ex, action_msg='propagating exception'):
+  """Log the exception and stackdrace if it hasnt been logged already."""
+  if not hasattr(ex, 'logged'):
+    text = traceback.format_exc()
+    logging.error('"%s" caught exception\n%s', where, text)
+    ex.logged = True
+  logging.error('"%s" %s', where, action_msg)
+
+
+def run_subprocess(cmd, stream=None, echo=False, **kwargs):
+  """Returns retcode, stdout."""
+  split_cmd = shlex.split(cmd)
+
+  if echo:
+    logging.info('Running %s ...', cmd)
+  else:
+    logging.debug('Running %s ...', cmd)
+
+  start_date = datetime.datetime.now()
+  if stream:
+    stream.write('{time} Spawning {cmd}\n----\n\n'.format(
+        time=timestring(now=start_date), cmd=cmd))
+    stream.flush()
+
+  process = subprocess.Popen(
+      split_cmd,
+      close_fds=True,
+      stdout=subprocess.PIPE,
+      stderr=subprocess.STDOUT,
+      **kwargs)
+  time.sleep(0) # yield this thread
+
+  stdout_lines = []
+  for line in iter(process.stdout.readline, ''):
+    stdout_lines.append(line)
+    if stream:
+      stream.write(line)
+      stream.flush()
+  process.wait()
+  end_date = datetime.datetime.now()
+  delta_time_str = timedelta_string(end_date - start_date)
+  returncode = process.returncode
+  stdout = ''.join(stdout_lines)
+
+  if stream:
+    stream.write(
+        '\n\n----\n{time} Spawned process completed'
+        ' with returncode {returncode} in {delta_time}.\n'
+        .format(time=timestring(now=end_date), returncode=returncode,
+                delta_time=delta_time_str))
+    stream.flush()
+
+  if echo:
+    logging.info('%s returned %d with output:\n%s',
+                 split_cmd[0], returncode, stdout)
+  logging.debug('Finished %s with returncode=%d in %s',
+                split_cmd[0], returncode, delta_time_str)
+
+  return returncode, stdout.strip()
+
+
+def check_subprocess(cmd, stream=None, **kwargs):
+  """run_subprocess and raise CalledProcessError if it fails."""
+  retcode, stdout = run_subprocess(cmd, stream=stream, **kwargs)
+
+  try:
+    if retcode != 0:
+      lines = stdout.split('\n')
+      if lines > 5:
+        lines = lines[-5:]
+      logging.error('Command failed with last %d lines:\n   %s',
+                    len(lines), '\n   '.join(lines))
+      raise subprocess.CalledProcessError(retcode, cmd, output=stdout)
+  except subprocess.CalledProcessError as ex:
+    maybe_log_exception(shlex.split(cmd)[0], ex)
+    raise
+
+  return stdout.strip()
+
+
+def check_subprocess_sequence(cmd_list, stream=None, **kwargs):
+  """Run multiple commands until one fails.
+
+  Returns:
+    A list of each result in sequence if all succeeded.
+  """
+  response = []
+  for one in cmd_list:
+    response.append(check_subprocess(one, stream=stream, **kwargs))
+  return response
+
+
+def run_subprocess_sequence(cmd_list, stream=None, **kwargs):
+  """Run multiple commands until one fails.
+
+  Returns:
+    A list of (code, output) tuples for each result in sequence.
+  """
+  response = []
+  for one in cmd_list:
+    response.append(run_subprocess(one, stream=stream, **kwargs))
+  return response
+
+
+def ensure_dir_exists(path):
+  """Ensure a directory exists, creating it if not."""
+  try:
+    os.makedirs(path)
+  except OSError:
+    if not os.path.exists(path):
+      raise
+
+
+def write_to_path(content, path):
+  """Write the given content to the file specified by the <path>.
+
+  This will create the parent directory if needed.
+  """
+  ensure_dir_exists(os.path.dirname(os.path.abspath(path)))
+  with open(path, 'w') as f:
+    f.write(content)

--- a/unittest/buildtool/git_test.py
+++ b/unittest/buildtool/git_test.py
@@ -1,0 +1,455 @@
+# Copyright 2017 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=missing-docstring
+
+import datetime
+import os
+import shutil
+import tempfile
+import unittest
+
+import dateutil.parser
+
+from buildtool.git import (
+    GitRunner,
+    CommitMessage,
+    RemoteGitRepository,
+    RepositorySummary,
+    SemanticVersion
+)
+
+from buildtool.util import (
+    check_subprocess,
+    check_subprocess_sequence
+)
+TAG_VERSION_PATTERN = r'^version-[0-9]+\.[0-9]+\.[0-9]+$'
+
+VERSION_BASE = 'version-0.1.0'
+VERSION_A = 'version-0.4.0'
+VERSION_B = 'version-0.5.0'
+BRANCH_A = 'branch-a'
+BRANCH_B = 'branch-b'
+BRANCH_BASE = 'baseline'
+UPSTREAM_USER = 'unittest'
+TEST_REPO_NAME = 'test_repository'
+
+class TestGitRunner(unittest.TestCase):
+  @classmethod
+  def run_git(cls, command):
+    return check_subprocess(
+        'git -C "{dir}" {command}'.format(dir=cls.git_dir, command=command))
+
+  @classmethod
+  def setUpClass(cls):
+    cls.git = GitRunner()
+    cls.base_temp_dir = tempfile.mkdtemp(prefix='git_test')
+    cls.git_dir = os.path.join(cls.base_temp_dir, UPSTREAM_USER, TEST_REPO_NAME)
+    os.makedirs(cls.git_dir)
+
+    git_dir = cls.git_dir
+    gitify = lambda args: 'git -C "{dir}" {args}'.format(dir=git_dir, args=args)
+    check_subprocess_sequence([
+        gitify('init'),
+        'touch "{dir}/base_file"'.format(dir=git_dir),
+        gitify('add "{dir}/base_file"'.format(dir=git_dir)),
+        gitify('commit -a -m "feat(test): added file"'),
+        gitify('tag {base_version} HEAD'.format(base_version=VERSION_BASE)),
+        gitify('checkout -b {base_branch}'.format(base_branch=BRANCH_BASE)),
+        gitify('checkout -b {a_branch}'.format(a_branch=BRANCH_A)),
+        'touch "{dir}/a_file"'.format(dir=git_dir),
+        gitify('add "{dir}/a_file"'.format(dir=git_dir)),
+        gitify('commit -a -m "feat(test): added a_file"'),
+        gitify('tag {a_version} HEAD'.format(a_version=VERSION_A)),
+        gitify('checkout -b {b_branch}'.format(b_branch=BRANCH_B)),
+        'touch "{dir}/b_file"'.format(dir=git_dir),
+        gitify('add "{dir}/b_file"'.format(dir=git_dir)),
+        gitify('commit -a -m "feat(test): added b_file"'),
+        gitify('tag {b_version} HEAD'.format(b_version=VERSION_B))])
+
+  @classmethod
+  def tearDownClass(cls):
+    shutil.rmtree(cls.base_temp_dir)
+
+  def setUp(self):
+    self.run_git('checkout master'.format(dir=self.git_dir))
+
+  def test_query_local_repository_branch(self):
+    initial_branch = self.git.query_local_repository_branch(self.git_dir)
+    self.assertEqual('master', initial_branch)
+
+    self.run_git('checkout -b branch_test')
+    final_branch = self.git.query_local_repository_branch(self.git_dir)
+    self.assertEqual('branch_test', final_branch)
+
+  def test_determine_tag_at_head(self):
+    # pylint: disable=too-many-locals
+    git = self.git
+    all_tags = git.query_tag_commits(self.git_dir, TAG_VERSION_PATTERN)
+    test_method = git.query_local_repository_commits_to_existing_tag_from_id
+
+    tests = [(None, VERSION_BASE),
+             (BRANCH_A, VERSION_A),
+             (BRANCH_B, VERSION_B)]
+    for branch, version in tests:
+      if branch is not None:
+        self.run_git('checkout ' + branch)
+        commit_id = git.query_local_repository_commit_id(self.git_dir)
+        tag, messages = test_method(self.git_dir, commit_id, all_tags)
+        self.assertEquals([], messages)
+        self.assertEquals(version, tag)
+
+  def test_determine_tag_at_patch(self):
+    git = self.git
+    test_method = git.query_local_repository_commits_to_existing_tag_from_id
+
+    tests = [(BRANCH_A, VERSION_A),
+             (BRANCH_B, VERSION_B)]
+    for branch, version in tests:
+      new_version = str(version)
+      new_version = new_version[:-1] + '1'
+      self.run_git('checkout ' + branch)
+      self.run_git('checkout -b {branch}-patch'.format(branch=branch))
+      pending_messages = []
+      for change in ['first', 'second']:
+        new_path = os.path.join(self.git_dir, change + '_file')
+        check_subprocess('touch "{path}"'.format(path=new_path))
+        self.run_git('add "{path}"'.format(path=new_path))
+        message = 'fix(test): Made {change} change for testing.'.format(
+            change=change)
+        self.run_git('commit -a -m "{message}"'.format(message=message))
+        pending_messages.append(' '*4 + message)
+
+      commit_id = git.query_local_repository_commit_id(self.git_dir)
+
+      # The pending change shows up for the old tag (and are most recent first)
+      all_tags = git.query_tag_commits(self.git_dir, TAG_VERSION_PATTERN)
+      tag, messages = test_method(self.git_dir, commit_id, all_tags)
+      self.assertEquals(version, tag)
+      self.assertEquals(len(pending_messages), len(messages))
+      self.assertEquals(sorted(pending_messages, reverse=True),
+                        [m.message for m in messages])
+
+      # When we re-tag at this change,
+      # the new tag shows up without pending change.
+      self.run_git('tag {version} HEAD'.format(version=new_version))
+      all_tags = git.query_tag_commits(self.git_dir, TAG_VERSION_PATTERN)
+
+      tag, messages = test_method(self.git_dir, commit_id, all_tags)
+      self.assertEquals(new_version, tag)
+      self.assertEquals([], messages)
+
+  def test_clone_upstream(self):
+    git = self.git
+    test_parent = os.path.join(self.base_temp_dir, 'test_clone_upstream')
+    os.makedirs(test_parent)
+
+    test_dir = os.path.join(test_parent, TEST_REPO_NAME)
+    git.clone_repository_to_path(self.git_dir, test_dir)
+    self.assertTrue(os.path.exists(os.path.join(test_dir, 'base_file')))
+
+    want_tags = git.query_tag_commits(self.git_dir, TAG_VERSION_PATTERN)
+    have_tags = git.query_tag_commits(test_dir, TAG_VERSION_PATTERN)
+    self.assertEquals(want_tags, have_tags)
+
+    got = check_subprocess('git -C "{dir}" remote -v'.format(dir=test_dir))
+    # Disable pushes to the origni
+    # No upstream since origin is upstream
+    self.assertEquals(
+        '\n'.join([
+            'origin\t{origin} (fetch)'.format(origin=self.git_dir),
+            'origin\tdisabled (push)'
+            ]),
+        got)
+
+    reference = git.determine_remote_git_repository(test_dir)
+    self.assertEquals(
+        RemoteGitRepository.make_from_url(self.git_dir),
+        reference)
+
+  def test_clone_origin(self):
+    git = self.git
+
+    # Make the origin we're going to test the clone against
+    # This is intentionally different from upstream so that
+    # we can confirm that upstream is also setup properly.
+    origin_user = 'origin_user'
+    origin_basedir = os.path.join(self.base_temp_dir, origin_user)
+    os.makedirs(origin_basedir)
+    check_subprocess(
+        'git -C "{origin_dir}" clone "{upstream}"'.format(
+            origin_dir=origin_basedir, upstream=self.git_dir))
+
+    test_parent = os.path.join(self.base_temp_dir, 'test_clone_origin')
+    os.makedirs(test_parent)
+
+    test_dir = os.path.join(test_parent, TEST_REPO_NAME)
+    origin_dir = os.path.join(origin_basedir, TEST_REPO_NAME)
+    self.git.clone_repository_to_path(
+        origin_dir, test_dir, upstream_url=self.git_dir)
+
+    want_tags = git.query_tag_commits(self.git_dir, TAG_VERSION_PATTERN)
+    have_tags = git.query_tag_commits(test_dir, TAG_VERSION_PATTERN)
+    self.assertEquals(want_tags, have_tags)
+
+    got = check_subprocess('git -C "{dir}" remote -v'.format(dir=test_dir))
+
+    # Upstream repo is configured for pulls, but not for pushes.
+    self.assertEquals(
+        '\n'.join([
+            'origin\t{origin} (fetch)'.format(origin=origin_dir),
+            'origin\t{origin} (push)'.format(origin=origin_dir),
+            'upstream\t{upstream} (fetch)'.format(upstream=self.git_dir),
+            'upstream\tdisabled (push)'
+            ]),
+        got)
+
+    reference = git.determine_remote_git_repository(test_dir)
+    self.assertEquals(
+        RemoteGitRepository.make_from_url(
+            origin_dir,
+            upstream_ref=RemoteGitRepository.make_from_url(self.git_dir)),
+        reference)
+
+  def test_clone_branch(self):
+    test_parent = os.path.join(self.base_temp_dir, 'test_clone_branch')
+    os.makedirs(test_parent)
+
+    test_dir = os.path.join(test_parent, TEST_REPO_NAME)
+    self.git.clone_repository_to_path(
+        self.git_dir, test_dir, branch=BRANCH_A)
+    self.assertEquals(BRANCH_A,
+                      self.git.query_local_repository_branch(test_dir))
+
+  def test_branch_not_found_exception(self):
+    test_parent = os.path.join(self.base_temp_dir, 'test_bad_branch')
+    os.makedirs(test_parent)
+    test_dir = os.path.join(test_parent, TEST_REPO_NAME)
+    self.assertFalse(os.path.exists(test_dir))
+
+    branch = 'Bogus'
+    regexp = r"Branches \['{branch}'\] do not exist in {url}\.".format(
+        branch=branch, url=self.git_dir)
+
+    with self.assertRaisesRegexp(Exception, regexp):
+      self.git.clone_repository_to_path(
+          self.git_dir, test_dir, branch=branch)
+    self.assertFalse(os.path.exists(test_dir))
+
+  def test_clone_failure(self):
+    test_dir = os.path.join(
+        self.base_temp_dir, 'clone_failure', TEST_REPO_NAME)
+    os.makedirs(test_dir)
+    with open(os.path.join(test_dir, 'something'), 'w') as f:
+      f.write('not empty')
+
+    regexp = '.* clone .*'
+    with self.assertRaisesRegexp(Exception, regexp):
+      self.git.clone_repository_to_path(
+          self.git_dir, test_dir, branch='master')
+
+  def test_default_branch(self):
+    test_parent = os.path.join(self.base_temp_dir, 'test_default_branch')
+    os.makedirs(test_parent)
+    test_dir = os.path.join(test_parent, TEST_REPO_NAME)
+
+    self.git.clone_repository_to_path(
+        self.git_dir, test_dir, branch='Bogus', default_branch=BRANCH_B)
+    self.assertEquals(BRANCH_B,
+                      self.git.query_local_repository_branch(test_dir))
+
+
+class TestSemanticVersion(unittest.TestCase):
+  def test_semver_make_valid(self):
+    tests = [('simple-1.0.0', SemanticVersion('simple', 1, 0, 0)),
+             ('another-10.11.12', SemanticVersion('another', 10, 11, 12))]
+    for tag, expect in tests:
+      semver = SemanticVersion.make(tag)
+      self.assertEquals(semver, expect)
+      self.assertEquals(tag, semver.to_tag())
+      self.assertEquals(tag[tag.rfind('-') + 1:], semver.to_version())
+
+  def test_semver_next(self):
+    semver = SemanticVersion('A', 1, 2, 3)
+    tests = [
+        (SemanticVersion.TAG_INDEX, SemanticVersion('B', 1, 2, 3), None),
+        (None, SemanticVersion('A', 1, 2, 3), None),
+
+        (SemanticVersion.MAJOR_INDEX,
+         SemanticVersion('A', 2, 2, 3),
+         SemanticVersion('A', 2, 0, 0)),  # next major index to semver
+
+        (SemanticVersion.MINOR_INDEX,
+         SemanticVersion('A', 1, 3, 3),
+         SemanticVersion('A', 1, 3, 0)),  # next minor index to semver
+
+        (SemanticVersion.PATCH_INDEX,
+         SemanticVersion('A', 1, 2, 4),
+         SemanticVersion('A', 1, 2, 4)),  # next patch index to semver
+    ]
+    for expect_index, test, next_semver in tests:
+      self.assertEquals(expect_index, semver.most_significant_diff_index(test))
+      self.assertEquals(expect_index, test.most_significant_diff_index(semver))
+      if expect_index is not None and expect_index > SemanticVersion.TAG_INDEX:
+        self.assertEquals(next_semver, semver.next(expect_index))
+
+
+class TestCommitMessage(unittest.TestCase):
+  PATCH_BRANCH = 'patch_branch'
+  MINOR_BRANCH = 'minor_branch'
+  MAJOR_BRANCH = 'major_branch'
+  MERGED_BRANCH = 'merged_branch'
+
+  @classmethod
+  def run_git(cls, command):
+    return check_subprocess(
+        'git -C "{dir}" {command}'.format(dir=cls.git_dir, command=command))
+
+  @classmethod
+  def setUpClass(cls):
+    cls.git = GitRunner()
+    cls.base_temp_dir = tempfile.mkdtemp(prefix='git_test')
+    cls.git_dir = os.path.join(cls.base_temp_dir, 'commit_message_test')
+    os.makedirs(cls.git_dir)
+
+    git_dir = cls.git_dir
+    gitify = lambda args: 'git -C "{dir}" {args}'.format(dir=git_dir, args=args)
+    check_subprocess_sequence([
+        gitify('init'),
+        'touch "{dir}/base_file"'.format(dir=git_dir),
+        gitify('add "{dir}/base_file"'.format(dir=git_dir)),
+        gitify('commit -a -m "feat(test): added file"'),
+        gitify('tag {base_version} HEAD'.format(base_version=VERSION_BASE)),
+        gitify('checkout -b {patch_branch}'.format(
+            patch_branch=cls.PATCH_BRANCH)),
+        'touch "{dir}/patch_file"'.format(dir=git_dir),
+        gitify('add "{dir}/patch_file"'.format(dir=git_dir)),
+        gitify('commit -a -m "fix(testA): added patch_file"'),
+        gitify('checkout -b {minor_branch}'.format(
+            minor_branch=cls.MINOR_BRANCH)),
+        'touch "{dir}/minor_file"'.format(dir=git_dir),
+        gitify('add "{dir}/minor_file"'.format(dir=git_dir)),
+        gitify('commit -a -m "chore(testB): added minor_file"'),
+        gitify('checkout -b {major_branch}'.format(
+            major_branch=cls.MAJOR_BRANCH)),
+        'touch "{dir}/major_file"'.format(dir=git_dir),
+        gitify('add "{dir}/major_file"'.format(dir=git_dir)),
+        gitify('commit -a -m'
+               ' "feat(testC): added major_file\n'
+               '\nInterestingly enough, this is a BREAKING CHANGE.'
+               '"'),
+        gitify('checkout -b {merged_branch}'.format(
+            merged_branch=cls.MERGED_BRANCH)),
+        gitify('reset --hard HEAD~3'),
+        gitify('merge --squash HEAD@{1}')
+    ])
+    env = dict(os.environ)
+    if os.path.exists('/bin/true'):
+      env['EDITOR'] = '/bin/true'
+    elif os.path.exists('/usr/bin/true'):
+      env['EDITOR'] = '/usr/bin/true'
+    else:
+      raise NotImplementedError('platform not supported for this test')
+    check_subprocess('git -C "{dir}" commit'.format(dir=git_dir), env=env)
+
+  @classmethod
+  def tearDownClass(cls):
+    shutil.rmtree(cls.base_temp_dir)
+
+  def setUp(self):
+    self.run_git('checkout master'.format(dir=self.git_dir))
+
+  def test_merged_branch(self):
+    git = self.git
+    all_tags = git.query_tag_commits(self.git_dir, TAG_VERSION_PATTERN)
+    self.run_git('checkout {branch}'.format(branch=self.MERGED_BRANCH))
+    commit_id = git.query_local_repository_commit_id(self.git_dir)
+    tag, messages = git.query_local_repository_commits_to_existing_tag_from_id(
+        self.git_dir, commit_id, all_tags)
+    self.assertEqual(1, len(messages))
+    normalized_messages = CommitMessage.normalize_message_list(messages)
+    self.assertEqual(3, len(normalized_messages))
+
+    expected_messages = [
+        (' '*4 + 'feat(testC): added major_file\n'
+         '\n' + ' '*4 + 'Interestingly enough, this is a BREAKING CHANGE.'),
+        ' '*4 + 'chore(testB): added minor_file',
+        ' '*4 + 'fix(testA): added patch_file'
+    ]
+
+    prototype = messages[0]
+    for index, msg in enumerate(normalized_messages):
+      self.assertEqual(prototype.author, msg.author)
+      self.assertEqual(expected_messages[index], msg.message)
+
+      # The dates might be off by one sec because of roundoff with
+      # the sequential commits. Typically the times will be the same
+      # but we check for the drift explicitly so the assertion failure
+      # would make more sense should it be neither.
+      prototype_date = dateutil.parser.parse(prototype.date)
+      msg_date = dateutil.parser.parse(msg.date)
+      one_sec = datetime.timedelta(0, 1)
+      if msg_date + one_sec != prototype_date:
+        self.assertEqual(prototype.date, msg.date)
+
+  def test_message_analysis(self):
+    # pylint: disable=line-too-long
+    git = self.git
+    all_tags = git.query_tag_commits(self.git_dir, TAG_VERSION_PATTERN)
+
+    tests = [(self.MAJOR_BRANCH, SemanticVersion.MAJOR_INDEX),
+             (self.MINOR_BRANCH, SemanticVersion.MINOR_INDEX),
+             (self.PATCH_BRANCH, SemanticVersion.PATCH_INDEX)]
+    for branch, expect in tests:
+      self.run_git('checkout {branch}'.format(branch=branch))
+      commit_id = git.query_local_repository_commit_id(self.git_dir)
+      tag, messages = git.query_local_repository_commits_to_existing_tag_from_id(
+          self.git_dir, commit_id, all_tags)
+      self.assertEquals(
+          expect,
+          CommitMessage.determine_semver_implication_on_list(
+              messages,
+              major_regexs=CommitMessage.DEFAULT_MAJOR_REGEXS,
+              minor_regexs=CommitMessage.DEFAULT_MINOR_REGEXS,
+              patch_regexs=CommitMessage.DEFAULT_PATCH_REGEXS))
+      self.assertEquals(
+          expect,
+          CommitMessage.determine_semver_implication_on_list(
+              sorted(messages, reverse=True),
+              major_regexs=CommitMessage.DEFAULT_MAJOR_REGEXS,
+              minor_regexs=CommitMessage.DEFAULT_MINOR_REGEXS,
+              patch_regexs=CommitMessage.DEFAULT_PATCH_REGEXS))
+
+
+class TestRepositorySummary(unittest.TestCase):
+  def test_to_yaml(self):
+    summary = RepositorySummary(
+        'abcd1234', 'mytag-987', '0.0.1',
+        [CommitMessage('commit-abc', 'author', 'date', 'commit message')])
+
+    expect = """commit_id: {id}
+tag: {tag}
+version: {version}
+""".format(id=summary.commit_id, tag=summary.tag, version=summary.version)
+    self.assertEquals(expect, summary.to_yaml(with_commit_messages=False))
+
+
+if __name__ == '__main__':
+  import logging
+  logging.basicConfig(
+      format='%(levelname).1s %(asctime)s.%(msecs)03d %(message)s',
+      datefmt='%H:%M:%S',
+      level=logging.DEBUG)
+
+  unittest.main(verbosity=2)

--- a/unittest/buildtool/util_test.py
+++ b/unittest/buildtool/util_test.py
@@ -1,0 +1,143 @@
+# Copyright 2017 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=missing-docstring
+
+import datetime
+import logging
+import os
+import shutil
+import tempfile
+import unittest
+
+import buildtool.util
+
+
+class TestRunner(unittest.TestCase):
+  @classmethod
+  def setUpClass(cls):
+    cls.base_temp_dir = tempfile.mkdtemp(prefix='buildtool.util_test')
+
+  @classmethod
+  def tearDownClass(cls):
+    shutil.rmtree(cls.base_temp_dir)
+
+  def do_run_subprocess_ok(self, check):
+    if os.path.exists('/bin/true'):
+      true_path = '/bin/true'
+    elif os.path.exists('/usr/bin/true'):
+      true_path = '/usr/bin/true'
+    else:
+      raise NotImplementedError('Unsupported test platform.')
+
+    tests = [(true_path, ''),
+             ('/bin/echo Hello', 'Hello'),
+             ('/bin/echo "Hello"', 'Hello'),
+             ('/bin/echo "Hello World"', 'Hello World'),
+             ('/bin/echo "Hello\nWorld"', 'Hello\nWorld'),
+             ('/bin/echo \'"Hello World"\'', '"Hello World"')]
+    for cmd, expect in tests:
+      if check:
+        output = buildtool.util.check_subprocess(cmd)
+      else:
+        code, output = buildtool.util.run_subprocess(cmd)
+        self.assertEquals(0, code)
+
+      self.assertEquals(expect, output)
+
+  def test_run_subprocess_ok(self):
+    self.do_run_subprocess_ok(False)
+
+  def test_check_subprocess_ok(self):
+    self.do_run_subprocess_ok(False)
+
+  def test_run_subprocess_fail(self):
+    if os.path.exists('/bin/false'):
+      false_path = '/bin/false'
+    elif os.path.exists('/usr/bin/false'):
+      false_path = '/usr/bin/false'
+    else:
+      raise NotImplementedError('Unsupported test platform.')
+
+    got, output = buildtool.util.run_subprocess(false_path)
+    self.assertEquals((1, ''), (got, output))
+
+    got, output = buildtool.util.run_subprocess('/bin/ls /abc/def')
+    self.assertNotEquals(0, got)
+    self.assertTrue(output.find('No such file or directory') >= 0)
+
+  def test_check_subprocess_fail(self):
+    if os.path.exists('/bin/false'):
+      false_path = '/bin/false'
+    elif os.path.exists('/usr/bin/false'):
+      false_path = '/usr/bin/false'
+    else:
+      raise NotImplementedError('Unsupported test platform.')
+
+    tests = [false_path, '/bin/ls /abc/def']
+    for test in tests:
+      with self.assertRaises(Exception) as ex:
+        buildtool.util.check_subprocess(test)
+      self.assertTrue(hasattr(ex.exception, 'logged'))
+
+  def test_run_subprocess_get_pid(self):
+    # See if we can run a job by looking up our job
+    # This is also testing parsing command lines.
+    code, output = buildtool.util.run_subprocess('/bin/ps -f')
+    self.assertEquals(0, code)
+    my_pid = ' %d ' % os.getpid()
+    candidates = [line for line in output.split('\n') if line.find(my_pid) > 0]
+    if len(candidates) != 1:
+      logging.error('Unexpected output\n%s', output)
+    self.assertEquals(1, len(candidates))
+    self.assertTrue(candidates[0].find(' python ') > 0)
+
+  def test_ensure_dir(self):
+    want = os.path.join(self.base_temp_dir, 'ensure', 'a', 'b', 'c')
+    self.assertFalse(os.path.exists(want))
+    buildtool.util.ensure_dir_exists(want)
+    self.assertTrue(os.path.exists(want))
+
+    # Ok if already exists
+    buildtool.util.ensure_dir_exists(want)
+    self.assertTrue(os.path.exists(want))
+
+  def test_write_to_path(self):
+    path = os.path.join(self.base_temp_dir, 'test_write', 'file')
+    content = 'First Line\nSecond Line'
+    buildtool.util.write_to_path(content, path)
+    with open(path, 'r') as f:
+      self.assertEquals(content, f.read())
+
+  def test_deltatime_string(self):
+    timedelta = datetime.timedelta
+    tests = [
+        (timedelta(1, 60 * 60 * 4 + 60 * 5 + 2, 123456), 'days=1 + 04:05:02'),
+        (timedelta(1, 60 * 5 + 2, 123456), 'days=1 + 00:05:02'),
+        (timedelta(1, 2, 123456), 'days=1 + 00:00:02'),
+        (timedelta(0, 60 * 60 * 4 + 60 * 5 + 2, 123456), '04:05:02'),
+        (timedelta(0, 60 * 5 + 2, 123456), '05:02'),
+        (timedelta(0, 2, 123456), '2.123 secs')
+    ]
+    for test in tests:
+      self.assertEquals(test[1], buildtool.util.timedelta_string(test[0]))
+
+
+if __name__ == '__main__':
+  logging.basicConfig(
+      format='%(levelname).1s %(asctime)s.%(msecs)03d %(message)s',
+      datefmt='%H:%M:%S',
+      level=logging.DEBUG)
+
+  unittest.main(verbosity=2)

--- a/unittest/run_tests.sh
+++ b/unittest/run_tests.sh
@@ -10,7 +10,7 @@ cd $TEST_DIR/../..
 passed_tests=()
 failed_tests=()
 
-for test in `cd $TEST_DIR; ls *_test.py`; do
+for test in `cd $TEST_DIR; find . -name \*_test.py -print`; do
   echo "Running $test"
   PYTHONPATH=$TEST_DIR/../pylib:$TEST_DIR/../dev python $TEST_DIR/$test
   
@@ -26,7 +26,7 @@ if [[ ${#failed_tests[@]} -eq 0 ]]; then
   exit 0
 fi
 
->&2 echo "FAILED ${#failed_tests[@]} TESTS"
+>&2 echo "FAILED ${#failed_tests[@]} TESTS from $TEST_DIR"
 for test in ${failed_tests[@]}; do
     >&2 echo "FAILED: $test"
 done


### PR DESCRIPTION
@jtk54, @brandonnelson3 

This is the first in a series of PRs for the refactoring I've been working on.

This PR is a git module to handle the git commands. It also includes a "utility" module with helper functions shared across the buildtool package modules. This includes replacement functions for the spinnaker/pylib/run so we should soon be able to delete the entire spinnaker/pylib directory now that halyard can run from source.

I see in the release publishing operations (which I havent gotten to) there's an explicit git client library that's used to manage the credentials needed there. I'll probably refactor this again to be in terms of that after I take a look at it, however I want to get all the basic foundation I have in first.

The commands coded in here are pretty much scraped from the existing scripts which were not using that client library. It's just the code structure, programming model and organization that's different.