### PR TITLE
fix(citest): Log pipeline status in appengine tests

### DIFF
--- a/testing/citest/spinnaker_testing/spinnaker.py
+++ b/testing/citest/spinnaker_testing/spinnaker.py
@@ -169,7 +169,7 @@ class SpinnakerStatus(service_testing.HttpOperationStatus):
     super(SpinnakerStatus, self).__init__(operation, original_response)
     if original_response is not None:
       # The request ID is typically the response payload.
-      self.__request_id = original_response
+      self.__request_id = original_response.output
     self.__current_state = None  # Last known state (after last refresh()).
     self.__detail_path = None    # The URL path on spinnaker for this status.
     self.__exception_details = None

--- a/testing/citest/spinnaker_testing/spinnaker.py
+++ b/testing/citest/spinnaker_testing/spinnaker.py
@@ -167,8 +167,9 @@ class SpinnakerStatus(service_testing.HttpOperationStatus):
           indicate an error making the original request.
     """
     super(SpinnakerStatus, self).__init__(operation, original_response)
-    # The request ID is typically the response payload.
-    self.__request_id = original_response.output
+    if original_response is not None:
+      # The request ID is typically the response payload.
+      self.__request_id = original_response
     self.__current_state = None  # Last known state (after last refresh()).
     self.__detail_path = None    # The URL path on spinnaker for this status.
     self.__exception_details = None

--- a/testing/citest/tests/appengine_gcs_pubsub_test.py
+++ b/testing/citest/tests/appengine_gcs_pubsub_test.py
@@ -322,7 +322,7 @@ class AppengineGcsPubsubTestScenario(sk.SpinnakerTestScenario):
          [jp.DICT_MATCHES({'name': jp.STR_EQ(group_name)})]
        )))
 
-    executions_path = 'executions?pipelineConfigIds={}&limit=1&statuses=SUCCEEDED'.format(self.__pipeline_id)
+    executions_path = 'executions?pipelineConfigIds={}'.format(self.__pipeline_id)
     return st.OperationContract(
       self.__gcs_pubsub_agent.new_gcs_pubsub_trigger_operation(
         gate_agent=self.agent,
@@ -330,7 +330,7 @@ class AppengineGcsPubsubTestScenario(sk.SpinnakerTestScenario):
         bucket_name=self.bucket,
         upload_path='{}'.format(name),
         local_filename=os.path.abspath(name),
-        status_class=None,
+        status_class=gate.GatePipelineStatus,
         status_path=executions_path
       ),
       contract=builder.build())


### PR DESCRIPTION
The appengine tests currently only request succeeded pipelines from Gate, so there is no information in the logs if the pipeline fails.