### PR TITLE
test(provider/kubernetes): add owner label for cleanup

### DIFF
--- a/testing/citest/tests/kube_v2_artifact_test.py
+++ b/testing/citest/tests/kube_v2_artifact_test.py
@@ -125,6 +125,7 @@ class KubeV2ArtifactTestScenario(sk.SpinnakerTestScenario):
             'namespace': self.TEST_NAMESPACE,
             'labels': {
                 'app': self.TEST_APP,
+                'owner': 'citest',
             }
         },
         'spec': {
@@ -138,6 +139,7 @@ class KubeV2ArtifactTestScenario(sk.SpinnakerTestScenario):
                 'metadata': {
                     'labels': {
                         'app': self.TEST_APP,
+                        'owner': 'citest',
                     }
                 },
                 'spec': {

--- a/testing/citest/tests/kube_v2_smoke_test.py
+++ b/testing/citest/tests/kube_v2_smoke_test.py
@@ -124,6 +124,7 @@ class KubeV2SmokeTestScenario(sk.SpinnakerTestScenario):
             'namespace': self.TEST_NAMESPACE,
             'labels': {
                 'app': self.TEST_APP,
+                'owner': 'citest',
             }
         },
         'spec': {
@@ -137,6 +138,7 @@ class KubeV2SmokeTestScenario(sk.SpinnakerTestScenario):
                 'metadata': {
                     'labels': {
                         'app': self.TEST_APP,
+                        'owner': 'citest',
                     }
                 },
                 'spec': {


### PR DESCRIPTION
This is for test writers to have an easier job of cleaning up orphaned test resources