### PR TITLE
feat(spinbot): do not mark beginner-friendly issues as stale

### DIFF
--- a/spinbot/policy/stale_issue_policy.py
+++ b/spinbot/policy/stale_issue_policy.py
@@ -7,6 +7,7 @@ class StaleIssuePolicy(Policy):
         super().__init__()
         self.stale_days = self.config.get('stale_days')
         self.ignore_lifecycle_label = self.config.get('ignore_lifecycle_label', 'no-lifecycle')
+        self.beginner_friendly_label = self.config.get('beginner-friendly_label', 'beginner-friendly')
         self.count = 0
         if not self.stale_days:
             self.stale_days = 45
@@ -37,7 +38,7 @@ class StaleIssuePolicy(Policy):
         if days_since_updated < self.stale_days:
             return
 
-        if HasLabel(o, self.ignore_lifecycle_label):
+        if HasLabel(o, self.ignore_lifecycle_label) or HasLabel(o, self.beginner_friendly_label):
             return
 
         if HasLabel(o, 'to-be-closed'):


### PR DESCRIPTION
After conferring with the Spinnaker SIG leads, we think it will help us curate a healthy backlog of beginner-friendly issues if they are never tagged as stale and auto-closed by Spinnakerbot.