### PR TITLE
fix(build): Enable publishing for Gradle plugins

### DIFF
--- a/.github/workflows/spinnaker-gradle-project.yml
+++ b/.github/workflows/spinnaker-gradle-project.yml
@@ -47,4 +47,4 @@ jobs:
           GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
           ORG_GRADLE_PROJECT_version: ${{ steps.version.outputs.version }}
         run: |
-          ./gradlew --info -Pgradle.publish.key="${GRADLE_PUBLISH_KEY}" -Pgradle.publish.secret="${GRADLE_PUBLISH_SECRET}" :spinnaker-gradle-project:publishPlugins
+          ./gradlew --info -Pgradle.publish.key="${GRADLE_PUBLISH_KEY}" -Pgradle.publish.secret="${GRADLE_PUBLISH_SECRET}" :spinnaker-gradle-project:publish

--- a/spinnaker-gradle-project/build.gradle
+++ b/spinnaker-gradle-project/build.gradle
@@ -51,6 +51,6 @@ tasks.register('clean') {
 }
 
 tasks.register('publish') {
-  dependsOn ":spinnaker-project-plugin:publish"
-  dependsOn ":spinnaker-extensions:publish"
+  dependsOn ":spinnaker-project-plugin:publishPlugins"
+  dependsOn ":spinnaker-extensions:publishPlugins"
 }

--- a/spinnaker-gradle-project/spinnaker-extensions/build.gradle.kts
+++ b/spinnaker-gradle-project/spinnaker-extensions/build.gradle.kts
@@ -58,6 +58,7 @@ gradlePlugin {
     create("serviceExtension") {
       id = "io.spinnaker.plugin.service-extension"
       implementationClass = "com.netflix.spinnaker.gradle.extension.SpinnakerServiceExtensionPlugin"
+      description = "Spinnaker service extension development plugin"
       displayName = "Spinnaker service extension development plugin"
       tags.set(listOf("spinnaker"))
     }
@@ -65,6 +66,7 @@ gradlePlugin {
     create("uiExtension") {
       id = "io.spinnaker.plugin.ui-extension"
       implementationClass = "com.netflix.spinnaker.gradle.extension.SpinnakerUIExtensionPlugin"
+      description = "Spinnaker UI extension development plugin"
       displayName = "Spinnaker UI extension development plugin"
       tags.set(listOf("spinnaker"))
     }
@@ -72,6 +74,7 @@ gradlePlugin {
     create("bundler") {
       id = "io.spinnaker.plugin.bundler"
       implementationClass = "com.netflix.spinnaker.gradle.extension.SpinnakerExtensionsBundlerPlugin"
+      description = "Spinnaker extension bundler plugin"
       displayName = "Spinnaker extension bundler plugin"
       tags.set(listOf("spinnaker"))
     }
@@ -79,6 +82,7 @@ gradlePlugin {
     create("compatibilityTestRunner") {
       id = "io.spinnaker.plugin.compatibility-test-runner"
       implementationClass = "com.netflix.spinnaker.gradle.extension.compatibility.SpinnakerCompatibilityTestRunnerPlugin"
+      description = "Spinnaker compatibility test runner"
       displayName = "Spinnaker compatibility test runner"
       tags.set(listOf("spinnaker"))
     }

--- a/spinnaker-gradle-project/spinnaker-project-plugin/build.gradle
+++ b/spinnaker-gradle-project/spinnaker-project-plugin/build.gradle
@@ -18,36 +18,28 @@ dependencies {
 }
 
 gradlePlugin {
-  plugins {
-    spinnakerProject {
-      id = 'io.spinnaker.project'
-      implementationClass = 'com.netflix.spinnaker.gradle.project.SpinnakerProjectPlugin'
-    }
-    spinnakerPackage {
-      id = 'io.spinnaker.package'
-      implementationClass = 'com.netflix.spinnaker.gradle.application.SpinnakerPackagePlugin'
-    }
-    spinnakerArtifactRegistryPublish {
-      id = 'io.spinnaker.artifactregistry-publish'
-      implementationClass = 'com.netflix.spinnaker.gradle.publishing.artifactregistry.ArtifactRegistryPublishPlugin'
-    }
-  }
-}
-
-gradlePlugin {
   website = 'https://spinnaker.io'
   vcsUrl = 'https://github.com/spinnaker/spinnaker-gradle-project'
 
   plugins {
     spinnakerProject {
+      id = 'io.spinnaker.project'
+      implementationClass = 'com.netflix.spinnaker.gradle.project.SpinnakerProjectPlugin'
+      description = 'Build configuration for Spinnaker projects'
       displayName = 'Build configuration for Spinnaker projects'
       tags.set(['spinnaker'])
     }
     spinnakerPackage {
+      id = 'io.spinnaker.package'
+      implementationClass = 'com.netflix.spinnaker.gradle.application.SpinnakerPackagePlugin'
+      description = 'OS Packaging for Spinnaker applications'
       displayName = 'OS Packaging for Spinnaker applications'
       tags.set(['spinnaker'])
     }
     spinnakerArtifactRegistryPublish {
+      id = 'io.spinnaker.artifactregistry-publish'
+      implementationClass = 'com.netflix.spinnaker.gradle.publishing.artifactregistry.ArtifactRegistryPublishPlugin'
+      description = 'Google Artifact Registry publishing for spinnaker packages'
       displayName = 'Google Artifact Registry publishing for spinnaker packages'
       tags.set(['spinnaker'])
     }


### PR DESCRIPTION
- Publishing tasks are now exposed via the `spinnaker-gradle-project` composite, so they can be properly addressed from the root build
- Gradle plugins now have a required `description` field, so that is now set in the metadata
- Automatically publishes on `main` pushes to its subtree, which will produce a version like `main-1`
