### PR TITLE
fix(citest): Use a different Jenkins job for each test

### DIFF
--- a/dev/all_tests.yaml
+++ b/dev/all_tests.yaml
@@ -40,7 +40,7 @@ tests:
       alias: [standard_google_provider_params]
       test_google:
       jenkins_token: TRIGGER_TOKEN
-      jenkins_job: NoOpTrigger
+      jenkins_job: $test_jenkins_job_name
       jenkins_url: $jenkins_master_address
       jenkins_master: $jenkins_master_name
       jenkins_master_user: $jenkins_master_user

--- a/dev/validate_bom__test.py
+++ b/dev/validate_bom__test.py
@@ -949,6 +949,10 @@ def init_argument_parser(parser, defaults):
            ' to help trace the source of resources created within the'
            ' tests.')
 
+  add_parser_argument(
+      parser, 'test_jenkins_job_name', defaults, 'TriggerBake',
+      help='The Jenkins job name to use in tests.')
+
 
 def validate_options(options):
   """Validate testing related command-line parameters."""


### PR DESCRIPTION
We currently use the same Jenkins job for all of our CI tests, which means that sometimes the GKE tests are triggering pipelines in the GCE tests (and vice versa).  Use a different Jenkins job for each platform to avoid these issues.