### PR TITLE
feat(sponnet): camelCase, additional artifacts and stages

### DIFF
--- a/sponnet/demo/demo.jsonnet
+++ b/sponnet/demo/demo.jsonnet
@@ -79,12 +79,18 @@ local gitTrigger = sponnet.triggers
                    .withSlug(mySlug)
                    .withSource(mySource);
 
-local slack = sponnet.notifications
-              .withAddress(notificationAddress)
-              .withType(notificationType)
-              .withWhen('starting')
-              .withWhen('failed', 'testf: one two three, $variable, %value, "quoted": https://example.com')
-              .withWhen('complete', 'test');
+local emailNotification = sponnet.notification
+                          .withAddress('someone@example.com')
+                          .withCC('test@example.com')
+                          .withType('email')
+                          .withWhen('starting');
+
+local slackNotification = sponnet.notification
+                          .withAddress(notificationAddress)
+                          .withType(notificationType)
+                          .withWhen('starting')
+                          .withWhen('failed', 'testf: one two three, $variable, %value, "quoted": https://example.com')
+                          .withWhen('complete', 'test');
 
 local wait = sponnet.stages
              .wait('Wait')
@@ -126,6 +132,7 @@ local jenkinsJob = sponnet.stages
                    .withJob(myJenkinsJob)
                    .withMarkUnstableAsSuccessful('false')
                    .withMaster(myJenkinsMaster)
+                   .withNotifications(slackNotification)
                    .withOverrideTimeout('300000')
                    .withRequisiteStages(findArtifactsFromResource)
                    .withWaitForCompletion('true');
@@ -134,6 +141,6 @@ sponnet.pipeline()
 .withApplication(app)
 .withExpectedArtifacts([expectedDocker, expectedManifest])
 .withName('Demo pipeline')
-.withNotifications(slack)
+.withNotifications([emailNotification, slackNotification])
 .withTriggers([dockerTrigger, gitTrigger])
 .withStages([wait, deployManifestTextBaseline, deployManifestTextCanary, deployManifestArtifact, findArtifactsFromResource, jenkinsJob])

--- a/sponnet/demo/demo.jsonnet
+++ b/sponnet/demo/demo.jsonnet
@@ -1,6 +1,6 @@
+local sponnet = import '../pipeline.libsonnet';
 local deployment = import 'deployment.json';
 local kubeutils = import 'kubeutils.libsonnet';
-local sponnet = import 'pipeline.libsonnet';
 
 local canaryDeployment = kubeutils.canary(deployment);
 local account = 'staging-demo';

--- a/sponnet/demo/demo.jsonnet
+++ b/sponnet/demo/demo.jsonnet
@@ -79,11 +79,12 @@ local gitTrigger = sponnet.triggers
                    .withSlug(mySlug)
                    .withSource(mySource);
 
-local emailNotification = sponnet.notification
-                          .withAddress('someone@example.com')
-                          .withCC('test@example.com')
-                          .withType('email')
-                          .withWhen('starting');
+local emailPipelineNotification = sponnet.notification
+                                  .withAddress('someone@example.com')
+                                  .withCC('test@example.com')
+                                  .withLevel('pipeline')
+                                  .withType('email')
+                                  .withWhen('starting');
 
 local slackNotification = sponnet.notification
                           .withAddress(notificationAddress)
@@ -132,7 +133,7 @@ local jenkinsJob = sponnet.stages
                    .withJob(myJenkinsJob)
                    .withMarkUnstableAsSuccessful('false')
                    .withMaster(myJenkinsMaster)
-                   .withNotifications(slackNotification)
+                   .withNotifications(slackNotification.withLevel('stage'))
                    .withOverrideTimeout('300000')
                    .withRequisiteStages(findArtifactsFromResource)
                    .withWaitForCompletion('true');
@@ -141,6 +142,6 @@ sponnet.pipeline()
 .withApplication(app)
 .withExpectedArtifacts([expectedDocker, expectedManifest])
 .withName('Demo pipeline')
-.withNotifications([emailNotification, slackNotification])
+.withNotifications([emailPipelineNotification, slackNotification.withLevel('pipeline')])
 .withTriggers([dockerTrigger, gitTrigger])
 .withStages([wait, deployManifestTextBaseline, deployManifestTextCanary, deployManifestArtifact, findArtifactsFromResource, jenkinsJob])

