### PR TITLE
fix(google): Remove needless userdel from cleanup script

### DIFF
--- a/dev/clean_google_image.sh
+++ b/dev/clean_google_image.sh
@@ -47,7 +47,6 @@ for user in $(ls home); do
   fi
 
   if [[ "$user" != "spinnaker" && "$user" != "ubuntu" ]]; then
-    userdel -rf $user
     for file in $etc_files; do
       sed /^$user:.*/d -i etc/${file} || true
       sed /^$user:.*/d -i etc/${file}- || true


### PR DESCRIPTION
The disk we are cleaning is attached to a cleaner instance; running
userdel will only delete users on the cleaner instance not the users
on the mounted (but not running) disk we're trying to clean.