### PR TITLE
Adding mode: label to the delete manifest stages so label selectors a…

### DIFF
--- a/solutions/kayenta/pipelines/canary-deploy.json
+++ b/solutions/kayenta/pipelines/canary-deploy.json
@@ -328,6 +328,7 @@
         ]
       },
       "location": "default",
+      "mode": "label",
       "name": "Delete Canary",
       "options": {
         "cascading": true
@@ -356,6 +357,7 @@
         ]
       },
       "location": "default",
+      "mode": "label",
       "name": "Delete Baseline",
       "options": {
         "cascading": true


### PR DESCRIPTION
…re honored after the pipeline is loaded to Spinnaker

This change adds mode: label to the canary-deploy.json pipeline.  Without the mode being specified, Spinnaker doesn't use the label selectors as desired in the delete manifest stages.



---
### Instructions (that you should delete before submitting):

1. We prefer small, well tested pull requests.

2. Please refer to [Contributing to Spinnaker](https://spinnaker.io/community/contributing/).

3. When filling out a pull request, please consider the following:

    * Follow the commit message conventions [found here](https://www.spinnaker.io/community/contributing/submitting/).
    * Provide a descriptive summary for your changes.
    * If it fixes a bug or resolves a feature request, be sure to link to that issue.
    * Add inline code comments to changes that might not be obvious.
    * Squash your commits as you keep adding changes.
    * Add a comment to @spinnaker/reviewers for review if your issue has been outstanding for more than 3 days.
    * If this issue is UI/UX related, please tag @spinnaker/ui-ux-team.

4. We are unlikely to accept pull requests that add features without prior discussion. The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.
