### PR TITLE
feat(sponnet): Added support for pubsub triggers

### DIFF
--- a/sponnet/pipeline.libsonnet
+++ b/sponnet/pipeline.libsonnet
@@ -159,7 +159,14 @@
       withSource(source):: self + { source: source },
       addPayloadConstraint(key, value):: self + { payloadConstraints +: super.payloadConstraints + { [key]: value }},
     },
-
+    pubsub(name, pubsubSystem, subscriptionName):: trigger(name, 'pubsub') {
+      pubsubSystem: pubsubSystem,
+      subscriptionName: subscriptionName,
+      attributeConstraints: {},
+      addAttributeConstraints(key, value):: self + {attributeConstraints +: {[key]: value}},
+      payloadConstraints: {},
+      addPayloadConstraints(key, value):: self + {payloadConstraints +: {[key]: value}},
+    },
   },
 
   // stages

--- a/sponnet/pipeline.libsonnet
+++ b/sponnet/pipeline.libsonnet
@@ -163,9 +163,9 @@
       pubsubSystem: pubsubSystem,
       subscriptionName: subscriptionName,
       attributeConstraints: {},
-      addAttributeConstraints(key, value):: self + {attributeConstraints +: {[key]: value}},
+      addAttributeConstraints(key, value):: self + { attributeConstraints+: { [key]: value } },
       payloadConstraints: {},
-      addPayloadConstraints(key, value):: self + {payloadConstraints +: {[key]: value}},
+      addPayloadConstraints(key, value):: self + { payloadConstraints+: { [key]: value } },
     },
   },
 


### PR DESCRIPTION
I wasn't sure whether to add it to the demo.

Example with GCP:

```
pipeline.triggers.pubsub("the-trigger", "google", "subscription")
  .addAttributeConstraints("status", "SUCCESS")
  .addPayloadConstraints("buildTriggerId", "default-github-checks")
  .withExpectedArtifacts([my_expected_docker_image_artifact])
  ;
```