### PR TITLE
fix(provider/kubernetes): fix versioned configmap name check

### DIFF
--- a/testing/citest/spinnaker_testing/kubernetes_manifests.py
+++ b/testing/citest/spinnaker_testing/kubernetes_manifests.py
@@ -101,7 +101,7 @@ class KubernetesManifestPredicateFactory(object):
              'spec': jp.DICT_MATCHES({
                'volumes': jp.LIST_MATCHES([jp.DICT_MATCHES({
                   'configMap': jp.DICT_MATCHES({ 
-                    'name': jp.STR_EQ(configmap_name)
+                    'name': jp.STR_SUBSTR(configmap_name)
                    })
                  })
                ])

--- a/testing/citest/tests/kube_v2_artifact_test.py
+++ b/testing/citest/tests/kube_v2_artifact_test.py
@@ -182,9 +182,6 @@ class KubeV2ArtifactTestScenario(sk.SpinnakerTestScenario):
         description='Deploy manifest',
         application=self.TEST_APP)
 
-    if versioned:
-      configmap_name = configmap_name + '-v000'
-
     builder = kube.KubeContractBuilder(self.kube_v2_observer)
     (builder.new_clause_builder('Deployment created',
                                 retryable_for_secs=15)


### PR DESCRIPTION
Since the cache may not have updated yet (OK) we just check that the
configmap was mounted and the pod is healthy.