### PR TITLE
fix(build): Fix repository comparison to handle ssh/https difference

### DIFF
--- a/dev/buildtool/git_support.py
+++ b/dev/buildtool/git_support.py
@@ -1078,21 +1078,21 @@ class GitRunner(object):
     self.check_run(git_dir, 'tag -d ' + ' '.join(tags_to_remove))
     logging.debug('%d of %d tags removed', len(tags_to_remove), len(all_tags))
 
-  def determine_pull_url(self, repository):
+  def determine_pull_url(self, origin):
     """Return the pull URL for a given repository from its origin."""
-    parts = self.normalize_repo_url(repository.origin)
+    parts = self.normalize_repo_url(origin)
     if len(parts) == 3:
       return (self.make_ssh_url(*parts) if self.__options.github_pull_ssh
               else self.make_https_url(*parts))
-    return repository.origin
+    return origin
 
-  def determine_push_url(self, repository):
+  def determine_push_url(self, origin):
     """Return the push URL for a given repository from its origin."""
-    parts = self.normalize_repo_url(repository.origin)
+    parts = self.normalize_repo_url(origin)
     if len(parts) == 3:
       return (self.make_ssh_url(*parts) if self.__options.github_push_ssh
               else self.make_https_url(*parts))
-    return repository.origin
+    return origin
 
   def clone_repository_to_path(
       self, repository, commit=None, branch=None, default_branch=None):
@@ -1107,7 +1107,7 @@ class GitRunner(object):
       raise_and_log_error(
           ConfigError('At most one of commit or branch can be specified.'))
 
-    pull_url = self.determine_pull_url(repository)
+    pull_url = self.determine_pull_url(repository.origin)
     git_dir = repository.git_dir
     logging.debug('Begin cloning %s', pull_url)
     parent_dir = os.path.dirname(git_dir)
@@ -1143,7 +1143,7 @@ class GitRunner(object):
       if len(parts) == 3:
         # Origin is not a local path
         logging.debug('Fixing origin push url')
-        push_url = self.determine_push_url(repository)
+        push_url = self.determine_push_url(repository.origin)
         self.check_run(git_dir, 'remote set-url --push origin ' + push_url)
 
     logging.debug('Finished cloning %s', pull_url)

--- a/dev/buildtool/halyard_commands.py
+++ b/dev/buildtool/halyard_commands.py
@@ -522,7 +522,7 @@ class PublishHalyardCommand(CommandProcessor):
     git_dir = repository.git_dir
     git = self.__scm.git
 
-    release_url = git.determine_push_url(repository)
+    release_url = git.determine_push_url(repository.origin)
     logging.info('Pushing branch=%s and tag=%s to %s',
                  self.__release_branch, self.__release_tag, release_url)
 

--- a/dev/buildtool/scm.py
+++ b/dev/buildtool/scm.py
@@ -151,7 +151,7 @@ class SpinnakerSourceCodeManager(object):
     if os.path.exists(git_dir):
       logging.info('Confirming existing %s matches expectations', git_dir)
       existing = self.__git.determine_git_repository_spec(git_dir)
-      if existing.origin != origin:
+      if existing.origin not in [origin, self.__git.determine_pull_url(origin)]:
         raise_and_log_error(
             UnexpectedError(
                 'Repository "{dir}" origin="{have}" expected="{want}"'.format(


### PR DESCRIPTION
I noticed that `Push_RawChangelogGist` is re-cloning repos every time it runs (both the source repository repos and the gist which is technically also a repo).  There is logic to check if the repos have already been cloned and if so just fetch updates, but that logic is not running as we're deleting all these repos every time the script runs.  Removing the step to delete these (which is not a code change, but just a Jenkins config change) caused us to hit a bug where it doesn't realize that the repo on disk is the same repo it's considering cloning (as the one on disk has an ssh origin and the one it's considering cloning has an https origin).  This PR fixes said bug, allowing us to remove the step in the Jenkins job that deletes all these repos.

The hope is that by reducing the amount of data we're fetching from github every time this job runs we might also reduce the timeouts we've been seeing on this job.  I'm not sure if a fetch is less likely to time out than a clone, but it seems worth a try.

* refactor(build): Update determine push/pull URL to take the origin 

  We're passing a full repository to determine_pull_url and determine_push_url, but these functions only need to know the origin. To allow these to be re-used in cases where we only have an origin, change the functions to accept an origin and expect callers to pass one in.

* fix(build): Fix repository comparison to handle ssh/https difference 

  When checking to see if a directory contains the expected git repository, we compare the origin against the expected origin. This often doesn't work as we have logic to auto-translate an origin from https to SSH before cloning, so existing repositories will often have ssh origins even if the configured origin is https. Fix this by considering repositories equivalent if the origin is either the expected origin or the result of determine_pull_url on the expected origin.