### PR TITLE
Cherry pick commit into release-1.5.x: Xenial builds (#2116)

### DIFF
--- a/dev/build_release.py
+++ b/dev/build_release.py
@@ -239,6 +239,8 @@ class Builder(object):
 
     if name == 'halyard':
       extra_args.append('-PbintrayPackageDebDistribution=trusty-nightly')
+    else:
+      extra_args.append('-PbintrayPackageDebDistribution=trusty,xenial')
 
     cmds = [
       './gradlew {extra} {target}'.format(extra=' '.join(extra_args), target=target)


### PR DESCRIPTION
Construct xenial debs when building from the `release-1.5.x` branch.  This is a cherry-pick from master, commit d2dc70fb6a7876d1cdad189d76ff4e67cb433fa0

* feat(build_release): Add xenial builds for debian package.