### PR TITLE
fix(buildtool): Set trusty dist for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: java
 jdk:
 - oraclejdk8
 sudo: false
+dist: trusty
 install: gradle/installViaTravis.sh
 script: gradle/buildViaTravis.sh
 cache:


### PR DESCRIPTION
Travis builds are failing with the wrong distro, see this [PR](https://github.com/spinnaker/spinnaker/pull/4729) with a failed build.