### PR TITLE
fix(citest): Add queueing to front50 Hystrix config

### DIFF
--- a/dev/validate_bom__config.py
+++ b/dev/validate_bom__config.py
@@ -1525,10 +1525,11 @@ class SpinnakerConfigurator(Configurator):
 hystrix:
   threadpool:
     default:
-      maxQueueSize: 20
-      queueSizeRejectionThreshold: 20
+      maxQueueSize: 100
+      queueSizeRejectionThreshold: 100
 '''
     script.append('echo "{}" > ~/.hal/default/profiles/gate-local.yml'.format(hystrix_config))
+    script.append('echo "{}" > ~/.hal/default/profiles/front50-local.yml'.format(hystrix_config))
 
   def add_files_to_upload(self, options, file_set):
     """Implements interface."""


### PR DESCRIPTION
A number of the intermittent failures observed in running our CI tests are due to Front50 hitting a Hystrix circuit breaker when trying to fetch newly-created applications from cloud storage. We fixed a similar
issue in gate by adding queueing to the Hystrix config; do the same for front50, and also increase the queue size to give us a bit more buffer (as we send ~20 requests to create an application at the start of the tests). As this is primarily an issue with burstiness and not throughput, leaving the thread pool size at the default for now.