### PR TITLE
chore(test): adjust test code to execute on arm

### DIFF
--- a/clouddriver/clouddriver-artifacts/src/integration/resources/clouddriver.yml
+++ b/clouddriver/clouddriver-artifacts/src/integration/resources/clouddriver.yml
@@ -39,11 +39,11 @@ sql:
   connectionPools:
     default:
       default: true
-      jdbcUrl: jdbc:tc:mysql:5.7.22://somehostname:someport/clouddriver?user=root?password=&
+      jdbcUrl: jdbc:tc:mysql:8.0.40://somehostname:someport/clouddriver?user=root?password=&
     tasks:
-      jdbcUrl: jdbc:tc:mysql:5.7.22://somehostname:someport/clouddriver?user=root?password=&
+      jdbcUrl: jdbc:tc:mysql:8.0.40://somehostname:someport/clouddriver?user=root?password=&
   migration:
-    jdbcUrl: jdbc:tc:mysql:5.7.22://somehostname:someport/clouddriver?user=root?password=&
+    jdbcUrl: jdbc:tc:mysql:8.0.40://somehostname:someport/clouddriver?user=root?password=&
 
 redis:
   enabled: false

--- a/clouddriver/clouddriver-ecs/src/integration/resources/clouddriver.yml
+++ b/clouddriver/clouddriver-ecs/src/integration/resources/clouddriver.yml
@@ -47,11 +47,11 @@ sql:
   connectionPools:
     default:
       default: true
-      jdbcUrl: jdbc:tc:mysql:5.7.22://somehostname:someport/clouddriver?user=root?password=&
+      jdbcUrl: jdbc:tc:mysql:8.0.40://somehostname:someport/clouddriver?user=root?password=&
     tasks:
-      jdbcUrl: jdbc:tc:mysql:5.7.22://somehostname:someport/clouddriver?user=root?password=&
+      jdbcUrl: jdbc:tc:mysql:8.0.40://somehostname:someport/clouddriver?user=root?password=&
   migration:
-    jdbcUrl: jdbc:tc:mysql:5.7.22://somehostname:someport/clouddriver?user=root?password=&
+    jdbcUrl: jdbc:tc:mysql:8.0.40://somehostname:someport/clouddriver?user=root?password=&
 
 redis:
   enabled: false

