### PR TITLE
fix(spin): Build the checked out version of 'spin' (as opposed to HEAD)...

### DIFF
--- a/dev/buildtool/spin_commands.py
+++ b/dev/buildtool/spin_commands.py
@@ -129,13 +129,12 @@ class BuildSpinCommand(RepositoryCommandProcessor):
       labels = {'repository': repository.name,
                 'dist': dist_arch.dist,
                 'arch': dist_arch.arch}
-      cmd = 'go get -v -u {}'.format(spin_package_path)
+      cmd = 'go get -v'
       self.metrics.time_call(
           'GoGet', labels, self.metrics.default_determine_outcome_labels,
           check_subprocesses_to_logfile, 'Fetching Go packages ' + context,
-          logfile, [cmd], cwd=gopath, env=env)
+          logfile, [cmd], cwd=repository.git_dir, env=env)
 
-    for dist_arch in DIST_ARCH_LIST:
       # GCS sub-directory the binaries are stored in are specified by
       # ${build_version}/${dist}.
       version_bin_path = ('spin/{}/{}/{}/{}'
@@ -163,9 +162,9 @@ class BuildSpinCommand(RepositoryCommandProcessor):
       self.metrics.time_call(
           'GoBuild', labels, self.metrics.default_determine_outcome_labels,
           check_subprocesses_to_logfile, 'Building spin ' + context, logfile,
-          [cmd], cwd=config_root, env=env)
+          [cmd], cwd=repository.git_dir, env=env)
 
-      spin_path = '{}/{}'.format(config_root, dist_arch.filename)
+      spin_path = '{}/{}'.format(repository.git_dir, dist_arch.filename)
       self.__gcs_uploader.upload_from_filename(
         version_bin_path, spin_path)
       os.remove(spin_path)


### PR DESCRIPTION
using the exact declared dependencies (instead of doing 'go get -u' which pulls in potentially backwards incompatible changes).

This was brought up because of a [transitive dependency](https://github.com/posener/complete) that published a backwards-incompatible `v2` as their default git branch, which is what appears to be used when `go get -u` is used. 

From `go help get`:

```
Although get defaults to using the latest version of the module containing
a named package, it does not use the latest version of that module's
dependencies. Instead it prefers to use the specific dependency versions
requested by that module. For example, if the latest A requires module
B v1.2.3, while B v1.2.4 and v1.3.1 are also available, then 'go get A'
will use the latest A but then use B v1.2.3, as requested by A.
...
The -u flag instructs get to update modules providing dependencies
of packages named on the command line to use newer minor or patch
releases when available. Continuing the previous example, 'go get -u A'
will use the latest A with B v1.3.1 (not B v1.2.3). 
``` 

In debugging this, it revealed that we were checking out `github.com/spinnaker/spin@HEAD` via `go get` and building that version, as opposed to, say the release branch. I'm still not convinced that the changes below actually build from the release branch, though.