### PR TITLE
feat(sponnet) added secret and expected artifact to github trigger

### DIFF
--- a/sponnet/pipeline.libsonnet
+++ b/sponnet/pipeline.libsonnet
@@ -151,6 +151,8 @@
       withProject(project):: self + { project: project },
       withSlug(slug):: self + { slug: slug },
       withSource(source):: self + { source: source },
+      withSecret(secret):: self + { secret: secret },
+      withExpectedArtifacts(expectedArtifacts):: self + if std.type(expectedArtifacts) == 'array' then { expectedArtifactIds: std.map(function(expectedArtifact) expectedArtifact.id, expectedArtifacts) } else { expectedArtifactIds: [expectedArtifacts.id] },
     },
     webhook(name):: trigger(name, 'webhook') {
       payloadConstraints: {},


### PR DESCRIPTION
Github trigger was missing the secret(for the web-hook) and expected artifact.
These parameters are required when following this documentation.
https://www.spinnaker.io/guides/user/pipeline/triggers/github/#configure-the-github-trigger

Bug: https://github.com/spinnaker/spinnaker/issues/4653

Signed-off-by: David O'Dell <dave@helix.re>


