### PR TITLE
fix(retrofit2): fix the issue of retrofit2 being unable to convert the Event object to RequestBody.

### DIFF
--- a/igor-core/src/test/java/com/netflix/spinnaker/igor/history/EchoServiceTest.java
+++ b/igor-core/src/test/java/com/netflix/spinnaker/igor/history/EchoServiceTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2025 OpsMx, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.history;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import com.netflix.spinnaker.igor.build.model.GenericBuild;
+import com.netflix.spinnaker.igor.build.model.GenericProject;
+import com.netflix.spinnaker.igor.history.model.GenericBuildContent;
+import com.netflix.spinnaker.igor.history.model.GenericBuildEvent;
+import com.netflix.spinnaker.kork.retrofit.ErrorHandlingExecutorCallAdapterFactory;
+import com.netflix.spinnaker.kork.retrofit.Retrofit2SyncCall;
+import okhttp3.OkHttpClient;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import retrofit2.Retrofit;
+import retrofit2.converter.jackson.JacksonConverterFactory;
+
+public class EchoServiceTest {
+
+  @RegisterExtension
+  static WireMockExtension wmEcho =
+      WireMockExtension.newInstance().options(wireMockConfig().dynamicPort()).build();
+
+  static EchoService echoService;
+
+  @BeforeAll
+  public static void setup() {
+    wmEcho.stubFor(WireMock.post(urlEqualTo("/")).willReturn(WireMock.aResponse().withStatus(200)));
+
+    echoService =
+        new Retrofit.Builder()
+            .baseUrl(wmEcho.baseUrl())
+            .client(new OkHttpClient())
+            .addCallAdapterFactory(ErrorHandlingExecutorCallAdapterFactory.getInstance())
+            .addConverterFactory(JacksonConverterFactory.create())
+            .build()
+            .create(EchoService.class);
+  }
+
+  @Test
+  void testPostEvent_with_GenericBuildEvent() {
+    GenericBuildEvent event = buildGenericEvent();
+    // TODO: Fix this issue
+    Throwable thrown =
+        catchThrowable(() -> Retrofit2SyncCall.executeCall(echoService.postEvent(event)));
+    assertThat(thrown).isInstanceOf(IllegalArgumentException.class);
+    assertThat(thrown)
+        .hasMessageContaining(
+            "Unable to convert GenericBuildEvent(details={type=build, source=igor}, content=GenericBuildContent(project=GenericProject(name=spinnaker, lastBuild=GenericBuild(building=false, fullDisplayName=null, name=null, number=0, duration=null, timestamp=null, result=null, artifacts=null, testResults=null, url=null, id=null, genericGitRevisions=null, properties=null)), master=IgorHealthCheck, type=null)) to RequestBody (parameter #1)");
+  }
+
+  private static GenericBuildEvent buildGenericEvent() {
+    final GenericBuildEvent event = new GenericBuildEvent();
+    final GenericBuildContent buildContent = new GenericBuildContent();
+    final GenericProject project = new GenericProject("spinnaker", new GenericBuild());
+    buildContent.setMaster("IgorHealthCheck");
+    buildContent.setProject(project);
+    event.setContent(buildContent);
+    return event;
+  }
+}

--- a/igor/igor-core/igor-core.gradle
+++ b/igor/igor-core/igor-core.gradle
@@ -11,4 +11,5 @@ dependencies {
   testImplementation "com.netflix.spectator:spectator-reg-micrometer"
   testImplementation "io.spinnaker.kork:kork-retrofit"
   testImplementation "com.squareup.okhttp3:mockwebserver"
+  testImplementation "com.github.tomakehurst:wiremock-jre8-standalone"
 }

