### PR TITLE
feat(kayenta): expose mustHaveData checkbox in canary metric config modal

### DIFF
--- a/deck-kayenta/package.json
+++ b/deck-kayenta/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/kayenta",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/deck-kayenta/src/kayenta/actions/creators.ts
+++ b/deck-kayenta/src/kayenta/actions/creators.ts
@@ -43,6 +43,9 @@ export const updateMetricNanStrategy = createAction<{ id: string; strategy: stri
 export const updateMetricCriticality = createAction<{ id: string; critical: boolean }>(
   Actions.UPDATE_METRIC_CRITICALITY,
 );
+export const updateMetricDataRequired = createAction<{ id: string, mustHaveData: boolean }>(
+  Actions.UPDATE_METRIC_DATA_REQUIRED,
+);
 export const updateEffectSize = createAction<{ id: string; value: ICanaryMetricEffectSizeConfig }>(
   Actions.UPDATE_EFFECT_SIZE,
 );

--- a/deck-kayenta/src/kayenta/actions/index.ts
+++ b/deck-kayenta/src/kayenta/actions/index.ts
@@ -20,6 +20,7 @@ export const EDIT_METRIC_CANCEL = 'edit_metric_modal_cancel';
 export const UPDATE_METRIC_DIRECTION = 'update_metric_direction';
 export const UPDATE_METRIC_NAN_STRATEGY = 'update_metric_nan_strategy';
 export const UPDATE_METRIC_CRITICALITY = 'update_metric_criticality';
+export const UPDATE_METRIC_DATA_REQUIRED = 'update_metric_data_required';
 export const UPDATE_EFFECT_SIZE = 'update_effect_size';
 export const UPDATE_METRIC_GROUP = 'update_metric_group';
 export const UPDATE_METRIC_SCOPE_NAME = 'update_metric_scope_name';

--- a/deck-kayenta/src/kayenta/domain/MetricClassificationLabel.ts
+++ b/deck-kayenta/src/kayenta/domain/MetricClassificationLabel.ts
@@ -3,5 +3,6 @@ export enum MetricClassificationLabel {
   High = 'High',
   Low = 'Low',
   Nodata = 'Nodata',
+  NodataFailMetric = 'NodataFailMetric',
   Error = 'Error',
 }

--- a/deck-kayenta/src/kayenta/edit/editMetricModal.tsx
+++ b/deck-kayenta/src/kayenta/edit/editMetricModal.tsx
@@ -31,6 +31,7 @@ interface IEditMetricModalDispatchProps {
   updateDirection: (event: any) => void;
   updateNanStrategy: (event: any) => void;
   updateCriticality: (event: any) => void;
+  updateDataRequired: (event: any) => void;
   confirm: () => void;
   cancel: () => void;
 }
@@ -58,6 +59,7 @@ function EditMetricModal({
   updateDirection,
   updateNanStrategy,
   updateCriticality,
+  updateDataRequired,
   useInlineTemplateEditor,
   disableEdit,
   validationErrors,
@@ -69,6 +71,7 @@ function EditMetricModal({
   const direction = metric.analysisConfigurations?.canary?.direction ?? 'either';
   const nanStrategy = metric.analysisConfigurations?.canary?.nanStrategy ?? 'default';
   const critical = metric.analysisConfigurations?.canary?.critical ?? false;
+  const dataRequired = metric.analysisConfigurations?.canary?.mustHaveData ?? false;
   const isConfirmDisabled =
     !isTemplateValid ||
     disableEdit ||
@@ -155,6 +158,18 @@ function EditMetricModal({
               Fail the canary if this metric fails
             </label>
           </FormRow>
+          <FormRow label="Data Required" checkbox={true}>
+            <label>
+              <DisableableInput
+                type="checkbox"
+                checked={dataRequired}
+                onChange={updateDataRequired}
+                disabled={CanarySettings.disableConfigEdit}
+                disabledStateKeys={[DISABLE_EDIT_CONFIG]}
+              />
+              Fail the metric if data is missing
+            </label>
+          </FormRow>
           <FormRow label="NaN Strategy" helpId="canary.config.nanStrategy">
             <RadioChoice
               value="default"
@@ -226,6 +241,9 @@ function mapDispatchToProps(dispatch: any): IEditMetricModalDispatchProps {
     },
     updateCriticality: ({ target }: React.ChangeEvent<HTMLInputElement>) => {
       dispatch(Creators.updateMetricCriticality({ id: target.dataset.id, critical: Boolean(target.checked) }));
+    },
+    updateDataRequired: ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+      dispatch(Creators.updateMetricDataRequired({ id: target.dataset.id, mustHaveData: Boolean(target.checked) }));
     },
   };
 }

--- a/deck-kayenta/src/kayenta/reducers/selectedConfig.ts
+++ b/deck-kayenta/src/kayenta/reducers/selectedConfig.ts
@@ -157,6 +157,14 @@ const editingMetric = handleActions(
 
       return newState;
     },
+    [Actions.UPDATE_METRIC_DATA_REQUIRED]: (state: ICanaryMetricConfig, { payload }: Action & any) => {
+      const newState = cloneDeep(state);
+      payload.mustHaveData
+        ? set(newState, ['analysisConfigurations', 'canary', 'mustHaveData'], payload.mustHaveData)
+        : unset(newState, ['analysisConfigurations', 'canary', 'mustHaveData']);
+
+      return newState;
+    },
     [Actions.UPDATE_EFFECT_SIZE]: (state: ICanaryMetricConfig, { payload }: Action & any) => {
       const newState = cloneDeep(state);
       Object.keys(payload.value).length

--- a/deck-kayenta/src/kayenta/report/detail/colors.ts
+++ b/deck-kayenta/src/kayenta/report/detail/colors.ts
@@ -18,6 +18,7 @@ export const mapMetricClassificationToColor = (classification: MetricClassificat
     [MetricClassificationLabel.Low]: RED,
     [MetricClassificationLabel.Error]: YELLOW,
     [MetricClassificationLabel.Nodata]: GREY,
+    [MetricClassificationLabel.NodataFailMetric]: RED,
     [MetricClassificationLabel.Pass]: GREEN,
   }[classification]);
 


### PR DESCRIPTION
Adding `Data Required` checkbox in Kayenta deck in metric add/edit modal that corresponds to `mustHaveData` flag that exists in Kayenta json schema [here](https://github.com/spinnaker/spinnaker/blob/ff4c04b506f3ab320b72a0507ad3b8bb762186b0/kayenta/docs/canary-config.md?plain=1#L82) and used in the [backend](https://github.com/spinnaker/spinnaker/blob/ff4c04b506f3ab320b72a0507ad3b8bb762186b0/kayenta/kayenta-judge/src/main/scala/com/netflix/kayenta/judge/NetflixACAJudge.scala#L115) as well.
Also adding color for `NodataFailMetric` which can be returned when [data is missing](https://github.com/spinnaker/spinnaker/blob/ff4c04b506f3ab320b72a0507ad3b8bb762186b0/kayenta/kayenta-judge/src/main/scala/com/netflix/kayenta/judge/classifiers/metric/MannWhitneyClassifier.scala#L158).

<img width="902" alt="Screenshot 2025-05-03 at 11 49 14 PM" src="https://github.com/user-attachments/assets/18281192-a9e8-4ebe-bcb2-4a8acd1c66ee" />
