### PR TITLE
fix(retrofit2): fix a broken scenario related to LegacySignatureCallAdapter

### DIFF
--- a/kork/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/RetrofitServiceFactory.java
+++ b/kork/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/RetrofitServiceFactory.java
@@ -25,6 +25,7 @@ import com.netflix.spinnaker.config.ServiceEndpoint;
 import com.netflix.spinnaker.config.okhttp3.OkHttpClientProvider;
 import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
 import com.netflix.spinnaker.kork.client.ServiceClientFactory;
+import com.netflix.spinnaker.kork.client.ServiceClientProvider;
 import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerRetrofitErrorHandler;
 import com.netflix.spinnaker.retrofit.Slf4jRetrofitLogger;
 import java.util.List;
@@ -75,5 +76,13 @@ class RetrofitServiceFactory implements ServiceClientFactory {
         String.format(
             "Retrofit1 client doesn't support okhttp3 Interceptors. Failed to build %s ",
             type.getName()));
+  }
+
+  @Override
+  public boolean supports(
+      Class<?> type,
+      ServiceEndpoint serviceEndpoint,
+      ServiceClientProvider.RetrofitVersion version) {
+    return version.equals(ServiceClientProvider.RetrofitVersion.RETROFIT1);
   }
 }

--- a/kork/kork-retrofit/src/test/kotlin/com/netflix/spinnaker/kork/retrofit/RetrofitServiceProviderTest.kt
+++ b/kork/kork-retrofit/src/test/kotlin/com/netflix/spinnaker/kork/retrofit/RetrofitServiceProviderTest.kt
@@ -67,7 +67,7 @@ class RetrofitServiceProviderTest  : JUnit5Minutests {
         run { ctx: AssertableApplicationContext ->
           expect {
             that(ctx.getBeansOfType(ServiceClientProvider::class.java)).get { size }.isEqualTo(1)
-            that(ctx.getBean(ServiceClientProvider::class.java).getService(Retrofit1Service::class.java, DefaultServiceEndpoint("retrofit1", "https://www.test.com"))).isA<Retrofit1Service>()
+            that(ctx.getBean(ServiceClientProvider::class.java).getService(Retrofit1Service::class.java, DefaultServiceEndpoint("retrofit1", "https://www.test.com"), ServiceClientProvider.RetrofitVersion.RETROFIT1)).isA<Retrofit1Service>()
           }
         }
       }

--- a/kork/kork-retrofit2/src/main/java/com/netflix/spinnaker/kork/retrofit/Retrofit2ServiceFactory.java
+++ b/kork/kork-retrofit2/src/main/java/com/netflix/spinnaker/kork/retrofit/Retrofit2ServiceFactory.java
@@ -22,12 +22,12 @@ import com.netflix.spinnaker.config.ServiceEndpoint;
 import com.netflix.spinnaker.config.okhttp3.OkHttpClientProvider;
 import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
 import com.netflix.spinnaker.kork.client.ServiceClientFactory;
+import com.netflix.spinnaker.kork.client.ServiceClientProvider;
 import java.util.List;
 import java.util.Objects;
 import okhttp3.HttpUrl;
 import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
-import retrofit2.Call;
 import retrofit2.Retrofit;
 import retrofit2.converter.jackson.JacksonConverterFactory;
 
@@ -63,7 +63,10 @@ public class Retrofit2ServiceFactory implements ServiceClientFactory {
   }
 
   @Override
-  public boolean supports(Class<?> type, ServiceEndpoint serviceEndpoint) {
-    return type.getMethods()[0].getReturnType().getName().equalsIgnoreCase(Call.class.getName());
+  public boolean supports(
+      Class<?> type,
+      ServiceEndpoint serviceEndpoint,
+      ServiceClientProvider.RetrofitVersion version) {
+    return version.equals(ServiceClientProvider.RetrofitVersion.RETROFIT2);
   }
 }

--- a/kork/kork-retrofit2/src/test/java/com/netflix/spinnaker/kork/retrofit/Retrofit2ServiceFactoryTest.java
+++ b/kork/kork-retrofit2/src/test/java/com/netflix/spinnaker/kork/retrofit/Retrofit2ServiceFactoryTest.java
@@ -23,8 +23,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -40,7 +38,6 @@ import com.netflix.spinnaker.config.okhttp3.DefaultOkHttpClientBuilderProvider;
 import com.netflix.spinnaker.config.okhttp3.OkHttpClientProvider;
 import com.netflix.spinnaker.kork.client.ServiceClientFactory;
 import com.netflix.spinnaker.kork.client.ServiceClientProvider;
-import com.netflix.spinnaker.kork.exceptions.SystemException;
 import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerConversionException;
 import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerHttpException;
 import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerServerException;