--- a/igor/igor-core/src/main/java/com/netflix/spinnaker/igor/history/EchoConverterFactory.java
+++ b/igor/igor-core/src/main/java/com/netflix/spinnaker/igor/history/EchoConverterFactory.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2025 OpsMx, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.history;
+
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import okhttp3.MediaType;
+import okhttp3.RequestBody;
+import okhttp3.ResponseBody;
+import retrofit2.Converter;
+import retrofit2.Retrofit;
+
+public class EchoConverterFactory extends Converter.Factory {
+  private final ObjectMapper mapper;
+  private static final MediaType DEFAULT_MEDIA_TYPE =
+      MediaType.get("application/json; charset=UTF-8");
+
+  public static EchoConverterFactory create() {
+    return new EchoConverterFactory(new ObjectMapper());
+  }
+
+  private EchoConverterFactory(ObjectMapper mapper) {
+    this.mapper = mapper;
+  }
+
+  public Converter<ResponseBody, ?> responseBodyConverter(
+      Type type, Annotation[] annotations, Retrofit retrofit) {
+    if (type == Void.class) {
+      return (Converter<ResponseBody, Void>)
+          value -> {
+            value.close();
+            return null;
+          };
+    }
+    return (Converter<ResponseBody, Object>)
+        value -> {
+          JavaType javaType = mapper.getTypeFactory().constructType(type);
+          return mapper.readValue(value.charStream(), javaType);
+        };
+  }
+
+  public Converter<?, RequestBody> requestBodyConverter(
+      Type type,
+      Annotation[] parameterAnnotations,
+      Annotation[] methodAnnotations,
+      Retrofit retrofit) {
+    return (Converter<Object, RequestBody>)
+        value -> {
+          byte[] jsonValue = mapper.writeValueAsBytes(value);
+          return RequestBody.create(jsonValue, DEFAULT_MEDIA_TYPE);
+        };
+  }
+}

--- a/igor/igor-core/src/main/java/com/netflix/spinnaker/igor/history/EchoConverterFactory.java
+++ b/igor/igor-core/src/main/java/com/netflix/spinnaker/igor/history/EchoConverterFactory.java
@@ -26,6 +26,16 @@ import okhttp3.ResponseBody;
 import retrofit2.Converter;
 import retrofit2.Retrofit;
 
