### PR TITLE
fix(spinbot): Prepends spinbot's container tagging with the branch it…

### DIFF
--- a/spinbot/Makefile
+++ b/spinbot/Makefile
@@ -1,15 +1,15 @@
 PROJECT=spinnaker-marketplace
 IMAGE=gcr.io/${PROJECT}/spinbot
 
-HASH := $(shell git rev-parse HEAD)
+BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 
 init:
 	python3 -m pip install -r requirements.txt
 
 docker:
+	# Can only use 1 --tag (-t) tag via 'gcloud builds submit', otherwise last one wins.
 	gcloud builds submit . \
 		--project ${PROJECT} \
-		-t ${IMAGE}:${HASH} \
-		-t ${IMAGE}:latest
+		-t ${IMAGE}:${BRANCH}-latest
 
 .PHONY: init docker


### PR DESCRIPTION
I accidentally did a `make docker` when I was on the `release-1.17.x` branch and didn't realize it. In an attempt to add the branch, I discovered that the multiple `-t` flags is not supported, and that this was actually working by accident. 

This can be seen by looking in GCR: images should be tagged with their commit hashes but aren't:
![m44VDH9GcqL](https://user-images.githubusercontent.com/13141550/67890318-da38df00-fb26-11e9-891a-fff0643ad2af.png)

Spinbot appears to run as a k8s Cron Job that does an `ImagePullPolicy: Always` on the `latest` image, but I'll change it to `master-latest` to ensure someone doesn't accidentally do what I did again.