### PR TITLE
chore(build): Update gcloud build commands

### DIFF
--- a/codelabs/cicd-k8s-best-practice/app/scripts/build-image.sh
+++ b/codelabs/cicd-k8s-best-practice/app/scripts/build-image.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-gcloud container builds submit -q --tag gcr.io/spinnaker-playground/demo src/ --project spinnaker-playground
+gcloud builds submit -q --tag gcr.io/spinnaker-playground/demo src/ --project spinnaker-playground

--- a/codelabs/gke-source-to-prod/services/backend/build.sh
+++ b/codelabs/gke-source-to-prod/services/backend/build.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-gcloud container builds submit -q --tag gcr.io/{%PROJECT_ID%}/backend .
+gcloud builds submit -q --tag gcr.io/{%PROJECT_ID%}/backend .

--- a/codelabs/gke-source-to-prod/services/frontend/build.sh
+++ b/codelabs/gke-source-to-prod/services/frontend/build.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-gcloud container builds submit -q --tag gcr.io/{%PROJECT_ID%}/frontend .
+gcloud builds submit -q --tag gcr.io/{%PROJECT_ID%}/frontend .

--- a/dev/buildtool/container_commands.py
+++ b/dev/buildtool/container_commands.py
@@ -153,7 +153,7 @@ class BuildContainerCommand(GradleCommandProcessor):
       shutil.rmtree(gradle_cache)
 
     # Note this command assumes a cwd of git_dir
-    command = ('gcloud container builds submit '
+    command = ('gcloud builds submit '
                ' --account={account} --project={project}'
                ' --config="{config_path}" .'
                .format(account=options.gcb_service_account,

--- a/spinbot/Makefile
+++ b/spinbot/Makefile
@@ -7,7 +7,7 @@ init:
 	python3 -m pip install -r requirements.txt
 
 docker:
-	gcloud container builds submit . \
+	gcloud builds submit . \
 		--project ${PROJECT} \
 		-t ${IMAGE}:${HASH} \
 		-t ${IMAGE}:latest


### PR DESCRIPTION
The 'gcloud container builds' command group has been renamed to 'gcloud builds' as of Google Cloud SDK 210.0.0. The old commands are deprecated and will be removed in a future release; update
the calls in Spinnaker to account for this change.