### PR TITLE
feat(stats): Reenable stats in build process

### DIFF
--- a/dev/validate_bom__config.py
+++ b/dev/validate_bom__config.py
@@ -1561,7 +1561,7 @@ hystrix:
                         for _ in range(26))
     telemetry_config = '''\
 telemetry:
-  enabled: false
+  enabled: true
   endpoint: https://stats-staging.spinnaker.io
   instanceId: {}
   spinnakerVersion: {}


### PR DESCRIPTION
Basically reverts https://github.com/spinnaker/spinnaker/pull/5023

Changes in Echo should make this safe to turn back on: https://github.com/spinnaker/echo/pull/706

Fixes https://github.com/spinnaker/spinnaker/issues/5144