### PR TITLE
refactor(buildtool): Make libraries usable by validator.

### DIFF
--- a/dev/buildtool/__main__.py
+++ b/dev/buildtool/__main__.py
@@ -113,7 +113,7 @@ def __load_defaults_from_path(path, visited=None):
   return defaults
 
 
-def preprocess_args(args):
+def preprocess_args(args, default_home_path_filename='buildtool.yml'):
   """Preprocess the args to determine the defaults to use.
 
   This recognizes the --default_args_file override and, if present loads them.
@@ -129,7 +129,8 @@ def preprocess_args(args):
 
   options, args = parser.parse_known_args(args)
 
-  home_path = os.path.join(os.environ['HOME'], '.spinnaker', 'buildtool.yml')
+  home_path = os.path.join(os.environ['HOME'], '.spinnaker',
+                           default_home_path_filename)
   if CHECK_HOME_FOR_CONFIG and os.path.exists(home_path):
     defaults = __load_defaults_from_path(home_path)
     defaults['default_args_file'] = home_path
@@ -244,7 +245,7 @@ def main():
   finally:
     labels['success'] = success
     MetricsManager.singleton().observe_timer(
-        'BuildTool_Outcome', labels, 'Program Execution',
+        'BuildTool_Outcome', labels,
         time.time() - start_time)
     MetricsManager.shutdown_metrics()
 

--- a/dev/buildtool/base_metrics.py
+++ b/dev/buildtool/base_metrics.py
@@ -16,6 +16,7 @@
 
 import datetime
 import logging
+import sys
 import threading
 import time
 
@@ -160,11 +161,6 @@ class MetricFamily(object):
     return self.__name
 
   @property
-  def description(self):
-    """The documentation for this metric."""
-    return self.__description
-
-  @property
   def registry(self):
     """The MetricsRegistry containing this family."""
     return self.__registry
@@ -184,10 +180,9 @@ class MetricFamily(object):
     """Return all the label binding metric variations within this family."""
     return self.__instances.values()
 
-  def __init__(self, registry, name, description, factory, family_type):
+  def __init__(self, registry, name, factory, family_type):
     self.__mutex = threading.Lock()
     self.__name = name
-    self.__description = description
     self.__factory = factory
     self.__instances = {}
     self.__registry = registry
@@ -217,6 +212,17 @@ class BaseMetricsRegistry(object):
   """
   # pylint: disable=too-many-public-methods
 
+  @staticmethod
+  def default_determine_outcome_labels(result, base_labels):
+    """Return the outcome labels for a set of tracking labels."""
+    ex_type, _, _ = sys.exc_info()
+    result = dict(base_labels)
+    result.update({
+        'success': ex_type is None,
+        'exception_type': '' if ex_type is None else ex_type.__name__
+    })
+    return result
+
   @property
   def options(self):
     """Configured options."""
