### PR TITLE
fix(citest): Allow longer service startup time

### DIFF
--- a/dev/validate_bom__test.py
+++ b/dev/validate_bom__test.py
@@ -1061,7 +1061,7 @@ def init_argument_parser(parser, defaults):
       help='Limits how many tests to run at a time. Default is unbounded')
 
   add_parser_argument(
-      parser, 'test_service_startup_timeout', defaults, 300, type=int,
+      parser, 'test_service_startup_timeout', defaults, 600, type=int,
       help='Number of seconds to permit services to startup before giving up.')
 
   add_parser_argument(


### PR DESCRIPTION
We currently time out if a service takes more than 5 minutes to start. Some of the services currently take on the order of 5 minutes to start (at least in some of the citest environments), which is leading to flakiness.

Let's add a safety factor of 2, and give the services 10 minutes to start before we time out. (Ideally they would start faster, but let's at least not have flaky tests in the meantime.) This won't decrease the best-case time as the tests start when all the services are ready, even if it's shorter than the max time.