### PR TITLE
feat(buildtool): buildtool.source_code_manager module

### DIFF
--- a/dev/buildtool/source_code_manager.py
+++ b/dev/buildtool/source_code_manager.py
@@ -1,0 +1,294 @@
+# Copyright 2017 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Responsible for managing the source code that we are building.
+
+This includes fetching the source to be built as well as manipulating
+the git repositories for tagging and annotations.
+"""
+
+# Ideally something like a Pool is better because it will run in
+# different processes to bypass some of the global interpreter lock.
+# However because we often run commands in these, which forks another process,
+# we seem to deadlock sometimes (always when running gradle). I think this
+# could be because this pool fork has some locks grabbed which leads to
+# deadlock when something is trying to grab a lock that was already locked
+# at the point of the first fork. This doesnt really make sense because it
+# only happens with gradle and not with git, and the gradle jobs do complete
+# in the pool'd thread so at that point there shouldnt be a difference between
+# them. So maybe something else is going on in the build command.
+
+from multiprocessing.pool import (
+    Pool,
+    ThreadPool)
+
+import logging
+import os
+import yaml
+
+# pylint: disable=relative-import
+from buildtool.git import RemoteGitRepository
+from buildtool.util import (
+    check_subprocess,
+    ensure_dir_exists)
+
+
+def __new_spinnaker_git_repo(name):
+  return RemoteGitRepository.make_from_url(
+      'https://github.com/spinnaker/%s' % name)
+
+def _new_google_git_repo(name):
+  return RemoteGitRepository.make_from_url(
+      'https://github.com/google/%s' % name)
+
+
+# These would be required if running from source code
+SPINNAKER_RUNNABLE_REPOSITORIES = {
+    repo.name: repo for repo in [
+        __new_spinnaker_git_repo('clouddriver'),
+        __new_spinnaker_git_repo('deck'),
+        __new_spinnaker_git_repo('echo'),
+        __new_spinnaker_git_repo('fiat'),
+        __new_spinnaker_git_repo('front50'),
+        __new_spinnaker_git_repo('gate'),
+        __new_spinnaker_git_repo('igor'),
+        __new_spinnaker_git_repo('orca'),
+        __new_spinnaker_git_repo('rosco')
+    ]
+}
+
+# These would be required if specifying a BOM or building from one
+SPINNAKER_BOM_REPOSITORIES = {
+    repo.name: repo for repo in [
+        __new_spinnaker_git_repo('spinnaker'),
+        __new_spinnaker_git_repo('spinnaker-monitoring')
+    ]
+}
+SPINNAKER_BOM_REPOSITORIES.update(SPINNAKER_RUNNABLE_REPOSITORIES)
+
+
+# These would be required for testing a deployment
+SPINNAKER_TESTING_REPOSITORIES = {
+    repo.name: repo for repo in [
+        __new_spinnaker_git_repo('spinnaker'),
+        _new_google_git_repo('citest'),
+    ]
+}
+
+SPINNAKER_HALYARD_REPOSITORIES = {
+    'halyard': __new_spinnaker_git_repo('halyard')
+}
+
+
+class RepositoryWorker(object):
+  """A picklable callable for passing to inter-process mappers."""
+  # pylint: disable=too-few-public-methods
+
+  def __init__(self, fn, *pargs, **kwargs):
+    """ Constructor
+
+    Args:
+      fn: [callable] might need to be picklable depending on use case.
+         The first argument to fn should be a SourceRepository which will
+         be injected by the call() method.
+      pargs: [list] additional positional args required by fn
+      kwargs: [kwargs] keyword args to passthrough to fn
+    """
+    self.__fn = fn
+    self.__pargs = pargs
+    self.__kwargs = kwargs
+
+  def __call__(self, repository):
+    """Call the bound function with the repository plus bound args."""
+    name = repository.name
+    return name, self.__fn(repository, *self.__pargs, **self.__kwargs)
+
+
+class SpinnakerSourceCodeManager(object):
+  """Helper class for managing spinnaker source code repositories."""
+
+  @property
+  def git(self):
+    """The git controller for issuing git commands."""
+    return self.__git
+
+  @property
+  def root_path(self):
+    """The base directory for all the individual repositories being managed.
+
+    Each repository will be a child directory of this path.
+    """
+    return self.__root_path
+
+  @property
+  def source_repositories(self):
+    """Return the bound GitRemoteRepositories
+
+    This is a dictionary {<name>: <RemoteGitRepository>}
+    """
+    return self.__source_repositories
+
+  def __init__(self, git, root_path, source_repositories, **kwargs):
+    if not git:
+      raise ValueError('No git controller provided.')
+    if not root_path:
+      raise ValueError('No root_path provied.')
+    if not source_repositories:
+      raise ValueError('No source_repositories were provided.')
+    self.__git = git
+    self.__root_path = root_path
+    self.__source_repositories = source_repositories
+    self.__max_threads = kwargs.pop('max_threads', 100)
+    self.__add_upstream = kwargs.pop('attach_upstream', False)
+    if kwargs:
+      raise ValueError('Unexpected arguments: {}'.format(kwargs.keys()))
+
+  def get_local_repository_path(self, repository_name):
+    """Returns the path to the desired local repository directory."""
+    return os.path.join(self.__root_path, repository_name)
+
+  def bom_from_path(self, path):
+    """Load a BOM from a file."""
+    logging.debug('Loading bom from %s', path)
+    with open(path, 'r') as f:
+      bom_yaml_string = f.read()
+    return yaml.load(bom_yaml_string)
+
+  def bom_from_version(self, version):
+    """Load a BOM from halyard."""
+    logging.debug('Loading bom version %s', version)
+    bom_yaml_string = check_subprocess(
+        'hal version bom {0} --color false --quiet'
+        .format(version), echo=False)
+    return yaml.load(bom_yaml_string)
+
+  def maybe_pull_repository_source(
+      self, repository,
+      bom_version=None, bom_path=None,
+      git_branch=None, default_branch=None):
+    """Pull the source as specified, if it was specified."""
+    # pylint: disable=too-many-arguments
+
+    pull_version = 1 if bom_version else 0
+    pull_path = 1 if bom_path else 0
+    pull_branch = 1 if git_branch else 0
+    have = pull_version + pull_path + pull_branch
+    if have == 0:
+      logging.debug('No source pull requests to process.')
+      return
+
+    if have > 1:
+      raise ValueError('Ambiguous source code requests.')
+
+    if default_branch and not git_branch:
+      raise ValueError('A default_branch requires a git_branch')
+
+    git_dir = self.get_local_repository_path(repository.name)
+    if os.path.exists(git_dir):
+      message = '%s already exists. Cannot pull source.' % git_dir
+      logging.error(message)
+      raise ValueError(message)
+
+    logging.info('Pulling %s to %s', repository.url, git_dir)
+    ensure_dir_exists(os.path.dirname(git_dir))
+
+    if git_branch:
+      self.git.clone_repository_to_path(
+          repository.url, git_dir,
+          branch=git_branch, default_branch=default_branch)
+    else:
+      if bom_version:
+        bom = self.bom_from_version(bom_version)
+      else:
+        bom = self.bom_from_path(bom_path)
+      self.pull_source_from_bom(repository.name, git_dir, bom)
+
+  def pull_source_from_bom(self, repository_name, git_dir, bom):
+    """Pull the source for a particular repository name from a bom."""
+    if repository_name in ('monitoring-daemon', 'monitoring-third-party'):
+      repository_name = 'spinnaker-monitoring'
+
+    spec = bom['services'][repository_name]
+    commit = spec['commit']
+    version = spec['version']
+
+    git_tag = 'version-{}'.format(version[:version.index('-')])
+
+    # We're creating a local repo containing only the commit and tag.
+    # The reason for this is because nebula gets confused by our tags
+    # and wants to only use the latest Netflix tag, which is wrong.
+    # If we could control nebula, we wouldnt need to wipe the repo and
+    # add a new one, but we'd still need to add the new tag to ensure it
+    # exists because the bom may not have been pushed.
+    if os.path.exists(git_dir):
+      return None
+
+    base_url = bom['artifactSources']['gitPrefix']
+    origin_url = spec.get(
+        'sourceRepository',
+        '{base}/{name}'.format(base=base_url, name=repository_name))
+    branch = spec.get(
+        'sourceBranch',
+        bom['artifactSources'].get('gitBranch', '(unknown)'))
+
+    self.__git.clone_repository_to_path(origin_url, git_dir, commit=commit)
+    self.__git.reinit_local_repository_with_tag(
+        git_dir, git_tag,
+        'Repository snapshot from BOM\n'
+        '\ncommit={commit}\nurl={url}\nbranch={branch}'.format(
+            commit=commit, url=origin_url, branch=branch))
+
+  def foreach_source_repository(
+      self, call_function, *posargs, **kwargs):
+    """Call the function on each of the SourceRepository instances."""
+    use_threadpool = kwargs.pop('use_threadpool', False)
+
+    worker = RepositoryWorker(call_function, *posargs, **kwargs)
+    all_repos = self.__source_repositories
+    num_threads = min(self.__max_threads, len(all_repos))
+    if num_threads > 1:
+      if True or use_threadpool:
+        pool = ThreadPool(num_threads)
+      else:
+        pool = Pool(num_threads, maxtasksperchild=1)
+      logging.info('Mapping with %s %d/%s',
+                   pool.__class__,
+                   len(all_repos.keys()), all_repos.keys())
+      try:
+        raw_list = pool.map(worker, all_repos.values())
+        result = {name: value for name, value in raw_list}
+      except Exception:
+        logging.error('Map caught exception')
+        raise
+      logging.info('Finished mapping')
+      pool.terminate()
+    else:
+      # If we have only one thread, skip the pool
+      # this is primarily to make debugging easier.
+      result = {
+          name: worker(repository)[1]
+          for name, repository in all_repos.items()
+      }
+    return result
+
+  def push_to_origin_if_not_upstream(self, repository, branch):
+    """Push the local repository back to the origin, but not upstream."""
+    git_dir = self.get_local_repository_path(repository.name)
+    origin = repository.url
+    upstream = repository.upstream_url
+    if origin == upstream:
+      logging.warning('Skipping push origin %s because origin is upstream.',
+                      repository.name)
+      return
+    self.__git.push_branch_to_origin(git_dir, branch)

--- a/unittest/buildtool/source_code_manager_test.py
+++ b/unittest/buildtool/source_code_manager_test.py
@@ -1,0 +1,201 @@
+# Copyright 2017 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=missing-docstring
+# pylint: disable=invalid-name
+
+import os
+import shutil
+import tempfile
+import unittest
+
+from buildtool.git import (
+    GitRunner,
+    RemoteGitRepository,
+    SemanticVersion)
+from buildtool.source_code_manager import SpinnakerSourceCodeManager
+from buildtool.util import check_subprocess_sequence
+
+
+SCM_USER = 'scm_user'
+TEST_USER = 'test_user'
+
+BASE_VERSION = 'version-7.8.9'
+UNTAGGED_BRANCH = 'untagged-branch'
+
+
+def _foreach_func(repository, *pos_args, **kwargs):
+  return (repository, list(pos_args), dict(kwargs))
+
+
+class TestSourceCodeManager(unittest.TestCase):
+  @classmethod
+  def setUpClass(cls):
+    cls.git = GitRunner()
+    cls.base_temp_dir = tempfile.mkdtemp(prefix='scm_test')
+    origin_root = os.path.join(cls.base_temp_dir, 'origin_repos')
+
+    repository_list = [
+        RemoteGitRepository.make_from_url(url)
+        for url in [
+            os.path.join(origin_root, SCM_USER, 'RepoOne'),
+            os.path.join(origin_root, SCM_USER, 'RepoTwo'),
+            os.path.join(origin_root, TEST_USER, 'RepoTest')]
+    ]
+
+    cls.TEST_SOURCE_REPOSITORIES = {
+        repo.name: repo
+        for repo in repository_list
+    }
+
+    for repo in repository_list:
+      os.makedirs(repo.url)
+      base_file = os.path.join(
+          repo.url, '{name}-base.txt'.format(name=repo.name))
+      unique_file = os.path.join(
+          repo.url, '{name}-unique.txt'.format(name=repo.name))
+      untagged_file = os.path.join(
+          repo.url, '{name}-untagged.txt'.format(name=repo.name))
+
+      logging.debug('Initializing repository %s', repo.url)
+      git_prefix = 'git -C "{dir}" '.format(dir=repo.url)
+      run_git = lambda cmd: git_prefix + cmd
+
+      check_subprocess_sequence([
+          # BASE_VERSION
+          'touch "{file}"'.format(file=base_file),
+          run_git(' init'),
+          run_git('add "{file}"'.format(
+              file=os.path.basename(base_file))),
+          run_git('commit -a -m "feat(first): first commit"'),
+          run_git('tag {base_version} HEAD'.format(
+              base_version=BASE_VERSION)),
+
+          # Add Unique branch name per repo
+          run_git('checkout -b {name}-branch'.format(name=repo.name)),
+          'touch "{file}"'.format(file=unique_file),
+          run_git('add "{file}"'.format(file=os.path.basename(unique_file))),
+          run_git('commit -a -m "chore(uniq): unique commit"'),
+
+          # Add a common branch name, but without a tag on HEAD
+          run_git('checkout master'),
+          run_git('checkout -b {branch}'
+                  .format(branch=UNTAGGED_BRANCH)),
+          'touch "{file}"'.format(file=untagged_file),
+          run_git('add "{file}"'.format(
+              file=os.path.basename(untagged_file))),
+          run_git('commit -a -m "chore(uniq): untagged commit"'),
+          run_git('checkout master')
+          ])
+
+  @classmethod
+  def tearDownClass(cls):
+    shutil.rmtree(cls.base_temp_dir)
+
+  def test_get_local_repository_path(self):
+    test_root = os.path.join(self.base_temp_dir, 'unused_source')
+    scm = SpinnakerSourceCodeManager(
+        self.git, test_root, self.TEST_SOURCE_REPOSITORIES)
+
+    tests = ['RepoOne', 'RepoTwo', 'RepoTest', 'DoesNotExist']
+    for repo_name in tests:
+      expect = os.path.join(test_root, repo_name)
+      self.assertEquals(expect,
+                        scm.get_local_repository_path(repo_name))
+      self.assertFalse(os.path.exists(expect))
+
+  def test_maybe_pull_unknown_branch(self):
+    test_root = os.path.join(self.base_temp_dir, 'unknown_branch')
+    git = self.git
+    scm = SpinnakerSourceCodeManager(
+        git, test_root, self.TEST_SOURCE_REPOSITORIES)
+
+    repository = self.TEST_SOURCE_REPOSITORIES['RepoOne']
+    branch = 'XYZ'
+    regexp = r"Branches \['{branch}'\] do not exist in {url}\.".format(
+        branch=branch, url=repository.url)
+
+    with self.assertRaisesRegexp(Exception, regexp):
+      scm.maybe_pull_repository_source(repository, git_branch=branch)
+
+  def test_maybe_pull_repository_branch(self):
+    test_root = os.path.join(self.base_temp_dir, 'pulled_test')
+    git = self.git
+    scm = SpinnakerSourceCodeManager(
+        git, test_root, self.TEST_SOURCE_REPOSITORIES)
+
+    for repository in self.TEST_SOURCE_REPOSITORIES.values():
+      scm.maybe_pull_repository_source(
+          repository, git_branch=UNTAGGED_BRANCH)
+      git_dir = scm.get_local_repository_path(repository.name)
+
+      remote_git = git.determine_remote_git_repository(
+          git_dir)
+      self.assertEquals(repository, remote_git)
+
+      in_branch = git.query_local_repository_branch(git_dir)
+      self.assertEquals(UNTAGGED_BRANCH, in_branch)
+
+      summary = git.collect_repository_summary(git_dir)
+      semver = SemanticVersion.make(BASE_VERSION)
+      expect_version = semver.next(
+          SemanticVersion.MINOR_INDEX).to_version()
+
+      self.assertEquals(expect_version, summary.version)
+
+  def test_pull_repository_fallback_branch(self):
+    test_root = os.path.join(self.base_temp_dir, 'fallback_test')
+    git = self.git
+    scm = SpinnakerSourceCodeManager(
+        git, test_root, self.TEST_SOURCE_REPOSITORIES)
+
+    unique_branch = 'RepoTwo-branch'
+    for repository in self.TEST_SOURCE_REPOSITORIES.values():
+      scm.maybe_pull_repository_source(
+          repository,
+          git_branch=unique_branch,
+          default_branch='master')
+      git_dir = scm.get_local_repository_path(repository.name)
+      want_branch = (unique_branch
+                     if repository.name == 'RepoTwo'
+                     else 'master')
+      in_branch = git.query_local_repository_branch(git_dir)
+      self.assertEquals(want_branch, in_branch)
+
+  def test_foreach_repo(self):
+    test_root = os.path.join(self.base_temp_dir, 'foreach_test')
+    git = self.git
+    pos_args = [1, 2, 3]
+    kwargs = {'a': 'A', 'b': 'B'}
+
+    expect = {
+        repository.name: (repository, pos_args, kwargs)
+        for repository in self.TEST_SOURCE_REPOSITORIES.values()
+    }
+
+    scm = SpinnakerSourceCodeManager(
+        git, test_root, self.TEST_SOURCE_REPOSITORIES)
+    got = scm.foreach_source_repository(
+        _foreach_func, *pos_args, **kwargs)
+    self.assertEquals(expect, got)
+
+
+if __name__ == '__main__':
+  import logging
+  logging.basicConfig(
+      format='%(levelname).1s %(asctime)s.%(msecs)03d %(message)s',
+      datefmt='%H:%M:%S',
+      level=logging.INFO)
+
+  unittest.main(verbosity=2)

--- a/unittest/buildtool/util_test.py
+++ b/unittest/buildtool/util_test.py
@@ -97,7 +97,8 @@ class TestRunner(unittest.TestCase):
     code, output = buildtool.util.run_subprocess('/bin/ps -f')
     self.assertEquals(0, code)
     my_pid = ' %d ' % os.getpid()
-    candidates = [line for line in output.split('\n') if line.find(my_pid) > 0]
+    candidates = [line for line in output.split('\n')
+                  if line.find(my_pid) > 0 and line.find('/bin/ps') < 0]
     if len(candidates) != 1:
       logging.error('Unexpected output\n%s', output)
     self.assertEquals(1, len(candidates))


### PR DESCRIPTION
@jtk54, @brandonnelson3 

The second PR in the sequence adds source code management.
This is mostly to define the different spinnaker repositories and manage concurrency operating across them.

The weird nebula mirrored source code management is actually in the build module because it feels like a hack that I'm trying to hide where it is needed rather than institutionalize it here. That might prove to be a mistake later, but is how I feel at the moment. 