### PR TITLE
fix(build-cop): Use PAT in order to assign a team reviewer

### DIFF
--- a/.github/workflows/build-cop-rotation.yml
+++ b/.github/workflows/build-cop-rotation.yml
@@ -26,6 +26,11 @@ jobs:
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v2
       with:
+        token: ${{ secrets.SPINNAKERRELEASE_GHA_BUILD_COP_TOKEN }}
+        title: "Extend build cop schedule to ${{ steps.dates.outputs.day60 }}"
         team-reviewers: build-cops
+        body: |
+          cc @spinnaker/build-cops
+        labels: build-cop-rotation
         commit-message: |
           chore(build-cop): Update build cop rotation schedule


### PR DESCRIPTION
It appears assigning a team as a reviewer needs increased permissions, see https://github.com/peter-evans/create-pull-request/issues/155

Adding a bit more detail to the other fields.