### PR TITLE
fix(build): Fix Nexus library publishing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,18 @@ tasks.register('publish') { task ->
   }
 }
 
+tasks.register('publishToNexus') { task ->
+  mainProjects.each { build ->
+    task.dependsOn build.task(':publishToNexus')
+  }
+}
+
+tasks.register('closeAndReleaseNexusStagingRepository') { task ->
+  mainProjects.each { build ->
+    task.dependsOn build.task(':closeAndReleaseNexusStagingRepository')
+  }
+}
+
 tasks.register('test') { task ->
   mainProjects.each { build ->
     task.dependsOn build.task(':test')

--- a/spinnaker-gradle-project/spinnaker-project-plugin/build.gradle
+++ b/spinnaker-gradle-project/spinnaker-project-plugin/build.gradle
@@ -14,7 +14,7 @@ dependencies {
   implementation 'com.google.apis:google-api-services-artifactregistry:v1beta2-rev20221022-2.0.0'
   implementation 'com.google.api-client:google-api-client:2.0.0'
   implementation 'org.jetbrains.dokka:dokka-gradle-plugin:0.10.1'
-  implementation 'io.github.gradle-nexus:publish-plugin:1.3.0'
+  implementation 'io.github.gradle-nexus:publish-plugin:2.0.0'
 }
 
 gradlePlugin {


### PR DESCRIPTION
Plumbs the `publishToNexus` and related tasks up to the composite root.
