### PR TITLE
chore(build): Restores fullly-qualified version to "Latest Stable" list

### DIFF
--- a/dev/buildtool/changelog_commands.py
+++ b/dev/buildtool/changelog_commands.py
@@ -468,6 +468,7 @@ class PublishChangelogCommand(RepositoryCommandProcessor):
           title: Version {major}.{minor}
           date: {timestamp}
           tags: changelogs {major}.{minor}
+          version: {version}
           ---
           """.format(
               version=version,


### PR DESCRIPTION
#3099 removed an extraneous h1, and also changed the version displayed at the top of the [changelog page](https://www.spinnaker.io/community/releases/versions/1-8-5-changelog) so that it only shows major.minor, because the page actually contains all the point releases under that major minor.

A side effect was that the version listing under [Latest stable](https://www.spinnaker.io/community/releases/versions/#latest-stable) also now only showed major.minor, in contrast with earlier releases also shown on page. 

This should fix it.