### PR TITLE
chore(buildtool): implementation cleanup

### DIFF
--- a/dev/buildtool/__main__.py
+++ b/dev/buildtool/__main__.py
@@ -227,12 +227,32 @@ def main():
   return 0
 
 
+def dump_threads():
+  """Dump current threads to facilitate debugging possible deadlock.
+
+  A process did not exit when log file suggested it was. Maybe there was
+  a background thread it was joining on. If so, this might give a clue
+  should it happen again.
+  """
+  import threading
+  threads = []
+  for thread in threading.enumerate():
+    threads.append('  name={name} daemon={d} alive={a} id={id}'.format(
+        name=thread.name, d=thread.daemon, a=thread.is_alive(),
+        id=thread.ident))
+
+  logging.info('The following threads still running:\n%s', '\n'.join(threads))
+
+
 if __name__ == '__main__':
   # pylint: disable=broad-except
   try:
-    sys.exit(main())
+    retcode = main()
+    dump_threads()
+    sys.exit(retcode)
   except Exception as ex:
     sys.stdout.flush()
     maybe_log_exception('main()', ex, action_msg='Terminating')
     logging.error("FAILED")
+    dump_threads()
     sys.exit(-1)

--- a/dev/buildtool/apidocs_commands.py
+++ b/dev/buildtool/apidocs_commands.py
@@ -235,7 +235,7 @@ class GenerateApiDocsFactory(RepositoryCommandFactory):
   def _do_init_argparser(self, parser, defaults):
     """Implements CommandFactory interface."""
     self.add_argument(
-        parser, 'max_wait_secs_startup', defaults, 90, type=int,
+        parser, 'max_wait_secs_startup', defaults, 210, type=int,
         help='Number of seconds to wait for gate server to startup'
              ' before giving up and timing out.')
     self.add_argument(
@@ -250,7 +250,7 @@ class GenerateApiDocsFactory(RepositoryCommandFactory):
 
 
 class PublishApiDocsCommand(PullRequestCommandProcessor):
-  """Publish generated docs back up to the origin repository."""
+  """Publish generated docs back up to the ORIGIN repository."""
 
   def __init__(self, factory, options, **kwargs):
     super(PublishApiDocsCommand, self).__init__(
@@ -295,7 +295,7 @@ def register_commands(registry, subparsers, defaults):
   """Registers all the commands for this module."""
   publish_apidocs_factory = PullRequestCommandFactory(
       'publish_apidocs', PublishApiDocsCommand,
-      'Push apidocs to the spinnaker.github.io repository origin'
+      'Push apidocs to the spinnaker.github.io repository ORIGIN'
       ' and submit a Github Pull Request on it.')
 
   GenerateApiDocsFactory().register(registry, subparsers, defaults)

--- a/dev/buildtool/bom_commands.py
+++ b/dev/buildtool/bom_commands.py
@@ -21,6 +21,7 @@ import urllib2
 import yaml
 
 import buildtool.build_commands
+import buildtool.image_commands
 import buildtool.source_commands
 
 from buildtool.command import (
@@ -205,6 +206,7 @@ class GenerateBomCommandFactory(RepositoryCommandFactory):
     """Adds command-specific arguments."""
     super(GenerateBomCommandFactory, self)._do_init_argparser(parser, defaults)
     buildtool.build_commands.add_bom_parser_args(parser, defaults)
+    buildtool.image_commands.add_bom_parser_args(parser, defaults)
     buildtool.source_commands.FetchSourceCommandFactory.add_fetch_parser_args(
         parser, defaults)
 

--- a/dev/buildtool/build_commands.py
+++ b/dev/buildtool/build_commands.py
@@ -17,6 +17,7 @@
 import datetime
 import logging
 import os
+import re
 import shlex
 import shutil
 import subprocess
@@ -32,15 +33,101 @@ from buildtool.source_code_manager import (
 
 from buildtool.util import (
     check_subprocess,
+    check_subprocesses_to_logfile,
     determine_logfile_path,
+    ensure_dir_exists,
     timedelta_string,
     timestring,
-    check_subprocesses_to_logfile,
     write_to_path)
+
+
+class GradleMetricsUpdater(object):
+  """Collect gradle metrics, focusing on characterizing failures."""
+
+  def __init__(
+      self, metrics_repository, spinnaker_repository, gradle_context_name):
+    self.__metrics = metrics_repository
+    self.__name = spinnaker_repository.name
+    self.__context = gradle_context_name
+
+  def __call__(self, retcode, output):
+    """Update metrics considering the final return code and process output."""
+    labels = self.determine_labels(retcode, output)
+    self.__metrics.register_counter(
+        'GradleOutcome', 'Outcomes when running gradle', labels.keys())
+    counter = self.__metrics.counter('GradleOutcome', labels)
+    counter.inc()
+    return counter
+
+  def extract_failure_summary(self, retcode, output):
+    """Determine the top level failure message from gradle."""
+    summary_match = re.search(
+        "Execution failed for task '(.+)'.*\n", output, re.MULTILINE)
+    if not retcode or not summary_match:
+      return None, None
+
+    failed_task = summary_match.group(1)
+    remainder = output[summary_match.end(0):]
+    first_line = remainder[:remainder.find('\n')]
+    logging.debug('Instrumenting failure from after stdout %d - %d: %s',
+                  summary_match.start(0), summary_match.end(0), first_line)
+    return failed_task, first_line
+
+  def determine_labels(self, retcode, output):
+    """Determine label bindings for this outcome."""
+    labels = {
+        'repository': self.__name,
+        'context': self.__context,
+        'success': retcode == 0,
+        'failed_task': '',
+        'failed_by': '',
+        'failed_reason': ''
+    }
+    if retcode == 0:
+      return labels
+
+    failed_task, summary_line = self.extract_failure_summary(retcode, output)
+    self.update_failure_cause(labels, failed_task, summary_line)
+
+    return labels
+
+  def update_failure_cause(self, labels, failed_task, summary_line):
+    """Figure out the labels from the failure summary line."""
+
+    # This is an example of an error (wrapped from one to multiple lines
+    # for readability here. The ...jar was a long path to the bintray jar.
+    #
+    # > Could not upload to \
+    # 'https://api.bintray.com/content/...jar': HTTP/1.1 409 Conflict \
+    # [message:Unable to upload files: An artifact with the path \
+    # 'com/netflix/spinnaker/echo/echo-core/1.542.0/echo-core-1.542.0.jar' \
+    # already exists]
+
+    summary_match = re.match(
+        r"[> ]*(.*?)'(.+?)': HTTP/[0-9\.]+ ([0-9]{3}) ([\w]+)(.*)",
+        summary_line)
+    failed_by = 'unknown'
+    failed_reason = 'unknown'
+    if not summary_match:
+      logging.error('Cannot interpret cause of failure:\n%s', summary_line)
+    else:
+      # abstract = summary_match.group(1)
+      thing = summary_match.group(2)
+      abstract_http = summary_match.group(3)
+      # abstract_category = summary_match.group(4)
+      if thing.find('bintray.com') >= 0:
+        logging.debug('Counting another bintray failure.')
+        failed_by = 'bintray'
+      failed_reason = abstract_http
+
+    labels['failed_task'] = failed_task
+    labels['failed_by'] = failed_by
+    labels['failed_reason'] = failed_reason
 
 
 class GradleCommandFactory(RepositoryCommandFactory):
   """Base class for build commands using Gradle."""
+  # pylint: disable=too-few-public-methods
 
   @staticmethod
   def add_bom_parser_args(parser, defaults):
@@ -51,28 +138,13 @@ class GradleCommandFactory(RepositoryCommandFactory):
 
     GradleCommandFactory.add_argument(
         parser, 'build_bintray_repository', defaults, None,
-        help='bintray repository to publish debians into.')
+        help='bintray repository to publish packages and/or jars into.')
 
   def _do_init_argparser(self, parser, defaults):
     """Adds command-specific arguments."""
     super(GradleCommandFactory, self)._do_init_argparser(parser, defaults)
     self.add_bom_parser_args(parser, defaults)
 
-    # The gradle jobs in the foreach_repository seem to hang when using
-    # pools but not threadpools. I think this is a deadlock related to
-    # job forks. It only hangs after all the jobs completed (cycling through
-    # the reuse of workers). Forcing the pool to not reuse works seems to
-    # have fixed the problem. However I'm leaving this flag in as a
-    # break glass if needed should this crop up again.
-    #
-    # In general using Processes are more resource-efficient than threads
-    # because of the python GIL. The gradle jobs are so CPU heavy that
-    # they cannot run that concurrently anyway so this might not matter
-    # much where builds are local.
-    self.add_argument(
-        parser, 'use_threadpool', defaults, False, action='store_true',
-        help='Use ThreadPool rather than Pool as a workaround for'
-        ' gradle hanging.')
     self.add_argument(
         parser, 'max_local_builds', defaults, None, type=int,
         help='Maximum build concurrency.')
@@ -107,32 +179,49 @@ class GradleCommandFactory(RepositoryCommandFactory):
 
 class GradleCommandProcessor(RepositoryCommandProcessor):
   """Base class for build commands using Gradle."""
+  # pylint: disable=too-few-public-methods
   # pylint: disable=abstract-method
 
   def __init__(self, factory, options, upstream_boms, **kwargs):
-    self.__upstream_boms = upstream_boms
-    self.__nebula_repository_version = {}
-
     # This is to cut down on logging noise so we only emmit one
     # message on the test against freshness rather than on every access.
     self.__logged_is_newer = {}
     super(GradleCommandProcessor, self).__init__(
-        factory, options, use_threadpool=options.use_threadpool, **kwargs)
+        factory, options, **kwargs)
+    self.__nebula_repository_version = {}
+    self.__upstream_boms = self.filter_repositories(upstream_boms)
+
+  def make_gradle_metric_hook(self, repository, what):
+    """Return metric hook for processing a repository."""
+    return GradleMetricsUpdater(self.metrics, repository, what)
+
+  def determine_gradle_root(self, repository):
+    """Determine source directory root for gradle to run in."""
+    name = repository.name
+    return self.source_code_manager.get_local_repository_path(name)
 
   def _get_nebula_repository_version(self, name):
     """Get the GitSummary for the named repo."""
     if not self.__nebula_repository_version.get(name):
+      options = self.options
       summary_path = os.path.join(
-          self.options.scratch_dir, name,
-          '{name}-summary.yml'.format(name=name))
-      if not os.path.exists(summary_path):
-        logging.debug('Forcing a repository update because there is no %s',
+          options.scratch_dir, name, '{name}-summary.yml'.format(name=name))
+      if os.path.exists(summary_path):
+        with open(summary_path, 'r') as stream:
+          data = yaml.load(stream.read())
+          self.__nebula_repository_version[name] = data['version']
+      else:
+        logging.debug('Forcing a repository summary because there is no %s',
                       summary_path)
-        self._get_nebula_repository_path(name, force_new=True)
+        git_dir = self.source_code_manager.get_local_repository_path(name)
+        original_repo_path = os.path.abspath(git_dir)
+        summary = self.git.collect_repository_summary(original_repo_path)
+        summary_yaml = summary.to_yaml(with_commit_messages=False)
+        self.__nebula_repository_version[name] = summary.version
+        ensure_dir_exists(os.path.dirname(summary_path))
+        with open(summary_path, 'w') as stream:
+          stream.write(summary_yaml)
 
-      with open(summary_path, 'r') as stream:
-        data = yaml.load(stream)
-        self.__nebula_repository_version[name] = data['version']
     return self.__nebula_repository_version[name]
 
   def _do_determine_source_repositories(self):
@@ -144,42 +233,25 @@ class GradleCommandProcessor(RepositoryCommandProcessor):
     return {name: self.git.determine_remote_git_repository(git_dir)
             for name, git_dir in local_repository.items()}
 
-  def __make_gradle_args(self, name):
+  def _make_gradle_args(self, name):
     """Returns commandline arguments to pass to gradle."""
     options = self.options
-    bintray_key = os.environ['BINTRAY_KEY']
-    bintray_user = os.environ['BINTRAY_USER']
-    if not bintray_key:
-      raise ValueError('Expected BINTRAY_KEY set.')
-    if not bintray_user:
-      raise ValueError('Expected BINTRAY_USER set.')
 
-    parts = (options.build_bintray_repository or '').split('/')
-    if len(parts) != 2:
-      raise ValueError(
-          'Expected --build_bintray_repository to be in the form'
-          ' <owner>/<repo>')
-    org, package_repo = parts[0], parts[1]
-
-    jar_repo = options.build_jar_repository
-    if not jar_repo or len(jar_repo.split('/')) != 1:
-      raise ValueError('Expected --build_jar_repository in the form <repo>'
-                       ' using the implied owner from'
-                       ' --build_bintray_repository')
-
+    # Rather than using -Prelease.useLastTag for the last tag,
+    # we'll explicitly inject one because nebula is hardcoded
+    # for the tag pattern to v*, but those tags are already used
+    # in the repo (for netflix internal use).
     build_number = options.build_number
     extra_args = [
         '--stacktrace',
-        '-Prelease.useLastTag=true',
+        '-Prelease.version={version}-{number}'.format(
+            version=self._get_nebula_repository_version(name),
+            number=build_number),
         '-PbintrayPackageBuildNumber={number}'.format(number=build_number),
-        '-PbintrayOrg="{org}"'.format(org=org),
-        '-PbintrayPackageRepo="{repo}"'.format(repo=package_repo),
-        '-PbintrayJarRepo="{jarRepo}"'.format(jarRepo=jar_repo),
-        '-PbintrayKey="{key}"'.format(key=bintray_key),
-        '-PbintrayUser="{user}"'.format(user=bintray_user)
     ]
 
     if options.maven_custom_init_file:
+      # Note, this was only debians, not for rpms before.
       extra_args.append('-I {}'.format(options.maven_custom_init_file))
 
     gradle_cache_path = options.gradle_cache_path
@@ -196,15 +268,15 @@ class GradleCommandProcessor(RepositoryCommandProcessor):
 
     if not options.run_unit_tests and name == 'orca':
       extra_args.append('-x junitPlatformTest')
-#     extra_args.append('-x generateHtmlTestReports')
-
-    if name == 'halyard':
-      extra_args.append('-PbintrayPackageDebDistribution=trusty-nightly')
-    else:
-      extra_args.append('-PbintrayPackageDebDistribution=trusty,xenial')
 
     extra_args.extend(shlex.split(options.extra_gradle_args or ''))
+    self._do_append_extra_args(name, extra_args)
+
     return extra_args
+
+  def _do_append_extra_args(self, name, extra_args):
+    """Add command-specific extra gradle args."""
+    pass
 
   def __is_newer_repo(self, test_path, ref_path, log):
     """Determine if one path was modified more recently than another."""
@@ -234,235 +306,10 @@ class GradleCommandProcessor(RepositoryCommandProcessor):
         timedelta_string(ref_datetime - test_datetime))
     return False
 
-  def _get_nebula_repository_path(self, name, force_new=False):
-    """Return the path to the repository for nebula to build.
-
-    If the repository does not exist then one will be cloned from the
-    source repository.
-
-    Nebula gets confused by our tags because it expects the Netflix ones.
-    Since we dont understand how to change nebula and dont want to invest
-    the time into it, we're just going to remove all the tags and add the
-    one we want nebula to use so it isnt confused.
-
-    Rather than modifying the original repository, we'll do all this in a
-    new one. The bonus is that we can commit and tag the repo so that
-    gradle/nebula is happy but without modifying the original repo at all
-    until we are ready to later.
-
-    Args:
-      name: [string] The name of the repository
-      force_new: [bool] If true, clear any existing repository
-    """
-    git_dir = self.source_code_manager.get_local_repository_path(name)
-    original_repo_path = os.path.abspath(git_dir)
-
-    options = self.options
-    nebula_repo_path = os.path.join(options.scratch_dir, 'build', name)
-
-    if os.path.exists(nebula_repo_path):
-      if not force_new:
-        logged_is_newer = self.__logged_is_newer.get(nebula_repo_path, False)
-        if self.__is_newer_repo(nebula_repo_path, original_repo_path,
-                                not logged_is_newer):
-          if not logged_is_newer:
-            logging.info('Reusing existing %s', nebula_repo_path)
-            self.__logged_is_newer[nebula_repo_path] = True
-          return nebula_repo_path
-
-      self.__logged_is_newer[nebula_repo_path] = False
-      logging.info('Removing old nebula repo %s', nebula_repo_path)
-      shutil.rmtree(nebula_repo_path, ignore_errors=True)
-
-    logging.debug('Determining version and build tag of %s',
-                  original_repo_path)
-    summary = self.git.collect_repository_summary(original_repo_path)
-    build_tag = '{version}-{build}'.format(
-        version=summary.version, build=options.build_number)
-
-    logging.info('Cloning %s to nebula repo %s', name, nebula_repo_path)
-    self.git.clone_repository_to_path(original_repo_path, nebula_repo_path)
-
-    # Nebula complains if the git tag version doesn't match the branch's
-    # version, i.e. in patch releases. As a workaround, we checkout the
-    # HEAD commit of the current branch in a 'detached HEAD' state so
-    # Nebula doesn't complain about our branch version and git tag
-    # version not matching.
-    self.git.reinit_local_repository_with_tag(
-        nebula_repo_path, build_tag,
-        'Snapshot from {path} to satisfy nebula.\n\n'
-        'commit: {commit}\ntag: {tag}\nversion: {version}'
-        .format(path=original_repo_path,
-                commit=summary.commit_id,
-                tag=summary.tag,
-                version=summary.version))
-    self.__nebula_repository_version[name] = summary.version
-    summary_path = os.path.join(
-        options.scratch_dir, name, '{name}-summary.yml'.format(name=name))
-    write_to_path(summary.to_yaml(with_commit_messages=False), summary_path)
-    return nebula_repo_path
-
-  def _do_repository(self, repository):
-    """Implements RepositoryCommandProcessor interface."""
-    name = repository.name
-    options = self.options
-
-    gradle_root = self._get_nebula_repository_path(name)
-    extra_args = self.__make_gradle_args(name)
-
-    target = 'candidate'
-    cmd = './gradlew {extra} {target}'.format(
-        extra=' '.join(extra_args), target=target)
-
-    logfile = determine_logfile_path(options, name, 'debian-build')
-    check_subprocesses_to_logfile(
-        '{name} gradle build'.format(name=name), logfile,
-        [cmd], cwd=gradle_root)
-
-    return gradle_root
-
-
-class BuildHalyardCommand(GradleCommandProcessor):
-  """Implements the build_halyard command."""
-
-  HALYARD_VERSIONS_BASENAME = 'nightly-version-commits.yml'
-
-  def __init__(self, factory, options, upstream_repositories=None, **kwargs):
-    upstream_repositories = (upstream_repositories
-                             or SPINNAKER_HALYARD_REPOSITORIES)
-    self.__build_version = None  # recorded after build
-
-    # NOTE(ewiseblatt): 20171213
-    # I think we need this, though am confused by the release/all
-    # also building debians. Our parent class should publish to bintray
-    # whereas the release/all does not.
-    self.__build_halyard_to_bintray = True
-
-    super(BuildHalyardCommand, self).__init__(
-        factory, options, upstream_repositories,
-        max_threads=options.max_local_builds, **kwargs)
-
-  def publish_halyard_version_commits(self):
-    """Publish the halyard build to the bucket.
-
-    This also writes the built version to
-        <scratch>/halyard/last_version_commit.yml
-    so callers can know what version was written.
-    """
-    options = self.options
-    versions_url = options.halyard_version_commits_url
-    if not versions_url:
-      versions_url = '{base}/{filename}'.format(
-          base=options.halyard_bucket_base_url,
-          filename=self.HALYARD_VERSIONS_BASENAME)
-    named_scratch_dir = os.path.join(options.scratch_dir, 'halyard')
-    summary_path = os.path.join(named_scratch_dir, 'halyard-summary.yml')
-
-    with open(summary_path, 'r') as stream:
-      summary_info = yaml.load(stream)
-
-    # This is only because we need a file to gsutil cp
-    # We already need gsutil so its easier to just use it again here.
-    tmp_path = os.path.join(named_scratch_dir, self.HALYARD_VERSIONS_BASENAME)
-
-    logging.debug('Fetching existing halyard build versions')
-    try:
-      contents = check_subprocess(
-          'gsutil cat {url}'.format(url=versions_url))
-      contents += '\n'
-    except subprocess.CalledProcessError as error:
-      output = error.output
-      if output.find('No URLs matched') < 0:
-        raise
-      contents = ''
-      logging.warning('%s did not exist. Creating a new one.', versions_url)
-
-    new_entry = '{version}: {commit}\n'.format(
-        version=self.__build_version, commit=summary_info['commit_id'])
-
-    logging.info('Updating %s with %s', versions_url, new_entry)
-    if contents and contents[-1] != '\n':
-      contents += '\n'
-    contents = contents + new_entry
-    with open(tmp_path, 'w') as stream:
-      stream.write(contents)
-    check_subprocess('gsutil cp {path} {url}'.format(
-        path=tmp_path, url=versions_url))
-
-    last_version_commit_path = os.path.join(
-        named_scratch_dir, 'last_version_commit.yml')
-    with open(last_version_commit_path, 'w') as stream:
-      stream.write(new_entry)
-
-  def build_all_halyard_deployments(self, name):
-    """Helper function for building halyard."""
-    options = self.options
-
-    nebula_repo_path = self._get_nebula_repository_path(name)
-    raw_version = self._get_nebula_repository_version(name)
-    self.__build_version = '{version}-{build}'.format(
-        version=raw_version, build=options.build_number)
-
-    cmd = './release/all.sh {version} nightly'.format(
-        version=self.__build_version)
-    env = dict(os.environ)
-    logging.info(
-        'Preparing the environment variables for release/all.sh:\n'
-        '    PUBLISH_HALYARD_DOCKER_IMAGE_BASE=%s\n'
-        '    PUBLISH_HALYARD_BUCKET_BASE_URL=%s',
-        options.halyard_docker_image_base,
-        options.halyard_bucket_base_url)
-    env['PUBLISH_HALYARD_DOCKER_IMAGE_BASE'] = options.halyard_docker_image_base
-    env['PUBLISH_HALYARD_BUCKET_BASE_URL'] = options.halyard_bucket_base_url
-
-    logfile = determine_logfile_path(options, name, 'jar-build')
-    check_subprocesses_to_logfile(
-        '{name} build'.format(name='halyard'), logfile,
-        [cmd], cwd=nebula_repo_path, env=env)
-
-  def _do_repository(self, repository):
-    """Implements RepositoryCommandProcessor interface."""
-    if self.__build_halyard_to_bintray:
-      # I think this needs to be first, but am not sure.
-      super(BuildHalyardCommand, self)._do_repository(repository)
-
-    if repository.name == 'halyard':
-      self.build_all_halyard_deployments(repository.name)
-      self.publish_halyard_version_commits()
-
-
-class BuildHalyardFactory(GradleCommandFactory):
-  """Implements the build_halyard command."""
-
-  def __init__(self):
-    super(BuildHalyardFactory, self).__init__(
-        'build_halyard', BuildHalyardCommand,
-        'Build halyard from the local git repository.')
-
-  def _do_init_argparser(self, parser, defaults):
-    """Adds command-specific arguments."""
-    super(BuildHalyardFactory, self)._do_init_argparser(parser, defaults)
-
-    self.add_argument(
-        parser, 'halyard_version_commits_url', defaults, None,
-        help='URL to file containing version and git commit for successful'
-             ' nightly builds. By default this will be'
-             ' "{filename}" in the'
-             ' --halyard_bucket_base_url.'.format(
-                 filename=BuildHalyardCommand.HALYARD_VERSIONS_BASENAME))
-    self.add_argument(
-        parser, 'halyard_bucket_base_url',
-        defaults, 'gs://spinnaker-artifacts/halyard',
-        help='Base Google Cloud Storage URL for writing halyard builds.')
-    self.add_argument(
-        parser, 'halyard_docker_image_base',
-        defaults, 'gcr.io/spinnaker-marketplace/halyard',
-        help='Base Docker image name for writing halyard builds.')
-
-
 
 class BuildDebianCommand(GradleCommandProcessor):
   """Implements the build_debians command."""
+  # pylint: disable=too-few-public-methods
 
   def __init__(self, factory, options, upstream_repositories=None, **kwargs):
     upstream_repositories = upstream_repositories or SPINNAKER_BOM_REPOSITORIES
@@ -470,36 +317,116 @@ class BuildDebianCommand(GradleCommandProcessor):
         factory, options, upstream_repositories,
         max_threads=options.max_local_builds, **kwargs)
 
