### PR TITLE
fix(buildtool): log stderr of `gcloud compute instances describe`

### DIFF
--- a/dev/buildtool/subprocess_support.py
+++ b/dev/buildtool/subprocess_support.py
@@ -38,7 +38,7 @@ from buildtool.base_metrics import BaseMetricsRegistry
 # this module does not offer encapsulated configuration.
 ERROR_LOGFILE_DIR = 'errors'
 
-def start_subprocess(cmd, stream=None, stdout=None, echo=False, **kwargs):
+def start_subprocess(cmd, stream=None, stdout=None, stderr=None, echo=False, **kwargs):
   """Starts a subprocess and returns handle to it."""
   split_cmd = shlex.split(cmd)
   actual_command = cmd if kwargs.get('shell') else split_cmd
@@ -59,7 +59,7 @@ def start_subprocess(cmd, stream=None, stdout=None, echo=False, **kwargs):
       actual_command,
       close_fds=True,
       stdout=stdout or subprocess.PIPE,
-      stderr=subprocess.STDOUT,
+      stderr=stderr or subprocess.STDOUT,
       **kwargs)
   logging.log(log_level, 'Running %s as pid %s', split_cmd[0], process.pid)
   process.start_date = start_date
@@ -88,6 +88,14 @@ def wait_subprocess(process, stream=None, echo=False, postprocess_hook=None):
       if stream:
         stream.write(decoded_line)
         stream.flush()
+
+  if process.stderr is not None:
+    log_level = logging.INFO if echo else logging.DEBUG
+    # stderr isn't going to another file handle; log it
+    for raw_line in iter(process.stderr.readline, ''):
+      decoded_line = raw_line.decode(encoding='utf-8')
+      logging.log(log_level, 'PID %s wrote to stderr: %s', process.pid, decoded_line)
+
    
   process.wait()
   if stream is None and process.stdout is not None:

--- a/dev/validate_bom__deploy.py
+++ b/dev/validate_bom__deploy.py
@@ -24,6 +24,7 @@ import logging
 import os
 import shutil
 import stat
+import subprocess
 import sys
 import tempfile
 import time
@@ -1308,7 +1309,10 @@ class GoogleValidateBomDeployer(GenericVmValidateBomDeployer):
         .format(gcloud_account=options.deploy_hal_google_service_account,
                 project=options.deploy_google_project,
                 zone=options.deploy_google_zone,
-                instance=options.deploy_google_instance))
+                instance=options.deploy_google_instance),
+        # Setting this to PIPE means it will get logged instead of getting
+        # commingled with stdout into the response
+        stderr=subprocess.PIPE)
     nic = decode_json(response)['networkInterfaces'][0]
 
     use_internal_ip = options.deploy_google_use_internal_ip


### PR DESCRIPTION
By default, it was getting joined with stdout and then we tried to parse
it as JSON, which didn't work since it isn't, in fact, JSON.

My test run didn't actually have any of this stderr output, so I can't
say for certain that it actually works. But it doesn't make the
no-stderr case fail, so we're at least no worse off.