### PR TITLE
feat(sponnet): extend pipeline library

### DIFF
--- a/sponnet/demo/demo.jsonnet
+++ b/sponnet/demo/demo.jsonnet
@@ -19,7 +19,7 @@ local notificationConditions = ['pipeline.starting', 'pipeline.failed', 'pipelin
 local myManifestArtifactName = 'app/manifest.yaml';
 local myManifestArtifactVersion = 'master';
 local myManifestArtifactReference = 'https://gitlab.com/api/v4/projects/your-org%2Fyour-project/repository/files/app%2Fmanifest%2Eyaml/raw';
-local myManifestArtifactLocation = 'notsurewhat';
+local myManifestArtifactLocation = 'someLocation';
 // Must be specified in pipeline, but not in artifact creation
 local myManifestArtifactAccount = 'gitlab-account';
 
@@ -57,7 +57,8 @@ local expected_manifest = sponnet.expectedArtifact(myManifestArtifactName)
 
 local docker_trigger = sponnet.triggers
                        .docker('myDockerTrigger')
-                       // .withExpectedArtifacts([manifestArtifact, manifestArtifact2])
+                       // TODO verify expected artifact is inserted correctly in configuration.
+                       // .withExpectedArtifacts([expected_image])
                        .withAccount(myDockerAccount)
                        .withOrganization(myDockerOrganization)
                        .withRegistry(myDockerRegistry)
@@ -66,7 +67,8 @@ local docker_trigger = sponnet.triggers
 
 local git_trigger = sponnet.triggers
                     .git('myGitTrigger')
-                    // .withExpectedArtifacts([manifestArtifact, manifestArtifact2])
+                    // TODO verify expected artifact is inserted correctly in configuration.
+                    // .withExpectedArtifacts([expected_manifest])
                     .withBranch(myBranch)
                     .withProject(myProject)
                     .withSlug(mySlug)

--- a/sponnet/demo/demo.jsonnet
+++ b/sponnet/demo/demo.jsonnet
@@ -23,7 +23,7 @@ local myManifestArtifactLocation = 'someLocation';
 // Must be specified in pipeline, but not in artifact creation
 local myManifestArtifactAccount = 'gitlab-account';
 
-local myDockerArtifact = 'myDockerArtifactName';
+local myDockerArtifactName = 'docker-name';
 local myDockerAccount = 'docker-account';
 local myDockerOrganization = 'your-docker-org';
 local myDockerRegistry = 'index.docker.io';
@@ -36,9 +36,14 @@ local mySlug = 'your-project';
 local mySource = 'gitlab';
 
 
-local docker_artifact = sponnet.expectedArtifact('myImageArtifact')
-                        .withMatchArtifact('myContainerArtifact')
-                        .withDefaultArtifact(true)
+local docker_artifact = sponnet.artifacts
+                        .dockerImage()
+                        .withName(myDockerArtifactName)
+                        .withReference(myDockerRegistry + '/' + myDockerRepository);
+
+local expected_docker = sponnet.expectedArtifact(myDockerArtifactName)
+                        .withMatchArtifact(docker_artifact)
+                        .withDefaultArtifact(docker_artifact)
                         .withUsePriorArtifact(false)
                         .withUseDefaultArtifact(true);
 
@@ -57,8 +62,8 @@ local expected_manifest = sponnet.expectedArtifact(myManifestArtifactName)
 
 local docker_trigger = sponnet.triggers
                        .docker('myDockerTrigger')
-                       // TODO verify expected artifact is inserted correctly in configuration.
-                       // .withExpectedArtifacts([expected_image])
+                       // If ExpectedArtifact Required, add below.
+                       // .withExpectedArtifacts([expected_docker])
                        .withAccount(myDockerAccount)
                        .withOrganization(myDockerOrganization)
                        .withRegistry(myDockerRegistry)
@@ -67,7 +72,7 @@ local docker_trigger = sponnet.triggers
 
 local git_trigger = sponnet.triggers
                     .git('myGitTrigger')
-                    // TODO verify expected artifact is inserted correctly in configuration.
+                    // If ExpectedArtifact Required, add below.
                     // .withExpectedArtifacts([expected_manifest])
                     .withBranch(myBranch)
                     .withProject(myProject)
@@ -117,9 +122,8 @@ local jenkins_job = sponnet.stages
 
 sponnet.pipeline()
 .withApplication(app)
-.withExpectedArtifacts(expected_manifest)
+.withExpectedArtifacts([expected_docker, expected_manifest])
 .withName('Demo pipeline')
 .withNotifications(slack)
-// TO DO add ExpectedArtifactId somehow if constraint....
 .withTriggers([docker_trigger, git_trigger])
 .withStages([wait, manifest_baseline, manifest_canary, manifest_artifact, jenkins_job])

--- a/sponnet/demo/demo.jsonnet
+++ b/sponnet/demo/demo.jsonnet
@@ -1,31 +1,123 @@
-local sponnet = import "pipeline.libsonnet";
-local kubeutils = import "kubeutils.libsonnet";
-local deployment = import "deployment.json";
+local deployment = import 'deployment.json';
+local kubeutils = import 'kubeutils.libsonnet';
+local sponnet = import 'pipeline.libsonnet';
 
 local canary_deployment = kubeutils.canary(deployment);
-local account = "staging-demo";
-local app = "cluster";
-local moniker = sponnet.moniker(app, "some-cluster");
+local account = 'staging-demo';
+local app = 'cluster';
+local moniker = sponnet.moniker(app, 'some-cluster')
+                .withStack('someStack')
+                .withDetail('someDetail');
+
+local myJenkinsMaster = 'staging-jenkins';
+local myJenkinsJob = 'smoketest';
+
+local notificationAddress = 'development';
+local notificationType = 'slack';
+local notificationConditions = ['pipeline.starting', 'pipeline.failed', 'pipeline.complete'];
+
+local myManifestArtifactName = 'app/manifest.yaml';
+local myManifestArtifactVersion = 'master';
+local myManifestArtifactReference = 'https://gitlab.com/api/v4/projects/your-org%2Fyour-project/repository/files/app%2Fmanifest%2Eyaml/raw';
+local myManifestArtifactLocation = 'notsurewhat';
+// Must be specified in pipeline, but not in artifact creation
+local myManifestArtifactAccount = 'gitlab-account';
+
+local myDockerArtifact = 'myDockerArtifactName';
+local myDockerAccount = 'docker-account';
+local myDockerOrganization = 'your-docker-org';
+local myDockerRegistry = 'index.docker.io';
+local myDockerRepository = 'yourorg/app';
+local myDockerTag = '^git-.*$';
+
+local myBranch = 'master';
+local myProject = 'your-org';
+local mySlug = 'your-project';
+local mySource = 'gitlab';
+
+
+local docker_artifact = sponnet.expectedArtifact('myImageArtifact')
+                        .withMatchArtifact('myContainerArtifact')
+                        .withDefaultArtifact(true)
+                        .withUsePriorArtifact(false)
+                        .withUseDefaultArtifact(true);
+
+local gitlab_artifact = sponnet.artifacts
+                        .gitlabFile()
+                        .withName(myManifestArtifactName)
+                        .withVersion(myManifestArtifactVersion)
+                        .withReference(myManifestArtifactReference)
+                        .withLocation(myManifestArtifactLocation);
+
+local expected_manifest = sponnet.expectedArtifact(myManifestArtifactName)
+                          .withMatchArtifact(gitlab_artifact)
+                          .withDefaultArtifact(gitlab_artifact)
+                          .withUsePriorArtifact(false)
+                          .withUseDefaultArtifact(true);
+
+local docker_trigger = sponnet.triggers
+                       .docker('myDockerTrigger')
+                       // .withExpectedArtifacts([manifestArtifact, manifestArtifact2])
+                       .withAccount(myDockerAccount)
+                       .withOrganization(myDockerOrganization)
+                       .withRegistry(myDockerRegistry)
+                       .withRepository(myDockerRepository)
+                       .withTag(myDockerTag);
+
+local git_trigger = sponnet.triggers
+                    .git('myGitTrigger')
+                    // .withExpectedArtifacts([manifestArtifact, manifestArtifact2])
+                    .withBranch(myBranch)
+                    .withProject(myProject)
+                    .withSlug(mySlug)
+                    .withSource(mySource);
+
+local slack = sponnet.notifications
+              .withAddress(notificationAddress)
+              .withType(notificationType)
+              .withWhen('starting')
+              .withWhen('failed', 'testf: one two three, $variable, %value, "quoted": https://example.com')
+              .withWhen('complete', 'test');
 
 local wait = sponnet.stages
-  .wait("Wait")
-  .withWaitTime(30);
+             .wait('Wait')
+             .withWaitTime(30);
+
+local manifest_artifact = sponnet.stages
+                          .deploy_manifest('Deploy a manifest with artifact')
+                          .withManifestArtifact(expected_manifest)
+                          .withManifestArtifactAccount(myManifestArtifactAccount)
+                          .withAccount(account)
+                          .withMoniker(moniker)
+                          .withOverrideTimeout('300000')
+                          .withRequisiteStages(wait);
 
 local manifest_baseline = sponnet.stages
-  .deploy_manifest("Deploy a manifest")
-  .withManifests(deployment)
-  .withAccount(account)
-  .withMoniker(moniker)
-  .withRequisiteStages(wait);
+                          .deploy_manifest('Deploy a manifest')
+                          .withManifests(deployment)
+                          .withAccount(account)
+                          .withMoniker(moniker)
+                          .withRequisiteStages(wait);
 
 local manifest_canary = sponnet.stages
-  .deploy_manifest("Deploy a canary manifest")
-  .withManifests(canary_deployment)
-  .withAccount(account)
-  .withMoniker(moniker)
-  .withRequisiteStages(wait);
+                        .deploy_manifest('Deploy a canary manifest')
+                        .withManifests(canary_deployment)
+                        .withAccount(account)
+                        .withMoniker(moniker)
+                        .withRequisiteStages(wait);
+
+local jenkins_job = sponnet.stages
+                    .jenkins('Run Jenkins Job')
+                    .withMaster(myJenkinsMaster)
+                    .withJob(myJenkinsJob)
+                    .withOverrideTimeout('300000')
+                    .withRequisiteStages(wait);
 
 sponnet.pipeline()
-  .withStages([wait, manifest_baseline, manifest_canary])
-  .withName("Demo pipeline")
-  .withApplication(app)
+.withApplication(app)
+.withExpectedArtifacts(expected_manifest)
+.withName('Demo pipeline')
+.withNotifications(slack)
+// TO DO add ExpectedArtifactId somehow if constraint....
+.withTriggers([docker_trigger, git_trigger])
+.withStages([wait, manifest_baseline, manifest_canary, manifest_artifact, jenkins_job])

--- a/sponnet/pipeline.libsonnet
+++ b/sponnet/pipeline.libsonnet
@@ -38,6 +38,9 @@
     gcsObject():: artifact('gcs/object'),
   },
 