+  def _do_append_extra_args(self, name, extra_args):
+    """Add build-specific gradle arguments."""
 
-class BuildDebianFactory(GradleCommandFactory):
-  """Implements the build_debians command."""
+    bintray_key = os.environ['BINTRAY_KEY']
+    bintray_user = os.environ['BINTRAY_USER']
+    if not bintray_key:
+      raise ValueError('Expected BINTRAY_KEY set.')
+    if not bintray_user:
+      raise ValueError('Expected BINTRAY_USER set.')
 
-  def __init__(self):
-    super(BuildDebianFactory, self).__init__(
-        'build_debians', BuildDebianCommand,
-        'Build one or more debians from the local git repository.')
+    options = self.options
+    jar_repo = options.build_jar_repository
+    if not jar_repo or len(jar_repo.split('/')) != 1:
+      raise ValueError('Expected --build_jar_repository in the form <repo>'
+                       ' using the implied owner from'
+                       ' --build_bintray_repository')
 
-  @staticmethod
-  def add_bom_parser_args(parser, defaults):
-    """Adds publishing arguments of interest to the BOM commands as well."""
-    if hasattr(parser, 'added_debians'):
-      return
-    parser.added_debians = True
+    parts = (options.build_bintray_repository or '').split('/')
+    if len(parts) != 2:
+      raise ValueError(
+          'Expected --build_bintray_repository to be in the form'
+          ' <owner>/<repo>')
+    org, package_repo = parts[0], parts[1]
 