--- a/clouddriver/clouddriver-kubernetes/src/integration/java/com/netflix/spinnaker/clouddriver/kubernetes/it/containers/KubernetesCluster.java
+++ b/clouddriver/clouddriver-kubernetes/src/integration/java/com/netflix/spinnaker/clouddriver/kubernetes/it/containers/KubernetesCluster.java
@@ -141,7 +141,11 @@ public class KubernetesCluster {
     Files.createDirectories(IT_BUILD_HOME);
     String os = "linux";
     String arch = "amd64";
-    // TODO: Support running tests in other os/archs
+
+    if (System.getProperty("os.arch").toLowerCase().equals("aarch64")) {
+      arch = "arm64";
+    }
+
     if (System.getProperty("os.name").toLowerCase().contains("mac")) {
       os = "darwin";
     }

--- a/clouddriver/clouddriver-kubernetes/src/integration/resources/clouddriver.yml
+++ b/clouddriver/clouddriver-kubernetes/src/integration/resources/clouddriver.yml
@@ -90,11 +90,11 @@ sql:
   connectionPools:
     default:
       default: true
-      jdbcUrl: jdbc:tc:mysql:5.7.22://somehostname:someport/clouddriver?user=root?password=&
+      jdbcUrl: jdbc:tc:mysql:8.0.40://somehostname:someport/clouddriver?user=root?password=&
     tasks:
-      jdbcUrl: jdbc:tc:mysql:5.7.22://somehostname:someport/clouddriver?user=root?password=&
+      jdbcUrl: jdbc:tc:mysql:8.0.40://somehostname:someport/clouddriver?user=root?password=&
   migration:
-    jdbcUrl: jdbc:tc:mysql:5.7.22://somehostname:someport/clouddriver?user=root?password=&
+    jdbcUrl: jdbc:tc:mysql:8.0.40://somehostname:someport/clouddriver?user=root?password=&
 
 redis:
   enabled: false

--- a/front50/front50-sql/src/test/kotlin/com/netflix/spinnaker/front50/model/SqlStorageServiceTests.kt
+++ b/front50/front50-sql/src/test/kotlin/com/netflix/spinnaker/front50/model/SqlStorageServiceTests.kt
@@ -543,11 +543,11 @@ internal object SqlStorageServiceTests : JUnit5Minutests {
   fun tests() = rootContext<JooqConfig> {
 
     fixture {
-      JooqConfig(SQLDialect.MYSQL, "jdbc:tc:mysql:5.7.22://somehostname/databasename")
+      JooqConfig(SQLDialect.MYSQL, "jdbc:tc:mysql:8.0.40://somehostname/databasename")
     }
 
     context("mysql CRUD operations") {
-      crudOperations(JooqConfig(SQLDialect.MYSQL, "jdbc:tc:mysql:5.7.22://somehostname/databasename"))
+      crudOperations(JooqConfig(SQLDialect.MYSQL, "jdbc:tc:mysql:8.0.40://somehostname/databasename"))
     }
 
     context("postgresql CRUD operations") {

--- a/kork/kork-sql-test/src/main/java/com/netflix/spinnaker/kork/sql/test/SqlTestUtil.java
+++ b/kork/kork-sql-test/src/main/java/com/netflix/spinnaker/kork/sql/test/SqlTestUtil.java
@@ -59,7 +59,7 @@ public class SqlTestUtil {
   // https://www.testcontainers.org/modules/databases/jdbc/#database-containers-launched-via-jdbc-url-scheme
   // for background.  Providing this as a jdbc URL makes testcontainers
   // automatically start a mysql container.
-  public static String tcJdbcUrl = "jdbc:tc:mysql:5.7.22:///somedb";
+  public static String tcJdbcUrl = "jdbc:tc:mysql:8.0.40:///somedb";
 
   public static String tcPgJdbcUrl = "jdbc:tc:postgres:10.13:///test";
 
@@ -105,7 +105,7 @@ public class SqlTestUtil {
   @Deprecated
   public static TestDatabase initPreviousTcMysqlDatabase() {
     MySQLContainer container =
-        new MySQLContainer("mysql:5.7.22")
+        new MySQLContainer("mysql:8.0.40")
             .withDatabaseName("previous")
             .withUsername("test")
             .withPassword("test");
@@ -121,7 +121,7 @@ public class SqlTestUtil {
   }
 
   public static TestDatabase initDualTcMysqlDatabases() {
-    return initDualTcDatabases("mysql:5.7.34", SQLDialect.MYSQL);
+    return initDualTcDatabases("mysql:8.0.40", SQLDialect.MYSQL);
   }
 
   public static TestDatabase initDualTcPostgresDatabases() {

--- a/kork/kork-sql/src/test/java/com/netflix/spinnaker/kork/sql/config/TransactionIsolationMysqlTest.java
+++ b/kork/kork-sql/src/test/java/com/netflix/spinnaker/kork/sql/config/TransactionIsolationMysqlTest.java
@@ -268,9 +268,10 @@ class TransactionIsolationMysqlTest {
 
   private void verifyGlobalTransactionIsolationLevel(Statement stmt, String expectedLevel)
       throws SQLException {
-    try (ResultSet global_tx_isolation_rs = stmt.executeQuery("SELECT @@global.tx_isolation")) {
+    try (ResultSet global_tx_isolation_rs =
+        stmt.executeQuery("SELECT @@global.transaction_isolation")) {
       assertThat(global_tx_isolation_rs.next()).isTrue();
-      assertThat(global_tx_isolation_rs.getString("@@global.tx_isolation"))
+      assertThat(global_tx_isolation_rs.getString("@@global.transaction_isolation"))
           .isEqualTo(expectedLevel);
       assertThat(global_tx_isolation_rs.isLast()).isTrue();
     }
@@ -278,9 +279,10 @@ class TransactionIsolationMysqlTest {
 
   private void verifySessionTransactionIsolationLevel(Statement stmt, String expectedLevel)
       throws SQLException {
-    try (ResultSet session_tx_isolation_rs = stmt.executeQuery("SELECT @@tx_isolation")) {
+    try (ResultSet session_tx_isolation_rs = stmt.executeQuery("SELECT @@transaction_isolation")) {
       assertThat(session_tx_isolation_rs.next()).isTrue();
-      assertThat(session_tx_isolation_rs.getString("@@tx_isolation")).isEqualTo(expectedLevel);
+      assertThat(session_tx_isolation_rs.getString("@@transaction_isolation"))
+          .isEqualTo(expectedLevel);
       assertThat(session_tx_isolation_rs.isLast()).isTrue();
     }
   }


### PR DESCRIPTION
Before this, tests would fail because there's no arm docker image for mysql 5.7.22 nor 5.7.34 with errors like:

> Task :orca:orca-sql:test
```
MySqlPipelineExecutionRepositorySpec > initializationError FAILED
    org.testcontainers.containers.ContainerFetchException: Can't get Docker image: RemoteDockerImage(imageName=mysql:5.7.34, imagePullPolicy=DefaultPullPolicy(), imageNameSubstitutor=org.testcontainers.utility.ImageNameSubstitutor$LogWrappedImageNameSubstitutor@41c1b23c)
        at app//org.testcontainers.containers.GenericContainer.getDockerImageName(GenericContainer.java:1364)
        at app//org.testcontainers.containers.GenericContainer.doStart(GenericContainer.java:359)
        at app//org.testcontainers.containers.GenericContainer.start(GenericContainer.java:330)
        at app//com.netflix.spinnaker.kork.sql.test.SqlTestUtil.initDualTcDatabases(SqlTestUtil.java:154)
        at app//com.netflix.spinnaker.kork.sql.test.SqlTestUtil.initDualTcMysqlDatabases(SqlTestUtil.java:124)
        at app//com.netflix.spinnaker.orca.sql.pipeline.persistence.MySqlPipelineExecutionRepositorySpec.getDatabase(SqlPipelineExecutionRepositorySpec.groovy:708)

        Caused by:
        com.github.dockerjava.api.exception.NotFoundException: Status 404: {"message":"no matching manifest for linux/arm64/v8 in the manifest list entries: no match for platform in manifest: not found"}
            at app//org.testcontainers.shaded.com.github.dockerjava.core.DefaultInvocationBuilder.execute(DefaultInvocationBuilder.java:241)
            at app//org.testcontainers.shaded.com.github.dockerjava.core.DefaultInvocationBuilder.lambda$executeAndStream$1(DefaultInvocationBuilder.java:269)
            at java.base@17.0.11.0.101/java.lang.Thread.run(Thread.java:840)
```
The choice of 8.0.40 for mysql is relatively arbitrary.  It's new enough to have an arm docker image, but the goal of this PR isn't really about updating mysql.