### PR TITLE
refactor(release): apply multiple tags at build time

### DIFF
--- a/dev/buildtool/cloudbuild-build-java8.yml
+++ b/dev/buildtool/cloudbuild-build-java8.yml
@@ -2,27 +2,56 @@ steps:
   - id: buildCompileImage
     waitFor: ["-"]
     name: gcr.io/cloud-builders/docker
-    args: ["build", "-t", "compile", "-f", "Dockerfile.compile", "."]
+    args: [
+            "build",
+            "-t", "compile",
+            "-f", "Dockerfile.compile",
+            ".",
+          ]
   - id: buildSlimImage
     waitFor: ["buildCompileImage"]
     name: gcr.io/cloud-builders/docker
-    args: ["build", "-t", "gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-slim", "-f", "Dockerfile.slim", "."]
+    args: [
+            "build",
+            "-t", "gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-slim",
+            "-f", "Dockerfile.slim",
+            ".",
+          ]
   - id: buildUbuntuImage
     waitFor: ["buildCompileImage"]
     name: gcr.io/cloud-builders/docker
-    args: ["build", "-t", "gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-ubuntu", "-f", "Dockerfile.ubuntu", "."]
+    args: [
+            "build",
+            "-t", "gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-ubuntu",
+            "-f", "Dockerfile.ubuntu",
+            ".",
+          ]
   - id: tagDefaultImage
     waitFor: ["buildSlimImage"]
     name: gcr.io/cloud-builders/docker
-    args: ["tag", "gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-slim", "gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME"]
+    args: [
+            "tag",
+            "gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-slim",
+            "gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME",
+          ]
   - id: buildJava8Image
     waitFor: ["buildCompileImage"]
     name: gcr.io/cloud-builders/docker
-    args: ["build", "-t", "gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-java8", "-f", "Dockerfile.java8", "."]
+    args: [
+            "build",
+            "-t", "gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-java8",
+            "-f", "Dockerfile.java8",
+            ".",
+          ]
   - id: buildUbuntuJava8Image
     waitFor: ["buildCompileImage"]
     name: gcr.io/cloud-builders/docker
-    args: ["build", "-t", "gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-ubuntu-java8", "-f", "Dockerfile.ubuntu-java8", "."]
+    args: [
+            "build",
+            "-t", "gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-ubuntu-java8",
+            "-f", "Dockerfile.ubuntu-java8",
+            ".",
+          ]
 images:
   - gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-slim
   - gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-ubuntu

--- a/dev/buildtool/cloudbuild-build-java8.yml
+++ b/dev/buildtool/cloudbuild-build-java8.yml
@@ -13,6 +13,7 @@ steps:
     name: gcr.io/cloud-builders/docker
     args: [
             "build",
+            "-t", "gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME",
             "-t", "gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-slim",
             "-f", "Dockerfile.slim",
             ".",
@@ -25,14 +26,6 @@ steps:
             "-t", "gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-ubuntu",
             "-f", "Dockerfile.ubuntu",
             ".",
-          ]
-  - id: tagDefaultImage
-    waitFor: ["buildSlimImage"]
-    name: gcr.io/cloud-builders/docker
-    args: [
-            "tag",
-            "gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-slim",
-            "gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME",
           ]
   - id: buildJava8Image
     waitFor: ["buildCompileImage"]
@@ -53,10 +46,10 @@ steps:
             ".",
           ]
 images:
-  - gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-slim
-  - gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-ubuntu
   - gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME
+  - gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-slim
   - gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-java8
+  - gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-ubuntu
   - gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-ubuntu-java8
 timeout: 3600s
 options:

--- a/dev/buildtool/cloudbuild-tag-java8.yml
+++ b/dev/buildtool/cloudbuild-tag-java8.yml
@@ -2,27 +2,54 @@ steps:
   - id: buildCompileImage
     waitFor: ["-"]
     name: gcr.io/cloud-builders/docker
-    args: ["build", "-t", "compile", "-f", "Dockerfile.compile", "."]
+    args: [
+            "build",
+            "-t", "compile",
+            "-f", "Dockerfile.compile",
+            ".",
+          ]
   - id: buildSlimImage
     waitFor: ["buildCompileImage"]
     name: gcr.io/cloud-builders/docker
-    args: ["build", "-t", "gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-slim", "-f", "Dockerfile.slim", "."]
+    args: [
+            "build",
+            "-t", "gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-slim",
+            "-f", "Dockerfile.slim",
+            ".",
+          ]
   - id: buildUbuntuImage
     waitFor: ["buildCompileImage"]
     name: gcr.io/cloud-builders/docker
-    args: ["build", "-t", "gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-ubuntu", "-f", "Dockerfile.ubuntu", "."]
+    args: [
+            "build",
+            "-t", "gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-ubuntu",
+            "-f", "Dockerfile.ubuntu",
+            ".",
+          ]
   - id: tagDefaultImage
     waitFor: ["buildSlimImage"]
     name: gcr.io/cloud-builders/docker
-    args: ["tag", "gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-slim", "gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME"]
+    args: [
+            "tag",
+            "gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-slim",
+            "gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME",
+          ]
   - id: tagJava8Image
     waitFor: ["buildSlimImage"]
     name: gcr.io/cloud-builders/docker
-    args: ["tag", "gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-slim", "gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-java8"]
+    args: [
+            "tag",
+            "gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-slim",
+            "gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-java8",
+          ]
   - id: tagUbuntuJava8Image
     waitFor: ["buildUbuntuImage"]
     name: gcr.io/cloud-builders/docker
-    args: ["tag", "gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-ubuntu", "gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-ubuntu-java8"]
+    args: [
+            "tag",
+            "gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-ubuntu",
+            "gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-ubuntu-java8",
+          ]
 images:
   - gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-slim
   - gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-ubuntu

--- a/dev/buildtool/cloudbuild-tag-java8.yml
+++ b/dev/buildtool/cloudbuild-tag-java8.yml
@@ -13,7 +13,9 @@ steps:
     name: gcr.io/cloud-builders/docker
     args: [
             "build",
+            "-t", "gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME",
             "-t", "gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-slim",
+            "-t", "gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-java8",
             "-f", "Dockerfile.slim",
             ".",
           ]
@@ -23,38 +25,15 @@ steps:
     args: [
             "build",
             "-t", "gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-ubuntu",
+            "-t", "gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-ubuntu-java8",
             "-f", "Dockerfile.ubuntu",
             ".",
           ]
-  - id: tagDefaultImage
-    waitFor: ["buildSlimImage"]
-    name: gcr.io/cloud-builders/docker
-    args: [
-            "tag",
-            "gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-slim",
-            "gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME",
-          ]
-  - id: tagJava8Image
-    waitFor: ["buildSlimImage"]
-    name: gcr.io/cloud-builders/docker
-    args: [
-            "tag",
-            "gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-slim",
-            "gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-java8",
-          ]
-  - id: tagUbuntuJava8Image
-    waitFor: ["buildUbuntuImage"]
-    name: gcr.io/cloud-builders/docker
-    args: [
-            "tag",
-            "gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-ubuntu",
-            "gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-ubuntu-java8",
-          ]
 images:
-  - gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-slim
-  - gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-ubuntu
   - gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME
+  - gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-slim
   - gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-java8
+  - gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-ubuntu
   - gcr.io/$PROJECT_ID/$_IMAGE_NAME:$TAG_NAME-ubuntu-java8
 timeout: 3600s
 options:


### PR DESCRIPTION
This removes the need for the `docker tag` build steps.

Had this lying around from an aborted attempt at something else, but it's worth checking in on its own...