### PR TITLE
BUGFIX: Update GKE version to 1.9.7-gke.3 for the codelab

### DIFF
--- a/codelabs/gke-source-to-prod/install/setup.sh
+++ b/codelabs/gke-source-to-prod/install/setup.sh
@@ -97,7 +97,7 @@ bold "Creating your cluster $GKE_CLUSTER..."
 
 gcloud container clusters create $GKE_CLUSTER --zone $ZONE \
   --service-account $SA_EMAIL \
-  --username admin --cluster-version 1.9.7-gke.3 \
+  --username admin \
   --machine-type n1-standard-4 --image-type COS --disk-size 100 \
   --num-nodes 3 --enable-cloud-logging --enable-cloud-monitoring
 

--- a/codelabs/gke-source-to-prod/install/setup.sh
+++ b/codelabs/gke-source-to-prod/install/setup.sh
@@ -97,7 +97,7 @@ bold "Creating your cluster $GKE_CLUSTER..."
 
 gcloud container clusters create $GKE_CLUSTER --zone $ZONE \
   --service-account $SA_EMAIL \
-  --username admin --cluster-version 1.8.8-gke.0 \
+  --username admin --cluster-version 1.9.7-gke.3 \
   --machine-type n1-standard-4 --image-type COS --disk-size 100 \
   --num-nodes 3 --enable-cloud-logging --enable-cloud-monitoring
 


### PR DESCRIPTION
When running the codelab https://codelabs.developers.google.com/codelabs/cloud-spinnaker-kubernetes-cd/ I see this error: 

```
ERROR: (gcloud.container.clusters.create) ResponseError: code=400, message=master version "1.8.8-gke.0" is unsupported.
```

The codelab remains unusable after this, there's no recovery. 
This proposed fix takes the currently latest table gke version to fix that. 

After merging, the files on gs://gke-spinnaker-codelab/install.tgz would also need to get fixed.