### PR TITLE
chore(clouddriver/kubernetes): upgrade kind to 0.29.0

### DIFF
--- a/clouddriver/clouddriver-kubernetes/src/integration/java/com/netflix/spinnaker/clouddriver/kubernetes/it/containers/KubernetesCluster.java
+++ b/clouddriver/clouddriver-kubernetes/src/integration/java/com/netflix/spinnaker/clouddriver/kubernetes/it/containers/KubernetesCluster.java
@@ -48,7 +48,7 @@ public class KubernetesCluster {
 
   private static KubernetesCluster INSTANCE;
   private static final String IMAGE = System.getenv("IMAGE");
-  private static final String KIND_VERSION = "0.20.0";
+  private static final String KIND_VERSION = "0.29.0";
   private static final String KUBECTL_VERSION = System.getenv("KUBECTL_VERSION");
   private static final Path IT_BUILD_HOME = Paths.get(System.getenv("IT_BUILD_HOME"));
   private static final Path KUBECFG_PATH = Paths.get(IT_BUILD_HOME.toString(), "kubecfg.yml");


### PR DESCRIPTION
to stay up to date.
[0.29.0](https://github.com/kubernetes-sigs/kind/releases/tag/v0.29.0) is the most recent as of 6-jul-25.
