### PR TITLE
feat(kayenta): enable using template for Datadog metric store

### DIFF
--- a/deck-kayenta/package.json
+++ b/deck-kayenta/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/kayenta",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/deck-kayenta/src/kayenta/metricStore/datadog/index.ts
+++ b/deck-kayenta/src/kayenta/metricStore/datadog/index.ts
@@ -5,4 +5,5 @@ metricStoreConfigStore.register({
   name: 'datadog',
   metricConfigurer: DatadogMetricConfigurer,
   queryFinder,
+  useTemplates: true,
 });


### PR DESCRIPTION
Enable using query templates with Datadog metric store. Previously this option was available only for stackdriver and prometheus, so the user has to modify the JSON directly in order to use additional tags or metric equations with Datadog metric store.
<img width="895" alt="Screenshot 2025-04-27 at 5 12 08 PM" src="https://github.com/user-attachments/assets/e8e950e7-2818-4a47-b193-9d819163f78a" />
