### PR TITLE
fix(validate): only configure/run pub sub tests when pubsub is enabled

### DIFF
--- a/dev/all_tests.yaml
+++ b/dev/all_tests.yaml
@@ -222,6 +222,8 @@ tests:
     requires:
       configuration:
         appengine_account_enabled: true
+        gcs_pubsub_enabled: true
+        pubsub_google_enabled: true
       services: [clouddriver, front50, gate, orca, echo]
     quota:
       appengine_deployment: 1

--- a/testing/citest/requirements.txt
+++ b/testing/citest/requirements.txt
@@ -18,3 +18,5 @@ pyopenssl
 python-openstackclient
 
 google-cloud-storage>=1.7
+google-cloud-pubsub>=0.26.0
+


### PR DESCRIPTION
@jtk54 

There are also a bunch of formating changes here to bring it mostly to 80 columns and use 4 space indents for continuing lines (which is the style used throughout).

The main gist here is to not require pubsub be configured and gate the pubsub test on pubsub being configured as is the pattern for all the other configurators. 