### PR TITLE
chore(build): Migrate from OSSRH to Central Portal

### DIFF
--- a/spinnaker-gradle-project/spinnaker-project-plugin/src/main/groovy/com/netflix/spinnaker/gradle/publishing/nexus/NexusPublishExtension.groovy
+++ b/spinnaker-gradle-project/spinnaker-project-plugin/src/main/groovy/com/netflix/spinnaker/gradle/publishing/nexus/NexusPublishExtension.groovy
@@ -34,8 +34,8 @@ class NexusPublishExtension {
     this.project = project
     ObjectFactory props = project.objects
     enabled = props.property(Boolean).convention(false)
-    nexusStagingUrl = props.property(String).convention("https://s01.oss.sonatype.org/service/local/")
-    nexusSnapshotUrl = props.property(String).convention("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+    nexusStagingUrl = props.property(String).convention("https://ossrh-staging-api.central.sonatype.com/service/local/")
+    nexusSnapshotUrl = props.property(String).convention("https://central.sonatype.com/repository/maven-snapshots/")
     nexusStagingProfileId = props.property(String).convention("b6b58aed9c738")
   }
 


### PR DESCRIPTION
OSSRH is reaching EOL on the 30th of June https://central.sonatype.org/news/20250326_ossrh_sunset/

According to the https://github.com/gradle-nexus/publish-plugin?tab=readme-ov-file#publishing-to-maven-central-via-sonatype-central the migration on the plugin side is simple on the plugin side. 

However some manual steps are needed to migrate according to this https://central.sonatype.org/faq/what-is-different-between-central-portal-and-legacy-ossrh/#authentication 