+  // expected artifacts
+  // TODO: This section may need splitting out by artifact type due to differing field requirements.
+
   expectedArtifact(id):: {
     id: id,
     // Defaults to kind: custom
@@ -45,6 +48,7 @@
     withMatchArtifact(matchArtifact):: self + {
       matchArtifact+: {
         kind: std.splitLimit(matchArtifact.type, '/', 1)[0],
+        // TODO: For Docker, the name field should be registry and repository.
         name: matchArtifact.name,
         type: matchArtifact.type,
       },
@@ -54,7 +58,8 @@
         kind: 'default.' + std.splitLimit(defaultArtifact.type, '/', 1)[0],
         reference: defaultArtifact.reference,
         type: defaultArtifact.type,
-        version: defaultArtifact.version,
+        // TODO: Some Artifact types (docker) don't require version to be set. It may be better to do this differently.
+        [if std.objectHas(defaultArtifact, 'version') then 'version']: defaultArtifact.version,
       },
     },
     withUsePriorArtifact(usePriorArtifact):: self + { usePriorArtifact: usePriorArtifact },
@@ -79,6 +84,7 @@
     },
     withType(type):: self + { type: type },
   },
+
   local notification = self.notification,
   notifications:: notification('', '', '', '', ''),
 
@@ -90,8 +96,8 @@
     type: type,
     withExpectedArtifacts(expectedArtifacts):: self + if std.type(expectedArtifacts) == 'array' then { expectedArtifactIds: std.map(function(expectedArtifact) expectedArtifact.id, expectedArtifacts) } else { expectedArtifactIds: [expectedArtifacts.id] },
   },
