### PR TITLE
feat(sponnet): Make cluster optional in moniker

### DIFF
--- a/sponnet/pipeline.libsonnet
+++ b/sponnet/pipeline.libsonnet
@@ -24,9 +24,9 @@
     withVariableValues(variables):: self + { variables: variables },  // variables are key-value pairs of <variable name> -> <variable value>
   },
 
-  moniker(app, cluster):: {
+  moniker(app, cluster=null):: {
     app: app,
-    cluster: cluster,
+    [if cluster != null then "cluster"]: cluster,
     withStack(stack):: self + { stack: stack },
     withDetail(detail):: self + { detail: detail },
   },


### PR DESCRIPTION
I'm porting the JSON I get Deck so I can replicate the JSON document with Sponnet, and I noticed that Deck isn't giving me a cluster in the moniker field, so I'm making it optional.
