### PR TITLE
feat(sponnet): Add skip eval SPeL to Deploy Manifest

### DIFF
--- a/sponnet/demo/demo-pipeline.jsonnet
+++ b/sponnet/demo/demo-pipeline.jsonnet
@@ -126,7 +126,8 @@ local deployManifestArtifact = sponnet.stages
                                .withMoniker(moniker)
                                .withOverrideTimeout('300000')
                                .withRestrictedExecutionWindow(['1', '2', '3'], whitelist)
-                               .withRequisiteStages(wait);
+                               .withRequisiteStages(wait)
+                               .withSkipExpressionEvaluation();
 
 local deployManifestTextBaseline = sponnet.stages
                                    .deployManifest('Deploy a manifest')

--- a/sponnet/pipeline.libsonnet
+++ b/sponnet/pipeline.libsonnet
@@ -19,7 +19,7 @@
     withTemplate(templateArtifact):: self + { template: templateArtifact },
     withSchema(schema):: self + { schema: schema },
     withInherit(inheritedFields):: self + if std.type(inheritedFields) == 'array' then { inherit: inheritedFields } else { inherit: [inheritedFields] },
-    withVariableValues(variables):: self + { variables: variables }, // variables are key-value pairs of <variable name> -> <variable value>
+    withVariableValues(variables):: self + { variables: variables },  // variables are key-value pairs of <variable name> -> <variable value>
   },
 
   moniker(app, cluster):: {
@@ -52,7 +52,7 @@
     httpFile():: artifact('http/file', 'http'),
     // kubernetesObject to be tested. Where kind is Deployment/Configmap/Service/etc
     kubernetesObject(kind):: artifact('kubernetes/' + kind, 'custom'),
-    front50PipelineTemplate():: artifact('front50/pipelineTemplate', '').withArtifactAccount('front50ArtifactCredentials') // credentials are static
+    front50PipelineTemplate():: artifact('front50/pipelineTemplate', '').withArtifactAccount('front50ArtifactCredentials'),  // credentials are static
   },
 
   // expected artifacts
@@ -227,6 +227,7 @@
       withManifestArtifact(artifact):: self + { manifestArtifactId: artifact.id, source: 'artifact' },
       withManifests(manifests):: self + if std.type(manifests) == 'array' then { manifests: manifests } else { manifests: [manifests] },
       withMoniker(moniker):: self + { moniker: moniker },
+      withSkipExpressionEvaluation():: self + { skipExpressionEvaluation: true },
     },
     deleteManifest(name):: stage(name, 'deleteManifest') {
       cloudProvider: 'kubernetes',


### PR DESCRIPTION
Per: https://github.com/spinnaker/orca/pull/2761

Notes:

1.  Haven't added `evaluateOverrideExpressions` option to Bake Manifest stage. See Helm PR here: https://github.com/spinnaker/spinnaker/pull/3811

2. Added `withSkipExpressionEvaluation()` to `deployManifest()` in a way that could be used for artifact or text manifests. 
I can move it to an flag in `withManifestArtifact(artifact):: self + { <here> }`  if text manifests are fundamentally different.
Not sure if it's a `no-op` for text manifests if set to `true`. 

@maggieneterval would you mind advising?

Tested via:
1. `spin` CLI submitting `demo-pipeline.jsonnet` to Spinnaker and verifying in Deck
2. Our internal sponnet pipelines now all default to true and have been run.