### PR TITLE
refactor(provider/oracle): oraclebmcs provider renamed to oracle

### DIFF
--- a/codelabs/base/install/manifests.yml
+++ b/codelabs/base/install/manifests.yml
@@ -174,7 +174,7 @@ data:
           accounts: []
           bakeryDefaults:
             baseImages: []
-        oraclebmcs:
+        oracle:
           enabled: false
           accounts: []
       deploymentEnvironment:
@@ -198,7 +198,7 @@ data:
           rootFolder: front50
         redis: {}
         s3: {}
-        oraclebmcs: {}
+        oracle: {}
       features:
         artifacts: true
         auth: false

--- a/codelabs/gke-source-to-prod/install/manifests.yml
+++ b/codelabs/gke-source-to-prod/install/manifests.yml
@@ -173,7 +173,7 @@ data:
           accounts: []
           bakeryDefaults:
             baseImages: []
-        oraclebmcs:
+        oracle:
           enabled: false
           accounts: []
       deploymentEnvironment:
@@ -197,7 +197,7 @@ data:
           rootFolder: front50
         redis: {}
         s3: {}
-        oraclebmcs: {}
+        oracle: {}
       features:
         artifacts: true
         auth: false


### PR DESCRIPTION
The name oraclebmcs is no longer used in Oracle product offering. To avoid confusion, spinnaker provider "oracebmcs" is replaced with the name "oracle". 
halyard has made this refactoring in https://github.com/spinnaker/halyard/pull/959. 