### PR TITLE
feat(spinbot): improve formatting of commit messages

### DIFF
--- a/spinbot/event/master_branch_pull_request_handler.py
+++ b/spinbot/event/master_branch_pull_request_handler.py
@@ -1,6 +1,6 @@
 from .handler import Handler
 from .pull_request_event import GetBaseBranch, GetPullRequest, GetTitle, GetRepo
-from gh import ReleaseBranchFor, ParseCommitMessage
+from gh import ReleaseBranchFor, ParseCommitMessage, FormatCommit
 
 format_message = ('The following commits need their title changed:\n\n{}\n\n' +
     'Please format your commit title into the form: \n\n' +
@@ -35,14 +35,14 @@ class MasterBranchPullRequestHandler(Handler):
         bad_commits = []
 
         for commit in commits:
-            commit_message = commit.commit.message 
+            commit_message = commit.commit.message
             parsed_message = ParseCommitMessage(commit_message)
             if parsed_message is None and not commit_message.startswith('Merge branch'):
                 bad_commits.append(commit.commit)
 
         if len(bad_commits) > 0:
             pull_request.create_issue_comment(format_message.format(
-                '\n\n'.join(map(lambda c: '{}: {}'.format(c.sha, c.message), bad_commits))
+                '\n\n'.join(map(lambda c: ' * {}'.format(FormatCommit(c)), bad_commits))
             ))
 
 MasterBranchPullRequestHandler()

--- a/spinbot/event/release_branch_pull_request_handler.py
+++ b/spinbot/event/release_branch_pull_request_handler.py
@@ -1,6 +1,6 @@
 from .handler import Handler
 from .pull_request_event import GetBaseBranch, GetPullRequest, GetTitle, GetRepo
-from gh import ReleaseBranchFor, ParseCommitMessage
+from gh import ReleaseBranchFor, ParseCommitMessage, FormatCommit
 
 format_message = ('Features cannot be merged into release branches. The following commits ' +
     'are not tagged as one of "{}":\n\n{}\n\n' +
@@ -43,7 +43,7 @@ class ReleaseBranchPullRequestHandler(Handler):
         if len(bad_commits) > 0:
             pull_request.create_issue_comment(format_message.format(
                 ', '.join(self.allowed_types),
-                '\n\n'.join(map(lambda c: '{}: {}'.format(c.sha, c.message), bad_commits))
+                '\n\n'.join(map(lambda c: ' * {}'.format(FormatCommit(c)), bad_commits))
             ))
 
 ReleaseBranchPullRequestHandler()

--- a/spinbot/gh/__init__.py
+++ b/spinbot/gh/__init__.py
@@ -1,3 +1,3 @@
 from .client import Client
 from .util import ObjectType, IssueRepo, HasLabel, AddLabel, RemoveLabel, PullRequestRepo
-from .conventions import ReleaseBranchFor, ParseCommitMessage, ParseReleaseBranch
+from .conventions import ReleaseBranchFor, ParseCommitMessage, ParseReleaseBranch, FormatCommit

--- a/spinbot/gh/conventions.py
+++ b/spinbot/gh/conventions.py
@@ -5,6 +5,10 @@ commit_types = ['feat', 'fix', 'docs', 'style', 'refactor', 'perf', 'test', 'cho
 branchre = re.compile('release-(\d+\.\d+\.x)')
 commitre = re.compile('({})(.*): (.*)'.format('|'.join(commit_types)))
 
+def FormatCommit(commit):
+    title = commit.message.split('\n')[0]
+    return '{}: {}'.format(commit.sha, title)
+
 def ParseReleaseBranch(branch):
     branch = ReleaseBranchFor(branch)
     if branch is None:


### PR DESCRIPTION
Previously the commit messages included the commit bodies, mangling the
message written by spinnaker bot.

(hopefully this will be demonstrated here)