### PR TITLE
fix(boms): Do not including -validated BOMs in candidates to prune

### DIFF
--- a/dev/buildtool/inspection_commands.py
+++ b/dev/buildtool/inspection_commands.py
@@ -1012,7 +1012,8 @@ class AuditArtifactVersions(CommandProcessor):
     candidates = []
     with open(path, 'r') as stream:
       for line in stream.read().split('\n'):
-        if line.endswith('-latest-unvalidated.yml'):
+        # This matches both -unvalidated and -validated BOMs
+        if line.endswith('validated.yml'):
           continue
         bom = CollectBomVersions.url_to_bom_name(line)
         if not CollectBomVersions.RELEASED_VERSION_MATCHER.match(bom):


### PR DESCRIPTION
Used in `Admin_AuditBoms` and transitively in `Admin_DeleteObsoleteArtifacts` Jenkins jobs, which I am going to run to reduce the data in the `halconfig` bucket