### PR TITLE
fix(build): Fix BoM generation against release tags

### DIFF
--- a/.github/actions/spinnaker-release/src/bom/bom.ts
+++ b/.github/actions/spinnaker-release/src/bom/bom.ts
@@ -2,6 +2,7 @@ import { Service } from './service';
 import { StoredYml } from '../gcp/stored_yml';
 import * as util from '../util';
 import * as Path from 'path';
+import { Version } from '../versions';
 
 export class Bom extends StoredYml {
   artifactSources: Map<string, string>;
@@ -10,13 +11,13 @@ export class Bom extends StoredYml {
   timestamp: string;
   version: string;
 
-  constructor(version: string) {
+  constructor(version: Version) {
     super();
     this.artifactSources = this.getDefaultArtifactSources();
     this.dependencies = this.getDefaultDependencies();
     this.services = new Map<string, Map<string, string>>();
     this.timestamp = new Date().toISOString();
-    this.version = version;
+    this.version = version.toString();
   }
 
   getDefaultArtifactSources(): Map<string, string> {
@@ -67,13 +68,13 @@ export class Bom extends StoredYml {
     );
   }
 
-  setService(service: Service) {
+  setService(service: Service, version: Version) {
     this.services.set(
       service.name,
       new Map(
         Object.entries({
-          commit: service.getCommit(),
-          version: service.getVersion(),
+          commit: service.getCommit(version),
+          version: service.getVersion(version),
         }),
       ),
     );

--- a/.github/actions/spinnaker-release/src/bom/generate.ts
+++ b/.github/actions/spinnaker-release/src/bom/generate.ts
@@ -4,6 +4,7 @@ import { services } from './services/all';
 import * as util from '../util';
 import { fromCurrent, VersionsDotYml } from './versionsDotYml';
 import { forVersion, Changelog } from './changelog';
+import { Version } from '../versions';
 
 export async function generate(): Promise<void> {
   const bom = await generateBom().catch((err) => {
@@ -38,10 +39,13 @@ export async function generate(): Promise<void> {
 async function generateBom(): Promise<Bom> {
   core.info('Running BoM generator');
 
-  const version = util.getInput('version');
+  const version = Version.parse(util.getInput('version'));
+  if (!version) {
+    throw new Error('Valid version must be provided to generate a BoM');
+  }
   const bom = new Bom(version);
   for (const service of services) {
-    bom.setService(service);
+    bom.setService(service, version);
   }
 
   return bom;

--- a/.github/actions/spinnaker-release/src/versions.ts
+++ b/.github/actions/spinnaker-release/src/versions.ts
@@ -44,6 +44,14 @@ export class Version {
     return 0;
   }
 
+  equals(version: Version) {
+    return (
+      this.major === version.major &&
+      this.minor === version.minor &&
+      this.patch === version.patch
+    );
+  }
+
   toString() {
     return `${this.major}.${this.minor}.${this.patch}`;
   }


### PR DESCRIPTION
The original implementation of BoM generation was designed around branch-build numbers (e.g. `clouddriver-2025.0-1`) - we were not rebuilding containers on release.  Later in the process, we elected to do that (e.g. `clouddriver-2025.0.1` - note the dot), and tag searching was then broken.  

The design was also meant to always take the latest version unless overridden, which has been improved to always use a release version as a reference point.  This makes it possible to regenerate an older BoM if needed.  This can be used to update the incorrect existing BoMs for `2025.0.1` and `2025.0.2`.

Example BoM produced by this change with input version `2025.0.2`:

```yaml
artifactSources:
  debianRepository: https://us-apt.pkg.dev/projects/spinnaker-community
  dockerRegistry: us-docker.pkg.dev/spinnaker-community/docker
  gitPrefix: https://github.com/spinnaker
  googleImageProject: marketplace-spinnaker-release
dependencies:
  consul:
    version: 0.7.5
  redis:
    version: 2:2.8.4-2
  vault:
    version: 0.7.0
services:
  clouddriver:
    commit: 4cf4d4204f31aa5381abd0510151193ab65516f2
    version: 2025.0.2
  deck:
    commit: 4cf4d4204f31aa5381abd0510151193ab65516f2
    version: 2025.0.2
  echo:
    commit: 4cf4d4204f31aa5381abd0510151193ab65516f2
    version: 2025.0.2
  fiat:
    commit: 4cf4d4204f31aa5381abd0510151193ab65516f2
    version: 2025.0.2
  front50:
    commit: 4cf4d4204f31aa5381abd0510151193ab65516f2
    version: 2025.0.2
  gate:
    commit: 4cf4d4204f31aa5381abd0510151193ab65516f2
    version: 2025.0.2
  igor:
    commit: 4cf4d4204f31aa5381abd0510151193ab65516f2
    version: 2025.0.2
  kayenta:
    commit: 4cf4d4204f31aa5381abd0510151193ab65516f2
    version: 2025.0.2
  monitoring-daemon:
    commit: 96d510cb22f65dcf788324ed8b68447c31de255a
    version: 1.4.0
  monitoring-third-party:
    commit: 96d510cb22f65dcf788324ed8b68447c31de255a
    version: 1.4.0
  orca:
    commit: 4cf4d4204f31aa5381abd0510151193ab65516f2
    version: 2025.0.2
  rosco:
    commit: 4cf4d4204f31aa5381abd0510151193ab65516f2
    version: 2025.0.2
timestamp: 2025-05-21T07:00:01.126Z
version: 2025.0.2
```

Example BoM produced by this change with input version `2025.0.1`:

```yaml
artifactSources:
  debianRepository: https://us-apt.pkg.dev/projects/spinnaker-community
  dockerRegistry: us-docker.pkg.dev/spinnaker-community/docker
  gitPrefix: https://github.com/spinnaker
  googleImageProject: marketplace-spinnaker-release
dependencies:
  consul:
    version: 0.7.5
  redis:
    version: 2:2.8.4-2
  vault:
    version: 0.7.0
services:
  clouddriver:
    commit: 4f9ba539cd7aef1bfdee8922fc40aace3791fddd
    version: 2025.0.1
  deck:
    commit: 4f9ba539cd7aef1bfdee8922fc40aace3791fddd
    version: 2025.0.1
  echo:
    commit: 4f9ba539cd7aef1bfdee8922fc40aace3791fddd
    version: 2025.0.1
  fiat:
    commit: 4f9ba539cd7aef1bfdee8922fc40aace3791fddd
    version: 2025.0.1
  front50:
    commit: 4f9ba539cd7aef1bfdee8922fc40aace3791fddd
    version: 2025.0.1
  gate:
    commit: 4f9ba539cd7aef1bfdee8922fc40aace3791fddd
    version: 2025.0.1
  igor:
    commit: 4f9ba539cd7aef1bfdee8922fc40aace3791fddd
    version: 2025.0.1
  kayenta:
    commit: 4f9ba539cd7aef1bfdee8922fc40aace3791fddd
    version: 2025.0.1
  monitoring-daemon:
    commit: 96d510cb22f65dcf788324ed8b68447c31de255a
    version: 1.4.0
  monitoring-third-party:
    commit: 96d510cb22f65dcf788324ed8b68447c31de255a
    version: 1.4.0
  orca:
    commit: 4f9ba539cd7aef1bfdee8922fc40aace3791fddd
    version: 2025.0.1
  rosco:
    commit: 4f9ba539cd7aef1bfdee8922fc40aace3791fddd
    version: 2025.0.1
timestamp: 2025-05-21T07:07:53.157Z
version: 2025.0.1

```