### PR TITLE
feat(buildtool): Write changelog gists

### DIFF
--- a/dev/buildtool/base_metrics.py
+++ b/dev/buildtool/base_metrics.py
@@ -353,6 +353,7 @@ class BaseMetricsRegistry(object):
       except Exception as ex:
         logging.exception('label_func failed with %s', ex.message)
         raise ex
+      raise
     finally:
       timer = self.get_metric(MetricFamily.TIMER, name, outcome_labels)
       timer.observe(time.time() - start_time)

--- a/dev/buildtool/bom_commands.py
+++ b/dev/buildtool/bom_commands.py
@@ -431,7 +431,6 @@ class PublishBomCommandFactory(RepositoryCommandFactory):
     super(PublishBomCommandFactory, self).__init__(
         'publish_bom', PublishBomCommand, 'Publish a BOM file to Halyard.',
         BomSourceCodeManager,
-        source_repository_names=SPINNAKER_BOM_REPOSITORY_NAMES,
         **kwargs)
 
   def init_argparser(self, parser, defaults):

--- a/dev/buildtool/bom_scm.py
+++ b/dev/buildtool/bom_scm.py
@@ -162,6 +162,16 @@ class BomSourceCodeManager(SpinnakerSourceCodeManager):
     build_number = service['version'][service['version'].find('-') + 1:]
     return build_number
 
+  def determine_repository_version(self, repository):
+    service_name = self.repository_name_to_service_name(repository.name)
+    if not service_name in self.__bom['services'].keys():
+      raise_and_log_error(
+          UnexpectedError('"%s" is not a BOM repo' % service_name))
+
+    service = check_bom_service(self.__bom, service_name)
+    version = service['version'][:service['version'].find('-')]
+    return version
+
   def check_repository_is_current(self, repository):
     git_dir = repository.git_dir
     service_name = self.repository_name_to_service_name(repository.name)

--- a/dev/buildtool/config-template.yml
+++ b/dev/buildtool/config-template.yml
@@ -151,6 +151,7 @@
 ################################
 ### "build" only
 # include_changelog_details: false
+# build_changelog_gist_url: 
 
 
 ################################
@@ -193,4 +194,3 @@
 ################################
 # spinnaker_release_alias:
 # min_halyard_version:
-

--- a/dev/buildtool/flow_build.sh
+++ b/dev/buildtool/flow_build.sh
@@ -50,6 +50,9 @@ function run_build_flow() {
   start_command_unless NO_HALYARD "build_halyard" \
       $EXTRA_BUILD_HALYARD_ARGS
 
+  start_command_unless NO_CHANGELOG "build_changelog" \
+      $EXTRA_BOM_COMMAND_ARGS \
+
   # Synchronize here so we have all the artifacts build before we continue.
   wait_for_commands_or_die "Build"
 
@@ -112,6 +115,9 @@ function process_args() {
         --no_halyard)
           NO_HALYARD=true
           ;;
+        --no_changelog)
+          NO_CHANGELOG=true
+          ;;
         --no_bom_publish)
           NO_BOM_PUBLISH=true
           ;;
@@ -132,12 +138,6 @@ function process_args() {
         --base_bom_version)
           have_refresh=true
           EXTRA_BUILD_BOM_ARGS="$EXTRA_BUILD_BOM_ARGS --refresh_from_bom_version $1"
-          shift
-          ;;
-        --bom_branch)
-          >&2 echo "WARNING: --bom_branch is DEPRECATED."
-          >&2 echo "         Invoke $0 with the branch as the 2nd arg."
-          BOM_BRANCH=$1
           shift
           ;;
         --hal_branch)


### PR DESCRIPTION
This also changes publishing spinnaker to use changelog gists.
There is a process change here where the publish directly writes
the changelog entry to spinnaker.github.io, but takes the existing
gist URI as a parameter as discussed offline. This gist is assumed
to already be curated so no need for additional review step.

The push_changelog_to_gist introduced here is a new process step
where the changelog is uploaded to a separated volatile gist
(control outside this script) which is used offline while curating
the official changelog gist.

@jtk54 
@lwander 