### PR TITLE
fix(appengine): Add gcloud path to appengine config for localdebian

### DIFF
--- a/dev/validate_bom__config.py
+++ b/dev/validate_bom__config.py
@@ -578,6 +578,11 @@ class AppengineConfigurator(Configurator):
       return
 
     script.append('hal -q --log=info config provider appengine enable')
+
+    if options.deploy_spinnaker_type == 'localdebian':
+      script.append(
+          'hal -q --log=info config provider appengine edit --gcloudPath `which gcloud`')
+
     account_params = [
         options.appengine_account_name,
         '--project', options.appengine_account_project


### PR DESCRIPTION
Fixes #3349

Gcloud is not in the path by default for systemd services in ubuntu 18.04. In order to allow appengine to still work, pass in the path to gcloud to the appengine provider.