### PR TITLE
fix(citest): Fix operation polling in kube v2 tests

### DIFF
--- a/testing/citest/tests/kube_v2_artifact_test.py
+++ b/testing/citest/tests/kube_v2_artifact_test.py
@@ -293,8 +293,7 @@ class KubeV2ArtifactTestScenario(sk.SpinnakerTestScenario):
     return st.OperationContract(
         self.new_post_operation(
             title='Deploy manifest', data=payload,
-            path='pipelines/' + self.TEST_APP + '/' + pipeline_name,
-            status_class=st.SynchronousHttpOperationStatus),
+            path='pipelines/' + self.TEST_APP + '/' + pipeline_name),
         contract=builder.build())
 
   def deploy_deployment_with_docker_artifact(self, image):

--- a/testing/citest/tests/kube_v2_helm_test.py
+++ b/testing/citest/tests/kube_v2_helm_test.py
@@ -241,8 +241,7 @@ class KubeV2HelmTestScenario(sk.SpinnakerTestScenario):
     return st.OperationContract(
         self.new_post_operation(
             title='Deploy manifest', data=payload,
-            path='pipelines/' + self.TEST_APP + '/bake-deploy-pipeline',
-            status_class=st.SynchronousHttpOperationStatus),
+            path='pipelines/' + self.TEST_APP + '/bake-deploy-pipeline'),
         contract=builder.build())
 
   def delete_kind(self, kind, version=None):

--- a/testing/citest/tests/kube_v2_smoke_test.py
+++ b/testing/citest/tests/kube_v2_smoke_test.py
@@ -292,8 +292,7 @@ class KubeV2SmokeTestScenario(sk.SpinnakerTestScenario):
     return st.OperationContract(
         self.new_post_operation(
             title='Deploy manifest', data=payload,
-            path='pipelines/' + self.TEST_APP + '/deploy-manifest-pipeline',
-            status_class=st.SynchronousHttpOperationStatus),
+            path='pipelines/' + self.TEST_APP + '/deploy-manifest-pipeline'),
         contract=builder.build())
 
   def delete_manifest(self):


### PR DESCRIPTION
A few of the kube v2 tests use a status class of SynchronousHttpOperationStatus when sending a request to trigger a pipeline; this causes the test to return success immediately and move on to testing the contract condition. We should remove this and fall back on the default (GateTaskStatus) which will poll for completion of the pipeline before trying to verify the contract.