### PR TITLE
feat(retrofit2): Add CallAdapter for legacy Retrofit signatures

### DIFF
--- a/kork/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/ErrorHandlingExecutorCallAdapterFactory.java
+++ b/kork/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/ErrorHandlingExecutorCallAdapterFactory.java
@@ -79,7 +79,7 @@ public class ErrorHandlingExecutorCallAdapterFactory extends CallAdapter.Factory
      * it cannot be handled by this factory
      */
     if (getRawType(returnType) != Call.class) {
-      return null;
+      return new LegacySignatureCallAdapter(callbackExecutor, returnType, retrofit);
     }
 
     if (!(returnType instanceof ParameterizedType)) {

--- a/kork/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/LegacySignatureCallAdapter.java
+++ b/kork/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/LegacySignatureCallAdapter.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2025 Apple, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.retrofit;
+
+import com.netflix.spinnaker.kork.retrofit.ErrorHandlingExecutorCallAdapterFactory.ExecutorCallbackCall;
+import java.lang.reflect.Type;
+import java.util.concurrent.Executor;
+import lombok.RequiredArgsConstructor;
+import retrofit2.Call;
+import retrofit2.CallAdapter;
+import retrofit2.Retrofit;
+
+@RequiredArgsConstructor
+public class LegacySignatureCallAdapter implements CallAdapter<Object, Object> {
+  private final Executor callbackExecutor;
+  private final Type returnType;
+  private final Retrofit retrofit;
+
+  @Override
+  public Type responseType() {
+    return returnType;
+  }
+
+  @Override
+  public Object adapt(Call<Object> call) {
+    var call2 = new ExecutorCallbackCall<>(callbackExecutor, call, retrofit);
+    return Retrofit2SyncCall.execute(call2);
+  }
+}

--- a/kork/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/ErrorHandlingExecutorCallAdapterFactoryTest.java
+++ b/kork/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/ErrorHandlingExecutorCallAdapterFactoryTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2025 Apple, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.retrofit.exceptions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.netflix.spinnaker.kork.retrofit.ErrorHandlingExecutorCallAdapterFactory;
+import com.netflix.spinnaker.kork.retrofit.Retrofit2SyncCall;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import okhttp3.OkHttpClient;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import retrofit2.Call;
+import retrofit2.Retrofit;
+import retrofit2.converter.jackson.JacksonConverterFactory;
+import retrofit2.http.GET;
+
+public class ErrorHandlingExecutorCallAdapterFactoryTest {
+  public interface TestService {
+    @GET("legacy1")
+    Map<String, Object> legacy1();
+
+    @GET("legacy2")
+    Map legacy2();
+
+    @GET("modern1")
+    Call<Map<String, Object>> modern1();
+  }
+
+  private static final MockWebServer mockWebServer = new MockWebServer();
+  private static final String baseUrl = mockWebServer.url("/").toString();
+
+  private static TestService testService;
+
+  @BeforeAll
+  public static void setupAll() {
+    testService =
+        new Retrofit.Builder()
+            .baseUrl(baseUrl)
+            .client(
+                new OkHttpClient.Builder()
+                    .callTimeout(1, TimeUnit.SECONDS)
+                    .connectTimeout(1, TimeUnit.SECONDS)
+                    .build())
+            .addCallAdapterFactory(ErrorHandlingExecutorCallAdapterFactory.getInstance())
+            .addConverterFactory(JacksonConverterFactory.create())
+            .build()
+            .create(TestService.class);
+  }
+
+  @Test
+  public void testLegacySignature() {
+    mockWebServer.enqueue(new MockResponse().setBody("{\"foo\": \"bar\"}"));
+    var ret = testService.legacy1();
+    assertEquals("bar", ret.get("foo"));
+
+    mockWebServer.enqueue(new MockResponse().setBody("{\"foo\": \"bar\"}"));
+    var ret2 = testService.legacy2();
+    assertEquals("bar", ret2.get("foo"));
+  }
+
+  @Test
+  public void testModernSignature() {
+    mockWebServer.enqueue(new MockResponse().setBody("{\"foo\": \"bar\"}"));
+    var ret = Retrofit2SyncCall.execute(testService.modern1());
+    assertEquals("bar", ret.get("foo"));
+  }
+}

--- a/kork/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerRetrofit2ErrorHandleTest.java
+++ b/kork/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerRetrofit2ErrorHandleTest.java
@@ -171,19 +171,6 @@ class SpinnakerRetrofit2ErrorHandleTest {
         .isEqualTo("Call return type must be parameterized as Call<Foo> or Call<? extends Foo>");
   }
 
-  @Test
-  void testWrongReturnTypeException() {
-
-    IllegalArgumentException illegalArgumentException =
-        catchThrowableOfType(
-            () -> retrofit2Service.testWrongReturnType().execute(), IllegalArgumentException.class);
-
-    assertThat(illegalArgumentException)
-        .hasMessage(
-            "Unable to create call adapter for interface com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerRetrofit2ErrorHandleTest$DummyWithExecute\n"
-                + "    for method Retrofit2Service.testWrongReturnType");
-  }
-
   interface Retrofit2Service {
     @retrofit2.http.GET("/retrofit2")
     Call<String> getRetrofit2();


### PR DESCRIPTION
This adds a CallAdapter to support non-Call<..> signatures on Retrofit interfaces, similar to retrofit1.

This eliminates the need for `Retrofit2SyncCall` at every Retrofit method call point and eliminates the need to wrap all interface return types in Call<...>

This does lose some potential async and streaming capability, but could offer a much more light-touch migration path for anything that might remain.
