### PR TITLE
feat(kayenta): adding outlierStrategy field in metric config modal

### DIFF
--- a/deck-kayenta/package.json
+++ b/deck-kayenta/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinnaker/kayenta",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/deck-kayenta/src/kayenta/actions/creators.ts
+++ b/deck-kayenta/src/kayenta/actions/creators.ts
@@ -40,6 +40,9 @@ export const updateMetricDirection = createAction<{ id: string; direction: strin
 export const updateMetricNanStrategy = createAction<{ id: string; strategy: string }>(
   Actions.UPDATE_METRIC_NAN_STRATEGY,
 );
+export const updateMetricOutlierStrategy = createAction<{ id: string; strategy: string }>(
+  Actions.UPDATE_METRIC_OUTLIER_STRATEGY,
+);
 export const updateMetricCriticality = createAction<{ id: string; critical: boolean }>(
   Actions.UPDATE_METRIC_CRITICALITY,
 );

--- a/deck-kayenta/src/kayenta/actions/index.ts
+++ b/deck-kayenta/src/kayenta/actions/index.ts
@@ -19,6 +19,7 @@ export const EDIT_METRIC_CONFIRM = 'edit_metric_modal_confirm';
 export const EDIT_METRIC_CANCEL = 'edit_metric_modal_cancel';
 export const UPDATE_METRIC_DIRECTION = 'update_metric_direction';
 export const UPDATE_METRIC_NAN_STRATEGY = 'update_metric_nan_strategy';
+export const UPDATE_METRIC_OUTLIER_STRATEGY = 'update_metric_outlier_strategy';
 export const UPDATE_METRIC_CRITICALITY = 'update_metric_criticality';
 export const UPDATE_METRIC_DATA_REQUIRED = 'update_metric_data_required';
 export const UPDATE_EFFECT_SIZE = 'update_effect_size';

--- a/deck-kayenta/src/kayenta/canary.help.ts
+++ b/deck-kayenta/src/kayenta/canary.help.ts
@@ -73,6 +73,10 @@ const helpContents: { [key: string]: string } = {
     <p>When there is no value for a metric at a given point in time, it can either be ignored or assumed to be zero. The right choice depends on what is being measured. For example, when measuring successful attempts (like health checks) replacing missing values with zero may be appropriate.</p>
     <p>The default strategy for a given metric will be used if no strategy is selected.</p>
   `,
+  'canary.config.outlierStrategy': `
+    <p>When outliers are present in metric data, you can choose to either remove them or include them in the evaluation. The appropriate strategy depends on the metrics being assessed. For example, when measuring CPU or memory utilization, it might be appropriate to remove outliers that occur during startup times.</p> 
+    <p>If no strategy is chosen, the default strategy for the metric will be implemented.</p>
+  `,
   'canary.config.filterTemplate': `
     <p>Templates allow you to compose and parameterize advanced queries against your telemetry provider.</p>
     <p>Parameterized queries are hydrated by values provided in the canary stage. The <strong>project</strong>, <strong>resourceType</strong>, </string><strong>scope</strong>, and <strong>location</strong> variable bindings are implicitly available.</p>

--- a/deck-kayenta/src/kayenta/edit/editMetricModal.spec.tsx
+++ b/deck-kayenta/src/kayenta/edit/editMetricModal.spec.tsx
@@ -106,6 +106,13 @@ describe('EditMetricModal', () => {
     expect(store.dispatch).toHaveBeenCalledWith(Creators.updateMetricNanStrategy({ id: '1', strategy: 'replace' }));
   });
 
+  it('calls updateOutlierStrategy when the outlier strategy is changed', () => {
+    const component = buildComponent({});
+    const changeOutlierStrategyEvent = { target: { value: 'remove', dataset: { id: '1' } } };
+    component.find('input[name="outlierStrategy"][value="remove"]').simulate('change', changeOutlierStrategyEvent);
+    expect(store.dispatch).toHaveBeenCalledWith(Creators.updateMetricOutlierStrategy({ id: '1', strategy: 'remove' }));
+  });
+
   it('calls updateCriticality when the criticality checkbox is changed', () => {
     const component = buildComponent({});
     const changeCriticalityEvent = { target: { checked: true, dataset: { id: '1' } } };

--- a/deck-kayenta/src/kayenta/edit/editMetricModal.tsx
+++ b/deck-kayenta/src/kayenta/edit/editMetricModal.tsx
@@ -30,6 +30,7 @@ interface IEditMetricModalDispatchProps {
   changeGroup: (event: any) => void;
   updateDirection: (event: any) => void;
   updateNanStrategy: (event: any) => void;
+  updateOutlierStrategy: (event: any) => void;
   updateCriticality: (event: any) => void;
   updateDataRequired: (event: any) => void;
   confirm: () => void;
@@ -58,6 +59,7 @@ function EditMetricModal({
   isTemplateValid,
   updateDirection,
   updateNanStrategy,
+  updateOutlierStrategy,
   updateCriticality,
   updateDataRequired,
   useInlineTemplateEditor,
@@ -70,6 +72,7 @@ function EditMetricModal({
 
   const direction = metric.analysisConfigurations?.canary?.direction ?? 'either';
   const nanStrategy = metric.analysisConfigurations?.canary?.nanStrategy ?? 'default';
+  const outlierStrategy = metric.analysisConfigurations?.canary?.outliers?.strategy ?? 'default';
   const critical = metric.analysisConfigurations?.canary?.critical ?? false;
   const dataRequired = metric.analysisConfigurations?.canary?.mustHaveData ?? false;
   const isConfirmDisabled =
@@ -195,6 +198,29 @@ function EditMetricModal({
               action={updateNanStrategy}
             />
           </FormRow>
+          <FormRow label="Outlier Strategy" helpId="canary.config.outlierStrategy">
+            <RadioChoice
+              value="default"
+              label="Default (keep)"
+              name="outlierStrategy"
+              current={outlierStrategy}
+              action={updateOutlierStrategy}
+            />
+            <RadioChoice
+              value="remove"
+              label="Remove"
+              name="outlierStrategy"
+              current={outlierStrategy}
+              action={updateOutlierStrategy}
+            />
+            <RadioChoice
+              value="keep"
+              label="Keep"
+              name="outlierStrategy"
+              current={outlierStrategy}
+              action={updateOutlierStrategy}
+            />
+          </FormRow>
           <EditMetricEffectSizes />
           <MetricConfigurerDelegator />
           {templatesEnabled && !useInlineTemplateEditor && <FilterTemplateSelector />}
@@ -240,6 +266,9 @@ function mapDispatchToProps(dispatch: any): IEditMetricModalDispatchProps {
     },
     updateNanStrategy: ({ target }: React.ChangeEvent<HTMLInputElement>) => {
       dispatch(Creators.updateMetricNanStrategy({ id: target.dataset.id, strategy: target.value }));
+    },
+    updateOutlierStrategy: ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+      dispatch(Creators.updateMetricOutlierStrategy({ id: target.dataset.id, strategy: target.value }));
     },
     updateCriticality: ({ target }: React.ChangeEvent<HTMLInputElement>) => {
       dispatch(Creators.updateMetricCriticality({ id: target.dataset.id, critical: Boolean(target.checked) }));

--- a/deck-kayenta/src/kayenta/reducers/selectedConfig.ts
+++ b/deck-kayenta/src/kayenta/reducers/selectedConfig.ts
@@ -148,6 +148,15 @@ const editingMetric = handleActions(
 
       return newState;
     },
+    [Actions.UPDATE_METRIC_OUTLIER_STRATEGY]: (state: ICanaryMetricConfig, { payload }: Action & any) => {
+      const newState = cloneDeep(state);
+
+      payload.strategy === 'default'
+        ? unset(newState, ['analysisConfigurations', 'canary', 'outliers', 'strategy'])
+        : set(newState, ['analysisConfigurations', 'canary', 'outliers', 'strategy'], payload.strategy);
+
+      return newState;
+    },
     [Actions.UPDATE_METRIC_CRITICALITY]: (state: ICanaryMetricConfig, { payload }: Action & any) => {
       const newState = cloneDeep(state);
 


### PR DESCRIPTION
Add outlier strategy field to the canary config modal, this config exists in Kayenta config schema [here](https://github.com/spinnaker/spinnaker/blob/93ea3ff5b9c804d727797e871101b679bd8b1595/kayenta/docs/canary-config.md#properties-7) but was not exposed in the modal when metric configuration is created/updated.


<img width="964" alt="Screenshot 2025-05-16 at 9 53 55 PM" src="https://github.com/user-attachments/assets/d42c4af8-bd3f-4ec1-b1fa-7b1989c3d062" />
