### PR TITLE
feat(gha): gha to delete untagged images older than 48 hours

### DIFF
--- a/.github/workflows/clean-untagged-images.yml
+++ b/.github/workflows/clean-untagged-images.yml
@@ -1,0 +1,28 @@
+# .github/workflows/gcr-cleaner.yml
+name: 'gcr-cleaner'
+
+on:
+  schedule:
+    - cron: '0 0 */1 * *' # runs daily
+  workflow_dispatch: # allows for manual invocation
+
+jobs:
+  gcr-cleaner:
+    runs-on: 'ubuntu-latest'
+    steps:
+      # configure based on your registry
+      - name: Login to GAR
+        uses: 'docker/login-action@v2'
+        with:
+          registry: us-docker.pkg.dev
+          username: _json_key
+          password: ${{ secrets.GAR_JSON_KEY }}
+
+
+      # delete untaggd images older than 48 hours
+      - uses: 'docker://us-docker.pkg.dev/gcr-cleaner/gcr-cleaner/gcr-cleaner-cli'
+        with:
+          args: >-
+            -repo=us-docker.pkg.dev/spinnaker-community/docker
+            -grace=48h
+            -dry_run=true


### PR DESCRIPTION
In order to keeps costs under control, want to delete untagged images older than 48 hours. 

More info on GCR Cleaner can be found here: [https://github.com/GoogleCloudPlatform/gcr-cleaner/](https://github.com/GoogleCloudPlatform/gcr-cleaner/)

I have not tested this out via a GHA, but have done some dry runs locally. I've added the dry-run flag so that we can test this out on GHA and evaluate the output, before removing the dry-run flag