@@ -244,13 +250,12 @@ class BaseMetricsRegistry(object):
     self.__update_mutex = threading.Lock()
 
   def _do_make_family(
-      self, family_type, name, description, label_names):
+      self, family_type, name, label_names):
     """Creates new metric-system specific gauge family.
 
     Args:
       family_type: MetricFamily.COUNTER, GUAGE, or TIMER
       name: [string] Metric name.
-      description: [string] Metric help description.
       label_names: [list of string] The labels used to distinguish instances.
 
     Returns:
@@ -263,15 +268,13 @@ class BaseMetricsRegistry(object):
     with self.__update_mutex:
       self.__updated_metrics.add(metric)
 
-  def inc_counter(self, name, labels, description, **kwargs):
+  def inc_counter(self, name, labels, **kwargs):
     """Track number of completed calls to the given function."""
-    counter = self.__ensure_metric(
-        MetricFamily.COUNTER, name, labels, description)
+    counter = self.__ensure_metric(MetricFamily.COUNTER, name, labels)
     counter.inc(**kwargs)
     return counter
 
-  def count_call(self, name, labels, description,
-                 func, *pos_args, **kwargs):
+  def count_call(self, name, labels, func, *pos_args, **kwargs):
     """Track number of completed calls to the given function."""
     labels = dict(labels)
     success = False
@@ -281,45 +284,46 @@ class BaseMetricsRegistry(object):
       return result
     finally:
       labels['success'] = success
-      self.inc_counter(name, labels, description, **kwargs)
+      self.inc_counter(name, labels, **kwargs)
 
-  def set(self, name, labels, description, value):
+  def set(self, name, labels, value):
     """Sets the implied gauge with the specified value."""
     gauge = self.__ensure_metric(
-        MetricFamily.GAUGE, name, labels, description)
+        MetricFamily.GAUGE, name, labels)
     gauge.set(value)
     return gauge
 
-  def track_call(self, name, labels, description, func, *pos_args, **kwargs):
+  def track_call(self, name, labels, func, *pos_args, **kwargs):
     """Track number of active calls to the given function."""
-    gauge = self.__ensure_metric(
-        MetricFamily.GAUGE, name, labels, description)
+    gauge = self.__ensure_metric(MetricFamily.GAUGE, name, labels)
     return gauge.track(func, *pos_args, **kwargs)
 
-  def observe_timer(self, name, labels, description, seconds):
+  def observe_timer(self, name, labels, seconds):
     """Add an observation to the specified timer."""
-    timer = self.__ensure_metric(
-        MetricFamily.TIMER, name, labels, description)
+    timer = self.__ensure_metric(MetricFamily.TIMER, name, labels)
     timer.observe(seconds)
     return timer
 
-  def time_call(self, name, labels, description,
-                func, *pos_args, **kwargs):
+  def time_call(self, name, labels, label_func,
+                time_func, *pos_args, **kwargs):
     """Track number of completed calls to the given function."""
-    timer = self.__ensure_metric(
-        MetricFamily.TIMER, name, labels, description)
-
     try:
       start_time = time.time()
-      return func(*pos_args, **kwargs)
+      result = time_func(*pos_args, **kwargs)
+      outcome_labels = label_func(result, labels)
+      return result
+    except:
+      outcome_labels = label_func(None, labels)
+      raise
     finally:
+      timer = self.__ensure_metric(MetricFamily.TIMER, name, outcome_labels)
       timer.observe(time.time() - start_time)
 
   def lookup_family_or_none(self, name):
     return self.__metric_families.get(name)
 
   def __ensure_metric(
-      self, family_type, name, labels, description, *pos_args):
+      self, family_type, name, labels, *pos_args):
     """Find family with given name if it exists already, otherwise make one."""
     family = self.__metric_families.get(name)
     if family:
@@ -328,35 +332,28 @@ class BaseMetricsRegistry(object):
             have=family, want=family_type))
       return family.get(labels)
 
-    family = self._do_make_family(
-        family_type, name, description, labels.keys(), *pos_args)
+    family = self._do_make_family(family_type, name, labels.keys(), *pos_args)
     with self.__family_mutex:
       if name not in self.__metric_families:
         self.__metric_families[name] = family
     return family.get(labels)
 
-  def instrument_track_and_outcome(
-      self, name, description, track_labels, outcome_labels_func,
+  def track_and_time_call(
+      self, name, labels, outcome_labels_func,
       result_func, *pos_args, **kwargs):
     """Call the function with the given arguments while instrumenting it.
 
     This will instrument both tracking of call counts in progress
     as well as the final outcomes in terms of performance and outcome.
     """
-    start = time.time()
-    try:
-      tracking_name = name + '_InProgress'
-      result = self.track_call(tracking_name, track_labels, description,
-                               result_func, *pos_args, **kwargs)
-      outcome_labels = outcome_labels_func()
-      return result
-    except:
-      outcome_labels = outcome_labels_func()
-      raise
-    finally:
-      seconds = max(0, time.time() - start)
-      outcome_name = name + '_Outcome'
-      self.observe_timer(outcome_name, outcome_labels, description, seconds)
+    tracking_name = name + '_InProgress'
+    outcome_name = name + '_Outcome'
+
+    return self.track_call(
+        tracking_name, labels,
+        self.time_call,
+        outcome_name, labels, outcome_labels_func,
+        result_func, *pos_args, **kwargs)
 
   def start_pusher_thread(self):
     """Starts thread for pushing metrics."""
@@ -367,7 +364,7 @@ class BaseMetricsRegistry(object):
         if self.__pusher_thread:
           self.__pusher_thread_event.wait(
               self.options.monitoring_flush_frequency)
-          return self.__pusher_thread is not None
+        return self.__pusher_thread is not None
       except Exception as ex:
         logging.error('Pusher thread delay func caught %s', ex)
         return False
@@ -375,6 +372,7 @@ class BaseMetricsRegistry(object):
     self.__pusher_thread = threading.Thread(
         name='MetricsManager', target=self.flush_every_loop, args=[delay_func])
     self.__pusher_thread.start()
+    return True
 
   def stop_pusher_thread(self):
     """Stop thread for pushing metrics."""

--- a/dev/buildtool/bom_commands.py
+++ b/dev/buildtool/bom_commands.py
@@ -254,8 +254,7 @@ class BuildBomCommand(RepositoryCommandProcessor):
 
     labels = {'repository': name, 'branch': branch,
               'reason': reason, 'updated': result}
-    self.metrics.inc_counter('UpdateBomEntry', labels,
-                             'Attempts to update bom entries.')
+    self.metrics.inc_counter('UpdateBomEntry', labels)
     return result
 
   def _do_repository(self, repository):

--- a/dev/buildtool/bom_scm.py
+++ b/dev/buildtool/bom_scm.py
@@ -91,11 +91,13 @@ class BomSourceCodeManager(SpinnakerSourceCodeManager):
       check_path_exists(bom_path, why='options.bom_path')
       return BomSourceCodeManager.bom_from_path(bom_path)
 
-    if bom_version:
-      logging.debug('Retrieving bom version %s', bom_version)
-      return HalRunner(options).retrieve_bom_version(bom_version)
+    if not bom_version:
+      raise_and_log_error(
+          UnexpectedError('Not reachable', cause='NotReachable'))
 
-    raise_and_log_error(UnexpectedError('Not reachable', cause='NotReachable'))
+    logging.debug('Retrieving bom version %s', bom_version)
+    return HalRunner(options).retrieve_bom_version(bom_version)
+
 
   @property
   def bom(self):
@@ -165,11 +167,11 @@ class BomSourceCodeManager(SpinnakerSourceCodeManager):
     service_name = self.repository_name_to_service_name(repository.name)
     have_commit = self.git.query_local_repository_commit_id(git_dir)
     bom_commit = check_bom_service(self.__bom, service_name)['commit']
-    if have_commit == bom_commit:
-      return True
-    raise_and_log_error(
-        UnexpectedError(
-            '"%s" is at the wrong commit "%s"' % (git_dir, bom_commit)))
+    if have_commit != bom_commit:
+      raise_and_log_error(
+          UnexpectedError(
+              '"%s" is at the wrong commit "%s"' % (git_dir, bom_commit)))
+    return True
 
   def determine_upstream_url(self, name):
     # Disable upstream on BOM urls since we wont be pushing back.

--- a/dev/buildtool/branch_scm.py
+++ b/dev/buildtool/branch_scm.py
@@ -109,9 +109,10 @@ class BranchSourceCodeManager(SpinnakerSourceCodeManager):
 
   def check_repository_is_current(self, repository):
     branch = self.options.git_branch or 'master'
-    have_branch = self.git.query_local_repository_branch(repository.git_dir)
-    if have_branch == branch:
-      return True
-    raise_and_log_error(
-        UnexpectedError(
-            '"%s" is at the wrong branch "%s"' % (repository.git_dir, branch)))
+    git_dir = repository.git_dir
+    have_branch = self.git.query_local_repository_branch(git_dir)
+    if have_branch != branch:
+      raise_and_log_error(
+          UnexpectedError(
+              '"%s" is at the wrong branch "%s"' % (git_dir, branch)))
+    return True

--- a/dev/buildtool/command.py
+++ b/dev/buildtool/command.py
@@ -16,7 +16,6 @@
 
 import os
 import logging
-import sys
 
 # pylint: disable=relative-import
 from buildtool.metrics import MetricsManager
@@ -123,19 +122,9 @@ class CommandProcessor(object):
   def metrics(self):
     return self.__metrics
 
-  def determine_tracking_metric_labels(self):
+  def determine_metric_labels(self):
     """Returns the label bindings for the invocation tracking metrics."""
     return {'command': self.name}
-
-  def determine_outcome_metric_labels(self):
-    """Returns the label bindings for the invocation outcome metrics."""
-    ex_type, _, _ = sys.exc_info()
-
-    return {
-        'command': self.name,
-        'success': ex_type is None,
-        'exception_type': '' if ex_type is None else ex_type.__name__
-    }
 
   def __init__(self, factory, options):
     self.__factory = factory
@@ -145,10 +134,10 @@ class CommandProcessor(object):
   def __call__(self):
     logging.debug('Running command=%s...', self.name)
     try:
-      tracking_labels = self.determine_tracking_metric_labels()
-      result = self.metrics.instrument_track_and_outcome(
-          'RunCommand', 'Command Invocations', tracking_labels,
-          self.determine_outcome_metric_labels,
+      metric_labels = self.determine_metric_labels()
+      result = self.metrics.track_and_time_call(
+          'RunCommand',
+          metric_labels, self.metrics.default_determine_outcome_labels,
           self._do_command)
       logging.debug('Finished command=%s', self.name)
       return result

--- a/dev/buildtool/container_commands.py
+++ b/dev/buildtool/container_commands.py
@@ -93,8 +93,7 @@ class BuildContainerCommand(GradleCommandProcessor):
       labels = {'repository': repository.name, 'artifact': 'gcr-container'}
       if self.options.skip_existing:
         logging.info('Already have %s -- skipping build', image_name)
-        self.metrics.inc_counter('ReuseArtifact', labels,
-                                 'Kept existing container image.')
+        self.metrics.inc_counter('ReuseArtifact', labels)
         return True
       if self.options.delete_existing:
         self.__delete_gcb_image(repository, image_name, version)
@@ -114,7 +113,6 @@ class BuildContainerCommand(GradleCommandProcessor):
     labels = {'repository': repository.name, 'artifact': 'gcr-container'}
     self.metrics.count_call(
         'DeleteArtifact', labels,
-        'Attempts to delete existing GCR container images.',
         check_subprocess, ' '.join(command))
 
   def __build_with_gcb(self, repository, build_version):
@@ -165,8 +163,7 @@ class BuildContainerCommand(GradleCommandProcessor):
     logfile = self.get_logfile_path(name + '-gcb-build')
     labels = {'repository': repository.name}
     self.metrics.time_call(
-        'GcrBuild', labels,
-        'Attempts to build GCR container images.',
+        'GcrBuild', labels, self.metrics.default_determine_outcome_labels,
         check_subprocesses_to_logfile,
         name + ' container build', logfile, [command], cwd=git_dir)
 

--- a/dev/buildtool/errors.py
+++ b/dev/buildtool/errors.py
@@ -33,8 +33,7 @@ class BuildtoolError(Exception):
         'cause': cause,
         'classification': classification
     }
-    MetricsManager.singleton().inc_counter(
-        'BuildtoolError', labels, 'Errors raised during execution.')
+    MetricsManager.singleton().inc_counter('BuildtoolError', labels)
 
 
 class ConfigError(BuildtoolError):

--- a/dev/buildtool/halyard_commands.py
+++ b/dev/buildtool/halyard_commands.py
@@ -182,8 +182,7 @@ class BuildHalyardCommand(GradleCommandProcessor):
       if entry:
         logging.info('Found existing halyard version "%s"', entry)
         labels = {'repository': repository.name, 'artifact': 'halyard'}
-        self.metrics.inc_counter('ReuseArtifact', labels,
-                                 'Kept existing desired artifact build.')
+        self.metrics.inc_counter('ReuseArtifact', labels)
         self.__emit_last_commit_entry(entry)
         return True
     return False

--- a/dev/buildtool/image_commands.py
+++ b/dev/buildtool/image_commands.py
@@ -127,8 +127,7 @@ class BuildGceComponentImages(RepositoryCommandProcessor):
     labels = {'repository': repository.name, 'artifact': 'gce-image'}
     if self.options.skip_existing:
       logging.info('Already have %s -- skipping build', image_name)
-      self.metrics.inc_counter('ReuseArtifact', labels,
-                               'Kept existing GCE image.')
+      self.metrics.inc_counter('ReuseArtifact', labels)
       return True
     if not self.options.delete_existing:
       raise_and_log_error(
@@ -143,6 +142,7 @@ class BuildGceComponentImages(RepositoryCommandProcessor):
         'DeleteArtifact', labels,
         'Attempts to delete existing GCE images.',
         check_subprocess, ' '.join(delete_command))
+    return False
 
   def ensure_local_repository(self, repository):
     """Local repositories are used to get version information."""
@@ -156,9 +156,7 @@ class BuildGceComponentImages(RepositoryCommandProcessor):
       logging.debug('%s does not build a GCE component image -- skip',
                     repository.name)
       return True
-
-    if self.have_image(repository):
-      return
+    return self.have_image(repository)
 
   def _do_repository(self, repository):
     """Implements RepositoryCommandProcessor interface."""

--- a/dev/buildtool/inmemory_metrics.py
+++ b/dev/buildtool/inmemory_metrics.py
@@ -278,9 +278,9 @@ class InMemoryMetricsRegistry(BaseMetricsRegistry):
             command=options.command, pid=pid))
 
   def _do_make_family(
-      self, family_type, name, description, label_names):
+      self, family_type, name, label_names):
     """Implements interface."""
-    return self.__new_family(name, description, label_names, family_type)
+    return self.__new_family(name, label_names, family_type)
 
   def make_snapshot(self):
     """Writes metrics to file."""
@@ -321,7 +321,7 @@ class InMemoryMetricsRegistry(BaseMetricsRegistry):
     snapshot, _, _ = self.make_snapshot()
     self.__flush_snapshot(snapshot)
 
-  def __new_family(self, name, description, label_names, family_type):
+  def __new_family(self, name, label_names, family_type):
     """Defines a new family container instance."""
     # pylint: disable=unused-argument
     # We dont use label_names, but take it because it is part of the interface
@@ -329,7 +329,6 @@ class InMemoryMetricsRegistry(BaseMetricsRegistry):
     self.__metrics_snapshot_prototype[SNAPSHOT_CATEGORY[family_type]][name] = {
         'name': name,
         'type': family_type,
-        'description': description,
         'collectors': []
     }
     type_to_factory = {
@@ -338,4 +337,4 @@ class InMemoryMetricsRegistry(BaseMetricsRegistry):
         MetricFamily.TIMER: InMemoryTimer
     }
     factory = type_to_factory[family_type]
-    return MetricFamily(self, name, description, factory, family_type)
+    return MetricFamily(self, name, factory, family_type)

--- a/dev/buildtool/scm.py
+++ b/dev/buildtool/scm.py
@@ -27,7 +27,6 @@ import yaml
 
 # pylint: disable=relative-import
 from buildtool import (
-    SPINNAKER_GITHUB_IO_REPOSITORY_NAME,
     GitRepositorySpec,
     GitRunner,
     RepositorySummary,

--- a/dev/buildtool/subprocess_support.py
+++ b/dev/buildtool/subprocess_support.py
@@ -122,6 +122,7 @@ def run_subprocess(cmd, stream=None, echo=False, **kwargs):
 
 def check_subprocess(cmd, stream=None, **kwargs):
   """Run_subprocess and raise CalledProcessError if it fails."""
+  # pylint: disable=inconsistent-return-statements
   embed_errors = kwargs.pop('embed_errors', True)
   retcode, stdout = run_subprocess(cmd, stream=stream, **kwargs)
   if retcode == 0:


### PR DESCRIPTION
This includes some simplification:
   refactoring on metric API to get rid of descriptions
   lint cleanup
   fix bug where influxdb metrics assume labels

@jtk54 