### PR TITLE
fix(appengine): Deploy default app engine version if no version exists.

### DIFF
--- a/testing/citest/tests/appengine_smoke_test.py
+++ b/testing/citest/tests/appengine_smoke_test.py
@@ -178,7 +178,7 @@ class AppengineSmokeTestScenario(sk.SpinnakerTestScenario):
   def __has_default_version(self):
     command = 'gcloud app services list --project={project}'.format(project=self.__gcp_project)
     out, err = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True).communicate()
-    logging.debug('Checking if project has default app version: {command} returned: {out}'.format(out))
+    logging.debug('Checking if project has default app version: {command} returned: {out}'.format(command=command, out=out))
     # Expect an output similar to:
     # SERVICE        NUM_VERSIONS
     # default        1


### PR DESCRIPTION
This is to allow AppEngine smoke tests to pass even if no default version had been deployed prior to the test run.