### PR TITLE
fix(tests): Turns out we do actually need 'cloudProviderType'

### DIFF
--- a/testing/citest/tests/bake_and_deploy_test.py
+++ b/testing/citest/tests/bake_and_deploy_test.py
@@ -343,6 +343,7 @@ class BakeAndDeployTestScenario(sk.SpinnakerTestScenario):
         'baseOs': 'trusty',
         'baseLabel': 'release',
         'cloudProvider': providerType,
+        'cloudProviderType': providerType,
         'package': package,
         'rebake': True
     }


### PR DESCRIPTION
Testing now, but pretty sure this caused a failure last night (which also got hung, but I think that's still a separate issue).