### PR TITLE
feat(orca/webhook): add account property to webhook stages and introduce WebhookAccountProcessor interface

### DIFF
--- a/clouddriver/clouddriver-web/clouddriver-web.gradle
+++ b/clouddriver/clouddriver-web/clouddriver-web.gradle
@@ -47,6 +47,7 @@ dependencies {
 
   testImplementation "io.spinnaker.kork:kork-test"
   testImplementation "org.springframework.boot:spring-boot-starter-test"
+  testImplementation "org.springframework.security:spring-security-test"
   testImplementation "org.spockframework:spock-core"
   testImplementation "io.kubernetes:client-java-api-fluent:13.0.2"
   testImplementation "org.apache.groovy:groovy-json"

--- a/clouddriver/clouddriver-web/src/main/java/com/netflix/spinnaker/clouddriver/controllers/CredentialsController.java
+++ b/clouddriver/clouddriver-web/src/main/java/com/netflix/spinnaker/clouddriver/controllers/CredentialsController.java
@@ -34,6 +34,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.annotation.CheckForNull;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -80,6 +81,18 @@ public class CredentialsController {
       throw new NotFoundException(String.format("Account does not exist (name: %s)", accountName));
     }
     return accountDetail;
+  }
+
+  /**
+   * Return account details only when the caller has write permissions for the account
+   *
+   * @param accountName the account name for which to retrieve details
+   * @return a map of account details
+   */
+  @GetMapping("/{accountName}/authorized")
+  @PreAuthorize("hasPermission(#accountName, 'ACCOUNT', 'WRITE')")
+  public Map<String, Object> getAccountCredentialsWithAuth(@PathVariable String accountName) {
+    return getAccountCredentialsDetails(accountName);
   }
 
   @CheckForNull

--- a/clouddriver/clouddriver-web/src/test/java/com/netflix/spinnaker/clouddriver/controllers/CredentialsControllerTest.java
+++ b/clouddriver/clouddriver-web/src/test/java/com/netflix/spinnaker/clouddriver/controllers/CredentialsControllerTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2025 Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.controllers;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.clouddriver.configuration.CredentialsConfiguration;
+import com.netflix.spinnaker.clouddriver.security.AccountCredentials;
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithAnonymousUser;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+@AutoConfigureMockMvc
+@SpringBootTest(
+    classes = {CredentialsController.class, CredentialsControllerTest.TestConfiguration.class})
+public class CredentialsControllerTest {
+  @Autowired private MockMvc mockMvc;
+
+  @MockBean private AccountCredentialsProvider accountCredentialsProvider;
+
+  @Test
+  @WithAnonymousUser
+  public void testGetAccountCredentialsUnauthorized() throws Exception {
+    MockHttpServletRequestBuilder builder =
+        MockMvcRequestBuilders.get("/credentials/testAccount/authorized")
+            .accept(MediaType.APPLICATION_JSON)
+            .characterEncoding(StandardCharsets.UTF_8.toString());
+
+    mockMvc.perform(builder).andDo(print()).andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  @WithMockUser(value = "testUser")
+  public void testGetAccountCredentialsAuthorized() throws Exception {
+    doReturn(new TestAccountCredentials())
+        .when(accountCredentialsProvider)
+        .getCredentials("testAccount");
+    MockHttpServletRequestBuilder builder =
+        MockMvcRequestBuilders.get("/credentials/testAccount/authorized")
+            .accept(MediaType.APPLICATION_JSON)
+            .characterEncoding(StandardCharsets.UTF_8.toString());
+
+    MvcResult result = mockMvc.perform(builder).andDo(print()).andReturn();
+
+    assertThat(result.getResponse().getStatus()).isNotEqualTo(HttpStatus.FORBIDDEN);
+  }
+
+  static class TestConfiguration {
+    @Bean
+    CredentialsConfiguration credentialsConfiguration() {
+      return new CredentialsConfiguration();
+    }
+
+    @Bean
+    ObjectMapper objectMapper() {
+      return new ObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL);
+    }
+  }
+
+  static class TestAccountCredentials implements AccountCredentials<Map<String, String>> {
+    String name;
+
+    public TestAccountCredentials() {
+      name = "testAccount";
+    }
+
+    @Override
+    public String getName() {
+      return name;
+    }
+
+    @Override
+    public String getEnvironment() {
+      return "testEnv";
+    }
+
+    @Override
+    public String getAccountType() {
+      return "test";
+    }
+
+    @Override
+    public Map<String, String> getCredentials() {
+      return Map.of("name", name);
+    }
+
+    @Override
+    public String getCloudProvider() {
+      return "testProvider";
+    }
+  }
+}