--- a/sponnet/demo/demo.jsonnet
+++ b/sponnet/demo/demo.jsonnet
@@ -2,7 +2,7 @@ local deployment = import 'deployment.json';
 local kubeutils = import 'kubeutils.libsonnet';
 local sponnet = import 'pipeline.libsonnet';
 
-local canary_deployment = kubeutils.canary(deployment);
+local canaryDeployment = kubeutils.canary(deployment);
 local account = 'staging-demo';
 local app = 'cluster';
 local moniker = sponnet.moniker(app, 'some-cluster')
@@ -36,48 +36,48 @@ local mySlug = 'your-project';
 local mySource = 'gitlab';
 
 
-local docker_artifact = sponnet.artifacts
-                        .dockerImage()
-                        .withName(myDockerArtifactName)
-                        .withReference(myDockerRegistry + '/' + myDockerRepository);
+local dockerArtifact = sponnet.artifacts
+                       .dockerImage()
+                       .withName(myDockerArtifactName)
+                       .withReference(myDockerRegistry + '/' + myDockerRepository);
 
-local expected_docker = sponnet.expectedArtifact(myDockerArtifactName)
-                        .withMatchArtifact(docker_artifact)
-                        .withDefaultArtifact(docker_artifact)
-                        .withUsePriorArtifact(false)
-                        .withUseDefaultArtifact(true);
+local expectedDocker = sponnet.expectedArtifact(myDockerArtifactName)
+                       .withDefaultArtifact(dockerArtifact)
+                       .withMatchArtifact(dockerArtifact)
+                       .withUseDefaultArtifact(true)
+                       .withUsePriorArtifact(false);
 
-local gitlab_artifact = sponnet.artifacts
-                        .gitlabFile()
-                        .withName(myManifestArtifactName)
-                        .withVersion(myManifestArtifactVersion)
-                        .withReference(myManifestArtifactReference)
-                        .withLocation(myManifestArtifactLocation);
+local gitlabArtifact = sponnet.artifacts
+                       .gitlabFile()
+                       .withLocation(myManifestArtifactLocation)
+                       .withName(myManifestArtifactName)
+                       .withReference(myManifestArtifactReference)
+                       .withVersion(myManifestArtifactVersion);
 
-local expected_manifest = sponnet.expectedArtifact(myManifestArtifactName)
-                          .withMatchArtifact(gitlab_artifact)
-                          .withDefaultArtifact(gitlab_artifact)
-                          .withUsePriorArtifact(false)
-                          .withUseDefaultArtifact(true);
+local expectedManifest = sponnet.expectedArtifact(myManifestArtifactName)
+                         .withDefaultArtifact(gitlabArtifact)
+                         .withMatchArtifact(gitlabArtifact)
+                         .withUsePriorArtifact(false)
+                         .withUseDefaultArtifact(true);
 
-local docker_trigger = sponnet.triggers
-                       .docker('myDockerTrigger')
-                       // If ExpectedArtifact Required, add below.
-                       // .withExpectedArtifacts([expected_docker])
-                       .withAccount(myDockerAccount)
-                       .withOrganization(myDockerOrganization)
-                       .withRegistry(myDockerRegistry)
-                       .withRepository(myDockerRepository)
-                       .withTag(myDockerTag);
+local dockerTrigger = sponnet.triggers
+                      .docker('myDockerTrigger')
+                      // If ExpectedArtifact Required, add below.
+                      // .withExpectedArtifacts([expectedDocker])
+                      .withAccount(myDockerAccount)
+                      .withOrganization(myDockerOrganization)
+                      .withRegistry(myDockerRegistry)
+                      .withRepository(myDockerRepository)
+                      .withTag(myDockerTag);
 
-local git_trigger = sponnet.triggers
-                    .git('myGitTrigger')
-                    // If ExpectedArtifact Required, add below.
-                    // .withExpectedArtifacts([expected_manifest])
-                    .withBranch(myBranch)
-                    .withProject(myProject)
-                    .withSlug(mySlug)
-                    .withSource(mySource);
+local gitTrigger = sponnet.triggers
+                   .git('myGitTrigger')
+                   // If ExpectedArtifact Required, add below.
+                   // .withExpectedArtifacts([expectedManifest])
+                   .withBranch(myBranch)
+                   .withProject(myProject)
+                   .withSlug(mySlug)
+                   .withSource(mySource);
 
 local slack = sponnet.notifications
               .withAddress(notificationAddress)