-    GradleCommandFactory.add_bom_parser_args(parser, defaults)
-    BuildDebianFactory.add_argument(
-        parser, 'publish_gce_image_project', defaults,
-        'marketplace-spinnaker-release',
-        help='GCE project we publish HA Spinnaker component images to.')
+    extra_args.extend([
+        '-PbintrayOrg="{org}"'.format(org=org),
+        '-PbintrayPackageRepo="{repo}"'.format(repo=package_repo),
+        '-PbintrayJarRepo="{jarRepo}"'.format(jarRepo=jar_repo),
+        '-PbintrayKey="{key}"'.format(key=bintray_key),
+        '-PbintrayUser="{user}"'.format(user=bintray_user),
+        '-PbintrayPackageDebDistribution={distribution}'.format(
+            distribution=self._get_distribution(name))
+    ])
 
-  def _do_init_argparser(self, parser, defaults):
-    """Adds command-specific arguments."""
-    super(BuildDebianFactory, self)._do_init_argparser(parser, defaults)
-    self.add_bom_parser_args(parser, defaults)
+  def _get_distribution(self, name):
+    """Return the debian distribution label for the given system."""
+    # pylint: disable=unused-argument
+    return 'trusty,xenial'
+
+  def _do_repository(self, repository):
+    """Implements RepositoryCommandProcessor interface."""
+    name = repository.name
+    options = self.options
+
+    extra_args = self._make_gradle_args(name)
+
+    # Nebula insists on publishing tag to the ORIGIN when using candidate.
+    # we dont want to do that because it doesnt make sense to push the tag
+    # before we validate it. The point is moot because nebula also insists on
+    # the specific tag it pushes, which is the tag netflix uses for internal
+    # use so is not available to us.
+    #
+    # Supposedly we can use 'snapshot' here instead which wont push a tag.
+    # However snapshot brings its own set of opinions and doesnt even work
+    # pushing to bintray for reasons I dont understand, so we'll stick with
+    # candidate.
+    #
+    # The implication here is that we need to trick nebula by having our remote
+    # ORIGIN not be the github "origin", but some bogus bitbucket so that the
+    # tag pushes have no actual effect.
+    target = 'candidate'
+    cmd = './gradlew {extra} {target}'.format(
+        extra=' '.join(extra_args), target=target)
+
+    gradle_root = self.determine_gradle_root(repository)
+    logfile = determine_logfile_path(options, name, 'debian-build')
+    check_subprocesses_to_logfile(
+        '{name} gradle build'.format(name=name), logfile,
+        [cmd], cwd=gradle_root,
+        postprocess_hook=self.make_gradle_metric_hook(repository, target)
+    )
+
+    return gradle_root
+
+
+class BuildRpmCommand(GradleCommandProcessor):
+  """"Implements the build_rpm command."""
+  # pylint: disable=too-few-public-methods
+
+  def __init__(self, factory, options, upstream_repositories=None, **kwargs):
+    upstream_repositories = upstream_repositories or SPINNAKER_BOM_REPOSITORIES
+    super(BuildRpmCommand, self).__init__(
+        factory, options, upstream_repositories,
+        max_threads=options.max_local_builds, **kwargs)
+
+  def _do_repository(self, repository):
+    """Implements RepositoryCommandProcessor interface."""
+    name = repository.name
+    options = self.options
+
+    extra_args = self._make_gradle_args(name)
+
+    target = 'buildRpm'
+    cmd = './gradlew {extra} {target}'.format(
+        extra=' '.join(extra_args), target=target)
+
+    gradle_root = self.determine_gradle_root(repository)
+    logfile = determine_logfile_path(options, name, 'rpm-build')
+    check_subprocesses_to_logfile(
+        '{name} gradle build'.format(name=name), logfile,
+        [cmd], cwd=gradle_root,
+        postprocess_hook=self.make_gradle_metric_hook(repository, target)
+    )
+
+    return gradle_root
 
 
 class BuildContainerCommand(GradleCommandProcessor):
   """Implements the build_bom_containers command."""
