### PR TITLE
chore(orca): restore changes from https://github.com/spinnaker/orca/pull/4566

### DIFF
--- a/kork/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/kork/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -58,6 +58,7 @@ dependencies {
   //kotlinVersion comes from gradle.properties since we have kotlin code in
   // this project and need to configure gradle plugins etc.
   api(platform(libs.kotlin.bom))
+  api(platform("org.junit:junit-bom:5.9.0")) // until spring boot >= 3.0.0
   api(platform("io.zipkin.brave:brave-bom:${versions.brave}"))
   api(platform("org.apache.groovy:groovy-bom:${versions.groovy}")) // until upgrade of spring boot >= 3.0.13
   api(platform("org.springframework.boot:spring-boot-dependencies:${versions.springBoot}")) {

--- a/orca/gradle/groovy.gradle
+++ b/orca/gradle/groovy.gradle
@@ -26,5 +26,5 @@ dependencies {
   testImplementation("cglib:cglib-nodep")
   testImplementation("org.objenesis:objenesis")
   testRuntimeOnly("org.junit.platform:junit-platform-engine")
-  testRuntimeOnly("org.junit.vintage:junit-vintage-engine")
+  testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
 }

--- a/orca/gradle/spek.gradle
+++ b/orca/gradle/spek.gradle
@@ -24,13 +24,6 @@ dependencies {
 
   testRuntimeOnly("org.junit.platform:junit-platform-launcher")
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
-  testRuntimeOnly("org.junit.vintage:junit-vintage-engine")
   testRuntimeOnly("org.jetbrains.spek:spek-junit-platform-engine")
   testImplementation("io.strikt:strikt-core")
-}
-
-test {
-  useJUnitPlatform {
-    includeEngines "spek", "junit-vintage", "junit-jupiter"
-  }
 }

--- a/orca/gradle/spock.gradle
+++ b/orca/gradle/spock.gradle
@@ -26,7 +26,6 @@ dependencies {
   testImplementation("org.objenesis:objenesis")
   testImplementation("org.apache.groovy:groovy")
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
-  testRuntimeOnly("org.junit.vintage:junit-vintage-engine")
 }
 
 tasks.compileGroovy.enabled = false


### PR DESCRIPTION
https://github.com/spinnaker/orca/pull/4566 that were apparently lost in the monorepo migration.

Without the junit-jupiter-engine dependency in orca/gradle/groovy.gradle, WebhookServiceTest doesn't run as part of
```
$ ./gradlew orca:orca-webhook:test
```
The addition of junit-bom to spinnaker-dependencies isn't a functional change.  spock-core brings it in even before this change, but now it's explicit, and matches what's in the [individual kork repo](https://github.com/spinnaker/kork/blob/a7b6fdea15ec2e98c80093947f194afb0ee552f3/spinnaker-dependencies/spinnaker-dependencies.gradle#L57).
