### PR TITLE
fix(buildtool): Dont tag unchaged repos

### DIFF
--- a/dev/buildtool/git_support.py
+++ b/dev/buildtool/git_support.py
@@ -757,6 +757,17 @@ class GitRunner(object):
     messages = CommitMessage.make_list_from_result(result)
     return tag, messages
 
+  def query_commit_at_tag(self, git_dir, tag):
+    """Return the commit for the given tag, or None if tag is not known."""
+    retcode, stdout = self.run_git(git_dir, 'show-ref -- ' + tag)
+    if retcode != 0:
+      return None
+    lines = stdout.split('\n')
+    if len(lines) != 1:
+      raise_and_log_error(
+          UnexpectedError('"{tag}" -> "{msg}"'.format(tag=tag, msg=stdout)))
+    return stdout.split(' ')[0]
+
   def query_local_repository_commit_id(self, git_dir):
     """Returns the current commit for the repository at git_dir."""
     result = self.check_run(git_dir, 'rev-parse HEAD')

--- a/dev/buildtool/spinnaker_commands.py
+++ b/dev/buildtool/spinnaker_commands.py
@@ -165,6 +165,7 @@ class PublishSpinnakerCommand(CommandProcessor):
     # in the tagging pass. Since we are spread against multiple repositiories,
     # we cannot do this atomically. The two passes gives us more protection
     # from a partial push due to errors in a repo.
+    names_to_push = set([])
     for which in ['tag', 'push']:
       for name, spec in bom['services'].items():
         if name in ['monitoring-third-party', 'defaultArtifact']:
@@ -182,22 +183,51 @@ class PublishSpinnakerCommand(CommandProcessor):
         repository = self.__scm.make_repository_spec(name)
         self.__scm.ensure_local_repository(repository)
         if which == 'tag':
-          self.__branch_and_tag_repository(repository, branch)
+          added = self.__branch_and_tag_repository(repository, branch)
+          if added:
+            names_to_push.add(name)
         else:
-          self.__push_branch_and_tag_repository(repository, branch)
+          self.__push_branch_and_maybe_tag_repository(repository, branch,
+                                                      name in names_to_push)
+
+  def __already_have_tag(self, repository, tag):
+    """Determine if we already have the tag in the repository."""
+    git_dir = repository.git_dir
+    existing_commit = self.__git.query_commit_at_tag(git_dir, tag)
+    if not existing_commit:
+      return False
+    want_commit = self.__git.query_local_repository_commit_id(git_dir)
+    if want_commit == existing_commit:
+      logging.debug('Already have "%s" at %s', tag, want_commit)
+      return True
+
+    raise_and_log_error(
+        ConfigError(
+            '"{tag}" already exists in "{repo}" at commit {have}, not {want}'
+            .format(tag=tag, repo=git_dir,
+                    have=existing_commit, want=want_commit)))
 
   def __branch_and_tag_repository(self, repository, branch):
     """Create a branch and/or verison tag in the repository, if needed."""
     version = self.__scm.determine_repository_version(repository)
     tag = 'version-' + version
-    self.__git.check_run(repository.git_dir, 'tag ' + tag)
+    if self.__already_have_tag(repository, tag):
+      return False
 
-  def __push_branch_and_tag_repository(self, repository, branch):
+    self.__git.check_run(repository.git_dir, 'tag ' + tag)
+    return True
+
+  def __push_branch_and_maybe_tag_repository(self, repository, branch,
+                                             also_tag):
     """Push the branch and verison tag to the origin."""
     source_info = self.__scm.lookup_source_info(repository)
     tag = 'version-' + source_info.summary.version
     self.__git.push_branch_to_origin(repository.git_dir, branch)
-    self.__git.push_tag_to_origin(repository.git_dir, tag)
+    if also_tag:
+      self.__git.push_tag_to_origin(repository.git_dir, tag)
+    else:
+      logging.info('%s was already tagged with "%s" -- skip',
+                   repository.git_dir, tag)
 
   def _do_command(self):
     """Implements CommandProcessor interface."""

--- a/unittest/buildtool/git_support_test.py
+++ b/unittest/buildtool/git_support_test.py
@@ -314,6 +314,15 @@ class TestGitRunner(unittest.TestCase):
     self.assertEquals(BRANCH_B,
                       self.git.query_local_repository_branch(test_dir))
 
+  def test_commit_at_tag(self):
+    self.run_git('checkout ' + VERSION_A)
+    want = self.git.query_local_repository_commit_id(self.git_dir)
+    self.run_git('checkout master')
+    self.assertEquals(
+        want, self.git.query_commit_at_tag(self.git_dir, VERSION_A))
+    self.assertIsNone(
+        self.git.query_commit_at_tag(self.git_dir, 'BogusTag'))
+
   def test_summarize(self):
     # All the tags in this fixture are where the head is tagged, so
     # these are not that interesting. This is tested again in the


### PR DESCRIPTION
@lwander 

cherry-picked from master, this will tolerate exiting tags provided they are at the desired commit.
The assumption is that the repo was unchanged from before, though this will also handle the case of a failure in the middle of pushing release tags.