### PR TITLE
Adding pinned option for pipeline parameters

### DIFF
--- a/sponnet/pipeline.libsonnet
+++ b/sponnet/pipeline.libsonnet
@@ -124,10 +124,12 @@
     name: name,
     required: false,
     hasOptions: false,
+    pinned: false,
     withLabel(label):: self + { label: label },
     withDescription(description):: self + { description: description },
     withDefaultValue(default):: self + { default: default },
     isRequired(isRequired):: self + { required: isRequired },
+    isPinned(isPinned):: self + { pinned: isPinned },
     withOptions(options):: self + { hasOptions: true, options: [{ value: x } for x in options] },
   },
 


### PR DESCRIPTION
* Adds `pinned` option to Sponnet pipeline parameters

Pinned params show up in the executions of pipelines via the UI...