### PR TITLE
fix(bakery): Use xenial base image for GCE since trusty was deprecated

### DIFF
--- a/dev/build_google_image_functions.sh
+++ b/dev/build_google_image_functions.sh
@@ -45,7 +45,7 @@ function create_cleaner_instance() {
       --scopes storage-rw \
       --boot-disk-type pd-ssd \
       --boot-disk-size 20GB \
-      --image-family ubuntu-1404-lts \
+      --image-family ubuntu-1604-lts \
       --image-project ubuntu-os-cloud
 }
 

--- a/dev/build_halyard_image.sh
+++ b/dev/build_halyard_image.sh
@@ -42,7 +42,7 @@ UPDATE_OS=true
 TIME_DECORATOR=$(date +%Y%m%d%H%M%S)
 INSTALL_SCRIPT=https://raw.githubusercontent.com/spinnaker/spinnaker/master/dev/halyard_base_install.sh
 
-BASE_IMAGE_OR_FAMILY=ubuntu-1404-lts
+BASE_IMAGE_OR_FAMILY=ubuntu-1604-lts
 IMAGE_PROJECT=
 TARGET_IMAGE_FAMILY=
 TARGET_IMAGE=

--- a/dev/create_google_dev_vm.py
+++ b/dev/create_google_dev_vm.py
@@ -202,7 +202,7 @@ def copy_dir(options, source, target):
         '{instance}:{target}'.format(instance=options.instance,
                                      target=target)])
     try_until_ready(command)
-  
+
 def copy_custom_file(options, source, target):
     command = ' '.join([
         'gcloud compute copy-files',
@@ -325,7 +325,7 @@ def create_instance(options):
                '--project', get_project(options),
                '--zone', get_zone(options),
                '--machine-type', options.machine_type,
-               '--image-family', 'ubuntu-1404-lts',
+               '--image-family', 'ubuntu-1604-lts',
                '--image-project', 'ubuntu-os-cloud',
                '--scopes', options.scopes,
                '--boot-disk-size={size}'.format(size=options.disk_size),
@@ -367,7 +367,7 @@ if __name__ == '__main__':
     check_args(options)
     create_instance(options)
 
-       
+
     make_remote_directories(options)
     if options.copy_personal_files:
       copy_personal_files(options)

--- a/dev/validate-config-template.yml
+++ b/dev/validate-config-template.yml
@@ -50,7 +50,7 @@
 #############
 # deploy_hal_google_service_account:
 # deploy_google_machine_type: n1-standard-4
-# deploy_google_image_family: ubuntu-1404-lts
+# deploy_google_image_family: ubuntu-1604-lts
 # deploy_google_image_project: ubuntu-os-cloud
 # deploy_google_project:
 # deploy_google_zone: us-central1-f

--- a/dev/validate_bom__deploy.py
+++ b/dev/validate_bom__deploy.py
@@ -1346,7 +1346,7 @@ class GoogleValidateBomDeployer(GenericVmValidateBomDeployer):
         parser, 'deploy_google_machine_type', defaults, 'n1-standard-4',
         help='Google machine type if --deploy_hal_platform is "gce".')
     add_parser_argument(
-        parser, 'deploy_google_image_family', defaults, 'ubuntu-1404-lts',
+        parser, 'deploy_google_image_family', defaults, 'ubuntu-1604-lts',
         help='Google image family to deploy if --deploy_hal_platform is "gce".')
     add_parser_argument(
         parser, 'deploy_google_image_project', defaults, 'ubuntu-os-cloud',

--- a/testing/citest/tests/bake_and_deploy_test.py
+++ b/testing/citest/tests/bake_and_deploy_test.py
@@ -340,7 +340,7 @@ class BakeAndDeployTestScenario(sk.SpinnakerTestScenario):
         'type': 'bake',
         'name': 'Bake',
         'user': '[anonymous]',
-        'baseOs': 'trusty',
+        'baseOs': 'xenial' if providerType == 'gce' else 'trusty',
         'baseLabel': 'release',
         'cloudProvider': providerType,
         'cloudProviderType': providerType,


### PR DESCRIPTION
Not 100% sure this will fix the failing builds, but I think it's one of the reasons bake_and_deploy is failing