### PR TITLE
Adds blue-green deployment solution

### DIFF
--- a/solutions/bluegreen/README.md
+++ b/solutions/bluegreen/README.md
@@ -1,0 +1,15 @@
+# Blue-Green Deployments on Google Kubernetes Engine with Spinnaker 
+
+This directory contains the assets necessary to configure a simple blue-green pipeline
+with Spinnaker on GKE.  
+
+**Note**: this sample uses features only available in [Spinnaker 1.11](https://www.spinnaker.io/guides/user/kubernetes-v2/traffic-management/).  
+
+* The `app` directory contains the source code for the small "Hello World"
+  application used. The Docker image is available at
+  `gcr.io/spinnaker-marketplace/helloworld:v1`.
+
+* The `manifests` directory contains the Kubernetes that will be deployed to GKE
+  before the pipeline runs for the first time. 
+
+* The `pipelines` directory contains the blue-green pipeline JSON.

--- a/solutions/bluegreen/app/Dockerfile
+++ b/solutions/bluegreen/app/Dockerfile
@@ -1,0 +1,10 @@
+FROM golang:1.8-alpine
+COPY . /go/src/helloworld 
+WORKDIR /go/src/helloworld
+RUN go install helloworld
+
+FROM alpine:latest
+COPY --from=0 /go/bin/helloworld .
+ENV PORT 6000
+EXPOSE 6000 
+ENTRYPOINT ["./helloworld"]

--- a/solutions/bluegreen/app/main.go
+++ b/solutions/bluegreen/app/main.go
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2019 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+)
+
+func main() {
+	// get port, or default to 6000
+	port := "6000"
+	if fromEnv := os.Getenv("PORT"); fromEnv != "" {
+		port = fromEnv
+	}
+
+	// register /hello function
+	server := http.NewServeMux()
+	server.HandleFunc("/", hello)
+
+	// start server
+	log.Printf("Server listening on port %s", port)
+	err := http.ListenAndServe(":"+port, server)
+	log.Fatal(err)
+}
+
+// hello responds to the request with a plain-text "Hello, world" message.
+func hello(w http.ResponseWriter, r *http.Request) {
+	log.Printf("GET %s", r.URL.Path)
+	fmt.Fprintf(w, "Hello world v1\n")
+}

--- a/solutions/bluegreen/manifests/hellosvc.yaml
+++ b/solutions/bluegreen/manifests/hellosvc.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    artifact.spinnaker.io/location: default
+    artifact.spinnaker.io/name: hellosvc
+    artifact.spinnaker.io/type: kubernetes/service
+    moniker.spinnaker.io/application: helloworld
+    moniker.spinnaker.io/cluster: service hellosvc
+  labels:
+    app.kubernetes.io/managed-by: spinnaker
+    app.kubernetes.io/name: helloworld
+  name: hellosvc
+  namespace: default
+spec:
+  ports:
+    - port: 80
+      protocol: TCP
+      targetPort: 6000
+  selector:
+    app: helloworld
+  type: LoadBalancer

--- a/solutions/bluegreen/manifests/replicaset-v1.yaml
+++ b/solutions/bluegreen/manifests/replicaset-v1.yaml
@@ -1,0 +1,45 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  annotations:
+    artifact.spinnaker.io/location: default
+    artifact.spinnaker.io/name: helloworld
+    artifact.spinnaker.io/type: kubernetes/replicaSet
+    artifact.spinnaker.io/version: v000
+    moniker.spinnaker.io/application: helloworld
+    moniker.spinnaker.io/cluster: replicaSet helloworld
+    moniker.spinnaker.io/sequence: '0'
+    strategy.spinnaker.io/max-version-history: '2'
+    traffic.spinnaker.io/load-balancers: '["service hellosvc"]'
+  labels:
+    app.kubernetes.io/managed-by: spinnaker
+    app.kubernetes.io/name: helloworld
+    tier: helloworld
+  name: helloworld-v000
+  namespace: default
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      tier: helloworld
+  template:
+    metadata:
+      annotations:
+        artifact.spinnaker.io/location: default
+        artifact.spinnaker.io/name: helloworld
+        artifact.spinnaker.io/type: kubernetes/replicaSet
+        artifact.spinnaker.io/version: v000
+        moniker.spinnaker.io/application: helloworld
+        moniker.spinnaker.io/cluster: replicaSet helloworld
+        moniker.spinnaker.io/sequence: '0'
+      labels:
+        app: helloworld
+        app.kubernetes.io/name: helloworld
+        tier: helloworld
+    spec:
+      containers:
+        - image: 'gcr.io/spinnaker-marketplace/helloworld:v1'
+          imagePullPolicy: IfNotPresent
+          name: helloworld
+          ports:
+            - containerPort: 6000

