### PR TITLE
fix(citest): Increase timeout for resize server group

### DIFF
--- a/testing/citest/tests/google_server_group_test.py
+++ b/testing/citest/tests/google_server_group_test.py
@@ -252,7 +252,7 @@ class GoogleServerGroupTestScenario(sk.SpinnakerTestScenario):
 
     builder = gcp.GcpContractBuilder(self.gcp_observer)
     (builder.new_clause_builder(
-        self.__mig_title + ' Resized', retryable_for_secs=90)
+        self.__mig_title + ' Resized', retryable_for_secs=180)
      .inspect_resource(self.__mig_resource_name, self.__server_group_name,
                        **self.__mig_resource_kwargs)
      .EXPECT(ov_factory.value_list_path_contains('size', jp.NUM_EQ(2))))


### PR DESCRIPTION
When resizing a server group, Spinnaker reports success when the new instance is observed. Our test cases are actually testing that the instance group is reporting the new size, which can lag the instance actually appearing. Increase the amount of time we wait for the instance group to report its new size to reduce intermittent failures.