### PR TITLE
fix(validate): Log ntp time synchronization of instances

### DIFF
--- a/dev/validate_bom__config.py
+++ b/dev/validate_bom__config.py
@@ -1451,6 +1451,7 @@ class MonitoringConfigurator(Configurator):
 
   def add_init(self, options, script):
     """Implements interface."""
+    script.append('ntpq -p || true')
     if not options.monitoring_install_which:
       return
 

--- a/dev/validate_bom__config.py
+++ b/dev/validate_bom__config.py
@@ -1387,6 +1387,8 @@ class LoggingConfigurator(Configurator):
   def add_init(self, options, script):
     """Implements interface."""
 
+    script.append('ntpq -p || true')
+
     if not options.google_cloud_logging:
       return
 
@@ -1451,7 +1453,6 @@ class MonitoringConfigurator(Configurator):
 
   def add_init(self, options, script):
     """Implements interface."""
-    script.append('ntpq -p || true')
     if not options.monitoring_install_which:
       return
 


### PR DESCRIPTION
Some test failures, and the associated log timestamps, indicate that the machines running our tests may have a nontrivial time drift (on the order of hundreds of milliseconds).  To gather data on this, log the output of 'ntpq -p' before installing Spinnaker.