### PR TITLE
fix: adding in missing mode attribute on delete manifest stages

### DIFF
--- a/solutions/kayenta/pipelines/canary-deploy.json
+++ b/solutions/kayenta/pipelines/canary-deploy.json
@@ -328,6 +328,7 @@
         ]
       },
       "location": "default",
+      "mode": "label",
       "name": "Delete Canary",
       "options": {
         "cascading": true
@@ -356,6 +357,7 @@
         ]
       },
       "location": "default",
+      "mode": "label",
       "name": "Delete Baseline",
       "options": {
         "cascading": true


### PR DESCRIPTION
This change adds mode: label to the canary-deploy.json pipeline.  Without the mode being specified, Spinnaker doesn't use the label selectors as desired in the delete manifest stages.