### PR TITLE
refactor(retrofit2): Upgrade retrofit clients to retrofit2 in Kayenta

### DIFF
--- a/kayenta/build.gradle
+++ b/kayenta/build.gradle
@@ -86,8 +86,6 @@ subprojects { project ->
       api "io.spinnaker.kork:kork-swagger"
       api "io.spinnaker.orca:orca-core"
 
-      api "com.squareup.retrofit:retrofit"
-      api "com.squareup.retrofit:converter-jackson"
 
       testImplementation "org.springframework.boot:spring-boot-starter-test"
       testImplementation "org.spockframework:spock-core"

--- a/kayenta/kayenta-atlas/kayenta-atlas.gradle
+++ b/kayenta/kayenta-atlas/kayenta-atlas.gradle
@@ -1,9 +1,8 @@
 dependencies {
   implementation project(":kayenta-core")
 
-  api "com.squareup.retrofit:retrofit"
-  api "com.squareup.retrofit:converter-jackson"
   api "org.apache.commons:commons-io:1.3.2"
 
   implementation "io.spinnaker.kork:kork-retrofit"
+  implementation "com.squareup.retrofit2:converter-jackson"
 }

--- a/kayenta/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/backends/AtlasStorageUpdater.java
+++ b/kayenta/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/backends/AtlasStorageUpdater.java
@@ -28,8 +28,7 @@ import javax.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
-import okhttp3.OkHttpClient;
-import retrofit.converter.JacksonConverter;
+import retrofit2.converter.jackson.JacksonConverterFactory;
 
 @Slf4j
 @Builder
@@ -43,18 +42,14 @@ public class AtlasStorageUpdater {
   // is likely safe enough.
   @Builder.Default private boolean succeededAtLeastOnce = false;
 
-  boolean run(
-      RetrofitClientFactory retrofitClientFactory,
-      ObjectMapper objectMapper,
-      OkHttpClient okHttpClient) {
+  boolean run(RetrofitClientFactory retrofitClientFactory, ObjectMapper objectMapper) {
     RemoteService remoteService = new RemoteService();
     remoteService.setBaseUrl(uri);
     AtlasStorageRemoteService atlasStorageRemoteService =
         retrofitClientFactory.createClient(
             AtlasStorageRemoteService.class,
-            new JacksonConverter(objectMapper),
-            remoteService,
-            okHttpClient);
+            JacksonConverterFactory.create(objectMapper),
+            remoteService);
     try {
       Map<String, Map<String, AtlasStorage>> atlasStorageMap =
           AuthenticatedRequest.allowAnonymous(atlasStorageRemoteService::fetch);

--- a/kayenta/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/backends/AtlasStorageUpdaterService.java
+++ b/kayenta/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/backends/AtlasStorageUpdaterService.java
@@ -20,7 +20,6 @@ import com.netflix.kayenta.retrofit.config.RetrofitClientFactory;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
-import okhttp3.OkHttpClient;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.health.AbstractHealthIndicator;
 import org.springframework.boot.actuate.health.Health;
@@ -34,18 +33,14 @@ import org.springframework.stereotype.Service;
 public class AtlasStorageUpdaterService extends AbstractHealthIndicator {
   private final RetrofitClientFactory retrofitClientFactory;
   private final ObjectMapper objectMapper;
-  private final OkHttpClient okHttpClient;
   private final List<AtlasStorageUpdater> atlasStorageUpdaters = new ArrayList<>();
   private int checksCompleted = 0;
 
   @Autowired
   public AtlasStorageUpdaterService(
-      RetrofitClientFactory retrofitClientFactory,
-      ObjectMapper objectMapper,
-      OkHttpClient okHttpClient) {
+      RetrofitClientFactory retrofitClientFactory, ObjectMapper objectMapper) {
     this.retrofitClientFactory = retrofitClientFactory;
     this.objectMapper = objectMapper;
-    this.okHttpClient = okHttpClient;
   }
 
   @Scheduled(initialDelay = 2000, fixedDelay = 122000)
@@ -57,7 +52,7 @@ public class AtlasStorageUpdaterService extends AbstractHealthIndicator {
     int checks = 0;
     for (AtlasStorageUpdater updater : atlasStorageUpdaters) {
       synchronized (this) {
-        boolean result = updater.run(retrofitClientFactory, objectMapper, okHttpClient);
+        boolean result = updater.run(retrofitClientFactory, objectMapper);
         if (result) checks++;
       }
     }

--- a/kayenta/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/backends/BackendUpdater.java
+++ b/kayenta/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/backends/BackendUpdater.java
@@ -28,8 +28,7 @@ import javax.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
-import okhttp3.OkHttpClient;
-import retrofit.converter.JacksonConverter;
+import retrofit2.converter.jackson.JacksonConverterFactory;
 
 @Slf4j
 @Builder
@@ -43,18 +42,14 @@ public class BackendUpdater {
   // is likely safe enough.
   @Builder.Default private boolean succeededAtLeastOnce = false;
 
-  boolean run(
-      RetrofitClientFactory retrofitClientFactory,
-      ObjectMapper objectMapper,
-      OkHttpClient okHttpClient) {
+  boolean run(RetrofitClientFactory retrofitClientFactory, ObjectMapper objectMapper) {
     RemoteService remoteService = new RemoteService();
     remoteService.setBaseUrl(uri);
     BackendsRemoteService backendsRemoteService =
         retrofitClientFactory.createClient(
             BackendsRemoteService.class,
-            new JacksonConverter(objectMapper),
-            remoteService,
-            okHttpClient);
+            JacksonConverterFactory.create(objectMapper),
+            remoteService);
     try {
       List<Backend> backends = AuthenticatedRequest.allowAnonymous(backendsRemoteService::fetch);
       backendDatabase.update(backends);

--- a/kayenta/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/backends/BackendUpdaterService.java
+++ b/kayenta/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/backends/BackendUpdaterService.java
@@ -20,7 +20,6 @@ import com.netflix.kayenta.retrofit.config.RetrofitClientFactory;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
-import okhttp3.OkHttpClient;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.health.AbstractHealthIndicator;
 import org.springframework.boot.actuate.health.Health;
@@ -34,18 +33,14 @@ import org.springframework.stereotype.Service;
 public class BackendUpdaterService extends AbstractHealthIndicator {
   private final RetrofitClientFactory retrofitClientFactory;
   private final ObjectMapper objectMapper;
-  private final OkHttpClient okHttpClient;
   private final List<BackendUpdater> backendUpdaters = new ArrayList<>();
   private int checksCompleted = 0;
 
   @Autowired
   public BackendUpdaterService(
-      RetrofitClientFactory retrofitClientFactory,
-      ObjectMapper objectMapper,
-      OkHttpClient okHttpClient) {
+      RetrofitClientFactory retrofitClientFactory, ObjectMapper objectMapper) {
     this.retrofitClientFactory = retrofitClientFactory;
     this.objectMapper = objectMapper;
-    this.okHttpClient = okHttpClient;
   }
 
   @Scheduled(initialDelay = 2000, fixedDelay = 122000)
@@ -57,7 +52,7 @@ public class BackendUpdaterService extends AbstractHealthIndicator {
     int checks = 0;
     for (BackendUpdater updater : backendUpdaters) {
       synchronized (this) {
-        boolean result = updater.run(retrofitClientFactory, objectMapper, okHttpClient);
+        boolean result = updater.run(retrofitClientFactory, objectMapper);
         if (result) checks++;
       }
     }

--- a/kayenta/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/config/AtlasSSEConverter.java
+++ b/kayenta/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/config/AtlasSSEConverter.java
@@ -102,13 +102,13 @@ public class AtlasSSEConverter extends Converter.Factory {
     }
 
     @Override
-    public List<AtlasResults> convert(ResponseBody value) throws IOException {
+    public List<AtlasResults> convert(ResponseBody value) {
       try (BufferedReader reader = new BufferedReader(new InputStreamReader(value.byteStream()))) {
         return processInput(reader);
-      } catch (Exception e) {
-        log.error("Error processing Atlas SSE response", e);
-        throw new IOException("Failed to process Atlas SSE response", e);
+      } catch (IOException e) {
+        log.error("Cannot process Atlas results", e);
       }
+      return null;
     }
 
     protected List<AtlasResults> processInput(BufferedReader reader) {

--- a/kayenta/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/metrics/AtlasMetricsService.java
+++ b/kayenta/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/metrics/AtlasMetricsService.java
@@ -39,6 +39,7 @@ import com.netflix.kayenta.retrofit.config.RetrofitClientFactory;
 import com.netflix.kayenta.security.AccountCredentialsRepository;
 import com.netflix.kayenta.util.Retry;
 import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.config.OkHttp3ClientConfiguration;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.*;
@@ -71,6 +72,8 @@ public class AtlasMetricsService implements MetricsService {
 
   @Autowired private final Registry registry;
 
+  @Autowired private final OkHttp3ClientConfiguration okHttp3ClientConfig;
+
   private final Retry retry = new Retry();
 
   @Override
@@ -95,7 +98,8 @@ public class AtlasMetricsService implements MetricsService {
       CanaryScope canaryScope) {
 
     OkHttpClient okHttpClient =
-        new OkHttpClient.Builder()
+        okHttp3ClientConfig
+            .createForRetrofit2()
             .connectTimeout(30, TimeUnit.SECONDS)
             .readTimeout(90, TimeUnit.SECONDS)
             .build();

--- a/kayenta/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/service/AtlasRemoteService.java
+++ b/kayenta/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/service/AtlasRemoteService.java
@@ -18,12 +18,12 @@ package com.netflix.kayenta.atlas.service;
 
 import com.netflix.kayenta.atlas.model.AtlasResults;
 import java.util.List;
-import retrofit.http.GET;
-import retrofit.http.Query;
+import retrofit2.http.GET;
+import retrofit2.http.Query;
 
 public interface AtlasRemoteService {
 
-  @GET("/api/v2/fetch")
+  @GET("api/v2/fetch")
   List<AtlasResults> fetch(
       @Query("q") String q,
       @Query("s") Long start,

--- a/kayenta/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/service/AtlasStorageRemoteService.java
+++ b/kayenta/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/service/AtlasStorageRemoteService.java
@@ -17,10 +17,10 @@ package com.netflix.kayenta.atlas.service;
 
 import com.netflix.kayenta.atlas.model.AtlasStorage;
 import java.util.Map;
-import retrofit.http.GET;
+import retrofit2.http.GET;
 
 public interface AtlasStorageRemoteService {
 
-  @GET("/api/v1/atlas/storage.json")
+  @GET("api/v1/atlas/storage.json")
   Map<String, Map<String, AtlasStorage>> fetch();
 }

--- a/kayenta/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/service/BackendsRemoteService.java
+++ b/kayenta/kayenta-atlas/src/main/java/com/netflix/kayenta/atlas/service/BackendsRemoteService.java
@@ -18,10 +18,10 @@ package com.netflix.kayenta.atlas.service;
 
 import com.netflix.kayenta.atlas.model.Backend;
 import java.util.List;
-import retrofit.http.GET;
+import retrofit2.http.GET;
 
 public interface BackendsRemoteService {
 
-  @GET("/api/v1/atlas/backends.json")
+  @GET("api/v1/atlas/backends.json")
   List<Backend> fetch();
 }

--- a/kayenta/kayenta-atlas/src/test/java/com/netflix/kayenta/atlas/BackendsTest.java
+++ b/kayenta/kayenta-atlas/src/test/java/com/netflix/kayenta/atlas/BackendsTest.java
@@ -17,18 +17,30 @@ import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
+import org.springframework.boot.task.TaskExecutorBuilder;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ResourceLoader;
+import org.springframework.security.config.annotation.ObjectPostProcessor;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.configuration.ObjectPostProcessorConfiguration;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @Configuration
-@ComponentScan({"com.netflix.kayenta.retrofit.config"})
-class BackendsConfig {}
+@ComponentScan({"com.netflix.kayenta.retrofit.config", "com.netflix.spinnaker.config"})
+class BackendsConfig {
+  @Bean
+  public ObjectPostProcessor<Object> objectPostProcessor(AutowireCapableBeanFactory beanFactory) {
+    return new ObjectPostProcessorConfiguration().objectPostProcessor(beanFactory);
+  }
+}
 
 @ExtendWith(SpringExtension.class)
-@ContextConfiguration(classes = {BackendsConfig.class})
+@ContextConfiguration(
+    classes = {BackendsConfig.class, TaskExecutorBuilder.class, AuthenticationConfiguration.class})
 public class BackendsTest {
   @Autowired private ResourceLoader resourceLoader;
 

--- a/kayenta/kayenta-atlas/src/test/java/com/netflix/kayenta/atlas/IntegrationTest.java
+++ b/kayenta/kayenta-atlas/src/test/java/com/netflix/kayenta/atlas/IntegrationTest.java
@@ -22,15 +22,26 @@ import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
+import org.springframework.boot.task.TaskExecutorBuilder;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ResourceLoader;
+import org.springframework.security.config.annotation.ObjectPostProcessor;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.configuration.ObjectPostProcessorConfiguration;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @Configuration
-@ComponentScan({"com.netflix.kayenta.retrofit.config"})
-class TestConfig {}
+@ComponentScan({"com.netflix.kayenta.retrofit.config", "com.netflix.spinnaker.config"})
+class TestConfig {
+  @Bean
+  public ObjectPostProcessor<Object> objectPostProcessor(AutowireCapableBeanFactory beanFactory) {
+    return new ObjectPostProcessorConfiguration().objectPostProcessor(beanFactory);
+  }
+}
 
 @Builder
 @ToString
@@ -44,7 +55,8 @@ class CanaryMetricConfigWithResults {
 }
 
 @ExtendWith(SpringExtension.class)
-@ContextConfiguration(classes = {TestConfig.class})
+@ContextConfiguration(
+    classes = {TestConfig.class, TaskExecutorBuilder.class, AuthenticationConfiguration.class})
 public class IntegrationTest {
 
   @Autowired private ResourceLoader resourceLoader;

--- a/kayenta/kayenta-core/kayenta-core.gradle
+++ b/kayenta/kayenta-core/kayenta-core.gradle
@@ -16,5 +16,7 @@ dependencies {
   api "javax.validation:validation-api"
   api "io.swagger.core.v3:swagger-annotations"
 
+  implementation "com.squareup.retrofit2:converter-jackson"
+
   testImplementation "io.spinnaker.kork:kork-jedis-test"
 }

--- a/kayenta/kayenta-core/src/main/java/com/netflix/kayenta/metrics/ConversionException.java
+++ b/kayenta/kayenta-core/src/main/java/com/netflix/kayenta/metrics/ConversionException.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2025 OpsMx, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.kayenta.metrics;
+
+public class ConversionException extends RuntimeException {
+  public ConversionException(String message) {
+    super(message);
+  }
+
+  public ConversionException(String message, Throwable throwable) {
+    super(message, throwable);
+  }
+
+  public ConversionException(Throwable throwable) {
+    super(throwable);
+  }
+}

--- a/kayenta/kayenta-core/src/main/java/com/netflix/kayenta/retrofit/config/RetrofitClientFactory.java
+++ b/kayenta/kayenta-core/src/main/java/com/netflix/kayenta/retrofit/config/RetrofitClientFactory.java
@@ -17,20 +17,16 @@
 package com.netflix.kayenta.retrofit.config;
 
 import com.netflix.spinnaker.config.OkHttp3ClientConfiguration;
-import com.netflix.spinnaker.kork.annotations.VisibleForTesting;
 import com.netflix.spinnaker.kork.retrofit.ErrorHandlingExecutorCallAdapterFactory;
-import com.netflix.spinnaker.retrofit.Slf4jRetrofitLogger;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.function.Function;
 import okhttp3.Credentials;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.tomcat.util.codec.binary.Base64;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import retrofit2.Converter.Factory;
 import retrofit2.Retrofit;
@@ -38,14 +34,7 @@ import retrofit2.Retrofit;
 @Component
 public class RetrofitClientFactory {
 
-  @Value("${retrofit.log-level:BASIC}")
-  @VisibleForTesting
-  public String retrofitLogLevel;
-
   @Autowired OkHttp3ClientConfiguration okHttp3ClientConfig;
-
-  @VisibleForTesting
-  public Function<Class<?>, Slf4jRetrofitLogger> createRetrofitLogger = Slf4jRetrofitLogger::new;
 
   public <T> T createClient(Class<T> type, Factory converterFactory, RemoteService remoteService) {
     return createClient(

--- a/kayenta/kayenta-datadog/kayenta-datadog.gradle
+++ b/kayenta/kayenta-datadog/kayenta-datadog.gradle
@@ -1,5 +1,6 @@
 dependencies {
   implementation project(":kayenta-core")
+  implementation "com.squareup.retrofit2:converter-jackson"
 
   testImplementation "org.mock-server:mockserver-junit-jupiter:5.15.0"
 }

--- a/kayenta/kayenta-datadog/src/main/java/com/netflix/kayenta/datadog/config/DatadogConfiguration.java
+++ b/kayenta/kayenta-datadog/src/main/java/com/netflix/kayenta/datadog/config/DatadogConfiguration.java
@@ -27,17 +27,15 @@ import com.netflix.kayenta.retrofit.config.RetrofitClientFactory;
 import com.netflix.kayenta.security.AccountCredentials;
 import com.netflix.kayenta.security.AccountCredentialsRepository;
 import com.netflix.spinnaker.kork.annotations.VisibleForTesting;
-import java.io.IOException;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
-import okhttp3.OkHttpClient;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.util.CollectionUtils;
-import retrofit.converter.JacksonConverter;
+import retrofit2.converter.jackson.JacksonConverterFactory;
 
 @Configuration
 @ConditionalOnProperty("kayenta.datadog.enabled")
@@ -62,9 +60,7 @@ public class DatadogConfiguration {
       DatadogConfigurationProperties datadogConfigurationProperties,
       RetrofitClientFactory retrofitClientFactory,
       ObjectMapper objectMapper,
-      OkHttpClient okHttpClient,
-      AccountCredentialsRepository accountCredentialsRepository)
-      throws IOException {
+      AccountCredentialsRepository accountCredentialsRepository) {
     DatadogMetricsService.DatadogMetricsServiceBuilder metricsServiceBuilder =
         DatadogMetricsService.builder();
 
@@ -89,7 +85,7 @@ public class DatadogConfiguration {
         if (supportedTypes.contains(AccountCredentials.Type.METRICS_STORE)) {
           accountCredentialsBuilder.datadogRemoteService(
               createDatadogRemoteService(
-                  retrofitClientFactory, objectMapper, account.getEndpoint(), okHttpClient));
+                  retrofitClientFactory, objectMapper, account.getEndpoint()));
         }
         accountCredentialsBuilder.supportedTypes(supportedTypes);
       }
@@ -108,10 +104,9 @@ public class DatadogConfiguration {
   public static DatadogRemoteService createDatadogRemoteService(
       RetrofitClientFactory retrofitClientFactory,
       ObjectMapper objectMapper,
-      RemoteService endpoint,
-      OkHttpClient okHttpClient) {
+      RemoteService endpoint) {
 
     return retrofitClientFactory.createClient(
-        DatadogRemoteService.class, new JacksonConverter(objectMapper), endpoint, okHttpClient);
+        DatadogRemoteService.class, JacksonConverterFactory.create(objectMapper), endpoint);
   }
 }

--- a/kayenta/kayenta-datadog/src/main/java/com/netflix/kayenta/datadog/service/DatadogRemoteService.java
+++ b/kayenta/kayenta-datadog/src/main/java/com/netflix/kayenta/datadog/service/DatadogRemoteService.java
@@ -17,14 +17,14 @@
 package com.netflix.kayenta.datadog.service;
 
 import com.netflix.kayenta.model.DatadogMetricDescriptorsResponse;
-import retrofit.http.GET;
-import retrofit.http.Header;
-import retrofit.http.Query;
+import retrofit2.http.GET;
+import retrofit2.http.Header;
+import retrofit2.http.Query;
 
 public interface DatadogRemoteService {
 
   // See https://docs.datadoghq.com/api/?lang=python#query-time-series-points
-  @GET("/api/v1/query")
+  @GET("api/v1/query")
   DatadogTimeSeries getTimeSeries(
       @Header("DD-API-KEY") String apiKey,
       @Header("DD-APPLICATION-KEY") String applicationKey,
@@ -32,7 +32,7 @@ public interface DatadogRemoteService {
       @Query("to") int endTimestamp,
       @Query("query") String query);
 
-  @GET("/api/v1/metrics")
+  @GET("api/v1/metrics")
   DatadogMetricDescriptorsResponse getMetrics(
       @Header("DD-API-KEY") String apiKey,
       @Header("DD-APPLICATION-KEY") String applicationKey,

--- a/kayenta/kayenta-datadog/src/test/java/com/netflix/kayenta/datadog/functional/DatadogSecretsDoNotLeakWhenApiCalledFunctionalTest.java
+++ b/kayenta/kayenta-datadog/src/test/java/com/netflix/kayenta/datadog/functional/DatadogSecretsDoNotLeakWhenApiCalledFunctionalTest.java
@@ -26,17 +26,17 @@ import ch.qos.logback.core.read.ListAppender;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
-import com.netflix.kayenta.datadog.config.DatadogConfiguration;
 import com.netflix.kayenta.datadog.service.DatadogRemoteService;
 import com.netflix.kayenta.datadog.service.DatadogTimeSeries;
 import com.netflix.kayenta.model.DatadogMetricDescriptorsResponse;
 import com.netflix.kayenta.retrofit.config.RemoteService;
 import com.netflix.kayenta.retrofit.config.RetrofitClientFactory;
-import com.netflix.spinnaker.retrofit.Slf4jRetrofitLogger;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.stream.Collectors;
+import okhttp3.OkHttpClient;
+import okhttp3.logging.HttpLoggingInterceptor;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -45,6 +45,7 @@ import org.mockserver.model.HttpRequest;
 import org.mockserver.model.HttpResponse;
 import org.mockserver.netty.MockServer;
 import org.slf4j.LoggerFactory;
+import retrofit2.converter.jackson.JacksonConverterFactory;
 
 /** TDD for https://github.com/spinnaker/kayenta/issues/684 */
 public class DatadogSecretsDoNotLeakWhenApiCalledFunctionalTest {
@@ -71,18 +72,25 @@ public class DatadogSecretsDoNotLeakWhenApiCalledFunctionalTest {
     listAppender.start();
 
     RetrofitClientFactory retrofitClientFactory = new RetrofitClientFactory();
-    retrofitClientFactory.retrofitLogLevel = "BASIC";
-    retrofitClientFactory.createRetrofitLogger =
-        (type) -> {
-          return new Slf4jRetrofitLogger(mockLogger);
-        };
+
+    HttpLoggingInterceptor.Logger customLogger = mockLogger::info;
+
+    HttpLoggingInterceptor interceptor = new HttpLoggingInterceptor(customLogger);
+    interceptor.setLevel(HttpLoggingInterceptor.Level.BASIC);
+
+    OkHttpClient client = new OkHttpClient.Builder().addInterceptor(interceptor).build();
+
+    Logger retrofitLogger = (Logger) LoggerFactory.getLogger(HttpLoggingInterceptor.class);
+    retrofitLogger.addAppender(listAppender);
+    listAppender.start();
 
     objectMapper = new ObjectMapper();
     datadogRemoteService =
-        DatadogConfiguration.createDatadogRemoteService(
-            retrofitClientFactory,
-            objectMapper,
-            new RemoteService().setBaseUrl("http://localhost:" + mockServer.getPort()));
+        retrofitClientFactory.createClient(
+            DatadogRemoteService.class,
+            JacksonConverterFactory.create(objectMapper),
+            new RemoteService().setBaseUrl("http://localhost:" + mockServer.getPort()),
+            client);
   }
 
   @AfterEach

--- a/kayenta/kayenta-datadog/src/test/java/com/netflix/kayenta/datadog/functional/DatadogSecretsDoNotLeakWhenApiCalledFunctionalTest.java
+++ b/kayenta/kayenta-datadog/src/test/java/com/netflix/kayenta/datadog/functional/DatadogSecretsDoNotLeakWhenApiCalledFunctionalTest.java
@@ -37,7 +37,6 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.stream.Collectors;
-import okhttp3.OkHttpClient;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -83,8 +82,7 @@ public class DatadogSecretsDoNotLeakWhenApiCalledFunctionalTest {
         DatadogConfiguration.createDatadogRemoteService(
             retrofitClientFactory,
             objectMapper,
-            new RemoteService().setBaseUrl("http://localhost:" + mockServer.getPort()),
-            new OkHttpClient());
+            new RemoteService().setBaseUrl("http://localhost:" + mockServer.getPort()));
   }
 
   @AfterEach

--- a/kayenta/kayenta-graphite/kayenta-graphite.gradle
+++ b/kayenta/kayenta-graphite/kayenta-graphite.gradle
@@ -172,6 +172,7 @@ configurations {
 
 dependencies {
     implementation project(":kayenta-core")
+    implementation "com.squareup.retrofit2:converter-jackson"
 
     api "org.apache.commons:commons-io:1.3.2"
 

--- a/kayenta/kayenta-graphite/src/main/java/com/netflix/kayenta/graphite/config/GraphiteConfiguration.java
+++ b/kayenta/kayenta-graphite/src/main/java/com/netflix/kayenta/graphite/config/GraphiteConfiguration.java
@@ -25,17 +25,15 @@ import com.netflix.kayenta.metrics.MetricsService;
 import com.netflix.kayenta.retrofit.config.RetrofitClientFactory;
 import com.netflix.kayenta.security.AccountCredentials;
 import com.netflix.kayenta.security.AccountCredentialsRepository;
-import java.io.IOException;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
-import okhttp3.OkHttpClient;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.util.CollectionUtils;
-import retrofit.converter.JacksonConverter;
+import retrofit2.converter.jackson.JacksonConverterFactory;
 
 @Configuration
 @ConditionalOnProperty("kayenta.graphite.enabled")
@@ -60,9 +58,7 @@ public class GraphiteConfiguration {
       GraphiteConfigurationProperties graphiteConfigurationProperties,
       RetrofitClientFactory retrofitClientFactory,
       ObjectMapper objectMapper,
-      OkHttpClient okHttpClient,
-      AccountCredentialsRepository accountCredentialsRepository)
-      throws IOException {
+      AccountCredentialsRepository accountCredentialsRepository) {
     GraphiteMetricsService.GraphiteMetricsServiceBuilder graphiteMetricsServiceBuilder =
         GraphiteMetricsService.builder();
 
@@ -83,9 +79,8 @@ public class GraphiteConfiguration {
           accountCredentialsBuilder.graphiteRemoteService(
               retrofitClientFactory.createClient(
                   GraphiteRemoteService.class,
-                  new JacksonConverter(objectMapper),
-                  account.getEndpoint(),
-                  okHttpClient));
+                  JacksonConverterFactory.create(objectMapper),
+                  account.getEndpoint()));
         }
 
         accountCredentialsBuilder.supportedTypes(supportedTypes);

--- a/kayenta/kayenta-graphite/src/main/java/com/netflix/kayenta/graphite/service/GraphiteRemoteService.java
+++ b/kayenta/kayenta-graphite/src/main/java/com/netflix/kayenta/graphite/service/GraphiteRemoteService.java
@@ -19,20 +19,20 @@ package com.netflix.kayenta.graphite.service;
 import com.netflix.kayenta.graphite.model.GraphiteMetricDescriptorsResponse;
 import com.netflix.kayenta.graphite.model.GraphiteResults;
 import java.util.List;
-import retrofit.http.GET;
-import retrofit.http.Query;
+import retrofit2.http.GET;
+import retrofit2.http.Query;
 
 public interface GraphiteRemoteService {
 
   // From https://graphite.readthedocs.io/en/1.1.2/render_api.html#
-  @GET("/render")
+  @GET("render")
   List<GraphiteResults> rangeQuery(
-      @Query(value = "target", encodeValue = true) String target,
+      @Query(value = "target") String target,
       @Query("from") long from,
       @Query("until") long until,
       @Query("format") String format);
 
-  @GET("/metrics/find")
+  @GET("metrics/find")
   GraphiteMetricDescriptorsResponse findMetrics(
       @Query("query") String query, @Query("format") String format);
 }

--- a/kayenta/kayenta-graphite/src/test/java/com/netflix/kayenta/graphite/IntegrationTest.java
+++ b/kayenta/kayenta-graphite/src/test/java/com/netflix/kayenta/graphite/IntegrationTest.java
@@ -46,15 +46,26 @@ import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
+import org.springframework.boot.task.TaskExecutorBuilder;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ResourceLoader;
+import org.springframework.security.config.annotation.ObjectPostProcessor;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.configuration.ObjectPostProcessorConfiguration;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @Configuration
-@ComponentScan({"com.netflix.kayenta.retrofit.config"})
-class TestConfig {}
+@ComponentScan({"com.netflix.kayenta.retrofit.config", "com.netflix.spinnaker.config"})
+class TestConfig {
+  @Bean
+  public ObjectPostProcessor<Object> objectPostProcessor(AutowireCapableBeanFactory beanFactory) {
+    return new ObjectPostProcessorConfiguration().objectPostProcessor(beanFactory);
+  }
+}
 
 @Builder
 @ToString
@@ -68,7 +79,8 @@ class CanaryMetricConfigWithResults {
 }
 
 @ExtendWith(SpringExtension.class)
-@ContextConfiguration(classes = {TestConfig.class})
+@ContextConfiguration(
+    classes = {TestConfig.class, TaskExecutorBuilder.class, AuthenticationConfiguration.class})
 public class IntegrationTest {
 
   @Autowired private ResourceLoader resourceLoader;

--- a/kayenta/kayenta-influxdb/kayenta-influxdb.gradle
+++ b/kayenta/kayenta-influxdb/kayenta-influxdb.gradle
@@ -1,3 +1,4 @@
 dependencies {
   implementation project(":kayenta-core")
+  testImplementation "com.squareup.retrofit2:converter-jackson"
 }

--- a/kayenta/kayenta-influxdb/src/main/java/com/netflix/kayenta/influxdb/config/InfluxDbConfiguration.java
+++ b/kayenta/kayenta-influxdb/src/main/java/com/netflix/kayenta/influxdb/config/InfluxDbConfiguration.java
@@ -16,7 +16,6 @@
 
 package com.netflix.kayenta.influxdb.config;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.kayenta.influxdb.metrics.InfluxDbMetricsService;
 import com.netflix.kayenta.influxdb.security.InfluxDbNamedAccountCredentials;
 import com.netflix.kayenta.influxdb.security.InfluxdbCredentials;
@@ -28,7 +27,6 @@ import com.netflix.kayenta.security.AccountCredentialsRepository;
 import java.io.IOException;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
-import okhttp3.OkHttpClient;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -59,8 +57,6 @@ public class InfluxDbConfiguration {
       InfluxDbResponseConverter influxDbResponseConverter,
       InfluxDbConfigurationProperties influxDbConfigurationProperties,
       RetrofitClientFactory retrofitClientFactory,
-      ObjectMapper objectMapper,
-      OkHttpClient okHttpClient,
       AccountCredentialsRepository accountCredentialsRepository)
       throws IOException {
     InfluxDbMetricsService.InfluxDbMetricsServiceBuilder metricsServiceBuilder =
@@ -83,10 +79,7 @@ public class InfluxDbConfiguration {
         if (supportedTypes.contains(AccountCredentials.Type.METRICS_STORE)) {
           accountCredentialsBuilder.influxDbRemoteService(
               retrofitClientFactory.createClient(
-                  InfluxDbRemoteService.class,
-                  influxDbResponseConverter,
-                  account.getEndpoint(),
-                  okHttpClient));
+                  InfluxDbRemoteService.class, influxDbResponseConverter, account.getEndpoint()));
         }
         accountCredentialsBuilder.supportedTypes(supportedTypes);
       }

--- a/kayenta/kayenta-influxdb/src/main/java/com/netflix/kayenta/influxdb/config/InfluxDbResponseConverter.java
+++ b/kayenta/kayenta-influxdb/src/main/java/com/netflix/kayenta/influxdb/config/InfluxDbResponseConverter.java
@@ -16,31 +16,28 @@
 
 package com.netflix.kayenta.influxdb.config;
 
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.kayenta.influxdb.model.InfluxDbResult;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
+import okhttp3.ResponseBody;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.util.CollectionUtils;
-import retrofit.converter.ConversionException;
-import retrofit.converter.Converter;
-import retrofit.mime.TypedInput;
-import retrofit.mime.TypedOutput;
+import retrofit2.Converter;
+import retrofit2.Retrofit;
 
 @Component
 @Slf4j
-public class InfluxDbResponseConverter implements Converter {
-
+public class InfluxDbResponseConverter extends Converter.Factory {
   private static final int DEFAULT_STEP_SIZE = 0;
   private final ObjectMapper kayentaObjectMapper;
 
@@ -50,80 +47,103 @@ public class InfluxDbResponseConverter implements Converter {
   }
 
   @Override
-  public Object fromBody(TypedInput body, Type type) throws ConversionException {
+  public Converter<ResponseBody, ?> responseBodyConverter(
+      Type type, Annotation[] annotations, Retrofit retrofit) {
+    if (isListOfInfluxDbResults(type)) {
+      return new InfluxDbResultsConverter(kayentaObjectMapper);
+    }
+    return null;
+  }
 
-    try (BufferedReader reader = new BufferedReader(new InputStreamReader(body.in()))) {
-      String json = reader.readLine();
-      log.debug("Converting response from influxDb: {}", json);
+  private boolean isListOfInfluxDbResults(Type type) {
+    if (!(type instanceof java.lang.reflect.ParameterizedType)) {
+      return false;
+    }
+    java.lang.reflect.ParameterizedType parameterizedType =
+        (java.lang.reflect.ParameterizedType) type;
+    if (parameterizedType.getRawType() != List.class) {
+      return false;
+    }
+    Type[] typeArguments = parameterizedType.getActualTypeArguments();
+    return typeArguments.length > 0 && typeArguments[0] == InfluxDbResult.class;
+  }
 
-      Map result = getResultObject(json);
-      List<Map> seriesList = (List<Map>) result.get("series");
+  // Converter to handle InfluxDB results
+  private static class InfluxDbResultsConverter
+      implements Converter<ResponseBody, List<InfluxDbResult>> {
+    private final ObjectMapper objectMapper;
 
-      if (CollectionUtils.isEmpty(seriesList)) {
-        log.warn("Received no data from Influxdb.");
-        return null;
-      }
+    public InfluxDbResultsConverter(ObjectMapper objectMapper) {
+      this.objectMapper = objectMapper;
+    }
 
-      Map series = seriesList.get(0);
-      List<String> seriesColumns = (List<String>) series.get("columns");
-      List<List> seriesValues = (List<List>) series.get("values");
-      List<InfluxDbResult> influxDbResultsList = new ArrayList<InfluxDbResult>(seriesValues.size());
+    @Override
+    public List<InfluxDbResult> convert(ResponseBody value) throws IOException {
+      try (BufferedReader reader = new BufferedReader(new InputStreamReader(value.byteStream()))) {
+        String json = reader.readLine();
+        log.debug("Converting response from influxDb: {}", json);
 
-      // TODO(joerajeev): if returning tags (other than the field names) we will need to skip tags
-      // from this loop,
-      // and to extract and set the tag values to the influxDb result.
-      for (int i = 1;
-          i < seriesColumns.size();
-          i++) { // Starting from index 1 to skip 'time' column
+        Map result = getResultObject(json);
+        List<Map> seriesList = (List<Map>) result.get("series");
 
-        String id = seriesColumns.get(i);
-        long firstTimeMillis = extractTimeInMillis(seriesValues, 0);
-        long stepMillis = calculateStep(seriesValues, firstTimeMillis);
-        List<Double> values = new ArrayList<>(seriesValues.size());
-        for (List<Object> valueRow : seriesValues) {
-          if (valueRow.get(i) != null) {
-            String val = valueRow.get(i).toString();
-            values.add(Double.valueOf(val));
-          }
+        if (CollectionUtils.isEmpty(seriesList)) {
+          log.warn("Received no data from InfluxDB.");
+          return null;
         }
-        influxDbResultsList.add(new InfluxDbResult(id, firstTimeMillis, stepMillis, null, values));
+
+        Map series = seriesList.get(0);
+        List<String> seriesColumns = (List<String>) series.get("columns");
+        List<List> seriesValues = (List<List>) series.get("values");
+        List<InfluxDbResult> influxDbResultsList = new ArrayList<>(seriesValues.size());
+
+        // TODO(joerajeev): if returning tags (other than the field names) we will need to skip tags
+        // from this loop,
+        // and to extract and set the tag values to the influxDb result.
+        for (int i = 1;
+            i < seriesColumns.size();
+            i++) { // Starting from index 1 to skip 'time' column
+          String id = seriesColumns.get(i);
+          long firstTimeMillis = extractTimeInMillis(seriesValues, 0);
+          long stepMillis = calculateStep(seriesValues, firstTimeMillis);
+          List<Double> values = new ArrayList<>(seriesValues.size());
+
+          for (List<Object> valueRow : seriesValues) {
+            if (valueRow.get(i) != null) {
+              String val = valueRow.get(i).toString();
+              values.add(Double.valueOf(val));
+            }
+          }
+
+          influxDbResultsList.add(
+              new InfluxDbResult(id, firstTimeMillis, stepMillis, null, values));
+        }
+
+        log.debug("Converted response: {}", influxDbResultsList);
+        return influxDbResultsList;
+      } catch (IOException e) {
+        e.printStackTrace();
+        throw e;
       }
-
-      log.debug("Converted response: {} ", influxDbResultsList);
-      return influxDbResultsList;
-    } catch (IOException e) {
-      e.printStackTrace();
     }
 
-    return null;
-  }
-
-  private Map getResultObject(String json)
-      throws IOException, JsonParseException, JsonMappingException, ConversionException {
-    Map responseMap = kayentaObjectMapper.readValue(json, Map.class);
-    List<Map> results = (List<Map>) responseMap.get("results");
-    if (CollectionUtils.isEmpty(results)) {
-      throw new ConversionException("Unexpected response from influxDb");
+    private Map getResultObject(String json) throws IOException {
+      Map responseMap = objectMapper.readValue(json, Map.class);
+      List<Map> results = (List<Map>) responseMap.get("results");
+      if (CollectionUtils.isEmpty(results)) {
+        throw new IOException("Unexpected response from InfluxDB");
+      }
+      return results.get(0);
     }
-    Map result = (Map) results.get(0);
-    return result;
-  }
 
-  private long calculateStep(List<List> seriesValues, long firstTimeMillis) {
-    long nextTimeMillis = extractTimeInMillis(seriesValues, 1);
-    long stepMillis =
-        seriesValues.size() > 1 ? nextTimeMillis - firstTimeMillis : DEFAULT_STEP_SIZE;
-    return stepMillis;
-  }
+    private long calculateStep(List<List> seriesValues, long firstTimeMillis) {
+      return seriesValues.size() > 1
+          ? extractTimeInMillis(seriesValues, 1) - firstTimeMillis
+          : DEFAULT_STEP_SIZE;
+    }
 
-  private long extractTimeInMillis(List<List> seriesValues, int index) {
-    String firstUtcTime = (String) seriesValues.get(index).get(0);
-    long startTimeMillis = Instant.parse(firstUtcTime).toEpochMilli();
-    return startTimeMillis;
-  }
-
-  @Override
-  public TypedOutput toBody(Object object) {
-    return null;
+    private long extractTimeInMillis(List<List> seriesValues, int index) {
+      String utcTime = (String) seriesValues.get(index).get(0);
+      return Instant.parse(utcTime).toEpochMilli();
+    }
   }
 }

--- a/kayenta/kayenta-influxdb/src/main/java/com/netflix/kayenta/influxdb/config/InfluxDbResponseConverter.java
+++ b/kayenta/kayenta-influxdb/src/main/java/com/netflix/kayenta/influxdb/config/InfluxDbResponseConverter.java
@@ -18,6 +18,7 @@ package com.netflix.kayenta.influxdb.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.kayenta.influxdb.model.InfluxDbResult;
+import com.netflix.kayenta.metrics.ConversionException;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -78,7 +79,7 @@ public class InfluxDbResponseConverter extends Converter.Factory {
     }
 
     @Override
-    public List<InfluxDbResult> convert(ResponseBody value) throws IOException {
+    public List<InfluxDbResult> convert(ResponseBody value) {
       try (BufferedReader reader = new BufferedReader(new InputStreamReader(value.byteStream()))) {
         String json = reader.readLine();
         log.debug("Converting response from influxDb: {}", json);
@@ -122,15 +123,15 @@ public class InfluxDbResponseConverter extends Converter.Factory {
         return influxDbResultsList;
       } catch (IOException e) {
         e.printStackTrace();
-        throw e;
       }
+      return null;
     }
 
     private Map getResultObject(String json) throws IOException {
       Map responseMap = objectMapper.readValue(json, Map.class);
       List<Map> results = (List<Map>) responseMap.get("results");
       if (CollectionUtils.isEmpty(results)) {
-        throw new IOException("Unexpected response from InfluxDB");
+        throw new ConversionException("Unexpected response from InfluxDB");
       }
       return results.get(0);
     }

--- a/kayenta/kayenta-influxdb/src/main/java/com/netflix/kayenta/influxdb/service/InfluxDbRemoteService.java
+++ b/kayenta/kayenta-influxdb/src/main/java/com/netflix/kayenta/influxdb/service/InfluxDbRemoteService.java
@@ -18,13 +18,13 @@ package com.netflix.kayenta.influxdb.service;
 
 import com.netflix.kayenta.influxdb.model.InfluxDbResult;
 import java.util.List;
-import retrofit.http.GET;
-import retrofit.http.Query;
+import retrofit2.http.GET;
+import retrofit2.http.Query;
 
 public interface InfluxDbRemoteService {
 
   // See
   // https://docs.influxdata.com/influxdb/v1.5/guides/querying_data/#querying-data-with-the-http-api
-  @GET("/query")
+  @GET("query")
   List<InfluxDbResult> query(@Query("db") String databaseName, @Query("q") String query);
 }

--- a/kayenta/kayenta-influxdb/src/test/java/com/netflix/kayenta/influxdb/config/InfluxDbResponseConverterTest.java
+++ b/kayenta/kayenta-influxdb/src/test/java/com/netflix/kayenta/influxdb/config/InfluxDbResponseConverterTest.java
@@ -21,14 +21,17 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.kayenta.influxdb.model.InfluxDbResult;
-import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
+import okhttp3.ResponseBody;
 import org.junit.jupiter.api.Test;
-import retrofit.converter.ConversionException;
-import retrofit.mime.TypedByteArray;
-import retrofit.mime.TypedInput;
-import retrofit.mime.TypedOutput;
+import retrofit2.Converter;
+import retrofit2.Retrofit;
+import retrofit2.converter.jackson.JacksonConverterFactory;
 
 public class InfluxDbResponseConverterTest {
 
@@ -79,43 +82,80 @@ public class InfluxDbResponseConverterTest {
     return results;
   }
 
+  Retrofit retrofit =
+      new Retrofit.Builder()
+          .baseUrl("http://influxdb")
+          .addConverterFactory(JacksonConverterFactory.create())
+          .build();
+
   private final InfluxDbResponseConverter influxDbResponseConverter =
       new InfluxDbResponseConverter(new ObjectMapper());
 
+  Converter<ResponseBody, List<InfluxDbResult>> converter =
+      (Converter<ResponseBody, List<InfluxDbResult>>)
+          influxDbResponseConverter.responseBodyConverter(
+              new ParameterizedTypeImpl(List.class, InfluxDbResult.class),
+              new Annotation[0],
+              retrofit);
+
   @Test
-  public void serialize() throws Exception {
-    List<InfluxDbResult> results = setupAllIntegers();
-    assertThat(influxDbResponseConverter.toBody(results)).isNull();
+  public void serialize_shouldNotSupportRequestConversion() {
+    // The converter doesn't support request body conversion
+    assertThat(
+            influxDbResponseConverter.requestBodyConverter(
+                List.class, new Annotation[0], new Annotation[0], retrofit))
+        .isNull();
   }
 
   @Test
   public void deserialize() throws Exception {
-    List<InfluxDbResult> results = setupAllIntegers();
-    TypedInput input = new TypedByteArray(MIME_TYPE, EXAMPLE_ALL_INTEGERS.getBytes());
-    List<InfluxDbResult> result =
-        (List<InfluxDbResult>) influxDbResponseConverter.fromBody(input, List.class);
-    assertThat(result).isEqualTo(results);
+    List<InfluxDbResult> expectedResults = setupAllIntegers();
+    ResponseBody responseBody =
+        ResponseBody.create(okhttp3.MediaType.parse(MIME_TYPE), EXAMPLE_ALL_INTEGERS.getBytes());
+    List<InfluxDbResult> result = converter.convert(responseBody);
+
+    assertThat(result).isEqualTo(expectedResults);
   }
 
   @Test
   public void deserializeWithFloatValues() throws Exception {
-    List<InfluxDbResult> results = setupWithFloats();
-    TypedInput input = new TypedByteArray(MIME_TYPE, EXAMPLE_WITH_FLOATS.getBytes());
-    List<InfluxDbResult> result =
-        (List<InfluxDbResult>) influxDbResponseConverter.fromBody(input, List.class);
-    assertThat(result).isEqualTo(results);
+    List<InfluxDbResult> expectedResults = setupWithFloats();
+    ResponseBody responseBody =
+        ResponseBody.create(okhttp3.MediaType.parse(MIME_TYPE), EXAMPLE_WITH_FLOATS.getBytes());
+    List<InfluxDbResult> result = converter.convert(responseBody);
+
+    assertThat(result).isEqualTo(expectedResults);
   }
 
   @Test
-  public void deserializeWrongValue() throws Exception {
-    TypedInput input = new TypedByteArray(MIME_TYPE, "{\"foo\":\"bar\"}".getBytes());
-    assertThrows(
-        ConversionException.class, () -> influxDbResponseConverter.fromBody(input, List.class));
+  public void deserializeWrongValue() {
+    ResponseBody responseBody =
+        ResponseBody.create(okhttp3.MediaType.parse(MIME_TYPE), "{\"foo\":\"bar\"}".getBytes());
+    assertThrows(IOException.class, () -> converter.convert(responseBody));
   }
 
-  private String asString(TypedOutput typedOutput) throws Exception {
-    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
-    typedOutput.writeTo(bytes);
-    return new String(bytes.toByteArray());
+  private static class ParameterizedTypeImpl implements ParameterizedType {
+    private final Type rawType;
+    private final Type[] typeArguments;
+
+    public ParameterizedTypeImpl(Type rawType, Type... typeArguments) {
+      this.rawType = rawType;
+      this.typeArguments = typeArguments;
+    }
+
+    @Override
+    public Type[] getActualTypeArguments() {
+      return typeArguments;
+    }
+
+    @Override
+    public Type getRawType() {
+      return rawType;
+    }
+
+    @Override
+    public Type getOwnerType() {
+      return null;
+    }
   }
 }

--- a/kayenta/kayenta-influxdb/src/test/java/com/netflix/kayenta/influxdb/config/InfluxDbResponseConverterTest.java
+++ b/kayenta/kayenta-influxdb/src/test/java/com/netflix/kayenta/influxdb/config/InfluxDbResponseConverterTest.java
@@ -21,7 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.kayenta.influxdb.model.InfluxDbResult;
-import java.io.IOException;
+import com.netflix.kayenta.metrics.ConversionException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
@@ -131,7 +131,7 @@ public class InfluxDbResponseConverterTest {
   public void deserializeWrongValue() {
     ResponseBody responseBody =
         ResponseBody.create(okhttp3.MediaType.parse(MIME_TYPE), "{\"foo\":\"bar\"}".getBytes());
-    assertThrows(IOException.class, () -> converter.convert(responseBody));
+    assertThrows(ConversionException.class, () -> converter.convert(responseBody));
   }
 
   private static class ParameterizedTypeImpl implements ParameterizedType {

--- a/kayenta/kayenta-judge/kayenta-judge.gradle
+++ b/kayenta/kayenta-judge/kayenta-judge.gradle
@@ -4,6 +4,7 @@ apply plugin: 'scala'
 dependencies {
   implementation project(':kayenta-core')
   implementation project(':kayenta-mannwhitney')
+  implementation "com.squareup.retrofit2:converter-jackson"
 
   api "org.apache.commons:commons-math3"
 

--- a/kayenta/kayenta-judge/src/main/scala/com/netflix/kayenta/judge/RemoteJudge.java
+++ b/kayenta/kayenta-judge/src/main/scala/com/netflix/kayenta/judge/RemoteJudge.java
@@ -27,13 +27,14 @@ import com.netflix.kayenta.judge.service.RemoteJudgeService;
 import com.netflix.kayenta.metrics.MetricSetPair;
 import com.netflix.kayenta.retrofit.config.RemoteService;
 import com.netflix.kayenta.retrofit.config.RetrofitClientFactory;
+import com.netflix.spinnaker.config.OkHttp3ClientConfiguration;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.OkHttpClient;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
-import retrofit.converter.JacksonConverter;
+import retrofit2.converter.jackson.JacksonConverterFactory;
 
 @Component
 @ConditionalOnProperty("kayenta.remote-judge.enabled")
@@ -43,16 +44,19 @@ public class RemoteJudge extends CanaryJudge {
   private final RetrofitClientFactory retrofitClientFactory;
   private final ObjectMapper kayentaObjectMapper;
   private final RemoteService endpoint;
+  private final OkHttp3ClientConfiguration okHttp3ClientConfig;
 
   private final String JUDGE_NAME = "RemoteJudge-v1.0";
 
   public RemoteJudge(
       RetrofitClientFactory retrofitClientFactory,
       ObjectMapper kayentaObjectMapper,
-      RemoteJudgeConfigurationProperties config) {
+      RemoteJudgeConfigurationProperties config,
+      OkHttp3ClientConfiguration okHttp3ClientConfig) {
     this.retrofitClientFactory = retrofitClientFactory;
     this.kayentaObjectMapper = kayentaObjectMapper;
     this.endpoint = config.getEndpoint();
+    this.okHttp3ClientConfig = okHttp3ClientConfig;
 
     log.info("Configured " + JUDGE_NAME + " with base URI " + endpoint.getBaseUrl());
   }
@@ -74,7 +78,8 @@ public class RemoteJudge extends CanaryJudge {
       List<MetricSetPair> metricSetPairList) {
 
     OkHttpClient okHttpClient =
-        new OkHttpClient.Builder()
+        okHttp3ClientConfig
+            .createForRetrofit2()
             .connectTimeout(30, TimeUnit.SECONDS)
             .readTimeout(90, TimeUnit.SECONDS)
             .build();
@@ -82,7 +87,7 @@ public class RemoteJudge extends CanaryJudge {
     RemoteJudgeService remoteJudge =
         retrofitClientFactory.createClient(
             RemoteJudgeService.class,
-            new JacksonConverter(kayentaObjectMapper),
+            JacksonConverterFactory.create(kayentaObjectMapper),
             endpoint,
             okHttpClient);
 

--- a/kayenta/kayenta-judge/src/main/scala/com/netflix/kayenta/judge/service/RemoteJudgeService.java
+++ b/kayenta/kayenta-judge/src/main/scala/com/netflix/kayenta/judge/service/RemoteJudgeService.java
@@ -18,11 +18,11 @@ package com.netflix.kayenta.judge.service;
 
 import com.netflix.kayenta.canary.results.CanaryJudgeResult;
 import com.netflix.kayenta.judge.model.RemoteJudgeRequest;
-import retrofit.http.Body;
-import retrofit.http.POST;
+import retrofit2.http.Body;
+import retrofit2.http.POST;
 
 public interface RemoteJudgeService {
 
-  @POST("/judge")
+  @POST("judge")
   CanaryJudgeResult judge(@Body RemoteJudgeRequest body);
 }

--- a/kayenta/kayenta-newrelic-insights/kayenta-newrelic-insights.gradle
+++ b/kayenta/kayenta-newrelic-insights/kayenta-newrelic-insights.gradle
@@ -1,3 +1,4 @@
 dependencies {
   implementation project(":kayenta-core")
+  implementation "com.squareup.retrofit2:converter-jackson"
 }

--- a/kayenta/kayenta-newrelic-insights/src/main/java/com/netflix/kayenta/newrelic/config/NewRelicConfiguration.java
+++ b/kayenta/kayenta-newrelic-insights/src/main/java/com/netflix/kayenta/newrelic/config/NewRelicConfiguration.java
@@ -30,14 +30,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
-import okhttp3.OkHttpClient;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.util.CollectionUtils;
-import retrofit.converter.JacksonConverter;
+import retrofit2.converter.jackson.JacksonConverterFactory;
 
 @Configuration
 @ConditionalOnProperty("kayenta.newrelic.enabled")
@@ -87,7 +86,6 @@ public class NewRelicConfiguration {
       NewRelicConfigurationProperties newrelicConfigurationProperties,
       RetrofitClientFactory retrofitClientFactory,
       ObjectMapper objectMapper,
-      OkHttpClient okHttpClient,
       AccountCredentialsRepository accountCredentialsRepository) {
 
     NewRelicMetricsService.NewRelicMetricsServiceBuilder metricsServiceBuilder =
@@ -121,9 +119,8 @@ public class NewRelicConfiguration {
           accountCredentialsBuilder.newRelicRemoteService(
               retrofitClientFactory.createClient(
                   NewRelicRemoteService.class,
-                  new JacksonConverter(objectMapper),
-                  endpoint,
-                  okHttpClient));
+                  JacksonConverterFactory.create(objectMapper),
+                  endpoint));
         }
         accountCredentialsBuilder.supportedTypes(supportedTypes);
       }

--- a/kayenta/kayenta-newrelic-insights/src/main/java/com/netflix/kayenta/newrelic/service/NewRelicRemoteService.java
+++ b/kayenta/kayenta-newrelic-insights/src/main/java/com/netflix/kayenta/newrelic/service/NewRelicRemoteService.java
@@ -16,16 +16,16 @@
 
 package com.netflix.kayenta.newrelic.service;
 
-import retrofit.http.GET;
-import retrofit.http.Header;
-import retrofit.http.Headers;
-import retrofit.http.Path;
-import retrofit.http.Query;
+import retrofit2.http.GET;
+import retrofit2.http.Header;
+import retrofit2.http.Headers;
+import retrofit2.http.Path;
+import retrofit2.http.Query;
 
 public interface NewRelicRemoteService {
 
   @Headers("Accept: application/json")
-  @GET("/v1/accounts/{application_key}/query")
+  @GET("v1/accounts/{application_key}/query")
   NewRelicTimeSeries getTimeSeries(
       @Header("X-Query-Key") String apiKey,
       @Path("application_key") String applicationKey,

--- a/kayenta/kayenta-objectstore-configbin/src/main/java/com/netflix/kayenta/configbin/config/ConfigBinConfiguration.java
+++ b/kayenta/kayenta-objectstore-configbin/src/main/java/com/netflix/kayenta/configbin/config/ConfigBinConfiguration.java
@@ -26,7 +26,6 @@ import com.netflix.kayenta.security.AccountCredentials;
 import com.netflix.kayenta.security.AccountCredentialsRepository;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
-import okhttp3.OkHttpClient;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -51,7 +50,6 @@ public class ConfigBinConfiguration {
       ConfigBinResponseConverter configBinConverter,
       ConfigBinConfigurationProperties configBinConfigurationProperties,
       RetrofitClientFactory retrofitClientFactory,
-      OkHttpClient okHttpClient,
       AccountCredentialsRepository accountCredentialsRepository) {
     log.debug("Created a ConfigBin StorageService");
     ConfigBinStorageService.ConfigBinStorageServiceBuilder configbinStorageServiceBuilder =
@@ -84,8 +82,7 @@ public class ConfigBinConfiguration {
               retrofitClientFactory.createClient(
                   ConfigBinRemoteService.class,
                   configBinConverter,
-                  configBinManagedAccount.getEndpoint(),
-                  okHttpClient);
+                  configBinManagedAccount.getEndpoint());
           configBinNamedAccountCredentialsBuilder.remoteService(configBinRemoteService);
         }
         configBinNamedAccountCredentialsBuilder.supportedTypes(supportedTypes);

--- a/kayenta/kayenta-objectstore-configbin/src/main/java/com/netflix/kayenta/configbin/config/ConfigBinResponseConverter.java
+++ b/kayenta/kayenta-objectstore-configbin/src/main/java/com/netflix/kayenta/configbin/config/ConfigBinResponseConverter.java
@@ -56,7 +56,7 @@ public class ConfigBinResponseConverter extends Converter.Factory {
 
   private static class StringResponseConverter implements Converter<ResponseBody, String> {
     @Override
-    public String convert(ResponseBody value) throws IOException {
+    public String convert(ResponseBody value) {
       try (ByteArrayOutputStream buffer = new ByteArrayOutputStream();
           ResponseBody body = value) {
         byte[] data = new byte[1024];

--- a/kayenta/kayenta-objectstore-configbin/src/main/java/com/netflix/kayenta/configbin/service/ConfigBinRemoteService.java
+++ b/kayenta/kayenta-objectstore-configbin/src/main/java/com/netflix/kayenta/configbin/service/ConfigBinRemoteService.java
@@ -17,31 +17,36 @@
 package com.netflix.kayenta.configbin.service;
 
 import okhttp3.RequestBody;
-import retrofit.client.Response;
-import retrofit.http.*;
+import okhttp3.ResponseBody;
+import retrofit2.http.Body;
+import retrofit2.http.DELETE;
+import retrofit2.http.GET;
+import retrofit2.http.POST;
+import retrofit2.http.Path;
+import retrofit2.http.Query;
 
 public interface ConfigBinRemoteService {
 
-  @GET("/browse/{ownerApp}/{configType}?pageSize=1000&showDeleted=false")
+  @GET("browse/{ownerApp}/{configType}?pageSize=1000&showDeleted=false")
   String list(
       @Path("ownerApp") String ownerApp,
       @Path("configType") String configType,
       @Query("nextPageId") String nextPageId);
 
-  @DELETE("/{ownerApp}/{configType}/{configName}?user=kayenta&comment=spinnaker")
-  Response delete(
+  @DELETE("{ownerApp}/{configType}/{configName}?user=kayenta&comment=spinnaker")
+  ResponseBody delete(
       @Path("ownerApp") String ownerApp,
       @Path("configType") String configType,
       @Path("configName") String configName);
 
-  @GET("/{ownerApp}/{configType}/{configName}")
+  @GET("{ownerApp}/{configType}/{configName}")
   String get(
       @Path("ownerApp") String ownerApp,
       @Path("configType") String configType,
       @Path("configName") String configName);
 
-  @POST("/{ownerApp}/{configType}/{configName}?overwrite=true&user=kayenta&comment=spinnaker")
-  Response post(
+  @POST("{ownerApp}/{configType}/{configName}?overwrite=true&user=kayenta&comment=spinnaker")
+  ResponseBody post(
       @Path("ownerApp") String ownerApp,
       @Path("configType") String configType,
       @Path("configName") String configName,

--- a/kayenta/kayenta-prometheus/kayenta-prometheus.gradle
+++ b/kayenta/kayenta-prometheus/kayenta-prometheus.gradle
@@ -2,4 +2,5 @@ dependencies {
   implementation project(":kayenta-core")
 
   testImplementation "org.mock-server:mockserver-junit-jupiter:5.15.0"
+  testImplementation "com.squareup.retrofit2:converter-jackson"
 }

--- a/kayenta/kayenta-prometheus/src/main/java/com/netflix/kayenta/prometheus/config/PrometheusConfiguration.java
+++ b/kayenta/kayenta-prometheus/src/main/java/com/netflix/kayenta/prometheus/config/PrometheusConfiguration.java
@@ -29,7 +29,6 @@ import com.netflix.kayenta.security.AccountCredentialsRepository;
 import java.io.IOException;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
-import okhttp3.OkHttpClient;
 import org.springframework.boot.actuate.health.HealthIndicator;
 import org.springframework.boot.autoconfigure.condition.AllNestedConditions;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -71,7 +70,6 @@ public class PrometheusConfiguration {
       PrometheusResponseConverter prometheusConverter,
       PrometheusConfigurationProperties prometheusConfigurationProperties,
       RetrofitClientFactory retrofitClientFactory,
-      OkHttpClient okHttpClient,
       AccountCredentialsRepository accountCredentialsRepository) {
     PrometheusMetricsService.PrometheusMetricsServiceBuilder prometheusMetricsServiceBuilder =
         PrometheusMetricsService.builder();
@@ -92,7 +90,6 @@ public class PrometheusConfiguration {
                     PrometheusRemoteService.class,
                     prometheusConverter,
                     prometheusManagedAccount.getEndpoint(),
-                    okHttpClient,
                     prometheusManagedAccount.getUsername(),
                     prometheusManagedAccount.getPassword(),
                     prometheusManagedAccount.getUsernamePasswordFile(),

--- a/kayenta/kayenta-prometheus/src/main/java/com/netflix/kayenta/prometheus/config/PrometheusResponseConverter.java
+++ b/kayenta/kayenta-prometheus/src/main/java/com/netflix/kayenta/prometheus/config/PrometheusResponseConverter.java
@@ -1,6 +1,23 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.kayenta.prometheus.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.kayenta.metrics.ConversionException;
 import com.netflix.kayenta.prometheus.model.PrometheusMetricDescriptorsResponse;
 import com.netflix.kayenta.prometheus.model.PrometheusResults;
 import java.io.IOException;
@@ -49,7 +66,7 @@ public class PrometheusResponseConverter extends Factory {
     }
 
     @Override
-    public List<PrometheusResults> convert(ResponseBody value) throws IOException {
+    public List<PrometheusResults> convert(ResponseBody value) {
       try {
         Map responseMap = objectMapper.readValue(value.byteStream(), Map.class);
         Map data = (Map) responseMap.get("data");
@@ -87,6 +104,7 @@ public class PrometheusResponseConverter extends Factory {
 
           long startTimeMillis =
               doubleTimestampSecsToLongTimestampMillis(values.get(0).get(0) + "");
+          // If there aren't at least two data points, consider the step size to be zero.
           long stepSecs =
               values.size() > 1
                   ? TimeUnit.MILLISECONDS.toSeconds(
@@ -101,8 +119,8 @@ public class PrometheusResponseConverter extends Factory {
         }
 
         return prometheusResultsList;
-      } catch (Exception e) {
-        throw new IOException("Failed to parse response from Prometheus", e);
+      } catch (IOException e) {
+        throw new ConversionException("Failed to parse response from Prometheus", e);
       }
     }
   }

--- a/kayenta/kayenta-prometheus/src/main/java/com/netflix/kayenta/prometheus/config/PrometheusResponseConverter.java
+++ b/kayenta/kayenta-prometheus/src/main/java/com/netflix/kayenta/prometheus/config/PrometheusResponseConverter.java
@@ -1,48 +1,27 @@
-/*
- * Copyright 2017 Google, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License")
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.netflix.kayenta.prometheus.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.kayenta.prometheus.model.PrometheusMetricDescriptorsResponse;
 import com.netflix.kayenta.prometheus.model.PrometheusResults;
 import java.io.IOException;
-import java.io.InputStream;
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Scanner;
 import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
+import okhttp3.ResponseBody;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.util.CollectionUtils;
-import retrofit.converter.ConversionException;
-import retrofit.converter.Converter;
-import retrofit.converter.JacksonConverter;
-import retrofit.mime.TypedInput;
-import retrofit.mime.TypedOutput;
+import retrofit2.Converter;
+import retrofit2.Converter.Factory;
+import retrofit2.Retrofit;
 
 @Component
 @Slf4j
-public class PrometheusResponseConverter implements Converter {
-
+public class PrometheusResponseConverter extends Factory {
   private final ObjectMapper kayentaObjectMapper;
 
   @Autowired
@@ -51,22 +30,31 @@ public class PrometheusResponseConverter implements Converter {
   }
 
   @Override
-  public Object fromBody(TypedInput body, Type type) throws ConversionException {
-    if (type == PrometheusMetricDescriptorsResponse.class) {
-      return new JacksonConverter(kayentaObjectMapper).fromBody(body, type);
-    } else if (type == String.class) {
-      try {
-        return toString(body.in(), StandardCharsets.UTF_8);
-      } catch (IOException e) {
-        throw new ConversionException("Failed to parse response from Prometheus", e);
-      }
+  public Converter<ResponseBody, ?> responseBodyConverter(
+      Type type, Annotation[] annotations, Retrofit retrofit) {
+    if (type == PrometheusMetricDescriptorsResponse.class || type == String.class) {
+      return new JacksonResponseConverter<>(kayentaObjectMapper, type);
     } else {
+      return new PrometheusResultsConverter(kayentaObjectMapper);
+    }
+  }
+
+  // Converter to handle Prometheus results conversion
+  private static class PrometheusResultsConverter
+      implements Converter<ResponseBody, List<PrometheusResults>> {
+    private final ObjectMapper objectMapper;
+
+    public PrometheusResultsConverter(ObjectMapper objectMapper) {
+      this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public List<PrometheusResults> convert(ResponseBody value) throws IOException {
       try {
-        Map responseMap = kayentaObjectMapper.readValue(body.in(), Map.class);
+        Map responseMap = objectMapper.readValue(value.byteStream(), Map.class);
         Map data = (Map) responseMap.get("data");
         List<Map> resultList = (List<Map>) data.get("result");
-        List<PrometheusResults> prometheusResultsList =
-            new ArrayList<PrometheusResults>(resultList.size());
+        List<PrometheusResults> prometheusResultsList = new ArrayList<>(resultList.size());
 
         if (CollectionUtils.isEmpty(resultList)) {
           return null;
@@ -76,7 +64,7 @@ public class PrometheusResponseConverter implements Converter {
           Map<String, String> tags = (Map<String, String>) elem.get("metric");
           String id = tags.remove("__name__");
           List<List> values = (List<List>) elem.get("values");
-          List<Double> dataValues = new ArrayList<Double>(values.size());
+          List<Double> dataValues = new ArrayList<>(values.size());
 
           for (List tuple : values) {
             String val = (String) tuple.get(1);
@@ -99,7 +87,6 @@ public class PrometheusResponseConverter implements Converter {
 
           long startTimeMillis =
               doubleTimestampSecsToLongTimestampMillis(values.get(0).get(0) + "");
-          // If there aren't at least two data points, consider the step size to be zero.
           long stepSecs =
               values.size() > 1
                   ? TimeUnit.MILLISECONDS.toSeconds(
@@ -114,25 +101,36 @@ public class PrometheusResponseConverter implements Converter {
         }
 
         return prometheusResultsList;
-      } catch (IOException e) {
-        throw new ConversionException("Failed to parse response from Prometheus", e);
+      } catch (Exception e) {
+        throw new IOException("Failed to parse response from Prometheus", e);
       }
     }
   }
 
-  private Object toString(InputStream in, Charset charset) {
-    try (Scanner s = new Scanner(in, charset.toString())) {
-      s.useDelimiter("\\A");
-      return s.hasNext() ? s.next() : "";
+  // Simple converter for JSON responses using Jackson
+  private static class JacksonResponseConverter<T> implements Converter<ResponseBody, T> {
+    private final ObjectMapper objectMapper;
+    private final Type type;
+
+    JacksonResponseConverter(ObjectMapper objectMapper, Type type) {
+      this.objectMapper = objectMapper;
+      this.type = type;
+    }
+
+    @Override
+    public T convert(ResponseBody value) throws IOException {
+      try {
+        if (type == String.class) {
+          return (T) value.string();
+        }
+        return objectMapper.readValue(value.byteStream(), objectMapper.constructType(type));
+      } finally {
+        value.close();
+      }
     }
   }
 
   private static long doubleTimestampSecsToLongTimestampMillis(String doubleTimestampSecsAsString) {
     return (long) (Double.parseDouble(doubleTimestampSecsAsString) * 1000);
-  }
-
-  @Override
-  public TypedOutput toBody(Object object) {
-    return null;
   }
 }

--- a/kayenta/kayenta-prometheus/src/main/java/com/netflix/kayenta/prometheus/service/PrometheusRemoteService.java
+++ b/kayenta/kayenta-prometheus/src/main/java/com/netflix/kayenta/prometheus/service/PrometheusRemoteService.java
@@ -19,13 +19,13 @@ package com.netflix.kayenta.prometheus.service;
 import com.netflix.kayenta.prometheus.model.PrometheusMetricDescriptorsResponse;
 import com.netflix.kayenta.prometheus.model.PrometheusResults;
 import java.util.List;
-import retrofit.http.GET;
-import retrofit.http.Query;
+import retrofit2.http.GET;
+import retrofit2.http.Query;
 
 public interface PrometheusRemoteService {
 
   // See https://prometheus.io/docs/querying/api/#range-queries
-  @GET("/api/v1/query_range")
+  @GET("api/v1/query_range")
   List<PrometheusResults> rangeQuery(
       @Query("query") String query,
       @Query("start") String start,
@@ -33,10 +33,10 @@ public interface PrometheusRemoteService {
       @Query("step") Long step);
 
   // See https://prometheus.io/docs/querying/api/#querying-label-values
-  @GET("/api/v1/label/__name__/values")
+  @GET("api/v1/label/__name__/values")
   PrometheusMetricDescriptorsResponse listMetricDescriptors();
 
   // See https://prometheus.io/docs/prometheus/latest/management_api/#health-check
-  @GET("/-/healthy")
+  @GET("-/healthy")
   String isHealthy();
 }

--- a/kayenta/kayenta-prometheus/src/test/java/com/netflix/kayenta/prometheus/service/PrometheusRemoteServiceTest.java
+++ b/kayenta/kayenta-prometheus/src/test/java/com/netflix/kayenta/prometheus/service/PrometheusRemoteServiceTest.java
@@ -189,12 +189,6 @@ public class PrometheusRemoteServiceTest {
   @SneakyThrows
   private PrometheusRemoteService createClient(Integer port) {
     return retrofitClientFactory.createClient(
-        PrometheusRemoteService.class,
-        prometheusConverter,
-        getRemoteService(port),
-        okHttpClient,
-        null,
-        null,
-        null);
+        PrometheusRemoteService.class, prometheusConverter, getRemoteService(port), okHttpClient);
   }
 }

--- a/kayenta/kayenta-prometheus/src/test/java/com/netflix/kayenta/prometheus/service/PrometheusRemoteServiceTest.java
+++ b/kayenta/kayenta-prometheus/src/test/java/com/netflix/kayenta/prometheus/service/PrometheusRemoteServiceTest.java
@@ -49,7 +49,7 @@ public class PrometheusRemoteServiceTest {
 
   private MockServerClient mockServerClient;
 
-  RetrofitClientFactory retrofitClientFactory = getRetrofitClientFactory();
+  RetrofitClientFactory retrofitClientFactory = new RetrofitClientFactory();
   ObjectMapper objectMapper = new ObjectMapper();
   PrometheusResponseConverter prometheusConverter = new PrometheusResponseConverter(objectMapper);
   OkHttpClient okHttpClient = new OkHttpClient();
@@ -172,12 +172,6 @@ public class PrometheusRemoteServiceTest {
             .useDelimiter("\\Z")
             .next();
     return StringUtils.replace(text, "\n", "");
-  }
-
-  private RetrofitClientFactory getRetrofitClientFactory() {
-    RetrofitClientFactory factory = new RetrofitClientFactory();
-    factory.retrofitLogLevel = "BASIC";
-    return factory;
   }
 
   private RemoteService getRemoteService(int port) {

--- a/kayenta/kayenta-signalfx/kayenta-signalfx.gradle
+++ b/kayenta/kayenta-signalfx/kayenta-signalfx.gradle
@@ -117,7 +117,7 @@ dependencies {
   api 'com.signalfx.public:signalfx-java:1.0.5'
 
   testImplementation project(":kayenta-standalone-canary-analysis")
-
+  testImplementation "com.squareup.retrofit2:converter-jackson"
   // Integration Test dependencies
   integrationTestImplementation sourceSets.main.output
   integrationTestImplementation sourceSets.test.output

--- a/kayenta/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/config/SignalFxConfiguration.java
+++ b/kayenta/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/config/SignalFxConfiguration.java
@@ -32,7 +32,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
-import okhttp3.OkHttpClient;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -72,7 +71,6 @@ public class SignalFxConfiguration {
   MetricsService signalFxMetricService(
       SignalFxConfigurationProperties signalFxConfigurationProperties,
       RetrofitClientFactory retrofitClientFactory,
-      OkHttpClient okHttpClient,
       AccountCredentialsRepository accountCredentialsRepository) {
 
     SignalFxMetricsService.SignalFxMetricsServiceBuilder metricsServiceBuilder =
@@ -102,8 +100,7 @@ public class SignalFxConfiguration {
               retrofitClientFactory.createClient(
                   SignalFxSignalFlowRemoteService.class,
                   new SignalFxConverter(),
-                  signalFxSignalFlowEndpoint,
-                  okHttpClient));
+                  signalFxSignalFlowEndpoint));
         }
         accountCredentialsBuilder.supportedTypes(supportedTypes);
       }

--- a/kayenta/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/service/SignalFxConverter.java
+++ b/kayenta/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/service/SignalFxConverter.java
@@ -19,17 +19,16 @@ package com.netflix.kayenta.signalfx.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
+import com.netflix.kayenta.metrics.ConversionException;
 import com.signalfx.signalflow.ChannelMessage;
 import com.signalfx.signalflow.ServerSentEventsTransport;
 import com.signalfx.signalflow.StreamMessage;
-import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
-import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.RequestBody;
 import okhttp3.ResponseBody;
@@ -48,13 +47,12 @@ public class SignalFxConverter extends Converter.Factory {
   private static final List<Class<?>> CONVERTIBLE_TYPES =
       ImmutableList.of(SignalFlowExecutionResult.class, ErrorResponse.class);
 
-  @SneakyThrows
   @Override
   public @Nullable Converter<ResponseBody, ?> responseBodyConverter(
       Type type, Annotation[] annotations, Retrofit retrofit) {
 
     if (!CONVERTIBLE_TYPES.contains(type)) {
-      throw new IOException(
+      throw new ConversionException(
           String.format(
               "The SignalFxConverter Retrofit converter can only handle Types: [ %s ], received: %s",
               CONVERTIBLE_TYPES.stream().map(Type::getTypeName).collect(Collectors.joining(", ")),
@@ -90,7 +88,7 @@ public class SignalFxConverter extends Converter.Factory {
     }
 
     @Override
-    public SignalFlowExecutionResult convert(ResponseBody value) throws IOException {
+    public SignalFlowExecutionResult convert(ResponseBody value) {
       List<ChannelMessage> messages = new LinkedList<>();
       try (ServerSentEventsTransport.TransportEventStreamParser parser =
           new ServerSentEventsTransport.TransportEventStreamParser(value.byteStream())) {
@@ -101,7 +99,7 @@ public class SignalFxConverter extends Converter.Factory {
           messages.add(channelMessage);
         }
       } catch (Exception e) {
-        throw new IOException("There was an issue parsing the SignalFlow response", e);
+        throw new ConversionException("There was an issue parsing the SignalFlow response", e);
       }
       return new SignalFlowExecutionResult(messages);
     }
@@ -115,11 +113,11 @@ public class SignalFxConverter extends Converter.Factory {
     }
 
     @Override
-    public ErrorResponse convert(ResponseBody value) throws IOException {
+    public ErrorResponse convert(ResponseBody value) {
       try {
         return objectMapper.readValue(value.charStream(), ErrorResponse.class);
       } catch (Exception e) {
-        throw new IOException("Failed to parse error response", e);
+        throw new ConversionException("Failed to parse error response", e);
       }
     }
   }

--- a/kayenta/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/service/SignalFxSignalFlowRemoteService.java
+++ b/kayenta/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/service/SignalFxSignalFlowRemoteService.java
@@ -17,10 +17,10 @@
 
 package com.netflix.kayenta.signalfx.service;
 
-import retrofit.http.Body;
-import retrofit.http.Header;
-import retrofit.http.POST;
-import retrofit.http.Query;
+import retrofit2.http.Body;
+import retrofit2.http.Header;
+import retrofit2.http.POST;
+import retrofit2.http.Query;
 
 /** Retrofit interface for SignalFx API calls. */
 public interface SignalFxSignalFlowRemoteService {
@@ -40,7 +40,7 @@ public interface SignalFxSignalFlowRemoteService {
    * @param program The signal flow program to execute
    * @return The list of channel messages from the signal flow output
    */
-  @POST("/v2/signalflow/execute")
+  @POST("v2/signalflow/execute")
   SignalFlowExecutionResult executeSignalFlowProgram(
       @Header("X-SF-TOKEN") String accessToken,
       @Query("start") long startEpochMilli,

--- a/kayenta/kayenta-signalfx/src/test/java/com/netflix/kayenta/signalfx/config/SignalFxConfigLoadTest.java
+++ b/kayenta/kayenta-signalfx/src/test/java/com/netflix/kayenta/signalfx/config/SignalFxConfigLoadTest.java
@@ -25,7 +25,6 @@ import com.netflix.kayenta.security.AccountCredentials;
 import com.netflix.kayenta.security.AccountCredentialsRepository;
 import com.netflix.kayenta.security.MapBackedAccountCredentialsRepository;
 import java.util.List;
-import okhttp3.OkHttpClient;
 import org.junit.jupiter.api.Test;
 
 public class SignalFxConfigLoadTest {
@@ -39,10 +38,8 @@ public class SignalFxConfigLoadTest {
     when(signalFxConfigurationProperties.getAccounts())
         .thenReturn(List.of(new SignalFxManagedAccount().setName("Test-account")));
     RetrofitClientFactory mockRetrofitFactory = mock(RetrofitClientFactory.class);
-    OkHttpClient mockOkHttpFactory = mock(OkHttpClient.class);
     new SignalFxConfiguration()
-        .signalFxMetricService(
-            signalFxConfigurationProperties, mockRetrofitFactory, mockOkHttpFactory, accountRepo);
+        .signalFxMetricService(signalFxConfigurationProperties, mockRetrofitFactory, accountRepo);
     assertEquals("signalfx", accountRepo.getRequiredOne("Test-account").getType());
     assertEquals(
         List.of(AccountCredentials.Type.METRICS_STORE),

--- a/kayenta/kayenta-wavefront/kayenta-wavefront.gradle
+++ b/kayenta/kayenta-wavefront/kayenta-wavefront.gradle
@@ -1,3 +1,4 @@
 dependencies {
   implementation project(":kayenta-core")
+  implementation "com.squareup.retrofit2:converter-jackson"
 }

--- a/kayenta/kayenta-wavefront/src/main/java/com/netflix/kayenta/wavefront/config/WavefrontConfiguration.java
+++ b/kayenta/kayenta-wavefront/src/main/java/com/netflix/kayenta/wavefront/config/WavefrontConfiguration.java
@@ -24,17 +24,15 @@ import com.netflix.kayenta.wavefront.metrics.WavefrontMetricsService;
 import com.netflix.kayenta.wavefront.security.WavefrontCredentials;
 import com.netflix.kayenta.wavefront.security.WavefrontNamedAccountCredentials;
 import com.netflix.kayenta.wavefront.service.WavefrontRemoteService;
-import java.io.IOException;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
-import okhttp3.OkHttpClient;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.util.CollectionUtils;
-import retrofit.converter.JacksonConverter;
+import retrofit2.converter.jackson.JacksonConverterFactory;
 
 @Configuration
 @ConditionalOnProperty("kayenta.wavefront.enabled")
@@ -52,9 +50,7 @@ public class WavefrontConfiguration {
       WavefrontConfigurationProperties wavefrontConfigurationProperties,
       RetrofitClientFactory retrofitClientFactory,
       ObjectMapper objectMapper,
-      OkHttpClient okHttpClient,
-      AccountCredentialsRepository accountCredentialsRepository)
-      throws IOException {
+      AccountCredentialsRepository accountCredentialsRepository) {
     WavefrontMetricsService.WavefrontMetricsServiceBuilder wavefrontMetricsServiceBuilder =
         WavefrontMetricsService.builder();
 
@@ -79,9 +75,8 @@ public class WavefrontConfiguration {
           WavefrontRemoteService wavefrontRemoteService =
               retrofitClientFactory.createClient(
                   WavefrontRemoteService.class,
-                  new JacksonConverter(objectMapper),
-                  wavefrontManagedAccount.getEndpoint(),
-                  okHttpClient);
+                  JacksonConverterFactory.create(objectMapper),
+                  wavefrontManagedAccount.getEndpoint());
 
           wavefrontNamedAccountCredentialsBuilder.wavefrontRemoteService(wavefrontRemoteService);
         }

--- a/kayenta/kayenta-wavefront/src/main/java/com/netflix/kayenta/wavefront/service/WavefrontRemoteService.java
+++ b/kayenta/kayenta-wavefront/src/main/java/com/netflix/kayenta/wavefront/service/WavefrontRemoteService.java
@@ -15,12 +15,12 @@
  */
 package com.netflix.kayenta.wavefront.service;
 
-import retrofit.http.GET;
-import retrofit.http.Header;
-import retrofit.http.Query;
+import retrofit2.http.GET;
+import retrofit2.http.Header;
+import retrofit2.http.Query;
 
 public interface WavefrontRemoteService {
-  @GET("/api/v2/chart/api")
+  @GET("api/v2/chart/api")
   WavefrontTimeSeries fetch(
       @Header("Authorization") String authorization,
       @Query("n") String name,


### PR DESCRIPTION
- As part of spinnaker retrofit2 upgrade, this PR upgrades retrofit1 clients in kayenta to retrofit2. 
- With the recently added [LegacySignatureCallAdapter](https://github.com/spinnaker/spinnaker/pull/7088/files#diff-f90cbc0bd7a865a3ba9709dc96aa7b59b0e1d1ee50e975363b38fb92d7f38b5a), there is no need to wrap the API interface method return types with `Call` and no need to use Retrofit2SyncCall.execute() on API invocation. 