### PR TITLE
fix(build): make feat into patch bump to fix collision on clouddriver…

### DIFF
--- a/dev/buildtool/git_support.py
+++ b/dev/buildtool/git_support.py
@@ -322,7 +322,7 @@ class CommitMessage(
       # Some tags indicate only a patch release.
       re.compile(r'^\s*'
                  r'(?:\*\s+)?'
-                 r'((?:fix|bug|chore|docs?|perf|test)[\(:].*)',
+                 r'((?:feat|fix|bug|chore|docs?|perf|test)[\(:].*)',
                  re.MULTILINE)
   ]
   DEFAULT_MINOR_REGEXS = [
@@ -331,7 +331,7 @@ class CommitMessage(
       # implementation changes that suggest a higher level of risk.
       re.compile(r'^\s*'
                  r'(?:\*\s+)?'
-                 r'((?:feat|feature|refactor|config)[\(:].*)',
+                 r'((?:feature|refactor|config)[\(:].*)',
                  re.MULTILINE)
   ]
   DEFAULT_MAJOR_REGEXS = [


### PR DESCRIPTION
A [cherry pick](https://github.com/spinnaker/clouddriver/pull/3997) with the label "feat" was merged into 1.15 causing a bump in clouddriver to 6.3.0. This is causing a collision with 6.3.0 on 1.16 and blocking patch releases of 1.15.x. This workaround changes the build process for just the 1.15.x branch to treat "feat" changes as patch updates.