### PR TITLE
feat(sponnet): Adds permissions to pipeline.libssonet

### DIFF
--- a/sponnet/pipeline.libsonnet
+++ b/sponnet/pipeline.libsonnet
@@ -12,6 +12,7 @@
     withLimitConcurrent(limitConcurrent):: self + { limitConcurrent: limitConcurrent },
     withName(name):: self + { name: name },
     withNotifications(notifications):: self + if std.type(notifications) == 'array' then { notifications: notifications } else { notifications: [notifications] },
+    withRoles(roles):: self + if std.type(roles) == 'array' then { roles: roles } else { roles: [roles] },
     withStages(stages):: self + if std.type(stages) == 'array' then { stages: stages } else { stages: [stages] },
     withTriggers(triggers):: self + if std.type(triggers) == 'array' then { triggers: triggers } else { triggers: [triggers] },
 
@@ -115,6 +116,7 @@
       withAccount(account):: self + { account: account },
       withExpectedArtifacts(expectedArtifacts):: self + if std.type(expectedArtifacts) == 'array' then { expectedArtifactIds: std.map(function(expectedArtifact) expectedArtifact.id, expectedArtifacts) } else { expectedArtifactIds: [expectedArtifacts.id] },
       withOrganization(organization):: self + { organization: organization },
+      withRunAsUser(runAsUser):: self + { runAsUser: runAsUser },
       withRegistry(registry):: self + { registry: registry },
       withRepository(repository):: self + { repository: repository },
       withTag(tag):: self + { tag: tag },


### PR DESCRIPTION
Automated pipeline triggers can set permissions as below link,
however, pipeline.libsonnet can't set permissions.
This commit adds permissions settings to pipeline.libssonet.

Close: #4327



---
### Instructions (that you should delete before submitting):

1. We prefer small, well tested pull requests.

2. Please refer to [Contributing to Spinnaker](https://spinnaker.io/community/contributing/).

3. When filling out a pull request, please consider the following:

    * Follow the commit message conventions [found here](https://www.spinnaker.io/community/contributing/submitting/).
    * Provide a descriptive summary for your changes.
    * If it fixes a bug or resolves a feature request, be sure to link to that issue.
    * Add inline code comments to changes that might not be obvious.
    * Squash your commits as you keep adding changes.
    * Add a comment to @spinnaker/reviewers for review if your issue has been outstanding for more than 3 days.
    * If this issue is UI/UX related, please tag @spinnaker/ui-ux-team.

4. We are unlikely to accept pull requests that add features without prior discussion. The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.
