### PR TITLE
fix(sponnet): Output valid executionOptions for Find Artifact stage

### DIFF
--- a/sponnet/pipeline.libsonnet
+++ b/sponnet/pipeline.libsonnet
@@ -231,7 +231,9 @@
 
     findArtifactFromExecution(name):: stage(name, 'findArtifactFromExecution') {
       withApplication(application):: self + { application: application },
-      withExecutionOptions(executionOptions):: self + if std.type(executionOptions) == 'array' then { executionOptions: executionOptions } else { executionOptions: [executionOptions] },
+      withExecutionOptions(executionOptions)::
+        assert std.type(executionOptions) == 'object': 'Execution options must now be an object';
+        self + { executionOptions: executionOptions },
       withExpectedArtifact(expectedArtifact):: self + {
         expectedArtifact: {
           id: expectedArtifact.id,


### PR DESCRIPTION
BREAKING CHANGE: `findArtifactFromExecution().withExecutionOptions()` used to work with an array of `executionOptions` but it now requires an object.