### PR TITLE
(fix) sponnet - runJobManifest stage

### DIFF
--- a/sponnet/pipeline.libsonnet
+++ b/sponnet/pipeline.libsonnet
@@ -351,8 +351,10 @@
       withAccount(account):: self + { account: account },
       withApplication(application):: self + { application: application },
       withManifestArtifactAccount(account):: self + { manifestArtifactAccount: account },
-      withManifestArtifact(artifact):: self + { manifestArtifactId: artifact.id, source: 'artifact' },
+      withManifestArtifact(artifact):: self + { manifestArtifactId: artifact.id, manifestArtifactAccount: artifact.matchArtifact.artifactAccount, source: 'artifact' },
+      withManifestText(text):: self + { manifest: std.parseJson(text), source: 'text' },
     },
+
     // pipeline stages
 
     pipeline(name):: stage(name, 'pipeline') {


### PR DESCRIPTION
runJobManifest:
.withManifestArtifact(artifact) - reference manifestArtifactAccount from provided artefact
.withManifestText(text) - allow define manifest as text input