### PR TITLE
feat(sponnet): add pipelineParameters for the pipeline stage

### DIFF
--- a/sponnet/pipeline.libsonnet
+++ b/sponnet/pipeline.libsonnet
@@ -376,6 +376,8 @@
       withApplication(application):: self + { application: application },
       withPipeline(pipeline):: self + { pipeline: self.application + '-' + pipeline },
       withWaitForCompletion(waitForCompletion):: self + { waitForCompletion: waitForCompletion },
+      withPipelineParameters(parameters):: self + { pipelineParameters: parameters },
+      addPipelineParameter(key, value):: self + { pipelineParameters: super.pipelineParameters + { [key]: value } },
     },
 
     // wercker stages


### PR DESCRIPTION
Using the same pattern as the overrides in the bake stage with an additional `addPipelineParamter(key, value` function.


code 
```jsonnet
local pipelineStage = sponnet.stages
  .pipeline("run-pipeline")
  .withApplication("myApp")
  .withPipeline("other-pipeline")
  .withWaitForCompletion(true)
  .withPipelineParameters({"foo": "bar"},)
  .addPipelineParameter("baz", "stuff");
```

generates

```json
{
   "pipelineStage": {
      "application": "foo",
      "failPipeline": true,
      "name": "run-pipeline",
      "pipeline": "foo-other-pipeline",
      "pipelineParameters": {
         "baz": "stuff",
         "foo": "bar"
      },
      "refId": "run-pipeline",
      "requisiteStageRefIds": [ ],
      "type": "pipeline",
      "waitForCompletion": true
   }
}
```