### PR TITLE
feat(sponnet): Support Kubernetes V2 provider in Check Preconditions stage

### DIFF
--- a/sponnet/pipeline.libsonnet
+++ b/sponnet/pipeline.libsonnet
@@ -231,6 +231,7 @@
           type: 'expression',
         }],
       },
+      withCloudProvider(provider):: self + {cloudProvider: provider},
       withClusterSize(cluster, comparison, credentials, expected, moniker, regions, failPipeline):: self + {
         preconditions+: [{
           context: {


### PR DESCRIPTION
"cloudProvider" parameter is required for using type ClusterSize in Check Preconditions stage with Kubernetes V2 provider.

```
...
    {
      "name": "Check Cluster Size",
      "preconditions": [
        {
          "cloudProvider": "kubernetes",  # required
          "context": {
            "cluster": "replicaSet myapp",
            "comparison": "==",
            "credentials": "mycluster",
            "expected": 0,
            "moniker": {
              "app": "myapp",
              "cluster": "replicaSet myapp"
            },
            "regions": [
              "mynamespace"
            ]
          },
          "failPipeline": false,
          "type": "clusterSize"
        }
      ],
      "refId": "Check Cluster Size",
      "requisiteStageRefIds": [ ],
      "type": "checkPreconditions"
    },
...

```