### PR TITLE
chore(ISSUE_TEMPLATE): Put @ mentions in backticks

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -7,7 +7,7 @@
 ### Environment:
 
 
-### Feature Area (if this issue is UI/UX related, please tag @spinnaker/ui-ux-team):
+### Feature Area (if this issue is UI/UX related, please tag `@spinnaker/ui-ux-team`):
 
 
 ### Description:


### PR DESCRIPTION
Whenever somebody forgets to delete the issue template, this pings all the @ mentions.  Propose putting the mention in `backticks` to avoid the unintended ping.