--- a/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/DelegatingOortService.java
+++ b/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/DelegatingOortService.java
@@ -191,4 +191,9 @@ public class DelegatingOortService extends DelegatingClouddriverService<OortServ
   public Call<List<Map<String, Object>>> getCredentials(boolean expand) {
     return getService().getCredentials(expand);
   }
+
+  @Override
+  public Call<Map<String, Object>> getCredentialsAuthorized(String account, boolean expand) {
+    return getService().getCredentialsAuthorized(account, expand);
+  }
 }

--- a/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/OortService.java
+++ b/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/OortService.java
@@ -189,4 +189,8 @@ public interface OortService {
 
   @GET("credentials")
   Call<List<Map<String, Object>>> getCredentials(@Query("expand") boolean expand);
+
+  @GET("/credentials/{account}/authorized")
+  Call<Map<String, Object>> getCredentialsAuthorized(
+      @Path("account") String account, @Query("expand") boolean expand);
 }

--- a/orca/orca-webhook/orca-webhook.gradle
+++ b/orca/orca-webhook/orca-webhook.gradle
@@ -20,6 +20,7 @@ apply from: "$rootDir/gradle/groovy.gradle"
 dependencies {
   implementation(project(":orca-core"))
   implementation(project(":orca-api"))
+  implementation(project(":orca-clouddriver"))
   implementation("io.spinnaker.kork:kork-core")
   implementation("io.spinnaker.kork:kork-retrofit")
   implementation("io.spinnaker.kork:kork-web")
@@ -33,11 +34,13 @@ dependencies {
   implementation("net.logstash.logback:logstash-logback-encoder")
 
   testImplementation("com.github.tomakehurst:wiremock-jre8-standalone")
+  testImplementation("com.squareup.retrofit2:retrofit-mock")
   testImplementation("com.squareup.okhttp3:mockwebserver")
   testImplementation("io.spinnaker.kork:kork-test")
   testImplementation("org.assertj:assertj-core")
   testImplementation("org.bouncycastle:bcpkix-jdk18on")
   testImplementation("org.junit.jupiter:junit-jupiter-api")
+  testImplementation("org.junit.jupiter:junit-jupiter-params")
   testImplementation("org.mockito:mockito-core")
   testImplementation("org.springframework:spring-test")
   testImplementation("org.springframework.boot:spring-boot-test")

--- a/orca/orca-webhook/src/main/java/com/netflix/spinnaker/orca/webhook/config/WebhookProperties.java
+++ b/orca/orca-webhook/src/main/java/com/netflix/spinnaker/orca/webhook/config/WebhookProperties.java
@@ -102,6 +102,9 @@ public class WebhookProperties {
   /** True to enable audit logging */
   private boolean auditLoggingEnabled = false;
 
+  /** True to require an account property in webhook stage configuration */
+  private boolean requireAccount = false;
+
   @Data
   @NoArgsConstructor
   public static class TrustSettings {

--- a/orca/orca-webhook/src/main/java/com/netflix/spinnaker/orca/webhook/config/WebhookProperties.java
+++ b/orca/orca-webhook/src/main/java/com/netflix/spinnaker/orca/webhook/config/WebhookProperties.java
@@ -102,8 +102,14 @@ public class WebhookProperties {
   /** True to enable audit logging */
   private boolean auditLoggingEnabled = false;
 
-  /** True to require an account property in webhook stage configuration */
+  /** True to require an account property in webhook stage configurations */
   private boolean requireAccount = false;
+
+  /**
+   * True to validate the account property in webhook stage configurations, if the account property
+   * is present.
+   */
+  private boolean validateAccount = false;
 
   @Data
   @NoArgsConstructor

--- a/orca/orca-webhook/src/main/java/com/netflix/spinnaker/orca/webhook/pipeline/PreconfiguredWebhookStage.java
+++ b/orca/orca-webhook/src/main/java/com/netflix/spinnaker/orca/webhook/pipeline/PreconfiguredWebhookStage.java
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.kork.exceptions.SystemException;
 import com.netflix.spinnaker.kork.retrofit.Retrofit2SyncCall;
 import com.netflix.spinnaker.orca.api.pipeline.graph.TaskNode;
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
+import com.netflix.spinnaker.orca.webhook.config.WebhookProperties;
 import com.netflix.spinnaker.orca.webhook.config.WebhookProperties.PreconfiguredWebhook;
 import com.netflix.spinnaker.orca.webhook.exception.PreconfiguredWebhookNotFoundException;
 import com.netflix.spinnaker.orca.webhook.exception.PreconfiguredWebhookUnauthorizedException;
@@ -53,8 +54,9 @@ public class PreconfiguredWebhookStage extends WebhookStage {
   PreconfiguredWebhookStage(
       WebhookService webhookService,
       FiatService fiatService,
-      MonitorWebhookTask monitorWebhookTask) {
-    super(monitorWebhookTask);
+      MonitorWebhookTask monitorWebhookTask,
+      WebhookProperties webhookProperties) {
+    super(monitorWebhookTask, webhookProperties);
 
     this.webhookService = webhookService;
     this.fiatService = fiatService;

--- a/orca/orca-webhook/src/main/java/com/netflix/spinnaker/orca/webhook/service/WebhookAccountProcessor.java
+++ b/orca/orca-webhook/src/main/java/com/netflix/spinnaker/orca/webhook/service/WebhookAccountProcessor.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2025 Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.webhook.service;
+
+import java.util.Map;
+import org.springframework.http.HttpHeaders;
+
+/**
+ * If a bean that implements this interface is present in the Spring context, the return value of
+ * the getHeaders method determines the http request headers that webhook stages send.
+ */
+public interface WebhookAccountProcessor {
+  /**
+   * Determine the http request headers that webhook stages send. Throw an exception to fail the
+   * webook stage before sending an http request.
+   *
+   * @param account the name of the Spinnaker account associated with the webhook stage (possibly
+   *     null or empty)
+   * @param accountDetails details about the Spinnaker account (possibly null)
+   * @param customHeaders the custom headers specified in the webhook stage (possibly null)
+   * @return the http request headers to send
+   */
+  HttpHeaders getHeaders(
+      String account, Map<String, Object> accountDetails, Map<String, Object> customHeaders);
+}

--- a/orca/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/pipeline/PreconfiguredWebhookStageSpec.groovy
+++ b/orca/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/pipeline/PreconfiguredWebhookStageSpec.groovy
@@ -34,8 +34,10 @@ class PreconfiguredWebhookStageSpec extends Specification {
   def builder = new TaskNode.Builder()
   MonitorWebhookTask monitorWebhookTask = Mock(MonitorWebhookTask)
 
+  WebhookProperties webhookProperties = new WebhookProperties()
+
   @Subject
-  preconfiguredWebhookStage = new PreconfiguredWebhookStage(webhookService, null, monitorWebhookTask)
+  preconfiguredWebhookStage = new PreconfiguredWebhookStage(webhookService, null, monitorWebhookTask, webhookProperties)
 
   def "Context should be taken from PreconfiguredWebhookProperties"() {
     given:

--- a/orca/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/pipeline/WebhookStageSpec.groovy
+++ b/orca/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/pipeline/WebhookStageSpec.groovy
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.orca.api.pipeline.graph.TaskNode
 import com.netflix.spinnaker.orca.pipeline.model.PipelineExecutionImpl
 import com.netflix.spinnaker.orca.pipeline.model.StageExecutionImpl
 import com.netflix.spinnaker.orca.pipeline.tasks.WaitTask
+import com.netflix.spinnaker.orca.webhook.config.WebhookProperties
 import com.netflix.spinnaker.orca.webhook.tasks.CreateWebhookTask
 import com.netflix.spinnaker.orca.webhook.tasks.MonitorWebhookTask
 import groovy.json.JsonOutput
@@ -36,8 +37,10 @@ class WebhookStageSpec extends Specification {
 
   MonitorWebhookTask monitorWebhookTask = Mock()
 
+  WebhookProperties webhookProperties = new WebhookProperties()
+
   @Subject
-  webhookStage = new WebhookStage(monitorWebhookTask)
+  webhookStage = new WebhookStage(monitorWebhookTask, webhookProperties)
 
   @Unroll
   def "Should create correct tasks"() {
@@ -112,5 +115,47 @@ class WebhookStageSpec extends Specification {
     'get'        | HttpMethod.GET
     'GET'        | HttpMethod.GET
     'Get'        | HttpMethod.GET
+  }
+
+  @Unroll
+  def "requireAccount behaves as expected (requireAccount: #requireAccount, hasAccount: #hasAccount, account: #account)"() {
+    given:
+    webhookProperties.setRequireAccount(requireAccount)
+
+    Map<String, Object> stageProperties = [:]
+    if (hasAccount) {
+      stageProperties['account'] = account
+    }
+
+    def stage = new StageExecutionImpl(
+      PipelineExecutionImpl.newPipeline("orca"),
+      "webhook",
+      stageProperties)
+
+    when:
+    // thrown() fails if no exception is thrown, and isn't allowed inside a
+    // conditional, so catch any exceptions manually.
+    Exception ex = null;
+    try {
+      webhookStage.taskGraph(stage, builder)
+    } catch (Exception exception) {
+      ex = exception
+    }
+
+    then:
+    expectException ? (ex instanceof UserException) : (ex == null)
+
+    where:
+    requireAccount | hasAccount | account      | expectException
+    false          | false      | "ignored"    | false
+    false          | true       | null         | false
+    false          | true       | ""           | false
+    false          | true       | " "          | false
+    false          | true       | "my-account" | false
+    true           | false      | "ignored"    | true
+    true           | true       | null         | true
+    true           | true       | ""           | true
+    true           | true       | " "          | true
+    true           | true       | "my-account" | false
   }
 }

--- a/orca/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/service/WebhookServiceSpec.groovy
+++ b/orca/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/service/WebhookServiceSpec.groovy
@@ -74,7 +74,7 @@ class WebhookServiceSpec extends Specification {
   def webhookService = new WebhookService(List.of(restTemplateProvider),
                                           userConfiguredUrlRestrictions,
                                           preconfiguredWebhookProperties,
-                                          oortService)
+                                          oortService, Optional.empty())
 
   @Unroll
   def "Webhook is being called with correct parameters"() {

--- a/orca/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/service/WebhookServiceSpec.groovy
+++ b/orca/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/service/WebhookServiceSpec.groovy
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.orca.webhook.service
 
 import com.netflix.spinnaker.okhttp.OkHttpClientConfigurationProperties
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
+import com.netflix.spinnaker.orca.clouddriver.OortService
 import com.netflix.spinnaker.orca.config.UserConfiguredUrlRestrictions
 import com.netflix.spinnaker.orca.pipeline.model.StageExecutionImpl
 import com.netflix.spinnaker.orca.webhook.config.WebhookProperties
@@ -67,10 +68,13 @@ class WebhookServiceSpec extends Specification {
 
   def server = MockRestServiceServer.createServer(restTemplateProvider.restTemplate)
 
+  def oortService = Mock(OortService)
+
   @Subject
   def webhookService = new WebhookService(List.of(restTemplateProvider),
                                           userConfiguredUrlRestrictions,
-                                          preconfiguredWebhookProperties)
+                                          preconfiguredWebhookProperties,
+                                          oortService)
 
   @Unroll
   def "Webhook is being called with correct parameters"() {

--- a/orca/orca-webhook/src/test/java/com/netflix/spinnaker/orca/webhook/config/MtlsConfigurationTestBase.java
+++ b/orca/orca-webhook/src/test/java/com/netflix/spinnaker/orca/webhook/config/MtlsConfigurationTestBase.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spinnaker.fiat.shared.FiatService;
 import com.netflix.spinnaker.kork.crypto.StandardCrypto;
 import com.netflix.spinnaker.kork.crypto.StaticX509Identity;
+import com.netflix.spinnaker.orca.clouddriver.OortService;
 import com.netflix.spinnaker.orca.config.UserConfiguredUrlRestrictions;
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -90,6 +91,8 @@ class MtlsConfigurationTestBase {
     }
 
     @MockBean FiatService fiatService;
+
+    @MockBean OortService oortService;
   }
 
   @SneakyThrows

--- a/orca/orca-webhook/src/test/java/com/netflix/spinnaker/orca/webhook/config/WebhookConfigurationTest.java
+++ b/orca/orca-webhook/src/test/java/com/netflix/spinnaker/orca/webhook/config/WebhookConfigurationTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.mock;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spinnaker.fiat.shared.FiatService;
 import com.netflix.spinnaker.okhttp.OkHttpClientConfigurationProperties;
+import com.netflix.spinnaker.orca.clouddriver.OortService;
 import com.netflix.spinnaker.orca.config.UserConfiguredUrlRestrictions;
 import java.lang.reflect.Field;
 import okhttp3.OkHttpClient;
@@ -179,6 +180,11 @@ class WebhookConfigurationTest {
     @Bean
     FiatService fiatService() {
       return mock(FiatService.class);
+    }
+
+    @Bean
+    OortService oortService() {
+      return mock(OortService.class);
     }
   }
 }


### PR DESCRIPTION
There are a series of changes here:
* feat(clouddriver/web): add an endpoint to fetch account details
* feat(orca/webhook): add new account property to webhook stages
* feat(orca/webhook): add webhook.validateAccount
* feat(orca/webhook): add WebhookAccountProcessor interface

with these orca config flags to control behavior:
* `webhook.requireAccount` (default: false). If true and the account property is not present (i.e. a non-empty string),
the stage fails.
* `webhook.validateAcount` (default: false). If true, and an account property is present, call clouddriver's GET /credentials/{account}/authorized endpoint to validate that the current user has permission to use the account.

The bigger picture here is that this is a new mechanism to help lock down webhook stages.  The addition of the WebhookAccountProcessor interface could go in a separate PR, but it's so close to the rest of what's going on here that I included it.

Note that this code doesn't actually a WebhookAccountProcessor bean, so that part of the change is a no-op without custom code / a plugin that adds one.
