### PR TITLE
feat(sponnet): Add fields for namespaceOverride to deployManifest

### DIFF
--- a/sponnet/pipeline.libsonnet
+++ b/sponnet/pipeline.libsonnet
@@ -309,6 +309,7 @@
       withManifests(manifests):: self + if std.type(manifests) == 'array' then { manifests: manifests } else { manifests: [manifests] },
       withMoniker(moniker):: self + { moniker: moniker },
       withSkipExpressionEvaluation():: self + { skipExpressionEvaluation: true },
+      withNamespaceOverride(namespace):: self + { namespaceOverride: namespace },
     },
     deleteManifest(name):: stage(name, 'deleteManifest') {
       cloudProvider: 'kubernetes',


### PR DESCRIPTION
Adds fields for `namespaceOverride` to deployManifest at pipeline.libsonnet.

Ref. feat(provider/kubernetes): namespace deployManifest
https://github.com/spinnaker/deck/pull/7016