### PR TITLE
fix(citest): Don't retry server group cloning

### DIFF
--- a/testing/citest/tests/google_server_group_test.py
+++ b/testing/citest/tests/google_server_group_test.py
@@ -502,11 +502,7 @@ class GoogleServerGroupTest(st.AgentTestCase):
 
   def test_e_clone_server_group(self):
     self.run_test_case(self.scenario.clone_server_group(),
-                       poll_every_secs=3,
-                       # TODO(ewiseblatt): 20160314
-                       # There is a lock contention race condition
-                       # in clouddriver that causes intermittent failure.
-                       max_retries=5)
+                       poll_every_secs=3)
 
   def test_f_disable_server_group(self):
     self.run_test_case(self.scenario.disable_server_group())


### PR DESCRIPTION
The Google zonal and regional server group tests have a step to clone an existing server group by sending a clone request to gate. This logic is wrapped in a retry loop to prevent flakiness (as added in a35fdacc3d77403916558d94e038fe036b6c7caf).

Given that cloning a server group is a non-idempotent mutating operation, we should not be retrying it if it fails, as this will leave the system in an unknown state. (In a recent run of the tests, we ended up cloning the server group twice, leading to downstream failures that were hard to trace back to this particular test.)

Remove the retry logic from this test; if this does cause flakiness, it will at least be easier to trace the test that is failing and we can then investigate how to fix the flakiness.