### PR TITLE
chore(dependency): bump tomcat from 9.0.83 to 9.0.107

### DIFF
--- a/kork/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/kork/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -31,9 +31,9 @@ ext {
     springBoot       : "2.7.18",
     springCloud      : "2021.0.8",
     swagger          : "2.2.22",
-    // 2.7.18 brings in 9.0.83, which fixes all CVEs to date (20-feb-24). Continue to pin.
+    // 9.0.107, which fixes all CVEs to date (18-jul-25). Continue to pin.
     // See https://tomcat.apache.org/security-9.html for latest security fixes.
-    tomcat           : "9.0.83"
+    tomcat           : "9.0.107"
   ]
 }
 


### PR DESCRIPTION
chore(dependency): bump tomcat from 9.0.83 to 9.0.107

Fixes tomcat CVEs. Most importantly CVE-2024-56337, CVE-2024-50379, CVE-2025-24813
