### PR TITLE
fix(build): Allow re-use of git directories

### DIFF
--- a/dev/buildtool/bom_scm.py
+++ b/dev/buildtool/bom_scm.py
@@ -172,6 +172,14 @@ class BomSourceCodeManager(SpinnakerSourceCodeManager):
     version = service['version'][:service['version'].find('-')]
     return version
 
+  def ensure_repository(self, repository):
+    git_dir = repository.git_dir
+    service_name = self.repository_name_to_service_name(repository.name)
+    self.git.refresh_local_repository(git_dir, 'origin')
+    bom_commit = check_bom_service(self.__bom, service_name)['commit']
+    self.git.checkout(repository, bom_commit)
+    return
+
   def check_repository_is_current(self, repository):
     git_dir = repository.git_dir
     service_name = self.repository_name_to_service_name(repository.name)

--- a/dev/buildtool/branch_scm.py
+++ b/dev/buildtool/branch_scm.py
@@ -108,6 +108,9 @@ class BranchSourceCodeManager(SpinnakerSourceCodeManager):
                     build_number, repository.name)
     return build_number
 
+  def ensure_repository(self, repository):
+    return
+
   def check_repository_is_current(self, repository):
     git_dir = repository.git_dir
     commit = repository.commit_or_none()

--- a/dev/buildtool/scm.py
+++ b/dev/buildtool/scm.py
@@ -122,6 +122,9 @@ class SpinnakerSourceCodeManager(object):
       return 'monitoring-daemon'
     return repository_name
 
+  def ensure_repository(self, repository):
+    raise NotImplementedError(self.__class__.__name__)
+
   def check_repository_is_current(self, repository):
     raise NotImplementedError(self.__class__.__name__)
 
@@ -188,6 +191,7 @@ class SpinnakerSourceCodeManager(object):
     have_git_dir = os.path.exists(git_dir)
 
     if have_git_dir:
+      self.ensure_repository(repository)
       self.check_repository_is_current(repository)
     else:
       self.ensure_git_path(repository)


### PR DESCRIPTION
In a few places, we check if a directory containing a git repo already exists. If the directory does not exist, we clone the repo into the directory and check out the expected commit; if the directory does exist, we verify that it is at the expected commit.

This effectively makes it impossible to re-use directories, as there is no logic in the re-use path to fetch changes and check out the expected commit. Add this logic; now, if a the directory exists we'll attempt to fetch origin and check out the expected commit before moving on rather than expecting it to already be at the commit we want.