### PR TITLE
chore(buildtool): lazily compute summary_info

### DIFF
--- a/dev/buildtool/bom_commands.py
+++ b/dev/buildtool/bom_commands.py
@@ -259,7 +259,8 @@ class BuildBomCommand(RepositoryCommandProcessor):
     return result
 
   def _do_repository(self, repository):
-    source_info = self.scm.lookup_source_info(repository)
+    source_info = self.scm.refresh_source_info(
+        repository, self.options.build_number)
     self.__builder.add_repository(repository, source_info)
 
   def _do_postprocess(self, _):

--- a/dev/buildtool/container_commands.py
+++ b/dev/buildtool/container_commands.py
@@ -58,16 +58,16 @@ class BuildContainerCommand(GradleCommandProcessor):
         'docker': self.__build_with_docker,
         'gcb': self.__build_with_gcb
     }
-    builder_methods[options.container_builder](repository)
+    scm = self.source_code_manager
+    build_version = scm.get_repository_service_build_version(repository)
+    builder_methods[options.container_builder](repository, build_version)
 
-  def __build_with_docker(self, repository):
+  def __build_with_docker(self, repository, build_version):
     logging.warning('DOCKER builds are still under development')
     name = repository.name
-    source_info = self.source_code_manager.check_source_info(repository)
     docker_tag = '{reg}/{name}:{build_version}'.format(
         reg=self.options.docker_registry,
-        name=name,
-        build_version=source_info.to_build_version())
+        name=name, build_version=build_version)
 
     cmds = [
         'docker build -f Dockerfile -t %s .' % docker_tag,
@@ -117,10 +117,9 @@ class BuildContainerCommand(GradleCommandProcessor):
         'Attempts to delete existing GCR container images.',
         check_subprocess, ' '.join(command))
 
-  def __build_with_gcb(self, repository):
+  def __build_with_gcb(self, repository, build_version):
     name = repository.name
-    source_info = self.source_code_manager.check_source_info(repository)
-    gcb_config = self.__derive_gcb_config(repository, source_info)
+    gcb_config = self.__derive_gcb_config(repository, build_version)
     if gcb_config is None:
       logging.info('Skipping GCB for %s because there is config for it',
                    name)
@@ -184,7 +183,7 @@ class BuildContainerCommand(GradleCommandProcessor):
         'name': self.options.container_base_image
     }
 
-  def __derive_gcb_config(self, repository, source_info):
+  def __derive_gcb_config(self, repository, build_version):
     """Helper function for repository_main."""
     options = self.options
     name = repository.name
@@ -211,7 +210,7 @@ class BuildContainerCommand(GradleCommandProcessor):
                      if env]
     versioned_image = '{reg}/{repo}:{build_version}'.format(
         reg=options.docker_registry, repo=name,
-        build_version=source_info.to_build_version())
+        build_version=build_version)
     steps = ([self.__make_gradle_gcb_step(name, env_vars_list)]
              if has_gradle_step
              else [])

--- a/dev/buildtool/debian_commands.py
+++ b/dev/buildtool/debian_commands.py
@@ -43,8 +43,7 @@ class BuildDebianCommand(GradleCommandProcessor):
 
   def _do_can_skip_repository(self, repository):
     build_version = self.scm.get_repository_service_build_version(repository)
-    return self.gradle.consider_debian_on_bintray(
-        repository, build_version=build_version)
+    return self.gradle.consider_debian_on_bintray(repository, build_version)
 
   def _do_repository(self, repository):
     """Implements RepositoryCommandProcessor interface."""

--- a/dev/buildtool/gradle_support.py
+++ b/dev/buildtool/gradle_support.py
@@ -187,14 +187,8 @@ class GradleRunner(object):
     self.__git = GitRunner(options)
     self.__scm = scm
 
-  def __to_bintray_url(self, repo, package_name, repository,
-                       build_version=None, build_number=None):
+  def __to_bintray_url(self, repo, package_name, repository, build_version):
     """Return the url for the desired versioned repository in bintray repo."""
-    if not build_version:
-      source_info = self.__scm.lookup_source_info(repository)
-      build_number = build_number or source_info.build_number
-      build_version = '%s-%s' % (source_info.summary.version, build_number)
-
     bintray_path = (
         'packages/{subject}/{repo}/{package}/versions/{version}'.format(
             subject=self.__options.bintray_org,
@@ -210,13 +204,11 @@ class GradleRunner(object):
     request.add_header('Authorization', 'Basic ' + encoded_auth)
 
   def bintray_repo_has_version(self, repo, package_name, repository,
-                               build_version=None,
-                               build_number=None):
+                               build_version):
     """See if the given bintray repository has the package version to build."""
     try:
       bintray_url = self.__to_bintray_url(repo, package_name, repository,
-                                          build_version=build_version,
-                                          build_number=build_number)
+                                          build_version)
       logging.debug('Checking for %s', bintray_url)
       request = urllib2.Request(url=bintray_url)
       self.__add_bintray_auth_header(request)
