### PR TITLE
fix(citest): Further increase timeout for resize server group

### DIFF
--- a/testing/citest/tests/google_server_group_test.py
+++ b/testing/citest/tests/google_server_group_test.py
@@ -250,6 +250,13 @@ class GoogleServerGroupTestScenario(sk.SpinnakerTestScenario):
     }]
     job[0].update(self.__mig_payload_extra)
 
+    # We set the timeout to 10 minutes, as Spinnaker is returning success once
+    # it has seen the new instance appear, but the contract is waiting for the
+    # instance group's self-reported size to be the new size. There is sometimes a
+    # delay of several minutes between the instance first appearing and the instance
+    # group manager reporting the new size. In order to avoid intermittently failing
+    # tests, we set a reasonably long timeout to wait for consistency between the
+    # Spinnaker internal contract and the contract this test is measuring.
     builder = gcp.GcpContractBuilder(self.gcp_observer)
     (builder.new_clause_builder(
         self.__mig_title + ' Resized', retryable_for_secs=600)

--- a/testing/citest/tests/google_server_group_test.py
+++ b/testing/citest/tests/google_server_group_test.py
@@ -252,7 +252,7 @@ class GoogleServerGroupTestScenario(sk.SpinnakerTestScenario):
 
     builder = gcp.GcpContractBuilder(self.gcp_observer)
     (builder.new_clause_builder(
-        self.__mig_title + ' Resized', retryable_for_secs=180)
+        self.__mig_title + ' Resized', retryable_for_secs=600)
      .inspect_resource(self.__mig_resource_name, self.__server_group_name,
                        **self.__mig_resource_kwargs)
      .EXPECT(ov_factory.value_list_path_contains('size', jp.NUM_EQ(2))))


### PR DESCRIPTION
Looks like the timeout added in PR #3171 was not enough; let's extend to 10 minutes to reduce test flakiness.