### PR TITLE
feat(sponnet): Additional stages, execution options, application support, fixes

### DIFF
--- a/sponnet/application.libsonnet
+++ b/sponnet/application.libsonnet
@@ -1,0 +1,15 @@
+{
+  application():: {
+    withAccounts(accounts):: self + if std.type(accounts) == 'array' then { accounts: accounts } else { accounts: [accounts] },
+    withAliases(aliases):: self + { aliases: aliases },
+    withClusters(clusters):: self + if std.type(clusters) == 'array' then { clusters: clusters } else { clusters: [clusters] },
+    withCloudProviders(cloudProviders):: self + if std.type(cloudProviders) == 'array' then { cloudProviders: cloudProviders } else { cloudProviders: [cloudProviders] },
+    withDescription(description):: self + { attributes+: { description: description } },
+    // Email address must be put in both root and attributes for Spin to save application.
+    withEmail(email):: self + { email: email } + { attributes+: { email: email } },
+    withInstancePort(port):: self + { attributes+: { instancePort: port } },
+    withName(name):: self + { name: name },
+    withPlatformHealthOnly(platformHealthOnly):: self + { platformHealthOnly: platformHealthOnly },
+    withUser(user):: self + { attributes+: { user: user } },
+  },
+}

--- a/sponnet/demo/README.md
+++ b/sponnet/demo/README.md
@@ -21,10 +21,24 @@ You will need the following:
   sudo mv jsonnet /usr/local/bin/jsonnet
   ```
 
+To build the demo application, run:
+
+```bash
+jsonnet demo-app.jsonnet
+```
+
+If you have the [Spinnaker CLI
+installed](https://www.spinnaker.io/guides/spin/cli/) (`spin`), you can save
+this application in Spinnaker by running:
+
+```bash
+jsonnet demo-app.jsonnet > demo-app.json && spin application save --file demo-app.json
+```
+
 To build the demo pipeline, run:
 
 ```bash
-jsonnet demo.jsonnet
+jsonnet demo-pipeline.jsonnet
 ```
 
 If you have the [Spinnaker CLI
@@ -32,5 +46,5 @@ installed](https://www.spinnaker.io/guides/spin/cli/) (`spin`), you can save
 this pipeline in Spinnaker by running:
 
 ```bash
-jsonnet demo.jsonnet > demo.json && spin pipeline save --file demo.json
+jsonnet demo-pipeline.jsonnet > demo-pipeline.json && spin pipeline save --file demo-pipeline.json
 ```

--- a/sponnet/demo/demo-app.jsonnet
+++ b/sponnet/demo/demo-app.jsonnet
@@ -1,0 +1,8 @@
+local sponnet = import '../application.libsonnet';
+
+sponnet.application()
+.withName('myapp')
+.withEmail('youremail@example.com')
+.withCloudProviders('kubernetes')
+.withDescription('Demo sponnet application')
+.withUser('youremail@example.com')


### PR DESCRIPTION

Fixes:
Manual judgment stage fix to match Spinnaker locality naming or typo? (judgment not judgement) and add input value array.
Add Pipeline ID required for `spin` CLI to save pipeline. This has come up in slack channels.
```
$ jsonnet demo.jsonnet > demo.json && spin pipeline save --file demo.json
Required pipeline key 'id' missing...
```

Features:
Refactor notifications to support Manual Judgment stage notifications
Add Check Preconditions stage
Add additional stage execution options. Time Window is basic.
Add additional pipeline options
Add ability to create Applications
Update README.

Verified app and pipeline save with `spin` CLI per updated README.md instructions and both look ok in Deck.

Demo pipeline has become quite large and could be pared back a bit.
In practice one refactors shared variables and sections out into separate files for re-use by multiple apps/pipelines so leaving as is.