### PR TITLE
fix(sponnet): fix existing and add missing application attributes

### DIFF
--- a/sponnet/application.libsonnet
+++ b/sponnet/application.libsonnet
@@ -1,15 +1,37 @@
 {
   application():: {
+    // set default values
+    dataSources: {
+      disabled: [ ],
+      enabled: [ ]
+    },
+    platformHealthOnly: false,
+    platformHealthOnlyShowOverride: false,
+    providerSettings: {
+      aws: {
+        useAmiBlockDeviceMappings: false
+      },
+      gce: {
+        associatePublicIpAddress: false
+      }
+    },
+    trafficGuards: [],
+    // set overrides
     withAccounts(accounts):: self + if std.type(accounts) == 'array' then { accounts: accounts } else { accounts: [accounts] },
     withAliases(aliases):: self + { aliases: aliases },
     withClusters(clusters):: self + if std.type(clusters) == 'array' then { clusters: clusters } else { clusters: [clusters] },
-    withCloudProviders(cloudProviders):: self + if std.type(cloudProviders) == 'array' then { cloudProviders: cloudProviders } else { cloudProviders: [cloudProviders] },
-    withDescription(description):: self + { attributes+: { description: description } },
-    // Email address must be put in both root and attributes for Spin to save application.
-    withEmail(email):: self + { email: email } + { attributes+: { email: email } },
-    withInstancePort(port):: self + { attributes+: { instancePort: port } },
+    withCloudProviders(cloudProviders):: self + { cloudProviders: cloudProviders },
+    withDataSourcesDisabled(dataSourcesDisabled):: self + { dataSources+: if std.type(dataSourcesDisabled) == 'array' then { disabled: dataSourcesDisabled } else { disabled: [dataSourcesDisabled] } },
+    withDataSourcesEnabled(dataSourcesEnabled):: self + { dataSources+: if std.type(dataSourcesEnabled) == 'array' then { enabled: dataSourcesEnabled } else { enabled: [dataSourcesEnabled] } },
+    withDescription(description):: self + { description: description },
+    withEmail(email):: self + { email: email },
+    withAwsUseAmiBlockDeviceMappings(awsUseAmiBlockDeviceMappings):: self + { providerSettings+: { aws+: { useAmiBlockDeviceMappings: awsUseAmiBlockDeviceMappings } } },
+    withGceAssociatePublicIpAdddress(gceAssociatePublicIpAddress):: self + { providerSettings+: { gce+: { associatePublicIpAddress: gceAssociatePublicIpAddress } } },
+    withInstancePort(port):: self + { instancePort: port },
     withName(name):: self + { name: name },
     withPlatformHealthOnly(platformHealthOnly):: self + { platformHealthOnly: platformHealthOnly },
-    withUser(user):: self + { attributes+: { user: user } },
+    withPlatformHealthOnlyShowOverride(platformHealthOnlyShowOverride):: self + { platformHealthOnlyShowOverride: platformHealthOnlyShowOverride },
+    withTrafficGuards(trafficGuards):: self + if std.type(trafficGuards) == 'array' then { trafficGuards: trafficGuards } else { trafficGuards: [trafficGuards] },
+    withUser(user):: self + { user: user },
   },
 }

--- a/sponnet/demo/demo-app-gce.jsonnet
+++ b/sponnet/demo/demo-app-gce.jsonnet
@@ -1,0 +1,13 @@
+local sponnet = import '../application.libsonnet';
+
+sponnet.application()
+.withName('demoappgce')
+.withEmail('youremail@example.com')
+.withCloudProviders('gce')
+.withDescription('Demo sponnet application')
+.withUser('youremail@example.com')
+.withGceAssociatePublicIpAdddress(true)
+.withInstancePort(80)
+.withPlatformHealthOnly(true)
+.withPlatformHealthOnlyShowOverride(true)
+


### PR DESCRIPTION
Per https://github.com/spinnaker/orca/blob/master/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/model/Application.groovy#L40, cloudProviders should be a string, not an array.

I'm getting this error when I try to save an application generated from sponnet:
```
Caused by: com.fasterxml.jackson.databind.exc.MismatchedInputException: Cannot deserialize instance of `java.lang.String` out of START_ARRAY token
 at [Source: UNKNOWN; line: -1, column: -1] (through reference chain: com.netflix.spinnaker.orca.front50.model.Application["cloudProviders"])
	at com.fasterxml.jackson.databind.exc.MismatchedInputException.from(MismatchedInputException.java:63)
	at com.fasterxml.jackson.databind.DeserializationContext.reportInputMismatch(DeserializationContext.java:1343)
	at com.fasterxml.jackson.databind.DeserializationContext.handleUnexpectedToken(DeserializationContext.java:1139)
	at com.fasterxml.jackson.databind.deser.std.StdDeserializer._deserializeFromArray(StdDeserializer.java:675)
	at com.fasterxml.jackson.databind.deser.std.StringDeserializer.deserialize(StringDeserializer.java:40)
	at com.fasterxml.jackson.databind.deser.std.StringDeserializer.deserialize(StringDeserializer.java:10)
	at com.fasterxml.jackson.databind.deser.impl.FieldProperty.deserializeAndSet(FieldProperty.java:138)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.vanillaDeserialize(BeanDeserializer.java:288)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:151)
	at com.fasterxml.jackson.databind.ObjectMapper._convert(ObjectMapper.java:3745)
	... 38 more
```

We also need additional attributes for other cloud providers.