+  # pylint: disable=too-few-public-methods
 
   def __init__(self, factory, options, upstream_repositories=None, **kwargs):
     if not upstream_repositories:
@@ -507,11 +434,6 @@ class BuildContainerCommand(GradleCommandProcessor):
           'No upstream repositories provided by %s' % factory.name)
     super(BuildContainerCommand, self).__init__(
         factory, options, upstream_repositories, **kwargs)
-
-  def determine_gradle_root(self, repository):
-    """Determine source directory root for gradle to run in."""
-    name = repository.name
-    return self._get_nebula_repository_path(name)
 
   def _do_repository(self, repository):
     """Implements RepositoryCommandProcessor interface."""
@@ -545,10 +467,7 @@ class BuildContainerCommand(GradleCommandProcessor):
 
   def __build_with_gcb(self, repository):
     name = repository.name
-    nebula_dir = self._get_nebula_repository_path(name)
-
-    version = self._get_nebula_repository_version(name)
-    gcb_config = self.__derive_gcb_config(name, version)
+    gcb_config = self.__derive_gcb_config(repository)
     if gcb_config is None:
       logging.info('Skipping GCB for %s because there is config for it',
                    name)
@@ -572,10 +491,11 @@ class BuildContainerCommand(GradleCommandProcessor):
     #
     # This can still be shared among components as long as the
     # scratch directory remains around.
