### PR TITLE
fix(citest): Limit polling to US regions

### DIFF
--- a/dev/validate_bom__config.py
+++ b/dev/validate_bom__config.py
@@ -822,8 +822,7 @@ class GoogleConfigurator(Configurator):
         parser, 'google_account_name', defaults, 'my-google-account',
         help='The name of the primary google account to configure.')
     add_parser_argument(
-        parser, 'google_account_regions',
-        defaults, ','.join(['us-central1','us-east1','us-east4','us-west1','us-west2']),
+        parser, 'google_account_regions', defaults, None,
         help='The Google Cloud regions this account should manage.')
 
   def validate_options(self, options):
@@ -846,7 +845,10 @@ class GoogleConfigurator(Configurator):
     account_params = [options.google_account_name]
     account_params.extend([
         '--project', options.google_account_project,
-        '--json-path', os.path.basename(options.google_account_credentials),
+        '--json-path', os.path.basename(options.google_account_credentials)])
+
+    if options.google_account_regions:
+      account_params.extend([
         '--regions', options.google_account_regions])
 
     script.append('hal -q --log=info config provider google enable')

--- a/dev/validate_bom__config.py
+++ b/dev/validate_bom__config.py
@@ -821,6 +821,10 @@ class GoogleConfigurator(Configurator):
     add_parser_argument(
         parser, 'google_account_name', defaults, 'my-google-account',
         help='The name of the primary google account to configure.')
+    add_parser_argument(
+        parser, 'google_account_regions',
+        defaults, ','.join(['us-central1','us-east1','us-east4','us-west1','us-west2']),
+        help='The Google Cloud regions this account should manage.')
 
   def validate_options(self, options):
     """Implements interface."""
@@ -842,7 +846,8 @@ class GoogleConfigurator(Configurator):
     account_params = [options.google_account_name]
     account_params.extend([
         '--project', options.google_account_project,
-        '--json-path', os.path.basename(options.google_account_credentials)])
+        '--json-path', os.path.basename(options.google_account_credentials),
+        '--regions', options.google_account_regions])
 
     script.append('hal -q --log=info config provider google enable')
     if options.deploy_google_zone:


### PR DESCRIPTION
We use a lot of GCE operation quota when running multiple tests concurrently.  As our tests only deploy to US regions, limit the configured Google account to only poll US regions to reduce our quota usage.