+/**
+ * A custom Converter.Factory for the Echo postEvent API.
+ *
+ * <p>This Factory is specifically designed to handle the conversion of Event objects for the Echo
+ * API's postEvent method. The Event parameter is annotated with @Body and is an abstract class,
+ * which caused the default Retrofit2 Jackson converter Factory to fail.
+ *
+ * <p>This Factory uses a custom ObjectMapper to serialize and deserialize Event objects, ensuring
+ * compatibility with the Echo API.
+ */
 public class EchoConverterFactory extends Converter.Factory {
   private final ObjectMapper mapper;
   private static final MediaType DEFAULT_MEDIA_TYPE =
@@ -39,6 +49,29 @@ public class EchoConverterFactory extends Converter.Factory {
     this.mapper = mapper;
   }
 
+  /**
+   * Returns a Retrofit2 Converter for the ResponseBody of the API call.
+   *
+   * <p>The Converter is responsible for converting the ResponseBody of the Retrofit2 API call into
+   * an object of the specified type.
+   *
+   * <p>The Converter is used to handle the conversion of the response body of the API call to the
+   * type specified by the type parameter.
+   *
+   * <p>If the type parameter is Void.class, the Converter simply closes the ResponseBody and
+   * returns null.
+   *
+   * <p>Otherwise, the Converter uses the ObjectMapper to deserialize the response body into an
+   * object of the specified type. This case doesn't arise but is included for completeness.
+   *
+   * <p>The Converter is used to handle the conversion of the response body of the API call to the
+   * type specified by the type parameter.
+   *
+   * @param type the type of the object that the ResponseBody should be converted to
+   * @param annotations the annotations on the Retrofit2 API call
+   * @param retrofit the Retrofit2 instance
+   * @return a Converter that can convert the ResponseBody of the API call to the specified type
+   */
   public Converter<ResponseBody, ?> responseBodyConverter(
       Type type, Annotation[] annotations, Retrofit retrofit) {
     if (type == Void.class) {
@@ -55,6 +88,25 @@ public class EchoConverterFactory extends Converter.Factory {
         };
   }
 
+  /**
+   * Returns a Retrofit2 Converter for the RequestBody of the API call.
+   *
+   * <p>The Converter is responsible for converting the RequestBody of the Retrofit2 API call into a
+   * RequestBody object.
+   *
+   * <p>The Converter uses the ObjectMapper to serialize the object into a JSON byte array. It then
+   * creates a RequestBody object from the JSON byte array and returns it.
+   *
+   * <p>The Converter is used to handle the conversion of the RequestBody of the API call to a
+   * RequestBody object.
+   *
+   * @param type the type of the object that the RequestBody should be converted from
+   * @param parameterAnnotations the annotations on the Retrofit2 API call parameter
+   * @param methodAnnotations the annotations on the Retrofit2 API call method
+   * @param retrofit the Retrofit2 instance
+   * @return a Converter that can convert the request body of the API call of type `type` to a
+   *     RequestBody object
+   */
   public Converter<?, RequestBody> requestBodyConverter(
       Type type,
       Annotation[] parameterAnnotations,

--- a/igor/igor-core/src/main/java/com/netflix/spinnaker/igor/history/EchoService.java
+++ b/igor/igor-core/src/main/java/com/netflix/spinnaker/igor/history/EchoService.java
@@ -24,5 +24,5 @@ import retrofit2.http.POST;
 /** Posts new build executions to echo */
 public interface EchoService {
   @POST(".")
-  Call<String> postEvent(@Body Event event);
+  Call<Void> postEvent(@Body Event event);
 }

--- a/igor/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/EchoConfig.groovy
+++ b/igor/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/EchoConfig.groovy
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.igor.config
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.config.OkHttp3ClientConfiguration
 import com.netflix.spinnaker.igor.IgorConfigurationProperties
+import com.netflix.spinnaker.igor.history.EchoConverterFactory
 import com.netflix.spinnaker.igor.history.EchoService
 import com.netflix.spinnaker.igor.util.RetrofitUtils
 import com.netflix.spinnaker.kork.retrofit.ErrorHandlingExecutorCallAdapterFactory
@@ -37,8 +38,7 @@ class EchoConfig {
     @Bean
     EchoService echoService(
       OkHttp3ClientConfiguration okHttpClientConfig,
-      IgorConfigurationProperties igorConfigurationProperties,
-      ObjectMapper objectMapper
+      IgorConfigurationProperties igorConfigurationProperties
     ) {
         String address = igorConfigurationProperties.services.echo.baseUrl ?: 'none'
 
@@ -49,7 +49,7 @@ class EchoConfig {
         new Retrofit.Builder()
             .baseUrl(RetrofitUtils.getBaseUrl(address))
             .client(okHttpClientConfig.createForRetrofit2().build())
-            .addConverterFactory(JacksonConverterFactory.create(objectMapper))
+            .addConverterFactory(EchoConverterFactory.create())
             .addCallAdapterFactory(ErrorHandlingExecutorCallAdapterFactory.getInstance())
             .build()
             .create(EchoService)

--- a/igor/igor-web/src/test/java/com/netflix/spinnaker/igor/nexus/NexusEventPosterTest.java
+++ b/igor/igor-web/src/test/java/com/netflix/spinnaker/igor/nexus/NexusEventPosterTest.java
@@ -34,6 +34,7 @@ class NexusEventPosterTest {
   private EchoService echoService = mock(EchoService.class);
   private NexusProperties nexusProperties = new NexusProperties();
   private NexusProperties nexusPropertiesWithoutNodeId = new NexusProperties();
+  private Void voidResponse = null;
 
   {
     final NexusRepo nexusRepo = new NexusRepo();
@@ -81,7 +82,7 @@ class NexusEventPosterTest {
     Event event =
         new NexusAssetEvent(new NexusAssetEvent.Content("nexus-snapshots", expectedArtifact));
 
-    when(echoService.postEvent(event)).thenReturn(Calls.response(""));
+    when(echoService.postEvent(event)).thenReturn(Calls.response(voidResponse));
     nexusEventPoster.postEvent(payload);
     verify(echoService).postEvent(event);
   }
@@ -105,7 +106,7 @@ class NexusEventPosterTest {
     Event event =
         new NexusAssetEvent(new NexusAssetEvent.Content("nexus-snapshots", expectedArtifact));
 
-    when(echoService.postEvent(event)).thenReturn(Calls.response(""));
+    when(echoService.postEvent(event)).thenReturn(Calls.response(voidResponse));
     nexusEventPoster.postEvent(payload);
     verify(echoService).postEvent(event);
   }
@@ -160,7 +161,7 @@ class NexusEventPosterTest {
     Event event =
         new NexusAssetEvent(new NexusAssetEvent.Content("nexus-snapshots", expectedArtifact));
 
-    when(echoService.postEvent(event)).thenReturn(Calls.response(""));
+    when(echoService.postEvent(event)).thenReturn(Calls.response(voidResponse));
     nexusEventPoster.postEvent(payload);
     verify(echoService).postEvent(event);
   }
@@ -184,7 +185,7 @@ class NexusEventPosterTest {
     Event event =
         new NexusAssetEvent(new NexusAssetEvent.Content("nexus-snapshots", expectedArtifact));
 
-    when(echoService.postEvent(event)).thenReturn(Calls.response(""));
+    when(echoService.postEvent(event)).thenReturn(Calls.response(voidResponse));
     nexusEventPosterWithoutNodeId.postEvent(payload);
     verify(echoService).postEvent(event);
   }


### PR DESCRIPTION
- It was observed that the igor was throwing the following error related to retrofit2 serialization. This PR addresses the issue by replacing the @Body type from an abstract `Event` type to `Map<String, Object>` and make changes accordingly at all the required places.
- Added a test to demonstrate the issue. 

```
Caused by: java.lang.IllegalArgumentException: Unable to convert GenericBuildEvent(details={type=build, source=igor}, content=GenericBuildContent(project=GenericProject(name=spinnaker, lastBuild=GenericBuild(building=false, fullDisplayName=null, name=null, number=0, duration=null, timestamp=null, result=null, artifacts=null, testResults=null, url=null, id=null, genericGitRevisions=null, properties=null)), master=IgorHealthCheck, type=null)) to RequestBody (parameter #1)
    for method EchoService.postEvent
	at retrofit2.Utils.methodError(Utils.java:53) ~[retrofit-2.8.1.jar:na]
	at retrofit2.Utils.parameterError(Utils.java:58) ~[retrofit-2.8.1.jar:na]
	at retrofit2.ParameterHandler$Body.apply(ParameterHandler.java:413) ~[retrofit-2.8.1.jar:na]
	at retrofit2.RequestFactory.create(RequestFactory.java:117) ~[retrofit-2.8.1.jar:na]
	at retrofit2.OkHttpCall.createRawCall(OkHttpCall.java:194) ~[retrofit-2.8.1.jar:na]
	at retrofit2.OkHttpCall.getRawCall(OkHttpCall.java:99) ~[retrofit-2.8.1.jar:na]
	at retrofit2.OkHttpCall.execute(OkHttpCall.java:183) ~[retrofit-2.8.1.jar:na]
	at com.netflix.spinnaker.kork.retrofit.ErrorHandlingExecutorCallAdapterFactory$ExecutorCallbackCall.execute(ErrorHandlingExecutorCallAdapterFactory.java:150) ~[kork-retrofit-7.254.0.jar:7.254.0]
	at com.netflix.spinnaker.kork.retrofit.Retrofit2SyncCall.executeCall(Retrofit2SyncCall.java:47) ~[kork-retrofit-7.254.0.jar:7.254.0]
	at com.netflix.spinnaker.kork.retrofit.Retrofit2SyncCall.execute(Retrofit2SyncCall.java:34) ~[kork-retrofit-7.254.0.jar:7.254.0]
	at com.netflix.spinnaker.igor.health.EchoServiceHealthIndicator.lambda$checkHealth$1(EchoServiceHealthIndicator.java:83) ~[igor-web-4.22.0.jar:4.22.0]
```