### PR TITLE
fix(retrofit): fix retrofit1 client definition in kork

### DIFF
--- a/kork/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/RetrofitServiceFactory.java
+++ b/kork/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/RetrofitServiceFactory.java
@@ -27,9 +27,11 @@ import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
 import com.netflix.spinnaker.kork.client.ServiceClientFactory;
 import com.netflix.spinnaker.kork.client.ServiceClientProvider;
 import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerRetrofitErrorHandler;
+import com.netflix.spinnaker.kork.retrofit.util.RetrofitUtils;
 import com.netflix.spinnaker.retrofit.Slf4jRetrofitLogger;
 import java.util.List;
 import okhttp3.Interceptor;
+import okhttp3.OkHttpClient;
 import retrofit.Endpoint;
 import retrofit.RequestInterceptor;
 import retrofit.RestAdapter;
@@ -54,12 +56,14 @@ class RetrofitServiceFactory implements ServiceClientFactory {
   @Override
   public <T> T create(Class<T> type, ServiceEndpoint serviceEndpoint, ObjectMapper objectMapper) {
     Endpoint endpoint = newFixedEndpoint(serviceEndpoint.getBaseUrl());
+    OkHttpClient client =
+        RetrofitUtils.getClientForRetrofit1(clientProvider.getClient(serviceEndpoint));
     return new RestAdapter.Builder()
         .setRequestInterceptor(spinnakerRequestInterceptor)
         .setConverter(new JacksonConverter(objectMapper))
         .setEndpoint(endpoint)
         .setErrorHandler(SpinnakerRetrofitErrorHandler.getInstance())
-        .setClient(new Ok3Client(clientProvider.getClient(serviceEndpoint)))
+        .setClient(new Ok3Client(client))
         .setLogLevel(retrofitLogLevel)
         .setLog(new Slf4jRetrofitLogger(type))
         .build()

--- a/kork/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/util/RetrofitUtils.java
+++ b/kork/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/util/RetrofitUtils.java
@@ -16,7 +16,11 @@
 
 package com.netflix.spinnaker.kork.retrofit.util;
 
+import com.netflix.spinnaker.okhttp.Retrofit2EncodeCorrectionInterceptor;
+import com.netflix.spinnaker.okhttp.SpinnakerRequestHeaderInterceptor;
 import okhttp3.HttpUrl;
+import okhttp3.Interceptor;
+import okhttp3.OkHttpClient;
 
 public class RetrofitUtils {
 
@@ -38,5 +42,23 @@ public class RetrofitUtils {
       baseUrl += "/";
     }
     return baseUrl;
+  }
+
+  /**
+   * Creates a new client with the retrofit2 specific Interceptors
+   * (SpinnakerRequestHeaderInterceptor and Retrofit2EncodeCorrectionInterceptor) removed.
+   *
+   * @return a new ok client with the correct interceptors
+   */
+  public static OkHttpClient getClientForRetrofit1(OkHttpClient client) {
+    OkHttpClient.Builder clientBuilder = client.newBuilder();
+    clientBuilder.interceptors().clear();
+    for (Interceptor interceptor : client.interceptors()) {
+      if (!(interceptor instanceof SpinnakerRequestHeaderInterceptor)
+          && !(interceptor instanceof Retrofit2EncodeCorrectionInterceptor)) {
+        clientBuilder.addInterceptor(interceptor);
+      }
+    }
+    return clientBuilder.build();
   }
 }

--- a/orca/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/config/EchoConfiguration.groovy
+++ b/orca/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/config/EchoConfiguration.groovy
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.config.DefaultServiceEndpoint
 import com.netflix.spinnaker.config.okhttp3.OkHttpClientProvider
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
 import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerRetrofitErrorHandler
+import com.netflix.spinnaker.kork.retrofit.util.RetrofitUtils
 import com.netflix.spinnaker.orca.echo.EchoService
 import com.netflix.spinnaker.orca.echo.spring.EchoNotifyingExecutionListener
 import com.netflix.spinnaker.orca.echo.spring.EchoNotifyingStageListener
@@ -34,6 +35,7 @@ import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor
 import com.netflix.spinnaker.orca.retrofit.RetrofitConfiguration
 import com.netflix.spinnaker.orca.retrofit.logging.RetrofitSlf4jLog
 import groovy.transform.CompileStatic
+import okhttp3.OkHttpClient
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
@@ -66,9 +68,14 @@ class EchoConfiguration {
 
   @Bean
   EchoService echoService(Endpoint echoEndpoint) {
+    OkHttpClient client =
+        RetrofitUtils.getClientForRetrofit1(
+            clientProvider.getClient(
+                new DefaultServiceEndpoint("echo", echoEndpoint.url),
+                true))
     new RestAdapter.Builder()
       .setEndpoint(echoEndpoint)
-      .setClient(new Ok3Client(clientProvider.getClient(new DefaultServiceEndpoint("echo", echoEndpoint.url), true)))
+      .setClient(new Ok3Client(client))
       .setLogLevel(retrofitLogLevel)
       .setErrorHandler(SpinnakerRetrofitErrorHandler.getInstance())
       .setLog(new RetrofitSlf4jLog(EchoService))

--- a/orca/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/config/Front50Configuration.groovy
+++ b/orca/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/config/Front50Configuration.groovy
@@ -21,6 +21,7 @@ import com.jakewharton.retrofit.Ok3Client
 import com.netflix.spinnaker.config.DefaultServiceEndpoint
 import com.netflix.spinnaker.config.okhttp3.OkHttpClientProvider
 import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerRetrofitErrorHandler
+import com.netflix.spinnaker.kork.retrofit.util.RetrofitUtils
 import com.netflix.spinnaker.orca.events.ExecutionEvent
 import com.netflix.spinnaker.orca.events.ExecutionListenerAdapter
 import com.netflix.spinnaker.orca.front50.Front50Service
@@ -76,7 +77,7 @@ class Front50Configuration {
   @Bean
   Front50Service front50Service(Endpoint front50Endpoint, ObjectMapper mapper, Front50ConfigurationProperties front50ConfigurationProperties) {
     OkHttpClient okHttpClient = clientProvider.getClient(new DefaultServiceEndpoint("front50", front50Endpoint.getUrl()));
-    okHttpClient = okHttpClient.newBuilder()
+    okHttpClient = RetrofitUtils.getClientForRetrofit1(okHttpClient).newBuilder()
         .readTimeout(front50ConfigurationProperties.okhttp.readTimeoutMs, TimeUnit.MILLISECONDS)
         .writeTimeout(front50ConfigurationProperties.okhttp.writeTimeoutMs, TimeUnit.MILLISECONDS)
         .connectTimeout(front50ConfigurationProperties.okhttp.connectTimeoutMs, TimeUnit.MILLISECONDS)

--- a/orca/orca-igor/orca-igor.gradle
+++ b/orca/orca-igor/orca-igor.gradle
@@ -33,7 +33,10 @@ dependencies {
   testImplementation("org.springframework:spring-test")
   testImplementation("io.spinnaker.fiat:fiat-core")
   testImplementation("com.github.tomakehurst:wiremock-jre8-standalone")
+  testImplementation("org.springframework.boot:spring-boot-starter-test")
+  testImplementation("org.junit.jupiter:junit-jupiter-api")
   testRuntimeOnly("net.bytebuddy:byte-buddy")
+  implementation("io.zipkin.brave:brave-instrumentation-okhttp3")
 }
 
 sourceSets {

--- a/orca/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/config/IgorConfiguration.groovy
+++ b/orca/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/config/IgorConfiguration.groovy
@@ -21,10 +21,12 @@ import com.jakewharton.retrofit.Ok3Client
 import com.netflix.spinnaker.config.DefaultServiceEndpoint
 import com.netflix.spinnaker.config.okhttp3.OkHttpClientProvider
 import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerRetrofitErrorHandler
+import com.netflix.spinnaker.kork.retrofit.util.RetrofitUtils
 import com.netflix.spinnaker.orca.igor.IgorService
 import com.netflix.spinnaker.orca.retrofit.RetrofitConfiguration
 import com.netflix.spinnaker.orca.retrofit.logging.RetrofitSlf4jLog
 import groovy.transform.CompileStatic
+import okhttp3.OkHttpClient
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
@@ -57,9 +59,14 @@ class IgorConfiguration {
 
   @Bean
   IgorService igorService(Endpoint igorEndpoint, ObjectMapper mapper, RequestInterceptor spinnakerRequestInterceptor) {
+    OkHttpClient client =
+        RetrofitUtils.getClientForRetrofit1(
+            clientProvider.getClient(
+                new DefaultServiceEndpoint("igor", igorEndpoint.url),
+                true))
     new RestAdapter.Builder()
       .setEndpoint(igorEndpoint)
-      .setClient(new Ok3Client(clientProvider.getClient(new DefaultServiceEndpoint("igor", igorEndpoint.url), true)))
+      .setClient(new Ok3Client(client))
       .setLogLevel(retrofitLogLevel)
       .setErrorHandler(SpinnakerRetrofitErrorHandler.getInstance())
       .setRequestInterceptor(spinnakerRequestInterceptor)

--- a/orca/orca-igor/src/test/java/com/netflix/spinnaker/orca/igor/BuildServiceTest.java
+++ b/orca/orca-igor/src/test/java/com/netflix/spinnaker/orca/igor/BuildServiceTest.java
@@ -87,8 +87,8 @@ public class BuildServiceTest {
   }
 
   private static BuildService buildService;
-  private static final String ENDPOINT_WITH_INCORRECT_ENCODING =
-      "/masters/master/jobs/job1?param1=value%2Bwith%2Bspaces";
+  private static final String ENDPOINT_WITH_CORRECT_ENCODING =
+      "/masters/master/jobs/job1?param1=value+with+spaces";
 
   @Autowired IgorService igorService;
 
@@ -99,13 +99,12 @@ public class BuildServiceTest {
 
   @Test
   public void testBuildServiceBuildApi() {
-    // FIXME: the query params should be encoded with spaces, and not with +
     wmIgor.stubFor(
-        WireMock.put(urlEqualTo(ENDPOINT_WITH_INCORRECT_ENCODING))
+        WireMock.put(urlEqualTo(ENDPOINT_WITH_CORRECT_ENCODING))
             .willReturn(WireMock.aResponse().withStatus(200)));
     buildService.build("master", "job1", Map.of("param1", "value with spaces"));
 
-    wmIgor.verify(1, putRequestedFor(urlEqualTo(ENDPOINT_WITH_INCORRECT_ENCODING)));
+    wmIgor.verify(1, putRequestedFor(urlEqualTo(ENDPOINT_WITH_CORRECT_ENCODING)));
   }
 
   static class TestConfig {

--- a/orca/orca-igor/src/test/java/com/netflix/spinnaker/orca/igor/BuildServiceTest.java
+++ b/orca/orca-igor/src/test/java/com/netflix/spinnaker/orca/igor/BuildServiceTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2025 OpsMx, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.igor;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.putRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+
+import brave.Tracing;
+import brave.http.HttpTracing;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import com.netflix.spectator.api.NoopRegistry;
+import com.netflix.spinnaker.config.DefaultServiceClientProvider;
+import com.netflix.spinnaker.config.OkHttpClientComponents;
+import com.netflix.spinnaker.config.RetrofitConfiguration;
+import com.netflix.spinnaker.config.okhttp3.DefaultOkHttpClientBuilderProvider;
+import com.netflix.spinnaker.config.okhttp3.RawOkHttpClientFactory;
+import com.netflix.spinnaker.kork.core.RetrySupport;
+import com.netflix.spinnaker.kork.retrofit.RetrofitServiceFactoryAutoConfiguration;
+import com.netflix.spinnaker.kork.web.selector.ByAccountServiceSelector;
+import com.netflix.spinnaker.kork.web.selector.SelectableService;
+import com.netflix.spinnaker.okhttp.OkHttpClientConfigurationProperties;
+import com.netflix.spinnaker.orca.clouddriver.CloudDriverService;
+import com.netflix.spinnaker.orca.clouddriver.DelegatingOortService;
+import com.netflix.spinnaker.orca.igor.config.IgorConfiguration;
+import com.netflix.spinnaker.orca.pipeline.persistence.InMemoryExecutionRepository;
+import com.netflix.spinnaker.orca.pipeline.util.ArtifactUtils;
+import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor;
+import com.netflix.spinnaker.retrofit.RetrofitConfigurationProperties;
+import java.util.List;
+import java.util.Map;
+import okhttp3.Interceptor;
+import okhttp3.OkHttpClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.task.TaskExecutorBuilder;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import retrofit.RestAdapter;
+
+@SpringBootTest(
+    classes = {
+      IgorConfiguration.class,
+      DefaultServiceClientProvider.class,
+      RetrofitServiceFactoryAutoConfiguration.class,
+      BuildServiceTest.TestConfig.class,
+      OkHttpClientComponents.class,
+      DefaultOkHttpClientBuilderProvider.class,
+      ObjectMapper.class,
+      NoopRegistry.class,
+      ContextParameterProcessor.class,
+      TaskExecutorBuilder.class,
+      CloudDriverService.class,
+      DelegatingOortService.class,
+      RetrySupport.class,
+      ArtifactUtils.class,
+      InMemoryExecutionRepository.class,
+      RetrofitConfiguration.class
+    })
+public class BuildServiceTest {
+  @RegisterExtension
+  private static WireMockExtension wmIgor =
+      WireMockExtension.newInstance().options(wireMockConfig().dynamicPort()).build();
+
+  @DynamicPropertySource
+  private static void registerProperties(DynamicPropertyRegistry registry) {
+    registry.add("igor.base-url", wmIgor::baseUrl);
+  }
+
+  private static BuildService buildService;
+  private static final String ENDPOINT_WITH_INCORRECT_ENCODING =
+      "/masters/master/jobs/job1?param1=value%2Bwith%2Bspaces";
+
+  @Autowired IgorService igorService;
+
+  @BeforeEach
+  public void init() {
+    buildService = new BuildService(igorService, new IgorFeatureFlagProperties());
+  }
+
+  @Test
+  public void testBuildServiceBuildApi() {
+    // FIXME: the query params should be encoded with spaces, and not with +
+    wmIgor.stubFor(
+        WireMock.put(urlEqualTo(ENDPOINT_WITH_INCORRECT_ENCODING))
+            .willReturn(WireMock.aResponse().withStatus(200)));
+    buildService.build("master", "job1", Map.of("param1", "value with spaces"));
+
+    wmIgor.verify(1, putRequestedFor(urlEqualTo(ENDPOINT_WITH_INCORRECT_ENCODING)));
+  }
+
+  static class TestConfig {
+    @Bean
+    RestAdapter.LogLevel retrofitLogLevel(
+        RetrofitConfigurationProperties retrofitConfigurationProperties) {
+      return retrofitConfigurationProperties.getLogLevel();
+    }
+
+    // Since RawOkHttpClientConfiguration is not public, it can't be imported.
+    // So the following beans - HttpTracing &  OkHttpClient - are added to the test configuration
+    @Bean
+    public HttpTracing httpTracing() {
+      return HttpTracing.newBuilder(Tracing.newBuilder().build()).build();
+    }
+
+    @Bean
+    OkHttpClient okhttp3Client(
+        OkHttpClientConfigurationProperties okHttpClientConfigurationProperties,
+        List<Interceptor> interceptors,
+        HttpTracing httpTracing) {
+      return new RawOkHttpClientFactory()
+          .create(okHttpClientConfigurationProperties, interceptors, httpTracing);
+    }
+
+    @Bean
+    SelectableService selectableService() {
+      return new SelectableService(
+          List.of(new ByAccountServiceSelector("oort", 10, Map.of("accountPattern", ".*"))));
+    }
+  }
+}

--- a/orca/orca-retrofit/src/main/groovy/com/netflix/spinnaker/orca/retrofit/RetrofitConfiguration.groovy
+++ b/orca/orca-retrofit/src/main/groovy/com/netflix/spinnaker/orca/retrofit/RetrofitConfiguration.groovy
@@ -20,6 +20,7 @@ package com.netflix.spinnaker.orca.retrofit
 import com.jakewharton.retrofit.Ok3Client
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.config.OkHttp3ClientConfiguration
+import com.netflix.spinnaker.kork.retrofit.util.RetrofitUtils
 import com.netflix.spinnaker.orca.retrofit.exceptions.SpinnakerServerExceptionHandler
 import groovy.transform.CompileStatic
 import okhttp3.Interceptor
@@ -62,8 +63,8 @@ class RetrofitConfiguration {
         builder.addInterceptor(interceptor);
       }
     }
-
-    new Ok3Client(builder.build())
+    OkHttpClient client = RetrofitUtils.getClientForRetrofit1(builder.build())
+    new Ok3Client(client)
   }
 
   @Bean


### PR DESCRIPTION
- This PR addresses the issue - https://github.com/spinnaker/spinnaker/issues/7059#issuecomment-3003509067

- It is observed that the retrofit1 client is added with retrofit2 specific interceptors and this PR removes them.

- [RawOkHttpClientConfiguration.java](https://github.com/spinnaker/spinnaker/blob/release-2025.0.x/kork/kork-web/src/main/java/com/netflix/spinnaker/config/okhttp3/RawOkHttpClientConfiguration.java) is adding interceptors to a OkHttpClient which is then autowired in [DefaultOkHttpClientBuilderProvider.java](https://github.com/spinnaker/spinnaker/blob/release-2025.0.x/kork/kork-web/src/main/java/com/netflix/spinnaker/config/okhttp3/DefaultOkHttpClientBuilderProvider.java#L59) and getting to retrofit1 through [OkHttpClientProvider](https://github.com/spinnaker/spinnaker/blob/release-2025.0.x/kork/kork-web/src/main/java/com/netflix/spinnaker/config/okhttp3/OkHttpClientProvider.java) which is autowired in [IgorConfiguration](https://github.com/spinnaker/spinnaker/blob/release-2025.0.x/orca/orca-igor/src/main/groovy/com/netflix/spinnaker/orca/igor/config/IgorConfiguration.groovy#L48). OkHttpClientProvider, DefaultOkHttpClientBuilderProvider etc are common classes to retrofit1 and retrofit2. 

- Added a test to demonstrate the issue. 