### PR TITLE
Readme update

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -56,6 +56,4 @@ If you're interested in a detailed walkthrough of the Spinnaker systems, check t
 
 = Setting Up Spinnaker For Development
 
-To pull Spinnaker from source and set it up to run locally against any of the https://www.spinnaker.io/setup/install/providers/#supported-providers[Cloud Providers],
-
-follow the https://spinnaker.io/guides/developer/getting-set-up/[Developer Setup Guide]
+To pull Spinnaker from source and set it up to run locally against any of the https://www.spinnaker.io/setup/install/providers/#supported-providers[Cloud Providers], follow the https://spinnaker.io/guides/developer/getting-set-up/[Developer Setup Guide]

--- a/README.adoc
+++ b/README.adoc
@@ -3,12 +3,25 @@
 image:http://join.spinnaker.io/badge.svg[Slack Status,link=http://join.spinnaker.io]
 image:https://travis-ci.org/spinnaker/spinnaker.svg?branch=master["Build Status", link="https://travis-ci.org/spinnaker/spinnaker"]
 
+= Welcome to the Spinnaker Project
+
 Spinnaker is an open-source continuous delivery platform for releasing software changes with high velocity and confidence.
 Through a powerful abstraction layer, Spinnaker provides compelling tooling that empowers developers to own their application code from commit to delivery.
-Inside Spinnaker, manage deployments and cloud resources such as load balancers, security groups, server groups, and
-firewalls, either using a GUI (graphical user interface), or as code. Facilitate GitOps, and grant developers control of
-provisioning infrastructure for apps. Natively, use Spinnaker’s cloud driver to deploy to all of the major cloud providers, and the Kubernetes V2 provider
-for Kubernetes deployments. You may even orchestrate configuration and firmware changes as part of Spinnaker delivery pipelines.
+
+Inside Spinnaker, using a GUI (graphical user interface), or as code, manage deployments and cloud resources such as: 
+
+- VM "bake" deployments to a cloud
+- Container deployments to a cloud
+- Container deployments to Kubernetes
+- Load balancers
+- Security groups
+- Server groups
+- Clusters
+- Firewalls
+- Functions
+
+
+Facilitate GitOps, and grant developers control of provisioning infrastructure for apps. Natively, use Spinnaker’s cloud driver to deploy to all of the major cloud providers, and the Kubernetes V2 provider for Kubernetes deployments. You may even orchestrate configuration and firmware changes as part of Spinnaker delivery pipelines.
 
 With Spinnaker, create a “paved road” for application delivery, with guardrails that ensure only valid infrastructure and configuration reach production.
 Free development teams from burdensome ops provisioning while automating reinforcement of business and regulatory requirements. Delivery automation
@@ -16,7 +29,7 @@ strategies such as canary deployments provide the safety necessary to capture va
  impact. As the most mature and widely productionalized continuous delivery platform, Spinnaker can apply the expertise of Netflix, Google, Microsoft,
  and Amazon to your SDLC. User companies include Target, Salesforce, Airbnb, Cerner, Adobe, and JPMorgan Chase.
 
