### PR TITLE
fix(sponnet): fix issues in demo-v2-mpt.jsonnet

### DIFF
--- a/sponnet/demo/demo-v2-mpt.jsonnet
+++ b/sponnet/demo/demo-v2-mpt.jsonnet
@@ -147,7 +147,7 @@ local findArtifactsFromResource = pipelines.stages
                                   .findArtifactsFromResource('Find nginx-deployment')
                                   .withAccount(account)
                                   .withLocation('default')
-                                  .withManifestName('Deployment nginx-deployment')
+                                  .withManifestName('Deployment','nginx-deployment')
                                   .withRequisiteStages([deployManifestTextBaseline, deployManifestTextCanary, deployManifestArtifact]);
 
 local jenkinsJob = pipelines.stages
@@ -171,7 +171,7 @@ local pipeline = pipelines.pipeline()
 local metadata = mpt.metadata()
 .withName('My New MPT')
 .withDescription('Totally Rad k8s Pipeline')
-.withDescription('jacobkiefer@google.com')
+.withOwner('jacobkiefer@google.com')
 .withScopes(['global']);
 
 local waitTime = mpt.variable()


### PR DESCRIPTION
Fixes owner in mpt metadata and the following error when trying to run the demo:

```
$ jsonnet demo-v2-mpt.jsonnet 
RUNTIME ERROR: function parameter name not bound in call.
	demo-v2-mpt.jsonnet:(146:35)-(150:83)	thunk <findArtifactsFromResource>
	demo-v2-mpt.jsonnet:169:134-159	thunk <array_element>
	../pipeline.libsonnet:16:79-85	object <anonymous>
	../v2PipelineTemplate.libsonnet:10:49-57	object <anonymous>
	During manifestation
```
@louisjimenez 




