### PR TITLE
chore(buildtool): Various tweaks

### DIFF
--- a/dev/buildtool/build_commands.py
+++ b/dev/buildtool/build_commands.py
@@ -32,6 +32,7 @@ from buildtool.source_code_manager import (
 
 from buildtool.util import (
     check_subprocess,
+    determine_logfile_path,
     timedelta_string,
     timestring,
     check_subprocesses_to_logfile,
@@ -313,8 +314,7 @@ class GradleCommandProcessor(RepositoryCommandProcessor):
     cmd = './gradlew {extra} {target}'.format(
         extra=' '.join(extra_args), target=target)
 
-    logdir = os.path.join(options.scratch_dir, name)
-    logfile = os.path.join(logdir, '{name}-debian-build.log'.format(name=name))
+    logfile = determine_logfile_path(options, name, 'debian-build')
     check_subprocesses_to_logfile(
         '{name} gradle build'.format(name=name), logfile,
         [cmd], cwd=gradle_root)
@@ -415,7 +415,7 @@ class BuildHalyardCommand(GradleCommandProcessor):
     env['PUBLISH_HALYARD_DOCKER_IMAGE_BASE'] = options.halyard_docker_image_base
     env['PUBLISH_HALYARD_BUCKET_BASE_URL'] = options.halyard_bucket_base_url
 
-    logfile = os.path.join(options.scratch_dir, name, 'jar-build.log')
+    logfile = determine_logfile_path(options, name, 'jar-build')
     check_subprocesses_to_logfile(
         '{name} build'.format(name='halyard'), logfile,
         [cmd], cwd=nebula_repo_path, env=env)
@@ -538,8 +538,7 @@ class BuildContainerCommand(GradleCommandProcessor):
     ]
 
     gradle_root = self.determine_gradle_root(repository)
-    logfile = os.path.join(self.options.scratch_dir, name,
-                           '{name}-docker-build.log'.format(name=name))
+    logfile = determine_logfile_path(self.options, name, 'docker-build')
     check_subprocesses_to_logfile(
         '{name} docker build'.format(name=name), logfile,
         cmds, cwd=gradle_root)
@@ -594,8 +593,7 @@ class BuildContainerCommand(GradleCommandProcessor):
                    project=options.gcb_project,
                    config_path=config_path))
 
-    logfile = os.path.join(
-        name_scratch_dir, '{name}-gcb-build.log'.format(name=name))
+    logfile = determine_logfile_path(options, name, 'gcb-build')
     check_subprocesses_to_logfile(
         '{name} container build'.format(name=name), logfile,
         [cmd], cwd=nebula_dir)

--- a/dev/buildtool/command.py
+++ b/dev/buildtool/command.py
@@ -20,11 +20,18 @@ import logging
 # pylint: disable=relative-import
 from buildtool.git import GitRunner
 from buildtool.source_code_manager import SpinnakerSourceCodeManager
-from buildtool.util import maybe_log_exception
+from buildtool.util import (
+    add_parser_argument,
+    maybe_log_exception)
 
 
 class CommandFactory(object):
   """Abstract base class for CLI command injection."""
+
+  @staticmethod
+  def add_argument(parser, name, defaults, default_value, **kwargs):
+    """See buildtool.util.add_argument."""
+    add_parser_argument(parser, name, defaults, default_value, **kwargs)
 
   def register(self, registry, subparsers, defaults):
     """Registers a command factory.
@@ -42,21 +49,6 @@ class CommandFactory(object):
 
     factory.add_argparser(subparsers, defaults)
     registry[name] = factory
-
-  @staticmethod
-  def add_argument(parser, name, defaults, default_value, **kwargs):
-    """Helper function for adding parser.add_argument with a default value.
-
-    Args:
-      name: [string] The argument name is assumed optional, without '--' prefix.
-      defaults: [string] Dictionary of default value overrides keyed by name.
-      default_value: [any] The default value if not overriden.
-      kwargs: [kwargs] Additional kwargs for parser.add_argument
-    """
-    parser.add_argument(
-        '--{name}'.format(name=name),
-        default=defaults.get(name, default_value),
-        **kwargs)
 
   @property
   def name(self):

--- a/dev/buildtool/flow_generate.sh
+++ b/dev/buildtool/flow_generate.sh
@@ -54,7 +54,9 @@ function run_generate_flow() {
   start_command_unless NO_CONTAINERS "build_bom_containers"
   start_command_unless NO_CHANGELOG "generate_changelog"
   start_command_unless NO_BOM "generate_bom"
-  start_command_unless NO_APIDOCS "generate_api_docs"
+
+  # Allow a lot of time because machine is starved of resources at this point
+  start_command_unless NO_APIDOCS "generate_api_docs" --max_wait_secs_startup=90
 
   # Avoid a race condition where different jobs are git cloning into the
   # scratch directory
@@ -112,6 +114,10 @@ function process_args() {
           ;;
         --no_apidocs)
           NO_APIDOCS=true
+          ;;
+        --logs|--logs_dir)
+          LOGS_DIR=$1
+          shift
           ;;
         *)
           >&2 echo "Unexpeced argument '$key'"


### PR DESCRIPTION
Use build-specific bom_path
embed subprocess logfiles into parent log files on failure.
consolidate log files into a single directory, but copy out
failed subprocess log files to another error directory for ease
of surfacing them.

@jtk54 