@@ -88,42 +88,52 @@ local slack = sponnet.notifications
 
 local wait = sponnet.stages
              .wait('Wait')
+             .withSkipWaitText('Custom wait message')
              .withWaitTime(30);
 
-local manifest_artifact = sponnet.stages
-                          .deploy_manifest('Deploy a manifest with artifact')
-                          .withManifestArtifact(expected_manifest)
-                          .withManifestArtifactAccount(myManifestArtifactAccount)
-                          .withAccount(account)
-                          .withMoniker(moniker)
-                          .withOverrideTimeout('300000')
-                          .withRequisiteStages(wait);
+local deployManifestArtifact = sponnet.stages
+                               .deployManifest('Deploy a manifest with artifact')
+                               .withAccount(account)
+                               .withManifestArtifact(expectedManifest)
+                               .withManifestArtifactAccount(myManifestArtifactAccount)
+                               .withMoniker(moniker)
+                               .withOverrideTimeout('300000')
+                               .withRequisiteStages(wait);
 
-local manifest_baseline = sponnet.stages
-                          .deploy_manifest('Deploy a manifest')
-                          .withManifests(deployment)
-                          .withAccount(account)
-                          .withMoniker(moniker)
-                          .withRequisiteStages(wait);
+local deployManifestTextBaseline = sponnet.stages
+                                   .deployManifest('Deploy a manifest')
+                                   .withAccount(account)
+                                   .withManifests(deployment)
+                                   .withMoniker(moniker)
+                                   .withRequisiteStages(wait);
 
-local manifest_canary = sponnet.stages
-                        .deploy_manifest('Deploy a canary manifest')
-                        .withManifests(canary_deployment)
-                        .withAccount(account)
-                        .withMoniker(moniker)
-                        .withRequisiteStages(wait);
+local deployManifestTextCanary = sponnet.stages
+                                 .deployManifest('Deploy a canary manifest')
+                                 .withManifests(canaryDeployment)
+                                 .withAccount(account)
+                                 .withMoniker(moniker)
+                                 .withRequisiteStages(wait);
 
-local jenkins_job = sponnet.stages
-                    .jenkins('Run Jenkins Job')
-                    .withMaster(myJenkinsMaster)
-                    .withJob(myJenkinsJob)
-                    .withOverrideTimeout('300000')
-                    .withRequisiteStages(wait);
+local findArtifactsFromResource = sponnet.stages
+                                  .findArtifactsFromResource('Find nginx-deployment')
+                                  .withAccount(account)
+                                  .withLocation('default')
+                                  .withManifestName('Deployment nginx-deployment')
+                                  .withRequisiteStages([deployManifestTextBaseline, deployManifestTextCanary, deployManifestArtifact]);
+
+local jenkinsJob = sponnet.stages
+                   .jenkins('Run Jenkins Job')
+                   .withJob(myJenkinsJob)
+                   .withMarkUnstableAsSuccessful('false')
+                   .withMaster(myJenkinsMaster)
+                   .withOverrideTimeout('300000')
+                   .withRequisiteStages(findArtifactsFromResource)
+                   .withWaitForCompletion('true');
 
 sponnet.pipeline()
 .withApplication(app)
-.withExpectedArtifacts([expected_docker, expected_manifest])
+.withExpectedArtifacts([expectedDocker, expectedManifest])
 .withName('Demo pipeline')
 .withNotifications(slack)
-.withTriggers([docker_trigger, git_trigger])
-.withStages([wait, manifest_baseline, manifest_canary, manifest_artifact, jenkins_job])
+.withTriggers([dockerTrigger, gitTrigger])
+.withStages([wait, deployManifestTextBaseline, deployManifestTextCanary, deployManifestArtifact, findArtifactsFromResource, jenkinsJob])