+    gradle_root = self.determine_gradle_root(repository)
     if options.force_clean_gradle_cache:
       # If we're going to delete existing ones, then keep each component
       # separate so they dont stomp on one another
-      gradle_cache = os.path.abspath(os.path.join(nebula_dir, '.gradle'))
+      gradle_cache = os.path.abspath(os.path.join(gradle_root, '.gradle'))
     else:
       # Otherwise allow all the components to share a common gradle directory
       gradle_cache = os.path.abspath(
@@ -584,7 +504,7 @@ class BuildContainerCommand(GradleCommandProcessor):
     if options.force_clean_gradle_cache and os.path.isdir(gradle_cache):
       shutil.rmtree(gradle_cache)
 
-    # Note this command assumes a cwd of nebula_dir
+    # Note this command assumes a cwd of gradle_root
     cmd = ('gcloud container builds submit {log_flags}'
            ' --account={account} --project={project}'
            ' --config="{config_path}" .'
@@ -596,7 +516,7 @@ class BuildContainerCommand(GradleCommandProcessor):
     logfile = determine_logfile_path(options, name, 'gcb-build')
     check_subprocesses_to_logfile(
         '{name} container build'.format(name=name), logfile,
-        [cmd], cwd=nebula_dir)
+        [cmd], cwd=gradle_root)
 
   def __make_gradle_gcb_step(self, name, env_vars_list):
     if name == 'deck':
@@ -611,9 +531,10 @@ class BuildContainerCommand(GradleCommandProcessor):
         'name': self.options.build_container_base_image
     }
 
