### PR TITLE
fix(build_release): remove exclude html gen tests flag for orca

### DIFF
--- a/dev/build_release.py
+++ b/dev/build_release.py
@@ -233,10 +233,8 @@ class Builder(object):
             (name == 'deck' and not 'CHROME_BIN' in os.environ)):
       extra_args.append('-x test')
 
-    if name == 'orca':
-      extra_args.append('-x generateHtmlTestReports')
-      if not options.run_unit_tests:
-        extra_args.append('-x junitPlatformTest')
+    if name == 'orca' and not options.run_unit_tests:
+      extra_args.append('-x junitPlatformTest')
 
     if name == 'halyard':
       extra_args.append('-PbintrayPackageDebDistribution=trusty-nightly')


### PR DESCRIPTION
@ewiseblatt or @jtk54 or @duftler 

Orca doesn't have a `generateHtmlTestReports` task anymore (even though this is a flag to not run the task), which is why the build has been failing.