### PR TITLE
chore(build): Bump gradle_cache base image

### DIFF
--- a/google/release/gradle_cache_base_image.docker
+++ b/google/release/gradle_cache_base_image.docker
@@ -1,6 +1,6 @@
 # Provides a Docker image to start our Google Container Builder builds from.
 # Includes an updated Gradle cache in the produced image to decrease the traffic to Bintray.
-FROM java:8
+FROM openjdk:8-jdk
 
 # Docker can only manipulate directories within the root it is invoked in,
 # so the gradle cache needs copied to the CWD before executing the Docker build.


### PR DESCRIPTION
The 'java' docker repo has been deprecated and not maintained since the end of 2016 in favor of the 'openjdk' repo.

The old ones were using openjdk as well, so that's not a change, just the repo. This also makes the base debian image more modern (stretch instead of jesse).