### PR TITLE
fix(igor-web): fix Jenkins job's build response handling issue

### DIFF
--- a/igor/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/client/JenkinsClient.groovy
+++ b/igor/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/client/JenkinsClient.groovy
@@ -84,10 +84,10 @@ interface JenkinsClient {
     Call<QueuedJob> getQueuedItem(@Path('itemNumber') Long item)
 
     @POST('job/{jobName}/build')
-    Call<Response<ResponseBody>> build(@Path(value = 'jobName', encoded = true) String jobName, @Body String emptyRequest, @Header("Jenkins-Crumb") String crumb)
+    Call<Void> build(@Path(value = 'jobName', encoded = true) String jobName, @Body String emptyRequest, @Header("Jenkins-Crumb") String crumb)
 
     @POST('job/{jobName}/buildWithParameters')
-    Call<Response<ResponseBody>> buildWithParameters(@Path(value = 'jobName', encoded = true) String jobName, @QueryMap Map<String, String> queryParams, @Body String EmptyRequest, @Header("Jenkins-Crumb") String crumb)
+    Call<Void> buildWithParameters(@Path(value = 'jobName', encoded = true) String jobName, @QueryMap Map<String, String> queryParams, @Body String EmptyRequest, @Header("Jenkins-Crumb") String crumb)
 
     @FormUrlEncoded
     @POST('job/{jobName}/{buildNumber}/submitDescription')

--- a/igor/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/service/JenkinsService.java
+++ b/igor/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/service/JenkinsService.java
@@ -186,7 +186,7 @@ public class JenkinsService implements BuildOperations, BuildProperties {
 
   @Override
   public long triggerBuildWithParameters(String job, Map<String, String> queryParameters) {
-    Response<ResponseBody> response = buildWithParameters(job, queryParameters);
+    Response<Void> response = buildWithParameters(job, queryParameters);
     if (response.code() != 201) {
       throw new BuildJobError("Received a non-201 status when submitting job '" + job + "'");
     }
@@ -246,16 +246,15 @@ public class JenkinsService implements BuildOperations, BuildProperties {
     }
   }
 
-  public Response<ResponseBody> build(String jobName) {
+  public Response<Void> build(String jobName) {
     return circuitBreaker.executeSupplier(
-        () -> Retrofit2SyncCall.execute(jenkinsClient.build(encode(jobName), "", getCrumb())));
+        () -> Retrofit2SyncCall.executeCall(jenkinsClient.build(encode(jobName), "", getCrumb())));
   }
 
-  public Response<ResponseBody> buildWithParameters(
-      String jobName, Map<String, String> queryParams) {
+  public Response<Void> buildWithParameters(String jobName, Map<String, String> queryParams) {
     return circuitBreaker.executeSupplier(
         () ->
-            Retrofit2SyncCall.execute(
+            Retrofit2SyncCall.executeCall(
                 jenkinsClient.buildWithParameters(encode(jobName), queryParams, "", getCrumb())));
   }
 

--- a/igor/igor-web/src/test/java/com/netflix/spinnaker/igor/jenkins/service/JenkinsServiceTest.java
+++ b/igor/igor-web/src/test/java/com/netflix/spinnaker/igor/jenkins/service/JenkinsServiceTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2025 OpsMx, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.igor.jenkins.service;
+
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import com.netflix.spinnaker.fiat.model.resources.Permissions;
+import com.netflix.spinnaker.igor.jenkins.client.JenkinsClient;
+import com.netflix.spinnaker.igor.model.Crumb;
+import com.netflix.spinnaker.igor.util.RetrofitUtils;
+import com.netflix.spinnaker.kork.retrofit.ErrorHandlingExecutorCallAdapterFactory;
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerConversionException;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import okhttp3.OkHttpClient;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import retrofit2.Retrofit;
+import retrofit2.converter.jackson.JacksonConverterFactory;
+
+public class JenkinsServiceTest {
+
+  @RegisterExtension
+  static final WireMockExtension wmJenkins =
+      WireMockExtension.newInstance().options(wireMockConfig().dynamicPort()).build();
+
+  static JenkinsClient jenkinsClient;
+  static JenkinsService jenkinsService;
+  static ObjectMapper objectMapper;
+
+  @BeforeAll
+  public static void setup() {
+    objectMapper =
+        new XmlMapper()
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+            .registerModule(new JaxbAnnotationModule());
+    jenkinsClient =
+        new Retrofit.Builder()
+            .baseUrl(RetrofitUtils.getBaseUrl(wmJenkins.baseUrl()))
+            .client(new OkHttpClient())
+            .addCallAdapterFactory(ErrorHandlingExecutorCallAdapterFactory.getInstance())
+            .addConverterFactory(JacksonConverterFactory.create(objectMapper))
+            .build()
+            .create(JenkinsClient.class);
+    CircuitBreakerRegistry circuitBreakerRegistry = CircuitBreakerRegistry.ofDefaults();
+    jenkinsService =
+        new JenkinsService(
+            RetrofitUtils.getBaseUrl(wmJenkins.baseUrl()),
+            jenkinsClient,
+            true,
+            Permissions.EMPTY,
+            circuitBreakerRegistry);
+  }
+
+  @Test
+  public void testJenkinsJobBuild() throws JsonProcessingException {
+    Crumb crumb = new Crumb();
+    crumb.setCrumb("crumb");
+    wmJenkins.stubFor(
+        WireMock.get("/crumbIssuer/api/xml")
+            .willReturn(WireMock.aResponse().withBody(objectMapper.writeValueAsString(crumb))));
+
+    wmJenkins.stubFor(
+        WireMock.post("/job/job1/build").willReturn(WireMock.aResponse().withStatus(201)));
+
+    // TODO: fix this issue
+    Throwable thrown = catchThrowable(() -> jenkinsService.build("job1"));
+    assertThat(thrown).isInstanceOf(SpinnakerConversionException.class);
+    assertThat(thrown.getMessage())
+        .contains(
+            "Failed to process response body: Unexpected EOF in prolog\n"
+                + " at [row,col {unknown-source}]: [1,0]");
+  }
+}


### PR DESCRIPTION
- When a Jenkins job's build or buildWithParameters API is invoked, there won't be any response body(response code 201). But the Igor code responsible for handling the API response assumes a response body hence fails with the following error:

``` 
com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerConversionException: Failed to process response body: Unexpected EOF in prolog
at [row,col {unknown-source}]: [1,0]
at com.netflix.spinnaker.kork.retrofit.ErrorHandlingExecutorCallAdapterFactory$ExecutorCallbackCall.execute(ErrorHandlingExecutorCallAdapterFactory.java:156) ~[kork-retrofit-2025.0.3.jar:2025.0.3]
at com.netflix.spinnaker.kork.retrofit.Retrofit2SyncCall.executeCall(Retrofit2SyncCall.java:47) ~[kork-retrofit-2025.0.3.jar:2025.0.3]
2
``` 

- This PR addresses the above issue by changing the signatures of the retrofit2 API interface methods and updating the code handling the responses. 
- Added a test to demonstrate the issue. 