### PR TITLE
fix(publishing): Write all versions to Maven metadata

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,12 @@ tasks.register('closeAndReleaseNexusStagingRepository') { task ->
   }
 }
 
+tasks.register('publishToMavenLocal') { task ->
+  mainProjects.each { build ->
+    task.dependsOn build.task(':publishToMavenLocal')
+  }
+}
+
 tasks.register('test') { task ->
   mainProjects.each { build ->
     task.dependsOn build.task(':test')

--- a/spinnaker-gradle-project/spinnaker-project-plugin/src/main/groovy/com/netflix/spinnaker/gradle/project/SpinnakerProjectPlugin.groovy
+++ b/spinnaker-gradle-project/spinnaker-project-plugin/src/main/groovy/com/netflix/spinnaker/gradle/project/SpinnakerProjectPlugin.groovy
@@ -71,7 +71,7 @@ class SpinnakerProjectPlugin implements Plugin<Project> {
     //   when things like "build" or "publish" are run from the project root
     // When the task name is NOT run from the top level, we have to recurse through the subprojects ourselves
     // So, assemble and publish implement that below
-    def defaultTasks = ['assemble', 'check', 'clean', 'test', 'publish']
+    def defaultTasks = ['assemble', 'check', 'clean', 'test', 'publish', 'publishToMavenLocal']
     for(String taskName in defaultTasks) {
       dependOnTasksRecursively(project, taskName)
     }

--- a/spinnaker-gradle-project/spinnaker-project-plugin/src/main/groovy/com/netflix/spinnaker/gradle/publishing/PublishingPlugin.groovy
+++ b/spinnaker-gradle-project/spinnaker-project-plugin/src/main/groovy/com/netflix/spinnaker/gradle/publishing/PublishingPlugin.groovy
@@ -29,6 +29,15 @@ class PublishingPlugin implements Plugin<Project> {
             pub.artifact(it)
           }
           addLicenseMetadata(pub)
+          // Use enforcedPlatform versions
+          pub.versionMapping {
+            it.usage("java-api") {
+              it.fromResolutionOf("runtimeClasspath")
+            }
+            it.usage("java-runtime") {
+              it.fromResolutionResult()
+            }
+          }
         }
         // Presence of a module metadata file causes IntelliJ to not associate -sources jars with libraries.
         //  removing for now, can revisit if there is a good reason to have .modules
@@ -45,6 +54,15 @@ class PublishingPlugin implements Plugin<Project> {
         publishingExtension.publications.create(PUBLICATION_NAME, MavenPublication) { pub ->
           pub.from(project.components.getByName("javaPlatform"))
           addLicenseMetadata(pub)
+          // Use enforcedPlatform versions
+          pub.versionMapping {
+            it.usage("java-api") {
+              it.fromResolutionOf("runtimeClasspath")
+            }
+            it.usage("java-runtime") {
+              it.fromResolutionResult()
+            }
+          }
         }
       }
       // Presence of a module metadata file causes some weird failures in kork spinnaker-dependencies and we don't


### PR DESCRIPTION
Defines publication dependency versions explicitly from Gradle's classpath resolutions.

Also adds top-level hooks for `publishToMavenLocal` for testing purposes.