### PR TITLE
fix(buildtool): support utf-8 output from subprocesses.

### DIFF
--- a/dev/buildtool/subprocess_support.py
+++ b/dev/buildtool/subprocess_support.py
@@ -202,7 +202,7 @@ def check_subprocesses_to_logfile(what, logfile, cmds, append=False, **kwargs):
       traceback.print_exc()
 
       with open(logfile, 'rb') as readagain:
-        output = bytes.decode(readagain.read())
+        output = bytes.decode(readagain.read(), encoding='utf-8')
         log_embedded_output(logging.ERROR, logfile, output)
       logging.error('Caught exception %s\n%s failed. See embedded logfile above',
                     ex, what)


### PR DESCRIPTION
@ezimanyi 
TBR