### PR TITLE
fix(citest): Run hal deploy apply in a login shell

### DIFF
--- a/dev/validate_bom__deploy.py
+++ b/dev/validate_bom__deploy.py
@@ -618,7 +618,7 @@ class GenericVmValidateBomDeployer(BaseValidateBomDeployer):
           ' -o StrictHostKeyChecking=no'
           ' -o UserKnownHostsFile=/dev/null'
           ' {user}@{ip}'
-          ' ./{script_name}'
+          ' bash -l -c ./{script_name}'
           .format(user=self.hal_user,
                   ip=self.instance_ip,
                   ssh_key=self.__ssh_key_path,


### PR DESCRIPTION
Ubuntu 18.04 on GCE installs gcloud using snap, so it ends up in the /snap/bin directory. This directory is added to the path for login shells, but not for non-login shells. Let's run hal deploy apply in a login shell to prevent issues like this.