-  def __derive_gcb_config(self, name, version):
+  def __derive_gcb_config(self, repository):
     """Helper function for repository_main."""
-    orig_name = name
+    name = repository.name
+    version = self._get_nebula_repository_version(name)
     options = self.options
     is_spinnaker_monitoring = name == 'spinnaker-monitoring'
     if is_spinnaker_monitoring:
@@ -625,12 +546,12 @@ class BuildContainerCommand(GradleCommandProcessor):
       dockerfile = 'Dockerfile.slim'
 
     dockerfile_path = os.path.join(
-        self._get_nebula_repository_path(orig_name),
+        self.determine_gradle_root(repository),
         dirname,
         dockerfile)
     if not os.path.exists(dockerfile_path):
       logging.warning('No GCB config for %s because there is no %s',
-                      orig_name, dockerfile)
+                      repository.name, dockerfile)
       return None
 
     env_vars_list = [env
@@ -662,6 +583,7 @@ class BuildContainerCommand(GradleCommandProcessor):
 
 class BuildContainerFactory(GradleCommandFactory):
   """Implements the build_containers command."""
+  # pylint: disable=too-few-public-methods
 
   @staticmethod
   def add_bom_parser_args(parser, defaults):
@@ -705,10 +627,149 @@ class BuildContainerFactory(GradleCommandFactory):
         help='Base image to start from in the container builds.')
 
 
