### PR TITLE
Update kayenta tutorial for Spinnaker 1.12

### DIFF
--- a/solutions/kayenta/README.md
+++ b/solutions/kayenta/README.md
@@ -42,7 +42,7 @@ jq '(.stages[] | select(.refId == "9") | .pipeline) |= env.PIPELINE_ID | (.stage
 
 ### Create the "Automated Canary Deploy" pipeline
 
-#### Spinnaker 1.10
+#### Spinnaker 1.10+
 
 This command assumes that Kayenta is enabled and configured as instructed in the
 tutorial.

--- a/solutions/kayenta/ci/scripts/first-deployment.sh
+++ b/solutions/kayenta/ci/scripts/first-deployment.sh
@@ -19,7 +19,7 @@ kubectl -n spinnaker port-forward $DECK_POD 8080:9000 \
     >/dev/null &
 sleep 5
 
-spin application save --application-name sampleapp --owner-email example@example.com --cloud-providers "kubernetes" --gate-endpoint http://localhost:8080/gate/
+spin application save --application-name sampleapp --owner-email example@example.com --cloud-providers "kubernetes" --gate-endpoint http://localhost:8080/gate
 
 sleep 5
 

--- a/solutions/kayenta/ci/scripts/setup.sh
+++ b/solutions/kayenta/ci/scripts/setup.sh
@@ -8,9 +8,8 @@ gcloud config set compute/zone us-central1-f
 
 ## Create GKE cluster ##
 gcloud beta container clusters create kayenta-tutorial \
-    --machine-type=n1-standard-2 --cluster-version=1.10 \
-    --enable-stackdriver-kubernetes \
-    --scopes=gke-default,compute-ro
+    --machine-type=n1-standard-2 \
+    --enable-stackdriver-kubernetes
 gcloud container clusters get-credentials kayenta-tutorial
 
 ## Install Stackdriver Prometheus plugin ##
@@ -23,8 +22,8 @@ curl -sS "https://storage.googleapis.com/stackdriver-prometheus-documentation/pr
     kubectl apply -f -
 
 ## Install Spinnaker ##
-curl -sSL "https://spinnaker.io/downloads/kubernetes/quick-install.yml" | \
-    sed 's/version:.*/version: 1.10.5/g' | kubectl apply -f -
+curl -sSL "https://www.spinnaker.io/downloads/kubernetes/quick-install.yml" | \
+    sed 's/version:.*/version: 1.12.2/g' | kubectl apply -f -
 # A successful Spinnaker install has 11 pods
 # Timeout of 20minutes (1200s)
 set +x


### PR DESCRIPTION
This is for an update of the [kayenta tutorial](https://cloud.google.com/solutions/automated-canary-analysis-kubernetes-engine-spinnaker) to use Spinnaker 1.12.