### PR TITLE
turn off telemetry to test build

### DIFF
--- a/dev/validate_bom__config.py
+++ b/dev/validate_bom__config.py
@@ -1561,7 +1561,7 @@ hystrix:
                         for _ in range(26))
     telemetry_config = '''\
 telemetry:
-  enabled: true
+  enabled: false
   endpoint: https://stats-staging.spinnaker.io
   instanceId: {}
   spinnakerVersion: {}


### PR DESCRIPTION
@ttomsu @maggieneterval This temporarily disables the telemetry service for the build. Once it's determined why the service being unavailable causes echo to fail on the GKE provider, it can be turned back on.