### PR TITLE
chore(ISSUE_TEMPLATE): Remove UX at mention

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -7,7 +7,7 @@
 ### Environment:
 
 
-### Feature Area (if this issue is UI/UX related, please tag `@spinnaker/ui-ux-team`):
+### Feature Area:
 
 
 ### Description:


### PR DESCRIPTION
GitHub doesn't allow folks from outside the `spinnaker` org to add org-specific group mentions, so we're instructing people to do something they aren't allowed to do.