--- a/solutions/bluegreen/pipelines/pipeline.json
+++ b/solutions/bluegreen/pipelines/pipeline.json
@@ -1,0 +1,117 @@
+{
+	"name": "bluegreen",
+	"id": "bluegreen",
+	"application": "helloworld",
+	"appConfig": {},
+	"description": "blue green pipeline",
+	"executionEngine": "v2",
+	"keepWaitingPipelines": false,
+	"lastModifiedBy": "anonymous",
+	"limitConcurrent": true,
+	"parallel": true,
+	"parameterConfig": [{
+		"default": "v1",
+		"hasOptions": false,
+		"label": "helloworld image tag",
+		"name": "hellotag",
+		"options": [{
+			"value": ""
+		}],
+		"required": true
+	}],
+	"stages": [{
+			"account": "my-kubernetes-account",
+			"cloudProvider": "kubernetes",
+			"manifestArtifactAccount": "embedded-artifact",
+			"manifests": [{
+				"apiVersion": "apps/v1",
+				"kind": "ReplicaSet",
+				"metadata": {
+					"annotations": {
+						"strategy.spinnaker.io/max-version-history": "2",
+						"traffic.spinnaker.io/load-balancers": "[\"service hellosvc\"]"
+					},
+					"labels": {
+						"tier": "helloworld"
+					},
+					"name": "helloworld",
+					"namespace": "default"
+				},
+				"spec": {
+					"replicas": 3,
+					"selector": {
+						"matchLabels": {
+							"tier": "helloworld"
+						}
+					},
+					"template": {
+						"metadata": {
+							"labels": {
+								"app": "helloworld",
+								"tier": "helloworld"
+							}
+						},
+						"spec": {
+							"containers": [{
+								"image": "gcr.io/spinnaker-marketplace/helloworld:${ parameters.hellotag }",
+								"imagePullPolicy": "IfNotPresent",
+								"name": "helloworld",
+								"ports": [{
+									"containerPort": 6000
+								}]
+							}]
+						}
+					}
+				}
+			}],
+			"moniker": {
+				"app": "helloworld"
+			},
+			"name": "Deploy (Manifest)",
+			"refId": "1",
+			"relationships": {
+				"loadBalancers": [],
+				"securityGroups": []
+			},
+			"requisiteStageRefIds": [],
+			"source": "text",
+			"type": "deployManifest"
+		},
+		{
+			"account": "my-kubernetes-account",
+			"app": "helloworld",
+			"cloudProvider": "kubernetes",
+			"cluster": "replicaSet helloworld",
+			"criteria": "second_newest",
+			"kind": "replicaSet",
+			"location": "default",
+			"manifestName": " ",
+			"mode": "dynamic",
+			"name": "Disable (Manifest)",
+			"refId": "2",
+			"requisiteStageRefIds": [
+				"1"
+			],
+			"type": "disableManifest"
+		},
+		{
+			"account": "my-kubernetes-account",
+			"app": "helloworld",
+			"cloudProvider": "kubernetes",
+			"cluster": "replicaSet helloworld",
+			"criteria": "second_newest",
+			"kind": "replicaSet",
+			"location": "default",
+			"manifestName": " ",
+			"mode": "dynamic",
+			"name": "Scale (Manifest)",
+			"refId": "3",
+			"replicas": 1,
+			"requisiteStageRefIds": [
+				"2"
+			],
+			"type": "scaleManifest"
+		}
+	],
+	"triggers": []
+}


### PR DESCRIPTION
Added a blue-green deployment sample to the solutions/ directory. Supplements [the existing doc](https://www.spinnaker.io/guides/user/kubernetes-v2/traffic-management/#configure-the-disable-stage) for the Disable (Manifest) stage.  

**Sample includes**:

- `app/` - small Golang webserver, with a Dockerfile  
- `manifests/` - Kubernetes initial ReplicaSet  
- `pipeline/` - JSON, with 3 stages:
1. Deploy (Manifest) - deploy v2 ReplicaSet 
2. Disable (Manifest) - stop sending traffic to v1  
3. Scale (Maniefst) - scale v1 replicas from 3 down to 1 