-  local trigger = self.trigger,
 
+  local trigger = self.trigger,
   triggers:: {
     docker(name):: trigger(name, 'docker') {
       withAccount(account):: self + { account: account },
@@ -129,7 +135,6 @@
     },
 
     // jenkins stages
-
     jenkins(name):: stage(name, 'jenkins') {
       withJob(job):: self + { job: job },
       withMaster(master):: self + { master: master },

--- a/sponnet/pipeline.libsonnet
+++ b/sponnet/pipeline.libsonnet
@@ -43,11 +43,8 @@
 
   expectedArtifact(id):: {
     id: id,
-    // Defaults to kind: custom
-    defaultArtifact: { kind: 'custom' },
     withMatchArtifact(matchArtifact):: self + {
       matchArtifact+: {
-        kind: std.splitLimit(matchArtifact.type, '/', 1)[0],
         // TODO: For Docker, the name field should be registry and repository.
         name: matchArtifact.name,
         type: matchArtifact.type,
@@ -55,7 +52,6 @@
     },
     withDefaultArtifact(defaultArtifact):: self + {
       defaultArtifact: {
-        kind: 'default.' + std.splitLimit(defaultArtifact.type, '/', 1)[0],
         reference: defaultArtifact.reference,
         type: defaultArtifact.type,
         // TODO: Some Artifact types (docker) don't require version to be set. It may be better to do this differently.

--- a/sponnet/pipeline.libsonnet
+++ b/sponnet/pipeline.libsonnet
@@ -2,52 +2,112 @@
   pipeline():: {
     limitConcurrent: true,
     keepWaitingPipelines: false,
+    notifications: [],
     stages: [],
     triggers: [],
-    withApplication(application):: self + {application: application},
-    withName(name):: self + {name: name},
-    withStages(stages):: self + if std.type(stages) == "array" then {stages: stages} else {stages: [stages]},
-    withTriggers(triggers):: self + if std.type(triggers) == "array" then {triggers: triggers} else {triggers: [triggers]},
+    withApplication(application):: self + { application: application },
+    withExpectedArtifacts(expectedArtifacts):: self + if std.type(expectedArtifacts) == 'array' then { expectedArtifacts: expectedArtifacts } else { expectedArtifacts: [expectedArtifacts] },
+    withName(name):: self + { name: name },
+    withNotifications(notifications):: self + if std.type(notifications) == 'array' then { notifications: notifications } else { notifications: [notifications] },
+    withStages(stages):: self + if std.type(stages) == 'array' then { stages: stages } else { stages: [stages] },
+    withTriggers(triggers):: self + if std.type(triggers) == 'array' then { triggers: triggers } else { triggers: [triggers] },
   },
 
   moniker(app, cluster):: {
     app: app,
     cluster: cluster,
-    withStack(stack):: self + {stack: stack},
-    withDetail(detail):: self + {detail: detail},
+    withStack(stack):: self + { stack: stack },
+    withDetail(detail):: self + { detail: detail },
   },
 
   // artifacts
 
   artifact(type):: {
     type: type,
-    withName(name):: self + {name: name},
-    withVersion(version):: self + {version: version},
-    withReference(reference):: self + {reference: reference},
-    withLocation(location):: self + {location: location},
+    withName(name):: self + { name: name },
+    withVersion(version):: self + { version: version },
+    withReference(reference):: self + { reference: reference },
+    withLocation(location):: self + { location: location },
   },
 
   local artifact = self.artifact,
   artifacts:: {
-    dockerImage():: artifact("docker/image"),
-    githubFile():: artifact("github/file"),
-    gcsObject():: artifact("gcs/object"),
+    dockerImage():: artifact('docker/image'),
+    githubFile():: artifact('github/file'),
+    gitlabFile():: artifact('gitlab/file'),
+    gcsObject():: artifact('gcs/object'),
   },
 
   expectedArtifact(id):: {
     id: id,
-    withMatchArtifact(matchArtifact):: self + {matchArtifact: matchArtifact},
-    withDefaultArtifact(defaultArtifact):: self + {defaultArtifact: defaultArtifact},
-    withUsePriorArtifact(usePriorArtifact):: self + {usePriorArtifact: usePriorArtifact},
-    withUseDefaultArtifact(useDefaultArtifact):: self + {useDefaultArtifact: useDefaultArtifact},
+    // Defaults to kind: custom
+    defaultArtifact: { kind: 'custom' },
+    withMatchArtifact(matchArtifact):: self + {
+      matchArtifact+: {
+        kind: std.splitLimit(matchArtifact.type, '/', 1)[0],
+        name: matchArtifact.name,
+        type: matchArtifact.type,
+      },
+    },
+    withDefaultArtifact(defaultArtifact):: self + {
+      defaultArtifact: {
+        kind: 'default.' + std.splitLimit(defaultArtifact.type, '/', 1)[0],
+        reference: defaultArtifact.reference,
+        type: defaultArtifact.type,
+        version: defaultArtifact.version,
+      },
+    },
+    withUsePriorArtifact(usePriorArtifact):: self + { usePriorArtifact: usePriorArtifact },
+    withUseDefaultArtifact(useDefaultArtifact):: self + { useDefaultArtifact: useDefaultArtifact },
   },
+
+  // notifications
+  // TODO: refactor level to include stage level.
+
+  notification(address, type, conditions, when, message):: {
+    withAddress(address):: self + { address: address },
+    level: 'pipeline',
+    withWhen(when, message=false):: self + {
+      when+: [when],
+      // Notification messages are optional
+      [if std.isString(message) then 'message']+: {
+        ['pipeline.' + when]: {
+          // Doesn't look like need to escape function here, eg: // text: std.escapeStringJson(message),
+          text: message,
+        },
+      },
+    },
+    withType(type):: self + { type: type },
+  },
+  local notification = self.notification,
+  notifications:: notification('', '', '', '', ''),
 
   // triggers
 
-  trigger():: {
+  trigger(name, type):: {
     enabled: true,
-    withType(type):: self + {type: type},
-    withExpectedArtifacts(expectedArtifacts):: self + if std.type(expectedArtifacts) == "array" then {expectedArtifactIds: std.map(function(expectedArtifact) expectedArtifact.id, expectedArtifacts)} else {expectedArtifactIds: [expectedArtifacts.id]},
+    name: name,
+    type: type,
+    withExpectedArtifacts(expectedArtifacts):: self + if std.type(expectedArtifacts) == 'array' then { expectedArtifactIds: std.map(function(expectedArtifact) expectedArtifact.id, expectedArtifacts) } else { expectedArtifactIds: [expectedArtifacts.id] },
+  },
+  local trigger = self.trigger,
+
+  triggers:: {
+    docker(name):: trigger(name, 'docker') {
+      withAccount(account):: self + { account: account },
+      withExpectedArtifacts(expectedArtifacts):: self + if std.type(expectedArtifacts) == 'array' then { expectedArtifactIds: std.map(function(expectedArtifact) expectedArtifact.id, expectedArtifacts) } else { expectedArtifactIds: [expectedArtifacts.id] },
+      withOrganization(organization):: self + { organization: organization },
+      withRegistry(registry):: self + { registry: registry },
+      withRepository(repository):: self + { repository: repository },
+      withTag(tag):: self + { tag: tag },
+    },
+    git(name):: trigger(name, 'git') {
+      withBranch(branch):: self + { branch: branch },
+      withProject(project):: self + { project: project },
+      withSlug(slug):: self + { slug: slug },
+      withSource(source):: self + { source: source },
+    },
+
   },
 
   // stages
@@ -57,61 +117,72 @@
     name: name,
     type: type,
     requisiteStageRefIds: [],
-    withRequisiteStages(stages):: self + if std.type(stages) == "array" then {requisiteStageRefIds: std.map(function(stage) stage.refId, stages)} else {requisiteStageRefIds: [stages.refId]}
+    withRequisiteStages(stages):: self + if std.type(stages) == 'array' then { requisiteStageRefIds: std.map(function(stage) stage.refId, stages) } else { requisiteStageRefIds: [stages.refId] },
+    // execution options
+    withOverrideTimeout(timeoutMs):: self + { overrideTimeout: true, stageTimeoutMs: timeoutMs },
   },
 
   local stage = self.stage,
   stages:: {
-    wait(name):: stage(name, "wait") {
-      withWaitTime(waitTime):: self + {waitTime: waitTime},
+    wait(name):: stage(name, 'wait') {
+      withWaitTime(waitTime):: self + { waitTime: waitTime },
+    },
+
+    // jenkins stages
+    jenkins(name):: stage(name, 'jenkins') {
+      withJob(job):: self + { job: job },
+      withMaster(master):: self + { master: master },
     },
 
     // kubernetes stages
 
-    deploy_manifest(name):: stage(name, "deployManifest") {
-      cloudProvider: "kubernetes",
-      source: "text",
-      withAccount(account):: self + {account: account},
-      withManifests(manifests):: self + if std.type(manifests) == "array" then {manifests: manifests} else {manifests: [manifests]},
-      withMoniker(moniker):: self + {moniker: moniker},
+    deploy_manifest(name):: stage(name, 'deployManifest') {
+      cloudProvider: 'kubernetes',
+      source: 'text',
+      withAccount(account):: self + { account: account, source: 'artifact' },
+      withManifestArtifactAccount(account):: self + { manifestArtifactAccount: account },
+      // Add/Default to embedded-artifact? If so add:  /* , manifestArtifactAccount: 'embedded-artifact' */
+      withManifestArtifact(artifact):: self + { manifestArtifactId: artifact.id },
+      withManifests(manifests):: self + if std.type(manifests) == 'array' then { manifests: manifests } else { manifests: [manifests] },
+      withMoniker(moniker):: self + { moniker: moniker },
     },
-    delete_manifest(name):: stage(name, "deleteManifest") {
-      cloudProvider: "kubernetes",
+    delete_manifest(name):: stage(name, 'deleteManifest') {
+      cloudProvider: 'kubernetes',
       options: {
         cascading: true,
       },
-      withAccount(account):: self + {account: account},
-      withKinds(kinds):: self + if std.type(kinds) == "array" then {kinds: kinds} else {kinds: [kinds]},
-      withNamespace(namespace):: self + {location: namespace},
-      withLabelSelectors(selectors):: self + if std.type(selectors) == "array" then {labelSelectors: {selectors: selectors}} else {labelSelectors: {selectors: [selectors]}},
-      withGracePeriodSeconds(seconds):: self.options + {gracePeriodSeconds: seconds},
-      withManifestName(kind, name):: self.options + {manifestName: kind + " " + name},
+      withAccount(account):: self + { account: account },
+      withKinds(kinds):: self + if std.type(kinds) == 'array' then { kinds: kinds } else { kinds: [kinds] },
+      withNamespace(namespace):: self + { location: namespace },
+      withLabelSelectors(selectors):: self + if std.type(selectors) == 'array' then { labelSelectors: { selectors: selectors } } else { labelSelectors: { selectors: [selectors] } },
+      withGracePeriodSeconds(seconds):: self.options { gracePeriodSeconds: seconds },
+      withManifestName(kind, name):: self.options { manifestName: kind + ' ' + name },
     },
-    patch_manifest(name):: stage(name, "patchManifest") {
-      cloudProvider: "kubernetes",
-      source: "text",
+    patch_manifest(name):: stage(name, 'patchManifest') {
+      cloudProvider: 'kubernetes',
+      source: 'text',
       options: {
-        mergeStrategy: "strategic",
+        mergeStrategy: 'strategic',
         record: true,
       },
-      withAccount(account):: self + {account: account},
-      withNamespace(namespace):: self + {location: namespace},
-      withPatchBody(patchBody): self + {patchBody: patchBody},
-      withManifestName(kind, name):: self.options + {manifestName: kind + " " + name},
+      withAccount(account):: self + { account: account },
+      withNamespace(namespace):: self + { location: namespace },
+      withPatchBody(patchBody): self + { patchBody: patchBody },
+      withManifestName(kind, name):: self.options { manifestName: kind + ' ' + name },
     },
-    scale_manifest(name): stage(name, "scaleManifest") {
-      cloudProvider: "kubernetes",
-      withAccount(account):: self + {account: account},
-      withNamespace(namespace):: self + {location: namespace},
-      withReplicas(replicas): self + {replicas: replicas},
-      withManifestName(kind, name):: self.options + {manifestName: kind + " " + name},
+    scale_manifest(name): stage(name, 'scaleManifest') {
+      cloudProvider: 'kubernetes',
+      withAccount(account):: self + { account: account },
+      withNamespace(namespace):: self + { location: namespace },
+      withReplicas(replicas): self + { replicas: replicas },
+      withManifestName(kind, name):: self.options { manifestName: kind + ' ' + name },
     },
-    undo_rollout_manifest(name): stage(name, "undoRolloutManifest") {
-      cloudProvider: "kubernetes",
-      withAccount(account):: self + {account: account},
-      withNamespace(namespace):: self + {location: namespace},
-      withRevisionsBack(revisionsBack): self + {numRevisionsBack: revisionsBack},
-      withManifestName(kind, name):: self.options + {manifestName: kind + " " + name},
+    undo_rollout_manifest(name): stage(name, 'undoRolloutManifest') {
+      cloudProvider: 'kubernetes',
+      withAccount(account):: self + { account: account },
+      withNamespace(namespace):: self + { location: namespace },
+      withRevisionsBack(revisionsBack): self + { numRevisionsBack: revisionsBack },
+      withManifestName(kind, name):: self.options { manifestName: kind + ' ' + name },
     },
   },
 
@@ -122,28 +193,28 @@
       kind: kind,
     },
     local selector = self.selector,
-    anySelector(key, value):: selector("ANY"),
-    equalsSelector(key, value):: selector("EQUALS") {
+    anySelector(key, value):: selector('ANY'),
+    equalsSelector(key, value):: selector('EQUALS') {
       key: key,
       values: [value],
     },
-    notEqualsSelector(key, value):: selector("NOT_EQUALS") {
+    notEqualsSelector(key, value):: selector('NOT_EQUALS') {
       key: key,
       values: [value],
     },
-    containsSelector(key, values):: selector("CONTAINS") {
+    containsSelector(key, values):: selector('CONTAINS') {
       key: key,
       values: values,
     },
-    notContainsSelector(key, values):: selector("NOT_CONTAINS") {
+    notContainsSelector(key, values):: selector('NOT_CONTAINS') {
       key: key,
       values: values,
     },
-    existsSelector(key):: selector("EXISTS") {
+    existsSelector(key):: selector('EXISTS') {
       key: key,
     },
-    notExistsSelector(key):: selector("NOT_EXISTS") {
+    notExistsSelector(key):: selector('NOT_EXISTS') {
       key: key,
     },
-  }
+  },
 }

--- a/sponnet/pipeline.libsonnet
+++ b/sponnet/pipeline.libsonnet
@@ -129,6 +129,7 @@
     },
 
     // jenkins stages
+
     jenkins(name):: stage(name, 'jenkins') {
       withJob(job):: self + { job: job },
       withMaster(master):: self + { master: master },


### PR DESCRIPTION
RE: #3456 

Add jenkins stage
Add artifact option for deploy manifest
Add notifications
Add stage timeout
Add moniker
Add expectedArtifacts
Add triggers (docker and git only) constraints TODO

Notes:

The `jsonnet fmt` function is responsible for a most of the changes to pre-existing lines.
Inheritance using a sleek per app `appname.jsonnet` is not catered to here and subject to outcomes from the design doc on MPT v2, future PR's, etc.

Questions:

1. camelCase for variables and functions is common in other projects like Prometheus, Databricks. I'm tempted to change `deploy_manifest` etc. Thoughts?
