### PR TITLE
feat(sponnet): Add support for Google Cloud Build stages

### DIFF
--- a/sponnet/pipeline.libsonnet
+++ b/sponnet/pipeline.libsonnet
@@ -347,6 +347,16 @@
       withMaster(master):: self + { master: master },
     },
 
+    // Google Cloud Build stages
+
+    googleCloudBuild(name): stage(name, 'googleCloudBuild') {
+      withBuildDefinitionText(buildDefinition):: self + {
+        buildDefinitionSource: 'text',
+        buildDefinition: buildDefinition,
+      },
+      withAccount(account):: self + { account: account },
+    },
+
   },
 
   // kubernetes-provider help


### PR DESCRIPTION
Note that this only adds support for `cloudbuild.yml` structures passed to a function. Not structures coming from an artifact.

