### PR TITLE
feat(sponnet): add withStageStatus for checkPreconditions stage

### DIFF
--- a/sponnet/pipeline.libsonnet
+++ b/sponnet/pipeline.libsonnet
@@ -245,6 +245,13 @@
           type: 'clusterSize',
         }],
       },
+      withStageStatus(stageName, stageStatus, failPipeline):: self + {
+        preconditions+: [{
+          context: { stageName: stageName, stageStatus: stageStatus },
+          failPipeline: failPipeline,
+          type: 'stageStatus',
+        }],
+      },
     },
 
     findArtifactFromExecution(name):: stage(name, 'findArtifactFromExecution') {


### PR DESCRIPTION
```jsonnet
local checkStage = sponnet.stages
    .checkPreconditions("check")
    .withStageStatus("foo", "SUCCEEDED", true)
    .withStageStatus("bar", "FAILED", false);
```
generates 
```json
{
   "checkStage": {
      "name": "check",
      "preconditions": [
         {
            "context": {
               "stageName": "foo",
               "stageStatus": "SUCCEEDED"
            },
            "failPipeline": true,
            "type": "stageStatus"
         },
         {
            "context": {
               "stageName": "bar",
               "stageStatus": "FAILED"
            },
            "failPipeline": false,
            "type": "stageStatus"
         }
      ],
      "refId": "check",
      "requisiteStageRefIds": [ ],
      "type": "checkPreconditions"
   }
}
```