### PR TITLE
fix(googlechat): fix googlechat encoding issue

### DIFF
--- a/echo/echo-notifications/src/main/java/com/netflix/spinnaker/echo/googlechat/GoogleChatClient.java
+++ b/echo/echo-notifications/src/main/java/com/netflix/spinnaker/echo/googlechat/GoogleChatClient.java
@@ -21,9 +21,13 @@ import retrofit2.Call;
 import retrofit2.http.Body;
 import retrofit2.http.POST;
 import retrofit2.http.Path;
+import retrofit2.http.Query;
 
 public interface GoogleChatClient {
   @POST("v1/spaces/{address}")
   Call<ResponseBody> sendMessage(
-      @Path(value = "address", encoded = true) String webhook, @Body GoogleChatMessage message);
+      @Path(value = "address", encoded = true) String webhook,
+      @Query("key") String key,
+      @Query("token") String token,
+      @Body GoogleChatMessage message);
 }

--- a/echo/echo-notifications/src/main/java/com/netflix/spinnaker/echo/googlechat/GoogleChatNotificationService.java
+++ b/echo/echo-notifications/src/main/java/com/netflix/spinnaker/echo/googlechat/GoogleChatNotificationService.java
@@ -47,7 +47,8 @@ class GoogleChatNotificationService implements NotificationService {
     for (String addr : addressSet) {
       // In Chat, users can only copy the whole link easily. We just extract the information from
       // the whole link.
-      // Example: https://chat.googleapis.com/v1/spaces/{partialWebhookUrl}
+      // Example: https://chat.googleapis.com/v1/spaces/SPACE_ID/messages?key=KEY&token=TOKEN
+      // or   https://chat.googleapis.com/v1/spaces/{partialWebhookUrl}
       String baseUrl = "https://chat.googleapis.com/v1/spaces/";
       String completeLink = addr;
       String partialWebhookURL = completeLink.substring(baseUrl.length());

--- a/echo/echo-notifications/src/main/java/com/netflix/spinnaker/echo/googlechat/GoogleChatService.java
+++ b/echo/echo-notifications/src/main/java/com/netflix/spinnaker/echo/googlechat/GoogleChatService.java
@@ -18,6 +18,8 @@ package com.netflix.spinnaker.echo.googlechat;
 
 import com.netflix.spinnaker.kork.retrofit.Retrofit2SyncCall;
 import groovy.transform.Canonical;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 import okhttp3.ResponseBody;
 
 @Canonical
@@ -29,6 +31,43 @@ public class GoogleChatService {
   }
 
   ResponseBody sendMessage(String webhook, GoogleChatMessage message) {
-    return Retrofit2SyncCall.execute(googleChatClient.sendMessage(webhook, message));
+    WebhookUrlParts parts = extractWebhookUrlParts(webhook);
+    return Retrofit2SyncCall.execute(
+        googleChatClient.sendMessage(
+            parts.getSpaceId(), parts.getKey(), parts.getToken(), message));
+  }
+
+  @Getter
+  @AllArgsConstructor
+  private static class WebhookUrlParts {
+    private final String spaceId;
+    private final String key;
+    private final String token;
+  }
+
+  private WebhookUrlParts extractWebhookUrlParts(String partialWebhookURL) {
+    // Split SPACE_ID/messages?key=KEY&token=TOKEN into path and query parameters
+    String[] parts = partialWebhookURL.split("\\?");
+    if (parts.length != 2) {
+      throw new IllegalArgumentException("Invalid Google Chat webhook URL format");
+    }
+
+    String[] queryParams = parts[1].split("&");
+
+    String key = "";
+    String token = "";
+
+    for (String param : queryParams) {
+      String[] keyValue = param.split("=");
+      if (keyValue.length == 2) {
+        if ("key".equals(keyValue[0])) {
+          key = keyValue[1];
+        } else if ("token".equals(keyValue[0])) {
+          token = keyValue[1];
+        }
+      }
+    }
+
+    return new WebhookUrlParts(parts[0], key, token);
   }
 }

--- a/echo/echo-notifications/src/test/java/com/netflix/spinnaker/echo/googlechat/GoogleChatClientTest.java
+++ b/echo/echo-notifications/src/test/java/com/netflix/spinnaker/echo/googlechat/GoogleChatClientTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2025 OpsMx, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.echo.googlechat;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import com.netflix.spectator.api.NoopRegistry;
+import com.netflix.spinnaker.config.OkHttp3ClientConfiguration;
+import com.netflix.spinnaker.config.OkHttpClientComponents;
+import com.netflix.spinnaker.config.RetrofitConfiguration;
+import com.netflix.spinnaker.kork.retrofit.ErrorHandlingExecutorCallAdapterFactory;
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerHttpException;
+import com.netflix.spinnaker.kork.retrofit.util.RetrofitUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.task.TaskExecutorBuilder;
+import org.springframework.boot.test.context.SpringBootTest;
+import retrofit2.Retrofit;
+import retrofit2.converter.jackson.JacksonConverterFactory;
+
+@SpringBootTest(
+    classes = {
+      GoogleChatClient.class,
+      OkHttp3ClientConfiguration.class,
+      OkHttpClientComponents.class,
+      RetrofitConfiguration.class,
+      TaskExecutorBuilder.class,
+      NoopRegistry.class
+    })
+public class GoogleChatClientTest {
+
+  @Autowired OkHttp3ClientConfiguration okHttpClientConfig;
+
+  @RegisterExtension
+  static WireMockExtension wmGoogleChat =
+      WireMockExtension.newInstance().options(wireMockConfig().dynamicPort()).build();
+
+  private GoogleChatService googleChatService;
+
+  @BeforeEach
+  public void setup() {
+    GoogleChatClient googleChatClient = getGoogleChatClient(wmGoogleChat.baseUrl());
+    googleChatService = new GoogleChatService(googleChatClient);
+  }
+
+  @Test
+  public void testSendGoogleChatMessage() {
+    String incorrectly_encoded_endpoint =
+        "/v1/spaces/RANDOM/messages%3Fkey%3DXYZ-321%26token%3Dtesttoken123";
+    String expected_endpoint = "/v1/spaces/RANDOM/messages?key=XYZ-321&token=testtoken123";
+
+    wmGoogleChat.stubFor(
+        WireMock.post(urlEqualTo(incorrectly_encoded_endpoint))
+            .willReturn(
+                aResponse().withHeader("Content-Type", "application/json").withStatus(404)));
+
+    wmGoogleChat.stubFor(
+        WireMock.post(urlEqualTo(expected_endpoint))
+            .willReturn(
+                aResponse().withHeader("Content-Type", "application/json").withStatus(200)));
+
+    // FIXME: retrofit2 is incorrectly encoding the characters ?(to %3F) and &(to %26) related to
+    // query params as
+    // if they are part of the path variable.
+    Throwable thrown =
+        catchThrowable(
+            () ->
+                googleChatService.sendMessage(
+                    "RANDOM/messages?key=XYZ-321&token=testtoken123",
+                    new GoogleChatMessage("test message")));
+    assertThat(thrown).isInstanceOf(SpinnakerHttpException.class);
+    assertThat(thrown.getMessage())
+        .contains(
+            "Status: 404, Method: POST, URL: "
+                + wmGoogleChat.baseUrl()
+                + "/v1/spaces/RANDOM/messages%3Fkey%3DXYZ-321%26token%3Dtesttoken123, Message: Not Found");
+  }
+
+  private GoogleChatClient getGoogleChatClient(String baseUrl) {
+    return new Retrofit.Builder()
+        .baseUrl(RetrofitUtils.getBaseUrl(baseUrl))
+        .client(okHttpClientConfig.createForRetrofit2().build())
+        .addCallAdapterFactory(ErrorHandlingExecutorCallAdapterFactory.getInstance())
+        .addConverterFactory(JacksonConverterFactory.create())
+        .build()
+        .create(GoogleChatClient.class);
+  }
+}


### PR DESCRIPTION
- This PR addressed the issue https://github.com/spinnaker/spinnaker/issues/7022

- The issue occurred because the partial webhook url which contains query parameters(after two terms separated by slashes) was being sent as path variable due to which incorrect encoding was happening. This used to work with retrofit1 but retrofit2 is strict in this regard.

- From the [google chat official documentation](https://developers.google.com/workspace/chat/quickstart/webhooks?utm_source=chatgpt.com#python_1), found the webhook url is of the form - https://chat.googleapis.com/v1/spaces/SPACE_ID/messages?key=KEY&token=TOKEN so based on this, fix is provided by separated the path and query parameters.

- Added a test to demonstrate the issue.