### PR TITLE
feat(sponnet) added secret and expected artifact to github trigger

### DIFF
--- a/sponnet/pipeline.libsonnet
+++ b/sponnet/pipeline.libsonnet
@@ -151,6 +151,8 @@
       withProject(project):: self + { project: project },
       withSlug(slug):: self + { slug: slug },
       withSource(source):: self + { source: source },
+      withSecret(secret):: self + { secret: secret },
+      withExpectedArtifacts(expectedArtifacts):: self + if std.type(expectedArtifacts) == 'array' then { expectedArtifactIds: std.map(function(expectedArtifact) expectedArtifact.id, expectedArtifacts) } else { expectedArtifactIds: [expectedArtifacts.id] },
     },
     webhook(name):: trigger(name, 'webhook') {
       payloadConstraints: {},


### PR DESCRIPTION
Github trigger was missing the secret(for the web-hook) and expected artifact.
These parameters are required when following this documentation.
https://www.spinnaker.io/guides/user/pipeline/triggers/github/#configure-the-github-trigger

Signed-off-by: David O'Dell <dave@helix.re>



---
### Instructions (that you should delete before submitting):

1. We prefer small, well tested pull requests.

2. Please refer to [Contributing to Spinnaker](https://spinnaker.io/community/contributing/).

3. When filling out a pull request, please consider the following:

    * Follow the commit message conventions [found here](https://www.spinnaker.io/community/contributing/submitting/).
    * Provide a descriptive summary for your changes.
    * If it fixes a bug or resolves a feature request, be sure to link to that issue.
    * Add inline code comments to changes that might not be obvious.
    * Squash your commits as you keep adding changes.
    * Add a comment to @spinnaker/reviewers for review if your issue has been outstanding for more than 3 days.
    * If this issue is UI/UX related, please tag @spinnaker/ui-ux-team.

4. We are unlikely to accept pull requests that add features without prior discussion. The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.
