### PR TITLE
chore(*) add @maggieneterval to list of approvers

### DIFF
--- a/approvers.md
+++ b/approvers.md
@@ -27,6 +27,7 @@
 * jrsquared
 * jtk54
 * lwander
+* maggieneterval
 * robfletcher
 * robzienert
 * sbwsg


### PR DESCRIPTION
Previously had approver access prior to governance; meets criteria.