### PR TITLE
feat(buildtool): Ubuntu image variant support

### DIFF
--- a/dev/buildtool/cloudbuild.yml
+++ b/dev/buildtool/cloudbuild.yml
@@ -1,0 +1,24 @@
+steps:
+  - id: buildCompileImage
+    waitFor: ["-"]
+    name: gcr.io/cloud-builders/docker
+    args: ["build", "-t", "compile", "-f", "Dockerfile.compile", "."]
+  - id: buildSlimImage
+    waitFor: ["buildCompileImage"]
+    name: gcr.io/cloud-builders/docker
+    args: ["build", "-t", "gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-slim", "-f", "Dockerfile.slim", "."]
+  - id: buildUbuntuImage
+    waitFor: ["buildCompileImage"]
+    name: gcr.io/cloud-builders/docker
+    args: ["build", "-t", "gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-ubuntu", "-f", "Dockerfile.ubuntu", "."]
+  - id: tagDefaultImage
+    waitFor: ["buildSlimImage"]
+    name: gcr.io/cloud-builders/docker
+    args: ["tag", "gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-slim", "gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME"]
+images:
+  - gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-slim
+  - gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-ubuntu
+  - gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME
+timeout: 3600s
+options:
+  machineType: N1_HIGHCPU_8

--- a/dev/buildtool/config-template.yml
+++ b/dev/buildtool/config-template.yml
@@ -158,13 +158,10 @@
 # Container Commands
 ################################
 # docker_registry:
-# container_env_vars: GRADLE_USER_HOME=/gradle_cache/.gradle
-# container_builder: gcb
 # gcb_project:
 # gcb_service_account:
-# container_base_image:
-# force_clean_gradle_cache: true
-
+# image_variants: alpine,ubuntu
+# image_default_variant: alpine
 
 ################################
 # Halyard Commands


### PR DESCRIPTION
* Now tagging the images with `version-variant` but left the existing `version` tag on the `slim` image to make it backward compatible with halyard. The slim image is the only one with 2 tags: `version` and `version-slim`.
* Moved any service-specific build logic to their Dockerfiles, leaving the `cloudbuild.yaml` file fully generic so it could be stored in this repo as a single template.
* Expecting every service to have `Dockerfile.compile`, `Dockerfile.slim` and `Dockerfile.ubuntu`
* Removed config parameters from `config-template.yml` for features that have been removed in a previous commit.