### PR TITLE
fix(docker): fix the issue of fetching docker images

### DIFF
--- a/clouddriver/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/api/v2/client/DockerRegistryClient.groovy
+++ b/clouddriver/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/api/v2/client/DockerRegistryClient.groovy
@@ -499,7 +499,8 @@ class DockerRegistryClient {
     }
     if (queryParamsString) {
       queryParams = queryParamsString.split("&").collectEntries { param ->
-        def (key, value) = param.split("=")
+        // ensures two strings are returned even when a query parameter has no value(returns empty string).
+        def (key, value) = param.split("=", 2)
         [key, value]
       }
     }

--- a/clouddriver/clouddriver-docker/src/test/java/com/netflix/spinnaker/clouddriver/docker/registry/api/v2/client/DockerRegistryClientTest.java
+++ b/clouddriver/clouddriver-docker/src/test/java/com/netflix/spinnaker/clouddriver/docker/registry/api/v2/client/DockerRegistryClientTest.java
@@ -20,7 +20,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
-import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
@@ -276,8 +275,7 @@ public class DockerRegistryClientTest {
             .willReturn(
                 aResponse().withStatus(HttpStatus.OK.value()).withBody(tagsThirdResponseString)));
 
-    Throwable thrown = catchThrowable(() -> dockerRegistryClient.getTags("library/nginx"));
-    assertThat(thrown).isInstanceOf(ArrayIndexOutOfBoundsException.class);
-    assertThat(thrown).hasMessage("Index 1 out of bounds for length 1");
+    DockerRegistryTags dockerRegistryTags = dockerRegistryClient.getTags("library/nginx");
+    assertEquals(15, dockerRegistryTags.getTags().size());
   }
 }


### PR DESCRIPTION
- A docker registry when responding with next link to query for catalog repositories or tags, it is expected to send two query parameters : 1. `n` - number of items per page and 2. `last` - last item rendered in the current response. But Azure Container Registry was also sending one more query parameter (`orderby`) with no value which is causing the failure while parsing the `next` link.  https://github.com/spinnaker/spinnaker/issues/7065
```
java.lang.ArrayIndexOutOfBoundsException: Index 1 out of bounds for length 1
...
	at com.netflix.spinnaker.clouddriver.docker.registry.api.v2.client.DockerRegistryClient$_parseForQueryParams_closure20.doCall(DockerRegistryClient.groovy:502) ~[clouddriver-docker-2025.0.0.jar:2025.0.0]

```
- This PR addresses the issue by accepting blank value for a query param.
- Added a test to demonstrate the issue.