### PR TITLE
fix(changelog): Fix changelog title to the right version.

### DIFF
--- a/dev/buildtool/changelog_commands.py
+++ b/dev/buildtool/changelog_commands.py
@@ -465,7 +465,7 @@ class PublishChangelogCommand(RepositoryCommandProcessor):
       header = textwrap.dedent(
           """\
           ---
-          title: Version {major}.{minor}
+          title: Version {version}
           date: {timestamp}
           tags: changelogs {major}.{minor}
           version: {version}


### PR DESCRIPTION
Example title: `Version 1.9.3` instead of `Version 1.9`