### PR TITLE
fix(jsonnet): Fix parameter for withManifestName fn

### DIFF
--- a/sponnet/demo/demo-pipeline.jsonnet
+++ b/sponnet/demo/demo-pipeline.jsonnet
@@ -170,7 +170,7 @@ local findArtifactsFromResource = sponnet.stages
                                   .findArtifactsFromResource('Find nginx-deployment')
                                   .withAccount(account)
                                   .withLocation('default')
-                                  .withManifestName('Deployment nginx-deployment')
+                                  .withManifestName('Deployment', 'nginx-deployment')
                                   .withRequisiteStages([deployManifestTextBaseline, deployManifestTextCanary, deployManifestArtifact]);
 
 local bakeManifest = sponnet.stages


### PR DESCRIPTION
When attempting to run through the sponnet example you'll encounter this error recently introduced a recent fix and commit 62be7e5d874d903ef5152f7b0d6259ef33a47582. 

```
$ jsonnet demo-pipeline.jsonnet > demo-pipeline.json && spin pipeline save --file demo-pipeline.json
RUNTIME ERROR: function parameter name not bound in call.
	demo-pipeline.jsonnet:(169:35)-(173:83)	thunk <findArtifactsFromResource>
	demo-pipeline.jsonnet:211:169-194	thunk <array_element>
	../pipeline.libsonnet:16:79-85	object <anonymous>
	During manifestation
```

This PR fixes it.

```
$ jsonnet demo-pipeline.jsonnet > demo-pipeline.json && spin pipeline save --file demo-pipeline.json
Pipeline save succeeded
```

@Mahito  @louisjimenez 
