### PR TITLE
refactor(retrofit2/test): remove unused code

### DIFF
--- a/kork/kork-retrofit2/src/test/kotlin/com/netflix/spinnaker/kork/retrofit/Retrofit2ServiceProviderTest.kt
+++ b/kork/kork-retrofit2/src/test/kotlin/com/netflix/spinnaker/kork/retrofit/Retrofit2ServiceProviderTest.kt
@@ -29,7 +29,6 @@ import com.netflix.spinnaker.kork.client.ServiceClientFactory
 import com.netflix.spinnaker.kork.client.ServiceClientProvider
 import com.netflix.spinnaker.okhttp.OkHttpClientConfigurationProperties
 import com.netflix.spinnaker.okhttp.Retrofit2EncodeCorrectionInterceptor
-import com.netflix.spinnaker.okhttp.SpinnakerRequestInterceptor
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
 import okhttp3.OkHttpClient
@@ -99,11 +98,6 @@ private open class TestConfiguration {
   @Bean
   open fun okHttpClientProvider(okHttpClient: OkHttpClient): OkHttpClientProvider {
     return OkHttpClientProvider(listOf(DefaultOkHttpClientBuilderProvider(okHttpClient,  OkHttpClientConfigurationProperties())), Retrofit2EncodeCorrectionInterceptor())
-  }
-
-  @Bean
-  open fun spinnakerRequestInterceptor(): SpinnakerRequestInterceptor {
-    return SpinnakerRequestInterceptor(true)
   }
 
   @Bean


### PR DESCRIPTION
SpinnakerRetrofitInterceptor is for use with retrofit1.  It wasn't used in Retrofit2ServiceProviderTest.