@@ -220,14 +217,8 @@ public class Retrofit2ServiceFactoryTest {
     assertDoesNotThrow(
         () -> serviceClientProvider.getService(Retrofit2TestService.class, serviceEndpoint));
 
-    // FIXME: This should not throw exception
-    Throwable thrown =
-        catchThrowable(
-            () ->
-                serviceClientProvider.getService(Retrofit2CallTestService.class, serviceEndpoint));
-    assertThat(thrown).isInstanceOf(SystemException.class);
-    assertThat(thrown.getMessage())
-        .contains("No service client provider found for url (http://localhost:1234)");
+    assertDoesNotThrow(
+        () -> serviceClientProvider.getService(Retrofit2CallTestService.class, serviceEndpoint));
   }
 
   @Configuration

--- a/kork/kork-web/src/main/java/com/netflix/spinnaker/config/DefaultServiceClientProvider.java
+++ b/kork/kork-web/src/main/java/com/netflix/spinnaker/config/DefaultServiceClientProvider.java
@@ -44,14 +44,28 @@ public class DefaultServiceClientProvider implements ServiceClientProvider {
 
   @Override
   public <T> T getService(Class<T> type, ServiceEndpoint serviceEndpoint) {
-    ServiceClientFactory serviceClientFactory = findProvider(type, serviceEndpoint);
+    return getService(type, serviceEndpoint, RetrofitVersion.RETROFIT2);
+  }
+
+  @Override
+  public <T> T getService(Class<T> type, ServiceEndpoint serviceEndpoint, RetrofitVersion version) {
+    ServiceClientFactory serviceClientFactory = findProvider(type, serviceEndpoint, version);
     return serviceClientFactory.create(type, serviceEndpoint, objectMapper);
   }
 
   @Override
   public <T> T getService(
       Class<T> type, ServiceEndpoint serviceEndpoint, ObjectMapper objectMapper) {
-    ServiceClientFactory serviceClientFactory = findProvider(type, serviceEndpoint);
+    return getService(type, serviceEndpoint, objectMapper, RetrofitVersion.RETROFIT2);
+  }
+
+  @Override
+  public <T> T getService(
+      Class<T> type,
+      ServiceEndpoint serviceEndpoint,
+      ObjectMapper objectMapper,
+      RetrofitVersion version) {
+    ServiceClientFactory serviceClientFactory = findProvider(type, serviceEndpoint, version);
     return serviceClientFactory.create(type, serviceEndpoint, objectMapper);
   }
 
@@ -61,13 +75,24 @@ public class DefaultServiceClientProvider implements ServiceClientProvider {
       ServiceEndpoint serviceEndpoint,
       ObjectMapper objectMapper,
       List<Interceptor> interceptors) {
-    ServiceClientFactory serviceClientFactory = findProvider(type, serviceEndpoint);
+    return getService(type, serviceEndpoint, objectMapper, interceptors, RetrofitVersion.RETROFIT2);
+  }
+
+  @Override
+  public <T> T getService(
+      Class<T> type,
+      ServiceEndpoint serviceEndpoint,
+      ObjectMapper objectMapper,
+      List<Interceptor> interceptors,
+      RetrofitVersion version) {
+    ServiceClientFactory serviceClientFactory = findProvider(type, serviceEndpoint, version);
     return serviceClientFactory.create(type, serviceEndpoint, objectMapper, interceptors);
   }
 
-  private ServiceClientFactory findProvider(Class<?> type, ServiceEndpoint service) {
+  private ServiceClientFactory findProvider(
+      Class<?> type, ServiceEndpoint service, RetrofitVersion version) {
     return serviceClientFactories.stream()
-        .filter(provider -> provider.supports(type, service))
+        .filter(provider -> provider.supports(type, service, version))
         .findFirst()
         .orElseThrow(
             () ->

--- a/kork/kork-web/src/main/java/com/netflix/spinnaker/kork/client/ServiceClientFactory.java
+++ b/kork/kork-web/src/main/java/com/netflix/spinnaker/kork/client/ServiceClientFactory.java
@@ -57,9 +57,11 @@ public interface ServiceClientFactory {
    *
    * @param type client type
    * @param serviceEndpoint endpoint configuration
+   * @param version the retrofit version
    * @return a client builder
    */
-  public default boolean supports(Class<?> type, ServiceEndpoint serviceEndpoint) {
-    return true;
-  }
+  public boolean supports(
+      Class<?> type,
+      ServiceEndpoint serviceEndpoint,
+      ServiceClientProvider.RetrofitVersion version);
 }

--- a/kork/kork-web/src/main/java/com/netflix/spinnaker/kork/client/ServiceClientProvider.java
+++ b/kork/kork-web/src/main/java/com/netflix/spinnaker/kork/client/ServiceClientProvider.java
@@ -27,7 +27,39 @@ import okhttp3.Interceptor;
 public interface ServiceClientProvider {
 
   /**
+   * An enumeration of the supported retrofit versions.
+   *
+   * <p>The value passed here should match the annotations on the interface Class type passed in to
+   * getService() methods.
+   *
+   * <ul>
+   *   <li>{@link #RETROFIT1} corresponds to retrofit 1.x annotations like {@code retrofit.http.GET}
+   *       and {@code retrofit.http.PUT}.
+   *   <li>{@link #RETROFIT2} corresponds to retrofit 2.x annotations like {@code
+   *       retrofit2.http.GET} and {@code retrofit2.http.PUT}.
+   * </ul>
+   */
+  enum RetrofitVersion {
+    RETROFIT1,
+    RETROFIT2
+  }
+
+  /**
    * Returns the concrete retrofit service client
+   *
+   * @param type retrofit interface type
+   * @param serviceEndpoint endpoint definition
+   * @param <T> type of client , usually an interface with all the remote method definitions.
+   * @param version the retrofit version
+   * @return the retrofit interface implementation
+   */
+  public <T> T getService(Class<T> type, ServiceEndpoint serviceEndpoint, RetrofitVersion version);
+
+  /**
+   * Returns the concrete retrofit service client
+   *
+   * <p>This method behaves the same as {@link #getService(Class, ServiceEndpoint, RetrofitVersion)}
+   * but the retrofit version will be inferred from the implementation.
    *
    * @param type retrofit interface type
    * @param serviceEndpoint endpoint definition
@@ -43,6 +75,25 @@ public interface ServiceClientProvider {
    * @param serviceEndpoint endpoint definition
    * @param objectMapper object mapper for conversion
    * @param <T> type of client , usually an interface with all the remote method definitions.
+   * @param version the retrofit version
+   * @return the retrofit interface implementation
+   */
+  public <T> T getService(
+      Class<T> type,
+      ServiceEndpoint serviceEndpoint,
+      ObjectMapper objectMapper,
+      RetrofitVersion version);
+
+  /**
+   * Returns the concrete retrofit service client
+   *
+   * <p>This method behaves the same as {@link #getService(Class, ServiceEndpoint, ObjectMapper,
+   * RetrofitVersion)} but the retrofit version will be inferred from the implementation.
+   *
+   * @param type retrofit interface type
+   * @param serviceEndpoint endpoint definition
+   * @param objectMapper object mapper for conversion
+   * @param <T> type of client , usually an interface with all the remote method definitions.
    * @return the retrofit interface implementation
    */
   public <T> T getService(
@@ -50,6 +101,27 @@ public interface ServiceClientProvider {
 
   /**
    * Returns the concrete retrofit service client
+   *
+   * @param type retrofit interface type
+   * @param serviceEndpoint endpoint definition
+   * @param objectMapper object mapper for conversion
+   * @param interceptors list of interceptors
+   * @param <T> type of client , usually an interface with all the remote method definitions.
+   * @param version the retrofit version
+   * @return the retrofit interface implementation
+   */
+  public <T> T getService(
+      Class<T> type,
+      ServiceEndpoint serviceEndpoint,
+      ObjectMapper objectMapper,
+      List<Interceptor> interceptors,
+      RetrofitVersion version);
+
+  /**
+   * Returns the concrete retrofit service client
+   *
+   * <p>This method behaves the same as {@link #getService(Class, ServiceEndpoint, ObjectMapper,
+   * List, RetrofitVersion)} but the retrofit version will be inferred from the implementation.
    *
    * @param type retrofit interface type
    * @param serviceEndpoint endpoint definition

--- a/orca/orca-clouddriver/orca-clouddriver.gradle
+++ b/orca/orca-clouddriver/orca-clouddriver.gradle
@@ -32,6 +32,7 @@ dependencies {
   implementation(project(":orca-deploymentmonitor"))
   implementation("io.spinnaker.kork:kork-moniker")
   implementation("io.spinnaker.kork:kork-retrofit")
+  implementation("io.spinnaker.kork:kork-retrofit2")
   implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml")
   implementation("io.kubernetes:client-java")
   implementation("com.amazonaws:aws-java-sdk-lambda")
@@ -64,7 +65,6 @@ dependencies {
   testImplementation("ru.lanwen.wiremock:wiremock-junit5:1.3.1")
   testImplementation("com.squareup.retrofit2:retrofit")
   testImplementation("com.squareup.retrofit2:retrofit-mock")
-  testImplementation("io.spinnaker.kork:kork-retrofit2")
 
   testCompileOnly("org.projectlombok:lombok")
   testAnnotationProcessor("org.projectlombok:lombok")

--- a/orca/orca-retrofit/orca-retrofit.gradle
+++ b/orca/orca-retrofit/orca-retrofit.gradle
@@ -27,6 +27,7 @@ dependencies {
   implementation(project(":orca-core"))
   implementation("io.reactivex:rxjava")
   implementation("io.spinnaker.kork:kork-retrofit")
+  implementation("io.spinnaker.kork:kork-retrofit2")
   implementation "com.google.guava:guava"
 
   testImplementation("com.squareup.retrofit:retrofit-mock")


### PR DESCRIPTION
- With the introduction of `LegacySignatureCallAdapter` in https://github.com/spinnaker/spinnaker/pull/7088, the logic to verify whether the request is for retrofit2 client is no longer valid because the retrofit2 enabled API interface need not have method return types with Call wrapper.

- This PR addresses the issue by introducing the RetrofitVersion enum field in all the ServiceClientProvider.getService() calls. 

- Added a test to demonstrate the issue. 
