### PR TITLE
feat(build): Add support for java8 containers

### DIFF
--- a/dev/buildtool/cloudbuild-build-java8.yml
+++ b/dev/buildtool/cloudbuild-build-java8.yml
@@ -1,0 +1,34 @@
+steps:
+  - id: buildCompileImage
+    waitFor: ["-"]
+    name: gcr.io/cloud-builders/docker
+    args: ["build", "-t", "compile", "-f", "Dockerfile.compile", "."]
+  - id: buildSlimImage
+    waitFor: ["buildCompileImage"]
+    name: gcr.io/cloud-builders/docker
+    args: ["build", "-t", "gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-slim", "-f", "Dockerfile.slim", "."]
+  - id: buildUbuntuImage
+    waitFor: ["buildCompileImage"]
+    name: gcr.io/cloud-builders/docker
+    args: ["build", "-t", "gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-ubuntu", "-f", "Dockerfile.ubuntu", "."]
+  - id: tagDefaultImage
+    waitFor: ["buildSlimImage"]
+    name: gcr.io/cloud-builders/docker
+    args: ["tag", "gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-slim", "gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME"]
+  - id: buildJava8Image
+    waitFor: ["buildCompileImage"]
+    name: gcr.io/cloud-builders/docker
+    args: ["build", "-t", "gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-java8", "-f", "Dockerfile.java8", "."]
+  - id: buildUbuntuJava8Image
+    waitFor: ["buildCompileImage"]
+    name: gcr.io/cloud-builders/docker
+    args: ["build", "-t", "gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-ubuntu-java8", "-f", "Dockerfile.ubuntu-java8", "."]
+images:
+  - gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-slim
+  - gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-ubuntu
+  - gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME
+  - gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-java8
+  - gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-ubuntu-java8
+timeout: 3600s
+options:
+  machineType: N1_HIGHCPU_8

--- a/dev/buildtool/cloudbuild-tag-java8.yml
+++ b/dev/buildtool/cloudbuild-tag-java8.yml
@@ -15,10 +15,20 @@ steps:
     waitFor: ["buildSlimImage"]
     name: gcr.io/cloud-builders/docker
     args: ["tag", "gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-slim", "gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME"]
+  - id: tagJava8Image
+    waitFor: ["buildSlimImage"]
+    name: gcr.io/cloud-builders/docker
+    args: ["tag", "gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-slim", "gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-java8"]
+  - id: tagUbuntuJava8Image
+    waitFor: ["buildUbuntuImage"]
+    name: gcr.io/cloud-builders/docker
+    args: ["tag", "gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-ubuntu", "gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-ubuntu-java8"]
 images:
   - gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-slim
   - gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-ubuntu
   - gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME
+  - gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-java8
+  - gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-ubuntu-java8
 timeout: 3600s
 options:
   machineType: N1_HIGHCPU_8

--- a/dev/buildtool/container_commands.py
+++ b/dev/buildtool/container_commands.py
@@ -45,7 +45,7 @@ class BuildContainerCommand(GradleCommandProcessor):
     image_name = self.scm.repository_name_to_service_name(repository.name)
     version = self.scm.get_repository_service_build_version(repository)
 
-    for variant in ('slim', 'ubuntu'):
+    for variant in ('slim', 'ubuntu', 'java8', 'ubuntu-java8'):
       tag = "{version}-{variant}".format(version=version, variant=variant)
       if not self.__gcb_image_exists(image_name, tag):
         return False
@@ -93,7 +93,11 @@ class BuildContainerCommand(GradleCommandProcessor):
     if os.path.isdir(gradle_cache):
       shutil.rmtree(gradle_cache)
 
-    cloudbuild_config = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'cloudbuild.yml')
+    cloudbuild_file_name = 'cloudbuild-tag-java8.yml'
+    if os.path.exists(os.path.join(git_dir, 'Dockerfile.java8')):
+      cloudbuild_file_name = 'cloudbuild-build-java8.yml'
+
+    cloudbuild_config = os.path.join(os.path.dirname(os.path.abspath(__file__)), cloudbuild_file_name)
     service_name = self.scm.repository_name_to_service_name(repository.name)
     # Note this command assumes a cwd of git_dir
     command = ('gcloud builds submit '


### PR DESCRIPTION
If a `Dockerfile.java8` file exists, it (along with `Dockerfile.ubuntu-java8`) will be built, otherwise the standard `slim` and `ubuntu` containers will be tagged with `java8` suffixes.

This allows for a new `JAVA8` and `UBUNTU_JAVA8` `imageVariant` to be added to Halyard.

Once the builds are fully moved to Java 11, this PR can be reverted completely.