### PR TITLE
fix(citest): Limit polling to US regions (#3233)

### DIFF
--- a/dev/validate_bom__config.py
+++ b/dev/validate_bom__config.py
@@ -821,6 +821,9 @@ class GoogleConfigurator(Configurator):
     add_parser_argument(
         parser, 'google_account_name', defaults, 'my-google-account',
         help='The name of the primary google account to configure.')
+    add_parser_argument(
+        parser, 'google_account_regions', defaults, None,
+        help='The Google Cloud regions this account should manage.')
 
   def validate_options(self, options):
     """Implements interface."""
@@ -843,6 +846,10 @@ class GoogleConfigurator(Configurator):
     account_params.extend([
         '--project', options.google_account_project,
         '--json-path', os.path.basename(options.google_account_credentials)])
+
+    if options.google_account_regions:
+      account_params.extend([
+        '--regions', options.google_account_regions])
 
     script.append('hal -q --log=info config provider google enable')
     if options.deploy_google_zone:


### PR DESCRIPTION
We use a lot of GCE operation quota when running multiple tests concurrently.  As our tests only deploy to US regions, limit the configured Google account to only poll US regions to reduce our quota usage.