### PR TITLE
fix(citest): Add queueing to gate Hystrix config

### DIFF
--- a/dev/validate_bom__config.py
+++ b/dev/validate_bom__config.py
@@ -45,7 +45,6 @@ interface, which is provided via free functions.
 
 import logging
 import os
-import textwrap
 
 from buildtool import (
     add_parser_argument,

--- a/dev/validate_bom__config.py
+++ b/dev/validate_bom__config.py
@@ -1445,13 +1445,13 @@ class SpinnakerConfigurator(Configurator):
     script.append('mkdir -p  ~/.hal/default/profiles')
     script.append('echo "management.security.enabled: false"'
                   ' > ~/.hal/default/profiles/spinnaker-local.yml')
-    hystrix_config = textwrap.dedent('''\
-      hystrix:
-        threadpool:
-          default:
-            maxQueueSize: 20
-            queueSizeRejectionThreshold: 20
-    ''')
+    hystrix_config = '''\
+hystrix:
+  threadpool:
+    default:
+      maxQueueSize: 20
+      queueSizeRejectionThreshold: 20
+'''
     script.append('echo "{}" > ~/.hal/default/profiles/gate-local.yml'.format(hystrix_config))
 
   def add_files_to_upload(self, options, file_set):

--- a/dev/validate_bom__config.py
+++ b/dev/validate_bom__config.py
@@ -45,6 +45,7 @@ interface, which is provided via free functions.
 
 import logging
 import os
+import textwrap
 
 from buildtool import (
     add_parser_argument,
@@ -1444,6 +1445,14 @@ class SpinnakerConfigurator(Configurator):
     script.append('mkdir -p  ~/.hal/default/profiles')
     script.append('echo "management.security.enabled: false"'
                   ' > ~/.hal/default/profiles/spinnaker-local.yml')
+    hystrix_config = textwrap.dedent('''\
+      hystrix:
+        threadpool:
+          default:
+            maxQueueSize: 20
+            queueSizeRejectionThreshold: 20
+    ''')
+    script.append('echo "{}" > ~/.hal/default/profiles/gate-local.yml'.format(hystrix_config))
 
   def add_files_to_upload(self, options, file_set):
     """Implements interface."""


### PR DESCRIPTION
A number of the intermittent failures observed in running our CI tests are due to Gate returing a 500 on /tasks/task_id because Hystrix did not have an available thread to use to query Orca.  As this is primarily a problem with requests being bursty rather than an overall throughput problem, adding a modest queue to the Hystrix config so that Gate can handle and recover from short bursts of queries.