### PR TITLE
fix(citest): Add brief retry when validating a new pipeline

### DIFF
--- a/testing/citest/tests/bake_and_deploy_test.py
+++ b/testing/citest/tests/bake_and_deploy_test.py
@@ -440,7 +440,7 @@ class BakeAndDeployTestScenario(sk.SpinnakerTestScenario):
     payload = self.agent.make_json_payload_from_kwargs(**pipeline_spec)
 
     builder = st.HttpContractBuilder(self.agent)
-    (builder.new_clause_builder('Has Pipeline')
+    (builder.new_clause_builder('Has Pipeline', retryable_for_secs=5)
        .get_url_path(
            'applications/{app}/pipelineConfigs'.format(app=self.TEST_APP))
        .contains_path_value(None, pipeline_spec))
@@ -472,7 +472,7 @@ class BakeAndDeployTestScenario(sk.SpinnakerTestScenario):
     payload = self.agent.make_json_payload_from_kwargs(**pipeline_spec)
 
     builder = st.HttpContractBuilder(self.agent)
-    (builder.new_clause_builder('Has Pipeline')
+    (builder.new_clause_builder('Has Pipeline', retryable_for_secs=5)
        .get_url_path(
            'applications/{app}/pipelineConfigs'.format(app=self.TEST_APP))
        .contains_path_value(None, pipeline_spec))
@@ -539,7 +539,7 @@ class BakeAndDeployTestScenario(sk.SpinnakerTestScenario):
     payload = self.agent.make_json_payload_from_kwargs(**pipeline_spec)
 
     builder = st.HttpContractBuilder(self.agent)
-    (builder.new_clause_builder('Has Pipeline')
+    (builder.new_clause_builder('Has Pipeline', retryable_for_secs=5)
        .get_url_path(
            'applications/{app}/pipelineConfigs'.format(app=self.TEST_APP))
        .contains_path_value(None, pipeline_spec))
@@ -570,7 +570,7 @@ class BakeAndDeployTestScenario(sk.SpinnakerTestScenario):
     payload = self.agent.make_json_payload_from_kwargs(**pipeline_spec)
 
     builder = st.HttpContractBuilder(self.agent)
-    (builder.new_clause_builder('Has Pipeline')
+    (builder.new_clause_builder('Has Pipeline', retryable_for_secs=5)
        .get_url_path(
            'applications/{app}/pipelineConfigs'.format(app=self.TEST_APP))
        .contains_path_value(None, pipeline_spec))


### PR DESCRIPTION
In a number of places in the tests, we create a new pipeline by sending a POST to gate, then immediately poll to check that the pipeline is there.  While in principle the immediate call should show the pipeline as existing (as there is logic in front50 to provide read-after-write consistency) there are a couple of edge cases.

Most of the places we try to read a new pipeline allow a few retries to give the pipeline to show up, but a few don't.  Add retries to the remaining places to reduce flakiness.