+class BuildHalyardCommand(BuildDebianCommand):
+  """Implements the build_halyard command."""
+  # pylint: disable=too-few-public-methods
+
+  HALYARD_VERSIONS_BASENAME = 'nightly-version-commits.yml'
+
+  def __init__(self, factory, options, upstream_repositories=None, **kwargs):
+    upstream_repositories = (upstream_repositories
+                             or SPINNAKER_HALYARD_REPOSITORIES)
+    self.__build_version = None  # recorded after build
+    self.__build_halyard_to_bintray = True
+
+    super(BuildHalyardCommand, self).__init__(
+        factory, options, upstream_repositories=upstream_repositories, **kwargs)
+
+  def _get_distribution(self, name):
+    """Return the debian distribution label for the given system."""
+    # pylint: disable=unused-argument
+    return 'trusty-nightly'
+
+  def publish_halyard_version_commits(self):
+    """Publish the halyard build to the bucket.
+
+    This also writes the built version to
+        <scratch>/halyard/last_version_commit.yml
+    so callers can know what version was written.
+    """
+    options = self.options
+    versions_url = options.halyard_version_commits_url
+    if not versions_url:
+      versions_url = '{base}/{filename}'.format(
+          base=options.halyard_bucket_base_url,
+          filename=self.HALYARD_VERSIONS_BASENAME)
+    named_scratch_dir = os.path.join(options.scratch_dir, 'halyard')
+    summary_path = os.path.join(named_scratch_dir, 'halyard-summary.yml')
+
+    with open(summary_path, 'r') as stream:
+      summary_info = yaml.load(stream.read())
+
+    # This is only because we need a file to gsutil cp
+    # We already need gsutil so its easier to just use it again here.
+    tmp_path = os.path.join(named_scratch_dir, self.HALYARD_VERSIONS_BASENAME)
+
+    logging.debug('Fetching existing halyard build versions')
+    try:
+      contents = check_subprocess(
+          'gsutil cat {url}'.format(url=versions_url))
+      contents += '\n'
+    except subprocess.CalledProcessError as error:
+      output = error.output
+      if output.find('No URLs matched') < 0:
+        raise
+      contents = ''
+      logging.warning('%s did not exist. Creating a new one.', versions_url)
+
+    new_entry = '{version}: {commit}\n'.format(
+        version=self.__build_version, commit=summary_info['commit_id'])
+
+    logging.info('Updating %s with %s', versions_url, new_entry)
+    if contents and contents[-1] != '\n':
+      contents += '\n'
+    contents = contents + new_entry
+    with open(tmp_path, 'w') as stream:
+      stream.write(contents)
+    check_subprocess('gsutil cp {path} {url}'.format(
+        path=tmp_path, url=versions_url))
+    last_version_commit_path = os.path.join(
+        named_scratch_dir, 'last_version_commit.yml')
+    with open(last_version_commit_path, 'w') as stream:
+      stream.write(new_entry)
+
+  def build_all_halyard_deployments(self, repository):
+    """Helper function for building halyard."""
+    name = repository.name
+    options = self.options
+
+    nebula_repo_path = self.determine_gradle_root(repository)
+    raw_version = self._get_nebula_repository_version(name)
+    self.__build_version = '{version}-{build}'.format(
+        version=raw_version, build=options.build_number)
+
+    cmd = './release/all.sh {version} nightly'.format(
+        version=self.__build_version)
+    env = dict(os.environ)
+    logging.info(
+        'Preparing the environment variables for release/all.sh:\n'
+        '    PUBLISH_HALYARD_DOCKER_IMAGE_BASE=%s\n'
+        '    PUBLISH_HALYARD_BUCKET_BASE_URL=%s',
+        options.halyard_docker_image_base,
+        options.halyard_bucket_base_url)
+    env['PUBLISH_HALYARD_DOCKER_IMAGE_BASE'] = options.halyard_docker_image_base
+    env['PUBLISH_HALYARD_BUCKET_BASE_URL'] = options.halyard_bucket_base_url
+
+    logfile = determine_logfile_path(options, name, 'jar-build')
+    check_subprocesses_to_logfile(
+        '{name} build'.format(name='halyard'), logfile,
+        [cmd], cwd=nebula_repo_path, env=env)
+
+  def _do_repository(self, repository):
+    """Implements RepositoryCommandProcessor interface."""
+    if self.__build_halyard_to_bintray:
+      # I think this needs to be first, but am not sure.
+      super(BuildHalyardCommand, self)._do_repository(repository)
+
+    if repository.name == 'halyard':
+      self.build_all_halyard_deployments(repository)
+      self.publish_halyard_version_commits()
+
+
+class BuildHalyardFactory(GradleCommandFactory):
+  """Implements the build_halyard command."""
+  # pylint: disable=too-few-public-methods
+
+  def __init__(self):
+    super(BuildHalyardFactory, self).__init__(
+        'build_halyard', BuildHalyardCommand,
+        'Build halyard from the local git repository.')
+
+  def _do_init_argparser(self, parser, defaults):
+    """Adds command-specific arguments."""
+    super(BuildHalyardFactory, self)._do_init_argparser(parser, defaults)
+
+    self.add_argument(
+        parser, 'halyard_version_commits_url', defaults, None,
+        help='URL to file containing version and git commit for successful'
+             ' nightly builds. By default this will be'
+             ' "{filename}" in the'
+             ' --halyard_bucket_base_url.'.format(
+                 filename=BuildHalyardCommand.HALYARD_VERSIONS_BASENAME))
+    self.add_argument(
+        parser, 'halyard_bucket_base_url',
+        defaults, 'gs://spinnaker-artifacts/halyard',
+        help='Base Google Cloud Storage URL for writing halyard builds.')
+    self.add_argument(
+        parser, 'halyard_docker_image_base',
+        defaults, 'gcr.io/spinnaker-marketplace/halyard',
+        help='Base Docker image name for writing halyard builds.')
+
+
 def add_bom_parser_args(parser, defaults):
   """Adds parser arguments pertaining to publishing boms."""
   BuildContainerFactory.add_bom_parser_args(parser, defaults)
-  BuildDebianFactory.add_bom_parser_args(parser, defaults)
+  GradleCommandFactory.add_bom_parser_args(parser, defaults)
 
 
 def register_commands(registry, subparsers, defaults):
@@ -723,7 +784,16 @@ def register_commands(registry, subparsers, defaults):
       'Build one or more service containers from the local git repository.',
       upstream_repositories=SPINNAKER_HALYARD_REPOSITORIES)
 
+  build_debian_factory = BuildContainerFactory(
+      'build_debians', BuildDebianCommand,
+      'Build one or more debian packages from the local git repository.')
+
+  build_rpm_factory = BuildContainerFactory(
+      'build_rpms', BuildRpmCommand,
+      'Build one or more rpm packages from the local git repository.')
+
   build_bom_containers_factory.register(registry, subparsers, defaults)
   build_hal_containers_factory.register(registry, subparsers, defaults)
-  BuildDebianFactory().register(registry, subparsers, defaults)
+  build_debian_factory.register(registry, subparsers, defaults)
+  build_rpm_factory.register(registry, subparsers, defaults)
   BuildHalyardFactory().register(registry, subparsers, defaults)

--- a/dev/buildtool/changelog_commands.py
+++ b/dev/buildtool/changelog_commands.py
@@ -33,8 +33,7 @@ from buildtool.git import (
     CommitMessage)
 from buildtool.source_code_manager import (
     SPINNAKER_BOM_REPOSITORIES,
-    SPINNAKER_GITHUB_IO_REPOSITORY,
-    SPINNAKER_HALYARD_REPOSITORIES)
+    SPINNAKER_GITHUB_IO_REPOSITORY)
 from buildtool.util import (
     write_to_path)
 
@@ -374,7 +373,7 @@ def register_commands(registry, subparsers, defaults):
   """Registers all the commands for this module."""
   publish_changelog_factory = PullRequestCommandFactory(
       'publish_changelog', PublishChangelogCommand,
-      'Push changelog to the spinnaker.github.io repository origin'
+      'Push changelog to the spinnaker.github.io repository ORIGIN'
       ' and submit a Github Pull Request on it.')
 
   GenerateChangelogCommandFactory().register(registry, subparsers, defaults)

--- a/dev/buildtool/ga-defaults.yml
+++ b/dev/buildtool/ga-defaults.yml
@@ -65,8 +65,9 @@ github_user: default
 # maven_custom_init_file: [<spinnaker>/dev/maven-init.gradle]
 # gradle_cache_path: [<home>/.gradle]
 extra_gradle_args: info --stacktrace
-build_bintray_repository: spinnaker-releases/debians
-build_jar_repository: # jars, I think
+build bintray_org: spinnaker-releases
+build_bintray_repository: debians
+build_bintray_jar_repository: jars
 
 ### Used by: build_halyard
 halyard_bucket_base_url: gs://spinnaker-artifacts/halyard

