### PR TITLE
fix(build): Fix error message on halyard error

### DIFF
--- a/dev/buildtool/hal_support.py
+++ b/dev/buildtool/hal_support.py
@@ -94,7 +94,7 @@ class HalRunner(object):
       raise_and_log_error(
           ResponseError(
               '{url}: {code}\n{body}'.format(
-                  url=url, code=error.code, body=response.read()),
+                  url=url, code=error.code, body=error.read()),
               server='halyard'))
     self.__halyard_runtime_config = yaml.safe_load(response)
 


### PR DESCRIPTION
We're accessing the response variable in the catch block, where it doesn't exist, which throws a python error instead of reporting the actual error that occurred.