@@ -233,9 +225,7 @@ class GradleRunner(object):
       raise
 
 
-  def consider_debian_on_bintray(self, repository,
-                                 build_version=None,
-                                 build_number=None):
+  def consider_debian_on_bintray(self, repository, build_version):
     """Check whether desired version already exists on bintray."""
     options = self.__options
     exists = []
@@ -253,9 +243,7 @@ class GradleRunner(object):
         elif not package_name.startswith('spinnaker'):
           package_name = 'spinnaker-' + package_name
       if self.bintray_repo_has_version(
-          bintray_repo, package_name, repository,
-          build_version=build_version,
-          build_number=build_number):
+          bintray_repo, package_name, repository, build_version):
         exists.append(bintray_repo)
       else:
         missing.append(bintray_repo)
@@ -289,7 +277,7 @@ class GradleRunner(object):
     """Delete the given bintray repository version if it exsts."""
     try:
       bintray_url = self.__to_bintray_url(repo, package_name, repository,
-                                          build_version=build_version)
+                                          build_version)
       logging.debug('Checking for %s', bintray_url)
       request = urllib2.Request(url=bintray_url)
       request.get_method = lambda: 'DELETE'

--- a/dev/buildtool/scm.py
+++ b/dev/buildtool/scm.py
@@ -179,24 +179,13 @@ class SpinnakerSourceCodeManager(object):
 
   def ensure_local_repository(self, repository):
     """Make sure local repository directory exists, and make it so if not."""
-    summary_filename = repository.name + '-meta.yml'
-    summary_dir_path = os.path.join(self.__root_source_dir)
-    summary_cache_path = os.path.join(summary_dir_path, summary_filename)
     git_dir = repository.git_dir
     have_git_dir = os.path.exists(git_dir)
-    if (have_git_dir
-        and os.path.exists(summary_cache_path)
-        and self.check_repository_is_current(repository)):
-      return
 
-    # Refresh either because it is new or because it changed.
-    self.ensure_git_path(repository)
-    build_number = self.determine_build_number(repository)
-
-    if repository.name in [SPINNAKER_GITHUB_IO_REPOSITORY_NAME]:
-      logging.debug('Summary info for %s is disabled', repository.name)
+    if have_git_dir:
+      self.check_repository_is_current(repository)
     else:
-      self.refresh_source_info(repository, build_number)
+      self.ensure_git_path(repository)
 
   def refresh_source_info(self, repository, build_number):
     """Extract the source info from repository and cache with build number.

--- a/unittest/buildtool/bom_command_test.py
+++ b/unittest/buildtool/bom_command_test.py
@@ -144,10 +144,10 @@ class TestBuildBomCommand(BaseGitRepoTestFixture):
 
     # When the base command asks for the repository metadata, we'll return
     # this hardcoded info, then look for it later in the generated om.
-    mock_lookup = make_fake(BranchSourceCodeManager, 'lookup_source_info')
+    mock_refresh = make_fake(BranchSourceCodeManager, 'refresh_source_info')
     summary = RepositorySummary('CommitA', 'TagA', '9.8.7', '44.55.66', [])
     source_info = SourceInfo('MyBuildNumber', summary)
-    mock_lookup.return_value = source_info
+    mock_refresh.return_value = source_info
 
     # When asked to write the bom out, do nothing.
     # We'll verify the bom later when looking at the mock call sequencing.
@@ -178,7 +178,7 @@ class TestBuildBomCommand(BaseGitRepoTestFixture):
     mock_remote.assert_called_once_with(test_repository.origin,
                                         options.git_branch)
     mock_filter.assert_called_once_with(bom_repo_list)
-    mock_lookup.assert_called_once_with(test_repository)
+    mock_refresh.assert_called_once_with(test_repository, 'OptionBuildNumber')
     bom_text, bom_path = mock_write.call_args_list[0][0]
 
     self.assertEquals(bom_path, 'MY PATH')


### PR DESCRIPTION
@jtk54 

The summary info is rarely needed now that most builds are driven off boms supplying the version.