-Spinnaker consists of a number of [independent microservices](https://www.spinnaker.io/reference/architecture/), with the Halyard CLI administration service
+Spinnaker consists of a number of https://www.spinnaker.io/reference/architecture/[independent microservices], with the Halyard CLI administration service
 managing the lifecycle of the other services. A variety of SDLC tools integrate with Spinnaker, and its plugin framework offers an alternative to extending
 and maintaining individual Spinnaker extensions. Plugins allow us to add system integrations without restarting or updating Spinnaker, broadening its potential
 to easily leverage the entire software delivery toolchain. With this in place, Spinnaker is evolving towards leaner binaries and a smaller threat surface,

--- a/README.adoc
+++ b/README.adoc
@@ -57,4 +57,5 @@ If you're interested in a detailed walkthrough of the Spinnaker systems, check t
 = Setting Up Spinnaker For Development
 
 To pull Spinnaker from source and set it up to run locally against any of the https://www.spinnaker.io/setup/install/providers/#supported-providers[Cloud Providers],
+
 follow the https://spinnaker.io/guides/developer/getting-set-up/[Developer Setup Guide]

--- a/README.adoc
+++ b/README.adoc
@@ -31,7 +31,7 @@ strategies such as canary deployments provide the safety necessary to capture va
  impact. As the most mature and widely productionalized continuous delivery platform, Spinnaker can apply the expertise of Netflix, Google, Microsoft,
  and Amazon to your SDLC. User companies include Target, Salesforce, Airbnb, Cerner, Adobe, and JPMorgan Chase.
  
- = Tech Specs
+= Tech Specs
 
 Spinnaker consists of a number of https://www.spinnaker.io/reference/architecture/[independent microservices], with the Halyard CLI administration service
 managing the lifecycle of the other services. A variety of SDLC tools integrate with Spinnaker, and its plugin framework offers an alternative to extending

--- a/README.adoc
+++ b/README.adoc
@@ -21,7 +21,7 @@ Manage your SDLC in Spinnaker using the GUI (graphical user interface), or confi
 - Functions
 
 
-Facilitate GitOps, and grant developers control of provisioning infrastructure for apps. Natively, use Spinnaker’s Clouddriver to deploy to all of the major public cloud providers, and the Kubernetes V2 provider for Kubernetes deployments. You may even orchestrate configuration and firmware changes as part of Spinnaker delivery [pipelines](https://www.spinnaker.io/concepts/#firewall).
+Facilitate GitOps, and grant developers control of provisioning infrastructure for apps. Use Spinnaker’s Clouddriver to deploy to all of the major public cloud providers and Kubernetes. You may even orchestrate configuration and firmware changes as part of Spinnaker delivery [pipelines](https://www.spinnaker.io/concepts/#firewall).
 
 = Why Do I Need Spinnaker?
 

--- a/README.adoc
+++ b/README.adoc
@@ -42,7 +42,7 @@ prebuilt definitions and move changes through environments via a visual interfac
 
 '''
 
-This repository contains ancillary configuration, build, and testing tools for the Spinnaker project. It also centralizes issue tracking across Spinnaker, accepting issues from across the project.  
+This repository centralizes issue tracking across Spinnaker for each microservice. The core code making up Spinnaker’s microservices is found in the other https://github.com/spinnaker[Spinnaker repositories].
 The core code making up Spinnaker’s microservices is found in the other https://github.com/spinnaker[Spinnaker repositories].
 
 = Using Spinnaker

--- a/README.adoc
+++ b/README.adoc
@@ -9,20 +9,20 @@ Spinnaker is an open-source continuous delivery platform for releasing software 
 Through a powerful abstraction layer, Spinnaker provides compelling tooling that empowers developers to own their application code from commit to delivery. As the most mature and widely productionalized continuous delivery platform, Spinnaker can apply the expertise of Netflix, Google, Microsoft,
  and Amazon to your SDLC. User companies include Target, Salesforce, Airbnb, Cerner, Adobe, and JPMorgan Chase.
 
-Manage your SDLC in Spinnaker using the GUI (graphical user interface), or config-as-code. View, manage, and construct [application](https://www.spinnaker.io/concepts/#application) workflows involving one or all of these resources: 
+Manage your SDLC in Spinnaker using the GUI (graphical user interface), or config-as-code. View, manage, and construct https://www.spinnaker.io/concepts/#application[application] workflows involving one or all of these resources: 
 
-- [Virtual machine (VM) deployments to a public cloud provider, "baked" as immutable infrastructure](https://www.spinnaker.io/reference/pipeline/stages/#bake)
-- [Container deployments to a cloud](https://www.spinnaker.io/reference/providers/)
-- [Container deployments to Kubernetes](https://www.spinnaker.io/guides/user/kubernetes-v2/deploy-manifest/)
-- [Load balancers](https://www.spinnaker.io/concepts/#load-balancer)
+- https://www.spinnaker.io/reference/pipeline/stages/#bake[Virtual machine (VM) deployments to a public cloud provider], "baked" as immutable infrastructure
+- https://www.spinnaker.io/reference/providers/[Container deployments to a cloud]
+- https://www.spinnaker.io/guides/user/kubernetes-v2/deploy-manifest/[Container deployments to Kubernetes]
+- https://www.spinnaker.io/concepts/#load-balancer[Load balancers]
 - Security groups
-- [Server groups](https://www.spinnaker.io/concepts/#server-group)
-- [Clusters](https://www.spinnaker.io/concepts/#cluster)
-- [Firewalls](https://www.spinnaker.io/concepts/#firewall)
+- https://www.spinnaker.io/concepts/#server-group[Server groups]
+- https://www.spinnaker.io/concepts/#cluster[Clusters]
+- https://www.spinnaker.io/concepts/#firewall[Firewalls]
 - Functions
 
 
-Facilitate GitOps, and grant developers control of provisioning infrastructure for apps. Use Spinnaker’s Clouddriver to deploy to all of the major public cloud providers and Kubernetes. You may even orchestrate configuration and firmware changes as part of Spinnaker delivery [pipelines](https://www.spinnaker.io/concepts/#firewall).
+Facilitate GitOps, and grant developers control of provisioning infrastructure for apps. Use Spinnaker’s Clouddriver to deploy to all of the major public cloud providers and Kubernetes. You may even orchestrate configuration and firmware changes as part of Spinnaker delivery https://www.spinnaker.io/concepts/#firewall[pipelines].
 
 = Why Do I Need Spinnaker?
 
@@ -33,8 +33,8 @@ strategies such as canary deployments provide the safety necessary to capture va
  
 = Tech Specs
 
-Spinnaker consists of a number of https://www.spinnaker.io/reference/architecture/[independent microservices], with the [Halyard CLI tool](https://github.com/spinnaker/halyard) or the [Kubernetes Operator](https://docs.armory.io/spinnaker/operator/) (Beta)
-managing the lifecycle of the other services. A [variety of SDLC tools](https://www.spinnaker.io/setup/other_config/) integrate with Spinnaker, and its plugin framework makes Spinnaker more easily customizable to your needs. Plugins allow us to add system integrations without updating Spinnaker, broadening its potential
+Spinnaker consists of a number of https://www.spinnaker.io/reference/architecture/[independent microservices], with the https://github.com/spinnaker/halyard[Halyard CLI tool] or the https://docs.armory.io/spinnaker/operator/[Kubernetes Operator] (Beta)
+managing the lifecycle of the other services. A https://www.spinnaker.io/setup/other_config/[variety of SDLC tools] integrate with Spinnaker, and its plugin framework makes Spinnaker more easily customizable to your needs. Plugins allow us to add system integrations without updating Spinnaker, broadening its potential
 to easily leverage the entire software delivery toolchain. With this in place, Spinnaker is evolving towards a smaller threat surface,
 enabling performance and operational advantages. Meanwhile, managed delivery, a newer Spinnaker featureset, provides declarative definitions of common
 infrastructure and other requirements; users can declare requirements using those

--- a/README.adoc
+++ b/README.adoc
@@ -6,7 +6,8 @@ image:https://travis-ci.org/spinnaker/spinnaker.svg?branch=master["Build Status"
 = Welcome to the Spinnaker Project
 
 Spinnaker is an open-source continuous delivery platform for releasing software changes with high velocity and confidence.
-Through a powerful abstraction layer, Spinnaker provides compelling tooling that empowers developers to own their application code from commit to delivery.
+Through a powerful abstraction layer, Spinnaker provides compelling tooling that empowers developers to own their application code from commit to delivery. As the most mature and widely productionalized continuous delivery platform, Spinnaker can apply the expertise of Netflix, Google, Microsoft,
+ and Amazon to your SDLC. User companies include Target, Salesforce, Airbnb, Cerner, Adobe, and JPMorgan Chase.
 
 Manage your SDLC in Spinnaker using the GUI (graphical user interface), or config-as-code. View, manage, and construct [application](https://www.spinnaker.io/concepts/#application) workflows involving one or all of these resources: 
 
@@ -28,8 +29,7 @@ Facilitate GitOps, and grant developers control of provisioning infrastructure f
 With Spinnaker, create a “paved road” for application delivery, with guardrails that ensure only valid infrastructure and configuration reach production.
 Free development teams from burdensome ops provisioning while automating reinforcement of business and regulatory requirements. Delivery automation
 strategies such as canary deployments provide the safety necessary to capture value from quick innovation, while protecting against business and end-user
- impact. As the most mature and widely productionalized continuous delivery platform, Spinnaker can apply the expertise of Netflix, Google, Microsoft,
- and Amazon to your SDLC. User companies include Target, Salesforce, Airbnb, Cerner, Adobe, and JPMorgan Chase.
+ impact.
  
 = Tech Specs
 

--- a/README.adoc
+++ b/README.adoc
@@ -34,9 +34,8 @@ strategies such as canary deployments provide the safety necessary to capture va
 = Tech Specs
 
 Spinnaker consists of a number of https://www.spinnaker.io/reference/architecture/[independent microservices], with the [Halyard CLI tool](https://github.com/spinnaker/halyard) or the [Kubernetes Operator](https://docs.armory.io/spinnaker/operator/) (Beta)
-managing the lifecycle of the other services. A [variety of SDLC tools](https://www.spinnaker.io/setup/other_config/) integrate with Spinnaker, and its plugin framework offers an alternative to extending
-and maintaining individual Spinnaker extensions. Plugins allow us to add system integrations without restarting or updating Spinnaker, broadening its potential
-to easily leverage the entire software delivery toolchain. With this in place, Spinnaker is evolving towards leaner binaries and a smaller threat surface,
+managing the lifecycle of the other services. A [variety of SDLC tools](https://www.spinnaker.io/setup/other_config/) integrate with Spinnaker, and its plugin framework makes Spinnaker more easily customizable to your needs. Plugins allow us to add system integrations without updating Spinnaker, broadening its potential
+to easily leverage the entire software delivery toolchain. With this in place, Spinnaker is evolving towards a smaller threat surface,
 enabling performance and operational advantages. Meanwhile, managed delivery, a newer Spinnaker featureset, provides declarative definitions of common
 infrastructure and other requirements; users can declare requirements using those
 prebuilt definitions and move changes through environments via a visual interface.

--- a/README.adoc
+++ b/README.adoc
@@ -33,7 +33,7 @@ strategies such as canary deployments provide the safety necessary to capture va
  
 = Tech Specs
 
-Spinnaker consists of a number of https://www.spinnaker.io/reference/architecture/[independent microservices], with the Halyard CLI administration service
+Spinnaker consists of a number of https://www.spinnaker.io/reference/architecture/[independent microservices], with the [Halyard CLI tool](https://github.com/spinnaker/halyard)
 managing the lifecycle of the other services. A variety of SDLC tools integrate with Spinnaker, and its plugin framework offers an alternative to extending
 and maintaining individual Spinnaker extensions. Plugins allow us to add system integrations without restarting or updating Spinnaker, broadening its potential
 to easily leverage the entire software delivery toolchain. With this in place, Spinnaker is evolving towards leaner binaries and a smaller threat surface,

--- a/README.adoc
+++ b/README.adoc
@@ -48,7 +48,7 @@ The core code making up Spinnaker’s microservices is found in the other https
 = Using Spinnaker
 
 Spinnaker users should refer to the main
-Spinnaker site and https://www.spinnaker.io/setup/[Installation] guide.
+https://www.spinnaker.io/[Spinnaker site] and https://www.spinnaker.io/setup/[Installation] guide.
 
 For more information on how Spinnaker is designed, see the https://www.spinnaker.io/concepts/[Documentation Overview].
 

--- a/README.adoc
+++ b/README.adoc
@@ -23,11 +23,15 @@ Inside Spinnaker, using a GUI (graphical user interface), or as code, manage dep
 
 Facilitate GitOps, and grant developers control of provisioning infrastructure for apps. Natively, use Spinnaker’s cloud driver to deploy to all of the major cloud providers, and the Kubernetes V2 provider for Kubernetes deployments. You may even orchestrate configuration and firmware changes as part of Spinnaker delivery pipelines.
 
+= Why Do I Need Spinnaker?
+
 With Spinnaker, create a “paved road” for application delivery, with guardrails that ensure only valid infrastructure and configuration reach production.
 Free development teams from burdensome ops provisioning while automating reinforcement of business and regulatory requirements. Delivery automation
 strategies such as canary deployments provide the safety necessary to capture value from quick innovation, while protecting against business and end-user
  impact. As the most mature and widely productionalized continuous delivery platform, Spinnaker can apply the expertise of Netflix, Google, Microsoft,
  and Amazon to your SDLC. User companies include Target, Salesforce, Airbnb, Cerner, Adobe, and JPMorgan Chase.
+ 
+ = Tech Specs
 
 Spinnaker consists of a number of https://www.spinnaker.io/reference/architecture/[independent microservices], with the Halyard CLI administration service
 managing the lifecycle of the other services. A variety of SDLC tools integrate with Spinnaker, and its plugin framework offers an alternative to extending

--- a/README.adoc
+++ b/README.adoc
@@ -33,7 +33,7 @@ strategies such as canary deployments provide the safety necessary to capture va
  
 = Tech Specs
 
-Spinnaker consists of a number of https://www.spinnaker.io/reference/architecture/[independent microservices], with the [Halyard CLI tool](https://github.com/spinnaker/halyard)
+Spinnaker consists of a number of https://www.spinnaker.io/reference/architecture/[independent microservices], with the [Halyard CLI tool](https://github.com/spinnaker/halyard) or the [Kubernetes Operator](https://docs.armory.io/spinnaker/operator/) (Beta)
 managing the lifecycle of the other services. A variety of SDLC tools integrate with Spinnaker, and its plugin framework offers an alternative to extending
 and maintaining individual Spinnaker extensions. Plugins allow us to add system integrations without restarting or updating Spinnaker, broadening its potential
 to easily leverage the entire software delivery toolchain. With this in place, Spinnaker is evolving towards leaner binaries and a smaller threat surface,

--- a/README.adoc
+++ b/README.adoc
@@ -8,20 +8,20 @@ image:https://travis-ci.org/spinnaker/spinnaker.svg?branch=master["Build Status"
 Spinnaker is an open-source continuous delivery platform for releasing software changes with high velocity and confidence.
 Through a powerful abstraction layer, Spinnaker provides compelling tooling that empowers developers to own their application code from commit to delivery.
 
-Inside Spinnaker, using a GUI (graphical user interface), or as code, manage deployments and cloud resources such as: 
+Manage your SDLC in Spinnaker using the GUI (graphical user interface), or config-as-code. View, manage, and construct [application](https://www.spinnaker.io/concepts/#application) workflows involving one or all of these resources: 
 
-- VM "bake" deployments to a cloud
-- Container deployments to a cloud
-- Container deployments to Kubernetes
-- Load balancers
+- [Virtual machine (VM) deployments to a public cloud provider, "baked" as immutable infrastructure](https://www.spinnaker.io/reference/pipeline/stages/#bake)
+- [Container deployments to a cloud](https://www.spinnaker.io/reference/providers/)
+- [Container deployments to Kubernetes](https://www.spinnaker.io/guides/user/kubernetes-v2/deploy-manifest/)
+- [Load balancers](https://www.spinnaker.io/concepts/#load-balancer)
 - Security groups
-- Server groups
-- Clusters
-- Firewalls
+- [Server groups](https://www.spinnaker.io/concepts/#server-group)
+- [Clusters](https://www.spinnaker.io/concepts/#cluster)
+- [Firewalls](https://www.spinnaker.io/concepts/#firewall)
 - Functions
 
 
-Facilitate GitOps, and grant developers control of provisioning infrastructure for apps. Natively, use Spinnaker’s cloud driver to deploy to all of the major cloud providers, and the Kubernetes V2 provider for Kubernetes deployments. You may even orchestrate configuration and firmware changes as part of Spinnaker delivery pipelines.
+Facilitate GitOps, and grant developers control of provisioning infrastructure for apps. Natively, use Spinnaker’s cloud driver to deploy to all of the major cloud providers, and the Kubernetes V2 provider for Kubernetes deployments. You may even orchestrate configuration and firmware changes as part of Spinnaker delivery [pipelines](https://www.spinnaker.io/concepts/#firewall).
 
 = Why Do I Need Spinnaker?
 

--- a/README.adoc
+++ b/README.adoc
@@ -21,7 +21,7 @@ Manage your SDLC in Spinnaker using the GUI (graphical user interface), or confi
 - Functions
 
 
-Facilitate GitOps, and grant developers control of provisioning infrastructure for apps. Natively, use Spinnaker’s cloud driver to deploy to all of the major cloud providers, and the Kubernetes V2 provider for Kubernetes deployments. You may even orchestrate configuration and firmware changes as part of Spinnaker delivery [pipelines](https://www.spinnaker.io/concepts/#firewall).
+Facilitate GitOps, and grant developers control of provisioning infrastructure for apps. Natively, use Spinnaker’s Clouddriver to deploy to all of the major public cloud providers, and the Kubernetes V2 provider for Kubernetes deployments. You may even orchestrate configuration and firmware changes as part of Spinnaker delivery [pipelines](https://www.spinnaker.io/concepts/#firewall).
 
 = Why Do I Need Spinnaker?
 

--- a/README.adoc
+++ b/README.adoc
@@ -34,7 +34,7 @@ strategies such as canary deployments provide the safety necessary to capture va
 = Tech Specs
 
 Spinnaker consists of a number of https://www.spinnaker.io/reference/architecture/[independent microservices], with the [Halyard CLI tool](https://github.com/spinnaker/halyard) or the [Kubernetes Operator](https://docs.armory.io/spinnaker/operator/) (Beta)
-managing the lifecycle of the other services. A variety of SDLC tools integrate with Spinnaker, and its plugin framework offers an alternative to extending
+managing the lifecycle of the other services. A [variety of SDLC tools](https://www.spinnaker.io/setup/other_config/) integrate with Spinnaker, and its plugin framework offers an alternative to extending
 and maintaining individual Spinnaker extensions. Plugins allow us to add system integrations without restarting or updating Spinnaker, broadening its potential
 to easily leverage the entire software delivery toolchain. With this in place, Spinnaker is evolving towards leaner binaries and a smaller threat surface,
 enabling performance and operational advantages. Meanwhile, managed delivery, a newer Spinnaker featureset, provides declarative definitions of common

--- a/README.adoc
+++ b/README.adoc
@@ -3,21 +3,42 @@
 image:http://join.spinnaker.io/badge.svg[Slack Status,link=http://join.spinnaker.io]
 image:https://travis-ci.org/spinnaker/spinnaker.svg?branch=master["Build Status", link="https://travis-ci.org/spinnaker/spinnaker"]
 
-Spinnaker is a continuous delivery platform for releasing changes with high velocity and confidence.
+Spinnaker is an open-source continuous delivery platform for releasing software changes with high velocity and confidence.
+Through a powerful abstraction layer, Spinnaker provides compelling tooling that empowers developers to own their application code from commit to delivery.
+Inside Spinnaker, manage deployments and cloud resources such as load balancers, security groups, server groups, and
+firewalls, either using a GUI (graphical user interface), or as code. Facilitate GitOps, and grant developers control of
+provisioning infrastructure for apps. Natively, use Spinnaker’s cloud driver to deploy to all of the major cloud providers, and the Kubernetes V2 provider
+for Kubernetes deployments. You may even orchestrate configuration and firmware changes as part of Spinnaker delivery pipelines.
 
-This repository is used only to store and organize ancillary configuration, build, and testing tools for the Spinnaker project. The core code making up Spinnaker's microservices is found in the other https://github.com/spinnaker[Spinnaker repositories].
+With Spinnaker, create a “paved road” for application delivery, with guardrails that ensure only valid infrastructure and configuration reach production.
+Free development teams from burdensome ops provisioning while automating reinforcement of business and regulatory requirements. Delivery automation
+strategies such as canary deployments provide the safety necessary to capture value from quick innovation, while protecting against business and end-user
+ impact. As the most mature and widely productionalized continuous delivery platform, Spinnaker can apply the expertise of Netflix, Google, Microsoft,
+ and Amazon to your SDLC. User companies include Target, Salesforce, Airbnb, Cerner, Adobe, and JPMorgan Chase.
+
+Spinnaker consists of a number of [independent microservices](https://www.spinnaker.io/reference/architecture/), with the Halyard CLI administration service
+managing the lifecycle of the other services. A variety of SDLC tools integrate with Spinnaker, and its plugin framework offers an alternative to extending
+and maintaining individual Spinnaker extensions. Plugins allow us to add system integrations without restarting or updating Spinnaker, broadening its potential
+to easily leverage the entire software delivery toolchain. With this in place, Spinnaker is evolving towards leaner binaries and a smaller threat surface,
+enabling performance and operational advantages. Meanwhile, managed delivery, a newer Spinnaker featureset, provides declarative definitions of common
+infrastructure and other requirements; users can declare requirements using those
+prebuilt definitions and move changes through environments via a visual interface.
+
+'''
+
+This repository contains ancillary configuration, build, and testing tools for the Spinnaker project. It also centralizes issue tracking across Spinnaker, accepting issues from across the project.  
+The core code making up Spinnaker’s microservices is found in the other https://github.com/spinnaker[Spinnaker repositories].
 
 = Using Spinnaker
 
-If you are only interested in using Spinnaker, please refer to the main
+Spinnaker users should refer to the main
 Spinnaker site and https://www.spinnaker.io/setup/[Installation] guide.
 
-If you want more information on how Spinnaker is designed, see the https://www.spinnaker.io/concepts/[Documentation Overview].
+For more information on how Spinnaker is designed, see the https://www.spinnaker.io/concepts/[Documentation Overview].
 
 If you're interested in a detailed walkthrough of the Spinnaker systems, check the https://www.spinnaker.io/reference/[Reference Material].
 
 = Setting Up Spinnaker For Development
 
-These instructions cover pulling Spinnaker from source and setting up to run locally against any of the https://www.spinnaker.io/setup/install/providers/#supported-providers[Cloud Providers].
-
-To build from source and run on localhost follow the https://spinnaker.io/guides/developer/getting-set-up/[Developer Setup Guide]
+To pull Spinnaker from source and set it up to run locally against any of the https://www.spinnaker.io/setup/install/providers/#supported-providers[Cloud Providers],
+follow the https://spinnaker.io/guides/developer/getting-set-up/[Developer Setup Guide]


### PR DESCRIPTION
Fixes #5363 & copy @ttomsu @brian-armory 

This PR adds a more complete introduction to Spinnaker aimed at the AppDev and Delivery Engineer audience. Its goal is to provide more context to those newly encountering Spinnaker, and as part of an effort to apply more consistent and strategic product marketing to OSS Spinnaker.

All suggestions and edits welcome, especially for brevity and content accuracy. Also, I left the resource linking section at the bottom relatively untouched, and would welcome recommendations for additional links to add, or changes to existing links based on resource age and quality.