### PR TITLE
docs(citest): reformat README.md

### DIFF
--- a/testing/citest/README.md
+++ b/testing/citest/README.md
@@ -1,38 +1,37 @@
 # Summary
 
-These Spinnaker integration tests depend on the [Cloud Integration Testing]
-(https://github.com/google/citest) python package. You'll need to run the
-setup script to install the dependencies into your environment, then can
-run the tests at will.
+These Spinnaker integration tests depend on the
+[Cloud Integration Testing](https://github.com/google/citest) python package.
+You'll need to run the setup script to install the dependencies into your
+environment, then can run the tests at will.
 
 To write new tests refer to existing tests and see
 [the citest README.md](https://github.com/google/citest/blob/master/README.md)
-gifor the time being, and ask questions on the [Spinnaker #dev slack channel]
-(https://spinnakerteam.slack.com/messages/dev/).
+gifor the time being, and ask questions on the
+[Spinnaker #dev slack channel](https://spinnakerteam.slack.com/messages/dev/).
 
 # About This Subtree
 
 This part of the repository is divided into the following parts:
 
-Directory | Purpose
-----------|--------
-'tests'  | The actual Spinnaker integration tests.
-'spinnaker_testing' | Support modules for the Spinnaker integration tests.
-'unittests'        | Unit tests for parts of spinnaker_testing.
-
+Directory           | Purpose
+------------------- | ----------------------------------------------------
+`tests`             | The actual Spinnaker integration tests.
+`spinnaker_testing` | Support modules for the Spinnaker integration tests.
+`unittests`         | Unit tests for parts of spinnaker_testing.
 
 # Installing dependencies
 
 ## Install and Create a Virtual Env
-These tests are written in Python. Instead of installing the dependencies
-into system folders consider using something like [virtualenv]
-(https://virtualenv.pypa.io/en/stable/). This is optional,
-but suggested.
 
+These tests are written in Python. Instead of installing the dependencies into
+system folders consider using something like
+[virtualenv](https://virtualenv.pypa.io/en/stable/). This is optional, but
+suggested.
 
     # Install the python package manager if you dont already have it
     sudo apt-get install python-pip
-    
+
     # Instal FFI package needed by pyopenssl
     sudo apt-get install libffi-dev libssl-dev python-dev
 
@@ -48,24 +47,24 @@ but suggested.
     ...
     deactivate            # leave the virtualenv when you are done
 
-
-If you are using Virtual Env, then all the remaining instructions
-would be performed within the virtual environment, entered by
-`source $MYENV/bin/activate` within the shell you run the commands in.
+If you are using Virtual Env, then all the remaining instructions would be
+performed within the virtual environment, entered by `source
+$MYENV/bin/activate` within the shell you run the commands in.
 
 ## Install citest Dependencies
+
 The citest library is not yet published to a pip repository so you need to clone
 the citest repository and install it from there.
+
 ```
 # From another directoy, such as the parent directory to this repository.
-cd <parent directory>
-git clone https://github.com/google/citest.git
-cd citest
+cd <parent directory> git clone https://github.com/google/citest.git cd citest
 pip install -r requirements.txt
 ```
 
 Then navigate back to the Spinnaker testing directory and install the
 requirements for the Spinnaker testing library.
+
 ```
 cd <parent directory>/spinnaker/testing/citest
 pip install -r requirements.txt
@@ -78,97 +77,99 @@ needs to be added to your `PYTHONPATH`, e.g.
     PYTHONPATH=.:spinnaker_testing python <test name>.py <args>
 
 ## Install Platform Dependencies
-Installation of platform-specific tools are not yet automated.
-Depending on the platforms involved either by hosting Spinnaker
-or being the platform the test is running against, you may need
-additional tools.
 
-Platform | Tools | Installation Command
----------|-------|---------------------
-Amazon Web Services | awscli | ```sudo apt-get install -y awscli```
-Microsoft Azure | az | [See instructions](https://docs.microsoft.com/cli/azure/install-azure-cli)
-Google Cloud Platform | gcloud | ```curl https://sdk.cloud.google.com | bash```
-Kubernetes | kubectl | [See instructions](http://kubernetes.io/docs/user-guide/prereqs/)
-DC/OS | dcos | [See instructions](https://dcos.io/docs/1.9/cli/install/)
-OpenStack | openstack | [See instructions](https://docs.openstack.org/user-guide/common/cli-install-openstack-command-line-clients.html)
+Installation of platform-specific tools are not yet automated. Depending on the
+platforms involved either by hosting Spinnaker or being the platform the test is
+running against, you may need additional tools.
 
+Platform              | Tools     | Installation Command
+--------------------- | --------- | --------------------
+Amazon Web Services   | awscli    | `sudo apt-get install -y awscli`
+Microsoft Azure       | az        | [See instructions](https://docs.microsoft.com/cli/azure/install-azure-cli)
+Google Cloud Platform | gcloud    | `curl https://sdk.cloud.google.com`
+Kubernetes            | kubectl   | [See instructions](http://kubernetes.io/docs/user-guide/prereqs/)
+DC/OS                 | dcos      | [See instructions](https://dcos.io/docs/1.9/cli/install/)
+OpenStack             | openstack | [See instructions](https://docs.openstack.org/user-guide/common/cli-install-openstack-command-line-clients.html)
 
 ## Defining Environment Variables
+
 ### OpenStack
 
-Below mentioned environment variables are needed in order for OpenStack client to work.
- 
-Variable | Description
----------|------------
-OS_AUTH_URL | Keystone authentication server URL. (https://identityHost:portNumber/version)
-OS_PROJECT_ID | OpenStack project ID.
-OS_PROJECT_NAME | OpenStack project name.
-OS_USER_DOMAIN_NAME | OpenStack user domain name.
-OS_USERNAME | OpenStack user name.
-OS_PASSWORD | OpenStack user password.
-OS_REGION_NAME | OpenStack region name.
-OS_IDENTITY_API_VERSION | Keystone service endpoint version number.
-OS_PROJECT_DOMAIN_NAME | OpenStack project domain name.
+Below mentioned environment variables are needed in order for OpenStack client
+to work.
 
+| Variable                | Description                                 |
+| ----------------------- | ------------------------------------------- |
+| OS_AUTH_URL             | Keystone authentication server URL. (https\://identityHost\:portNumber/version) |
+| OS_PROJECT_ID           | OpenStack project ID.                       |
+| OS_PROJECT_NAME         | OpenStack project name.                     |
+| OS_USER_DOMAIN_NAME     | OpenStack user domain name.                 |
+| OS_USERNAME             | OpenStack user name.                        |
+| OS_PASSWORD             | OpenStack user password.                    |
+| OS_REGION_NAME          | OpenStack region name.                      |
+| OS_IDENTITY_API_VERSION | Keystone service endpoint version number.   |
+| OS_PROJECT_DOMAIN_NAME  | OpenStack project domain name.              |
 
 # Preparing a deployment to test against
-Normally these tests do not require any particular type of deployment.
-The tests themselves can be run from anywhere provided they can gain
-access to the microservices and backend services they need to talk to.
 
-You can run the tests against any standard deployment. The tests will 
-typically inspect your configuration and adapt themselves if possible
-while providing command-line flags for remaining parameters or overrides
-for what it may find.
+Normally these tests do not require any particular type of deployment. The tests
+themselves can be run from anywhere provided they can gain access to the
+microservices and backend services they need to talk to.
 
-Some tests require unique parameters, or may require certain features
-enabled in order to test them, but even so do not typically dictate any
-particular values beyond the feature being properly enabled in standard
-ways.
+You can run the tests against any standard deployment. The tests will typically
+inspect your configuration and adapt themselves if possible while providing
+command-line flags for remaining parameters or overrides for what it may find.
+
+Some tests require unique parameters, or may require certain features enabled in
+order to test them, but even so do not typically dictate any particular values
+beyond the feature being properly enabled in standard ways.
 
 2016-09-22 The documentation is sparse at this time. Currently only the
-bake_and_deploy test requires special configuration, which is basically
-a Jenkins job that it can trigger. Even there, the triggering information is
+bake_and_deploy test requires special configuration, which is basically a
+Jenkins job that it can trigger. Even there, the triggering information is
 passed to the test via command-line arguments. Instructions for this can be
-found in the test itself: [bake_and_deploy_test.py]
-(https://github.com/spinnaker/spinnaker/blob/master/testing/citest/tests/bake_and_deploy_test.py)
+found in the test itself:
+[bake_and_deploy_test.py](https://github.com/spinnaker/spinnaker/blob/master/testing/citest/tests/bake_and_deploy_test.py)
 
 ## Providing access
-If your deployment is firewalled in a way that the machine you are running
-from cannot normally access the service endpoints then you will need to tunnel
-in or use one of the other suggestions recommended for users to gain access
-to the Spinnaker UI. While these tests do not use the UI, the networking
-techniques are the same.
 
-If Spinnaker is deployed on the Google Cloud Platform, the tests will
-tunnel into them if you use the --gce_[project|zone|instance] parameters.
-Otherwise, if you use --native_hostname then you must tunnel in (or provide
-some other means).
+If your deployment is firewalled in a way that the machine you are running from
+cannot normally access the service endpoints then you will need to tunnel in or
+use one of the other suggestions recommended for users to gain access to the
+Spinnaker UI. While these tests do not use the UI, the networking techniques are
+the same.
+
+If Spinnaker is deployed on the Google Cloud Platform, the tests will tunnel
+into them if you use the `--gce_[project|zone|instance]` parameters. Otherwise,
+if you use --native_hostname then you must tunnel in (or provide some other
+means).
 
 ### Providing the SSH passphrase
-If spinnaker tunnels on your behalf, it will need your ssh passphrase.
-Since the tests are meant to be automated, these can be implicit by
-running something like ssh-agent in the shell you are running the tests from,
-or you can create a file containing the passphrase and pass the path on the
-command-line using --ssh_passphrase_file. If using the file, be sure to protect
-it using `chmod 200`.
 
+If spinnaker tunnels on your behalf, it will need your ssh passphrase. Since the
+tests are meant to be automated, these can be implicit by running something like
+ssh-agent in the shell you are running the tests from, or you can create a file
+containing the passphrase and pass the path on the command-line using
+--ssh_passphrase_file. If using the file, be sure to protect it using `chmod
+200`.
 
 # Running the tests
 
 ## Optional configuration for exposing deployment configuration
 
-Some configuration parameters in tests can be discovered from the runtime services
-rather than relying on manual flag passing. However doing so requires that the
-server security configuration be loosened up with the following configuration
-parameters which will expose the /resolvedEnv endpoint of microservices as well
-as prevent Spring from redacting the values of some sensitive values. While the
-tests do not rely on getting the senstive values from the server, they wind up
-getting exposed (and possibly logged) as collateral damage.
+Some configuration parameters in tests can be discovered from the runtime
+services rather than relying on manual flag passing. However doing so requires
+that the server security configuration be loosened up with the following
+configuration parameters which will expose the /resolvedEnv endpoint of
+microservices as well as prevent Spring from redacting the values of some
+sensitive values. While the tests do not rely on getting the senstive values
+from the server, they wind up getting exposed (and possibly logged) as
+collateral damage.
 
 Again, this particular configuration change is entirely optional.
 
 In spinnaker-local.yml, add the following:
+
 ```
 management:
   security:
@@ -179,24 +180,24 @@ endpoints:
     keys-to-sanitize: password,secret,key,token
 ```
 
-
 ## Standard Parameters For Talking To Spinnaker
 
 The following parameters can be passed on the command-line using a flag
 `--`*<parameter_name>*`=`*<parameter_value>*.
 
 ### Platform Independent Parameters
-Flag | Description
------|------------
-native_hostname | The hostname (or IP address) for the Spinnaker endpoint.
-native_port | The portnumber for the Spinnaker endpoint.
 
+Flag            | Description
+--------------- | --------------------------------------------------------
+native_hostname | The hostname (or IP address) for the Spinnaker endpoint.
+native_port     | The portnumber for the Spinnaker endpoint.
 
 ### When Spinnaker Is Deployed on GCE
-When spinnaker is on GCE you can use the `native_hostname` flag, or
-these custom flags which will locate the instance for you. If using the
-flags below, citest will automatically attempt to tunnel into the instance
-if it is not already reachable.
+
+When spinnaker is on GCE you can use the `native_hostname` flag, or these custom
+flags which will locate the instance for you. If using the flags below, citest
+will automatically attempt to tunnel into the instance if it is not already
+reachable.
 
 Flag | Description
 -----|------------
@@ -205,8 +206,8 @@ gce_instance | The name of the Google Cloud Instance that the instance is runnin
 gce_zone | The name of the Google Cloud Platform zone the instance is in.
 gce_ssh_passphrase_file | The path to the passphrase file for tunneling. Alternatively, you can run something like ssh-agent.
 
-
 ## Standard Parameters Controlling Created Resources
+
 These parameters are typically obtained from the deployed Spinnaker where
 possible, and if not have default values so do not need to be specified.
 
@@ -236,9 +237,8 @@ test_azure_rg_location | The azure location where the test resources should be c
 azure_storage_account_key | The key used to read the content from the Azure storage account used by Spinnaker when Spinnaker is configured to use Azure Storage for front50.
 azure_storage_account_name | The name of the Azure storage account used by Spinnaker when Spinnaker is configured to use Azure Storage for front50.
 
-
-
 ### Account Information
+
 Flag | Description
 -----|------------
 spinnaker_google_credentials | The name of the Spinnaker [clouddriver] account that you wish to use for Google operations. If not specified, this will use the configured primary account.
@@ -250,6 +250,7 @@ spinnaker_dcos_account | The name of the Spinnaker [clouddriver] account that yo
 spinnaker_dcos_cluster | The name of the DC/OS cluster associated to spinnaker_dcos_account to use for DC/OS operations.
 
 ## Standard Parameters For Configuring Observers
+
 Flag | Description
 -----|------------
 gce_credentials_path | The path to a service account JSON credentials file used by the test to verify effects on GCE. The permissions needed on the account may vary depending on what the test is doing. You can use the same service account that you have configured spinnaker with,
@@ -257,14 +258,13 @@ aws_profile | The name of the awscli profile to use when verifying effects on AW
 os_cloud | The name of the cloud. OpenStack will look for a clouds.yaml file that contains a cloud configuration to use for authentication.
 azure | For Azure, you must login with the following command on the test environment ```az login -u SPN_Client_ID -p SPN_Application_key --tenant Tenant_Name --service-principal``` prior to test execution.
 
-
 ## Typical Invocations
 
-Typical tests assume that the platform running Spinnaker is independent of
-the platform providing the resources that Spinnaker is managing. Therefore,
-a typical invocation has three sets of commandline parameters.
-One set specifies "spinnaker" things, another specifies "managed resource"
-things, and lastly, additional "observer" things.
+Typical tests assume that the platform running Spinnaker is independent of the
+platform providing the resources that Spinnaker is managing. Therefore, a
+typical invocation has three sets of commandline parameters. One set specifies
+"spinnaker" things, another specifies "managed resource" things, and lastly,
+additional "observer" things.
 
     # Assuming cwd is spinnaker/testing/citest
     PYTHONPATH=.:spinnaker_testing \
@@ -274,42 +274,51 @@ things, and lastly, additional "observer" things.
     <Observer Parameters>
 
 ### Talking to Spinnaker Parameters
+
 #### Google
+
         --gce_project=$PROJECT \
         --gce_zone=$ZONE \
         --gce_instance=$INSTANCE \
         --gce_ssh_passphrase_file=<path to optional passphrase file>
 
 #### Aws
-        --native_hostname=$HOST
-        
-#### Other
+
         --native_hostname=$HOST
 
+#### Other
+
+        --native_hostname=$HOST
 
 ### Managed Resource Parameters
 
 ### Observer Parameters
+
 #### Google
+
         --gce_credentials_path=<path to downloaded JSON credentials>
 
 ### Aws
+
         --aws_profile=$PROFILE
 
 ### Kubernetes
+
         None (when on GCE)
 
 ### OpenStack
+
         --os_cloud=$OS_CLOUD
 
 ### Azure
+
         --azure_storage_account_key=Key to access the storage account used by Spinnaker
         --azure_storage_account_name=Name of the Azure storage account used by Spinnaker
 
 # Usage Examples
 
-Assuming you are in the `spinnaker/testing/citest` directory and testing against GCE
-where:
+Assuming you are in the `spinnaker/testing/citest` directory and testing against
+GCE where:
 
     PROJECT_ID=ewiseblatt-spinnaker-test
     INSTANCE=ewiseblatt-20150805
@@ -333,11 +342,11 @@ If you were testing against some "native" host:
       --test_gce_zone=$ZONE
 
 Note that `google_kato_test.py` is written to specifically test managing GCE
-instances regardless of where Spinnaker is running from. So you can run
-it against an AWS deployment, but will still be observing changes on GCE.
+instances regardless of where Spinnaker is running from. So you can run it
+against an AWS deployment, but will still be observing changes on GCE.
 
-An example testing managing AWS instances, with Spinnaker running on
-a "native" host where:
+An example testing managing AWS instances, with Spinnaker running on a "native"
+host where:
 
     HOSTNAME=localhost  # IP address where spinnaker is running.
     PROFILE=test        # user creates profile for aws cli tool outside citest.
@@ -352,6 +361,5 @@ then:
       --test_aws_zone=$ZONE
 
 Note that `aws_kato_test.py` is written to specifically test managing AWS
-instances regardless of where Spinnaker is running from. So you can run
-it against a GCE deployment, but will still be observing changes on AWS.
-
+instances regardless of where Spinnaker is running from. So you can run it
+against a GCE deployment, but will still be observing changes on AWS.


### PR DESCRIPTION
There were several places where links weren't showing up because the link's text
and its URL were on separate lines. I just ran the whole thing through the 
(internal) `mdformat` tool to fix that.

It also justified all the paragraphs to 80 characters. But I had to paste back 
in most of the tables because our internal markdown engine has more table 
features than Github.