--- a/dev/buildtool/prometheus_metrics.py
+++ b/dev/buildtool/prometheus_metrics.py
@@ -27,7 +27,6 @@ how to work around this. Otherwise, use the file based metrics then
 upload them into some other database or metrics system via post-processing.
 """
 
-import logging
 from buildtool.base_metrics import (
     BaseMetricsRegistry,
     Counter,

--- a/dev/buildtool/source_commands.py
+++ b/dev/buildtool/source_commands.py
@@ -99,7 +99,7 @@ class FetchSourceCommand(RepositoryCommandProcessor):
       scm.pull_source_from_bom(repository.name, git_dir, self.__bom)
     else:
       self.git.refresh_local_repository(
-          git_dir, 'origin', options.refresh_branch)
+          git_dir, scm.git.ORIGIN_REMOTE_NAME, options.refresh_branch)
 
     self.__collect_halconfig_files(repository)
 
@@ -170,7 +170,7 @@ class FetchSourceCommandFactory(RepositoryCommandFactory):
   def __init__(self):
     super(FetchSourceCommandFactory, self).__init__(
         'fetch_source', FetchSourceCommand,
-        'Clone or refresh the local git repositories from the origin.')
+        'Clone or refresh the local git repositories from the ORIGIN.')
 
   def _do_init_argparser(self, parser, defaults):
     """Adds command-specific arguments."""

--- a/unittest/buildtool/build_command_test.py
+++ b/unittest/buildtool/build_command_test.py
@@ -1,0 +1,90 @@
+# Copyright 2017 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=missing-docstring
+
+import textwrap
+import unittest
+from buildtool.build_commands import GradleMetricsUpdater
+import buildtool.metrics
+import buildtool.git
+
+class SimpleNamespace(object):
+  def __init__(self):
+    self.metric_name_scope = 'unittest'
+    self.monitoring_flush_frequency = -1
+    self.monitoring_system = 'file'
+    self.monitoring_enabled = True
+
+REPOSITORY = buildtool.git.RemoteGitRepository('testRepo', '/path/to/repo', None)
+
+
+BINTRAY_ERROR_OUTPUT = textwrap.dedent("""\
+     :echo-web:publishBuildDeb
+     
+     FAILURE: Build completed with 9 failures.
+     
+     1: Task failed with an exception.
+     -----------
+     * What went wrong:
+     Execution failed for task ':echo-core:bintrayUpload'.
+     > Could not upload to 'https://api.bintray.com/content/spinnaker-releases/ewiseblatt-maven/echo/1.542.0/com/netflix/spinnaker/echo/echo-core/1.542.0/echo-core-1.542.0.jar': HTTP/1.1 409 Conflict [message:Unable to upload files: An artifact with the path 'com/netflix/spinnaker/echo/echo-core/1.542.0/echo-core-1.542.0.jar' already exists]
+     
+     * Try:
+     Run with --info or --debug option to get more log output.
+""")
+
+
+class TestGradleMetricsUpdater(unittest.TestCase):
+  def setUp(self):
+      self.metrics = buildtool.metrics.MetricsManager.singleton()
+
+  def test_ok(self):
+    updater = GradleMetricsUpdater(self.metrics, REPOSITORY, 'TestWhatThing')
+    counter = updater(0, BINTRAY_ERROR_OUTPUT)
+    self.assertEquals(1, counter.count)
+    self.assertEquals('GradleOutcome', counter.family.name)
+    self.assertEquals({
+        'repository': 'testRepo',
+        'context': 'TestWhatThing',
+        'success': True,
+        'failed_task': '',
+        'failed_by': '',
+        'failed_reason': ''
+    }, counter.labels)
+
+  def test_bintray_error(self):
+    updater = GradleMetricsUpdater(self.metrics, REPOSITORY, 'TestWhatThing')
+    counter = updater(-1, BINTRAY_ERROR_OUTPUT)
+    self.assertEquals(1, counter.count)
+    self.assertEquals('GradleOutcome', counter.family.name)
+    self.assertEquals({
+        'repository': 'testRepo',
+        'context': 'TestWhatThing',
+        'success': False,
+        'failed_task': ':echo-core:bintrayUpload',
+        'failed_by': 'bintray',
+        'failed_reason': '409'
+    }, counter.labels)
+
+
+if __name__ == '__main__':
+  import logging
+  logging.basicConfig(
+      format='%(levelname).1s %(asctime)s.%(msecs)03d %(message)s',
+      datefmt='%H:%M:%S',
+      level=logging.DEBUG)
+
+  buildtool.metrics.MetricsManager.startup_metrics(SimpleNamespace())
+  unittest.main(verbosity=2)

--- a/unittest/buildtool/source_code_manager_test.py
+++ b/unittest/buildtool/source_code_manager_test.py
@@ -43,6 +43,8 @@ def _foreach_func(repository, *pos_args, **kwargs):
 def make_default_options():
   """Helper function for creating default options for runner."""
   parser = argparse.ArgumentParser()
+  parser.add_argument('--scratch_dir',
+                      default=os.path.join('/tmp', 'scmtest.%d' % os.getpid()))
   GitRunner.add_git_parser_args(parser, {})
   return parser.parse_args([])
 
@@ -110,6 +112,7 @@ class TestSourceCodeManager(unittest.TestCase):
   @classmethod
   def tearDownClass(cls):
     shutil.rmtree(cls.base_temp_dir)
+    shutil.rmtree(cls.git.options.scratch_dir)
 
   def test_get_local_repository_path(self):
     test_root = os.path.join(self.base_temp_dir, 'unused_source')


### PR DESCRIPTION
Changed strategy for dealing with nebula friction by using a decoy origin
repository rather than removing all the confusing tags and versions.
Using the nebula release.verison switch eliminates the need to remove tags,
however it insists on pushing a new tag (and the wrong pattern at that).
The decoy repository tricks nebula into pushing the tag to somewhere irrelvant.

Cleaned up some of the gradle build command classes, adding build_rpms

@jtk54 
This contains the other changes I was working on before fixing nebula.
I combined them together because it was easier for me and doesnt affect anyone else yet.