--- a/sponnet/pipeline.libsonnet
+++ b/sponnet/pipeline.libsonnet
@@ -72,7 +72,7 @@
 
   notification:: {
     withAddress(address):: self + { address: address },
-    withCC(address):: self + { address: address },
+    withCC(cc):: self + { cc: cc },
     withLevel(level):: self + { level: level },
     // Custom notification messages are optional
     withWhen(when, message=false):: self + {

--- a/sponnet/pipeline.libsonnet
+++ b/sponnet/pipeline.libsonnet
@@ -49,11 +49,8 @@
 
   expectedArtifact(id):: {
     id: id,
-    // Defaults to kind: custom
-    defaultArtifact: { kind: 'custom' },
     withMatchArtifact(matchArtifact):: self + {
       matchArtifact+: {
-        kind: std.splitLimit(matchArtifact.type, '/', 1)[0],
         // TODO: For Docker, the name field should be registry and repository.
         name: matchArtifact.name,
         type: matchArtifact.type,
@@ -61,7 +58,6 @@
     },
     withDefaultArtifact(defaultArtifact):: self + {
       defaultArtifact: {
-        kind: 'default.' + std.splitLimit(defaultArtifact.type, '/', 1)[0],
         reference: defaultArtifact.reference,
         type: defaultArtifact.type,
         // TODO: Some Artifact types (docker) don't require version to be set. It may be better to do this differently.
@@ -152,6 +148,7 @@
       },
       withPipeline(pipeline):: self + { pipeline: pipeline },
     },
+
     manualJudgement(name):: stage(name, 'manualJudgement') {
       withInstructions(instructions):: self + { instructions: instructions },
       withJudgementInputs(judgementInputs):: self + if std.type(judgementInputs) == 'array' then { judgementInputs: judgementInputs } else { judgementInputs: [judgementInputs] },

--- a/sponnet/pipeline.libsonnet
+++ b/sponnet/pipeline.libsonnet
@@ -8,14 +8,7 @@
     withApplication(application):: self + { application: application },
     withExpectedArtifacts(expectedArtifacts):: self + if std.type(expectedArtifacts) == 'array' then { expectedArtifacts: expectedArtifacts } else { expectedArtifacts: [expectedArtifacts] },
     withName(name):: self + { name: name },
-    withNotifications(notifications):: self + if std.type(notifications) == 'array' then {
-      notifications: [
-        notification.withLevel('pipeline')
-        for notification in notifications
-      ],
-    } else {
-      notifications: [notifications.withLevel('pipeline')],
-    },
+    withNotifications(notifications):: self + if std.type(notifications) == 'array' then { notifications: notifications } else { notifications: [notifications] },
     withStages(stages):: self + if std.type(stages) == 'array' then { stages: stages } else { stages: [stages] },
     withTriggers(triggers):: self + if std.type(triggers) == 'array' then { triggers: triggers } else { triggers: [triggers] },
   },
@@ -133,12 +126,7 @@
     name: name,
     type: type,
     requisiteStageRefIds: [],
-    withNotifications(notifications):: self + { sendNotifications: true } +
-                                       if std.type(notifications) == 'array' then {
-                                         notifications: [notification.withLevel('stage') for notification in notifications],
-                                       } else {
-                                         notifications: [notifications.withLevel('stage')],
-                                       },
+    withNotifications(notifications):: self + if std.type(notifications) == 'array' then { notifications: notifications } else { notifications: [notifications] },
     withRequisiteStages(stages):: self + if std.type(stages) == 'array' then { requisiteStageRefIds: std.map(function(stage) stage.refId, stages) } else { requisiteStageRefIds: [stages.refId] },
     // execution options
     withOverrideTimeout(timeoutMs):: self + { overrideTimeout: true, stageTimeoutMs: timeoutMs },


### PR DESCRIPTION
- Style: camelCase stage types and demo.jsonnet variables.
- Add additional artifact types.
- Add Kubernetes FindArtifactsFromResource stage
- fix Kubernetes DeployManifest stage correctly sets source artifact or text
  based on whether artifact supplied or not.
- Extend Jenkins stage - add properties file and configuration options
- Extend Wait stage - add custom skip message
- Add pipeline stage
- Add Wercker stage, untested as don't have access to a Wercker install.

Picked up some missing configuration options from initial stage add.

Moving on now to putting into use internally. Will come back to add more missing stages and options 
 in a future PR later.