### PR TITLE
feat(orca/webhook): add regex pattern matching to the webhook allow list

### DIFF
--- a/orca/orca-webhook/src/main/java/com/netflix/spinnaker/orca/webhook/config/WebhookProperties.java
+++ b/orca/orca-webhook/src/main/java/com/netflix/spinnaker/orca/webhook/config/WebhookProperties.java
@@ -135,11 +135,21 @@ public class WebhookProperties {
     private String identityCertPem;
   }
 
+  /** Match strategies for the allow list */
+  public enum MatchStrategy {
+    /** The url must start with the urlPrefix property to be considered valid. */
+    STARTS_WITH;
+  }
+
   @Data
   @NoArgsConstructor
   public static class AllowedRequest {
+
     /** The allowed http method(s) (e.g. GET, POST, PUT) */
     private List<String> httpMethods;
+
+    /** The match strategy to use */
+    private MatchStrategy matchStrategy = MatchStrategy.STARTS_WITH;
 
     /** The url must start with this string to be considered valid. */
     private String urlPrefix;

--- a/orca/orca-webhook/src/main/java/com/netflix/spinnaker/orca/webhook/config/WebhookProperties.java
+++ b/orca/orca-webhook/src/main/java/com/netflix/spinnaker/orca/webhook/config/WebhookProperties.java
@@ -138,7 +138,10 @@ public class WebhookProperties {
   /** Match strategies for the allow list */
   public enum MatchStrategy {
     /** The url must start with the urlPrefix property to be considered valid. */
-    STARTS_WITH;
+    STARTS_WITH,
+
+    /** The url must match the urlPattern property to be considered valid. */
+    PATTERN_MATCHES;
   }
 
   @Data
@@ -153,6 +156,9 @@ public class WebhookProperties {
 
     /** The url must start with this string to be considered valid. */
     private String urlPrefix;
+
+    /** The url must match this pattern to be considered valid */
+    private String urlPattern;
   }
 
   @Data

--- a/orca/orca-webhook/src/main/java/com/netflix/spinnaker/orca/webhook/service/WebhookService.java
+++ b/orca/orca-webhook/src/main/java/com/netflix/spinnaker/orca/webhook/service/WebhookService.java
@@ -229,7 +229,24 @@ public class WebhookService {
         .anyMatch(
             allowedRequest ->
                 allowedRequest.getHttpMethods().contains(httpMethod.toString())
-                    && uri.toString().startsWith(allowedRequest.getUrlPrefix()));
+                    && uriMatches(allowedRequest, uri));
+  }
+
+  /**
+   * Determine if an AllowedRequest allows a given uri
+   *
+   * @param allowedRequest the AllowRequest to use
+   * @param uri the URI to consider
+   * @return true if the uri is allowed, false otherwise
+   */
+  private boolean uriMatches(WebhookProperties.AllowedRequest allowedRequest, URI uri) {
+    switch (allowedRequest.getMatchStrategy()) {
+      case STARTS_WITH:
+        return uri.toString().startsWith(allowedRequest.getUrlPrefix());
+      default:
+        throw new IllegalArgumentException(
+            "unknown match strategy " + allowedRequest.getMatchStrategy());
+    }
   }
 
   private static HttpHeaders buildHttpHeaders(Map<String, Object> customHeaders) {

--- a/orca/orca-webhook/src/main/java/com/netflix/spinnaker/orca/webhook/service/WebhookService.java
+++ b/orca/orca-webhook/src/main/java/com/netflix/spinnaker/orca/webhook/service/WebhookService.java
@@ -250,7 +250,19 @@ public class WebhookService {
   private boolean uriMatches(WebhookProperties.AllowedRequest allowedRequest, URI uri) {
     switch (allowedRequest.getMatchStrategy()) {
       case STARTS_WITH:
-        return uri.toString().startsWith(allowedRequest.getUrlPrefix());
+        String urlPrefix = allowedRequest.getUrlPrefix();
+
+        if (urlPrefix == null) {
+          throw new IllegalArgumentException(
+              "urlPrefix must not be null with STARTS_WITH strategy");
+        }
+        boolean startsWithRetval = uri.toString().startsWith(urlPrefix);
+        log.debug(
+            "uri '{}' {} '{}'",
+            uri.toString(),
+            startsWithRetval ? "starts with" : "does not start with",
+            urlPrefix);
+        return startsWithRetval;
       case PATTERN_MATCHES:
         String patternString = allowedRequest.getUrlPattern();
 
@@ -261,13 +273,13 @@ public class WebhookService {
               "urlPattern must not be null with PATTERN_MATCHES strategy");
         }
         Pattern pattern = getPatternFor(patternString);
-        boolean retval = pattern.matcher(uri.toString()).matches();
-        log.info(
+        boolean patternMatchesRetval = pattern.matcher(uri.toString()).matches();
+        log.debug(
             "uri '{}' {} pattern '{}'",
             uri.toString(),
-            retval ? "matches" : "does not match",
+            patternMatchesRetval ? "matches" : "does not match",
             pattern.toString());
-        return retval;
+        return patternMatchesRetval;
       default:
         throw new IllegalArgumentException(
             "unknown match strategy " + allowedRequest.getMatchStrategy());

--- a/orca/orca-webhook/src/test/java/com/netflix/spinnaker/orca/webhook/service/WebhookServiceTest.java
+++ b/orca/orca-webhook/src/test/java/com/netflix/spinnaker/orca/webhook/service/WebhookServiceTest.java
@@ -50,6 +50,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.regex.PatternSyntaxException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
@@ -88,9 +89,7 @@ class WebhookServiceTest {
           .withAllowedHostnamesRegex(".*")
           .build();
 
-  private WebhookService webhookService;
-
-  private WebhookService webhookServiceWithAccountProcessor;
+  private RestTemplateProvider restTemplateProvider;
 
   private OortService oortService = mock(OortService.class);
 
@@ -107,29 +106,21 @@ class WebhookServiceTest {
             userConfiguredUrlRestrictions,
             webhookProperties);
 
-    RestTemplateProvider restTemplateProvider =
+    restTemplateProvider =
         new DefaultRestTemplateProvider(webhookConfiguration.restTemplate(requestFactory));
+  }
 
-    webhookService =
+  @Test
+  void testAllowedRequestsEnabledTrueEmptyList() {
+    webhookProperties.setAllowedRequestsEnabled(true);
+
+    WebhookService webhookService =
         new WebhookService(
             List.of(restTemplateProvider),
             userConfiguredUrlRestrictions,
             webhookProperties,
             oortService,
             Optional.empty());
-
-    webhookServiceWithAccountProcessor =
-        new WebhookService(
-            List.of(restTemplateProvider),
-            userConfiguredUrlRestrictions,
-            webhookProperties,
-            oortService,
-            Optional.of(webhookAccountProcessor));
-  }
-
-  @Test
-  void testAllowedRequestsEnabledTrueEmptyList() {
-    webhookProperties.setAllowedRequestsEnabled(true);
 
     String url = "https://localhost"; // arbitrary, but needs to include a resolvable hostname
 
@@ -156,6 +147,14 @@ class WebhookServiceTest {
     allowedRequest.setMatchStrategy(WebhookProperties.MatchStrategy.STARTS_WITH);
     allowedRequest.setUrlPrefix("http://localhost:" + apiProvider.getPort() + "/path/to/an/");
     webhookProperties.setAllowedRequests(List.of(allowedRequest));
+
+    WebhookService webhookService =
+        new WebhookService(
+            List.of(restTemplateProvider),
+            userConfiguredUrlRestrictions,
+            webhookProperties,
+            oortService,
+            Optional.empty());
 
     String path = "/path/to/an/endpoint";
     String url = apiProvider.baseUrl() + path;
@@ -190,21 +189,15 @@ class WebhookServiceTest {
     assertThat(allowedRequest.getUrlPrefix()).isNull();
     webhookProperties.setAllowedRequests(List.of(allowedRequest));
 
-    String path = "/path/to/an/endpoint";
-    String url = apiProvider.baseUrl() + path;
-
-    String bodyStr = "{ \"foo\": \"bar\" }";
-    apiProvider.stubFor(
-        post(urlMatching(path))
-            .willReturn(aResponse().withStatus(HttpStatus.OK.value()).withBody(bodyStr)));
-
-    // The StageExecutionImpl constructor mutates the map, so use a mutable map.
-    Map<String, Object> webhookStageData =
-        new HashMap<>(Map.of("url", url, "method", HttpMethod.POST));
-    StageExecution stage =
-        new StageExecutionImpl(null, "webhook", "test-webhook-stage", webhookStageData);
-
-    Throwable thrown = catchThrowable(() -> webhookService.callWebhook(stage));
+    Throwable thrown =
+        catchThrowable(
+            () ->
+                new WebhookService(
+                    List.of(restTemplateProvider),
+                    userConfiguredUrlRestrictions,
+                    webhookProperties,
+                    oortService,
+                    Optional.empty()));
 
     assertThat(thrown)
         .isInstanceOf(IllegalArgumentException.class)
@@ -221,6 +214,14 @@ class WebhookServiceTest {
     allowedRequest.setMatchStrategy(WebhookProperties.MatchStrategy.STARTS_WITH);
     allowedRequest.setUrlPrefix("");
     webhookProperties.setAllowedRequests(List.of(allowedRequest));
+
+    WebhookService webhookService =
+        new WebhookService(
+            List.of(restTemplateProvider),
+            userConfiguredUrlRestrictions,
+            webhookProperties,
+            oortService,
+            Optional.empty());
 
     String path = "/path/to/an/endpoint";
     String url = apiProvider.baseUrl() + path;
@@ -255,6 +256,14 @@ class WebhookServiceTest {
     allowedRequest.setUrlPattern("");
     webhookProperties.setAllowedRequests(List.of(allowedRequest));
 
+    WebhookService webhookService =
+        new WebhookService(
+            List.of(restTemplateProvider),
+            userConfiguredUrlRestrictions,
+            webhookProperties,
+            oortService,
+            Optional.empty());
+
     String path = "/path/to/an/endpoint";
     String url = apiProvider.baseUrl() + path;
 
@@ -282,16 +291,15 @@ class WebhookServiceTest {
     assertThat(allowedRequest.getUrlPattern()).isNull();
     webhookProperties.setAllowedRequests(List.of(allowedRequest));
 
-    String path = "/path/to/an/endpoint";
-    String url = apiProvider.baseUrl() + path;
-
-    // The StageExecutionImpl constructor mutates the map, so use a mutable map.
-    Map<String, Object> webhookStageData =
-        new HashMap<>(Map.of("url", url, "method", HttpMethod.POST));
-    StageExecution stage =
-        new StageExecutionImpl(null, "webhook", "test-webhook-stage", webhookStageData);
-
-    Throwable thrown = catchThrowable(() -> webhookService.callWebhook(stage));
+    Throwable thrown =
+        catchThrowable(
+            () ->
+                new WebhookService(
+                    List.of(restTemplateProvider),
+                    userConfiguredUrlRestrictions,
+                    webhookProperties,
+                    oortService,
+                    Optional.empty()));
 
     assertThat(thrown)
         .isInstanceOf(IllegalArgumentException.class)
@@ -306,23 +314,23 @@ class WebhookServiceTest {
     WebhookProperties.AllowedRequest allowedRequest = new WebhookProperties.AllowedRequest();
     allowedRequest.setHttpMethods(List.of("POST"));
     allowedRequest.setMatchStrategy(WebhookProperties.MatchStrategy.PATTERN_MATCHES);
-    allowedRequest.setUrlPattern("[ is not a valid pattern");
+    String invalidPattern = "[ is not a valid pattern";
+    allowedRequest.setUrlPattern(invalidPattern);
     webhookProperties.setAllowedRequests(List.of(allowedRequest));
 
-    String path = "/path/to/an/endpoint";
-    String url = apiProvider.baseUrl() + path;
-
-    // The StageExecutionImpl constructor mutates the map, so use a mutable map.
-    Map<String, Object> webhookStageData =
-        new HashMap<>(Map.of("url", url, "method", HttpMethod.PUT));
-    StageExecution stage =
-        new StageExecutionImpl(null, "webhook", "test-webhook-stage", webhookStageData);
-
-    Throwable thrown = catchThrowable(() -> webhookService.callWebhook(stage));
+    Throwable thrown =
+        catchThrowable(
+            () ->
+                new WebhookService(
+                    List.of(restTemplateProvider),
+                    userConfiguredUrlRestrictions,
+                    webhookProperties,
+                    oortService,
+                    Optional.empty()));
 
     assertThat(thrown)
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("uri: '" + url + "' not allowed");
+        .isInstanceOf(PatternSyntaxException.class)
+        .hasMessageContaining(invalidPattern);
 
     apiProvider.verify(0, RequestPatternBuilder.allRequests());
   }
@@ -336,6 +344,14 @@ class WebhookServiceTest {
     allowedRequest.setUrlPattern(
         "http://localhost:" + apiProvider.getPort() + "/[a-zA-Z]+-[a-z0-9]+/to/.*");
     webhookProperties.setAllowedRequests(List.of(allowedRequest));
+
+    WebhookService webhookService =
+        new WebhookService(
+            List.of(restTemplateProvider),
+            userConfiguredUrlRestrictions,
+            webhookProperties,
+            oortService,
+            Optional.empty());
 
     String path = "/abcABC-def123/to/an/endpoint";
     String url = apiProvider.baseUrl() + path;
@@ -370,6 +386,14 @@ class WebhookServiceTest {
     allowedRequest.setUrlPrefix("http://localhost:" + apiProvider.getPort() + "/path/to/an/");
     webhookProperties.setAllowedRequests(List.of(allowedRequest));
 
+    WebhookService webhookService =
+        new WebhookService(
+            List.of(restTemplateProvider),
+            userConfiguredUrlRestrictions,
+            webhookProperties,
+            oortService,
+            Optional.empty());
+
     String path = "/path/to/an/endpoint";
     String url = apiProvider.baseUrl() + path;
 
@@ -402,6 +426,14 @@ class WebhookServiceTest {
     allowedRequest.setUrlPrefix("http://localhost:" + apiProvider.getPort() + "/path/to/an/");
     webhookProperties.setAllowedRequests(List.of(allowedRequest));
 
+    WebhookService webhookService =
+        new WebhookService(
+            List.of(restTemplateProvider),
+            userConfiguredUrlRestrictions,
+            webhookProperties,
+            oortService,
+            Optional.empty());
+
     String path = "/path/to/another/endpoint";
     String url = apiProvider.baseUrl() + path;
 
@@ -430,6 +462,14 @@ class WebhookServiceTest {
     // Even with an empty body, even one request header (e.g. Content-Length: 0) is too big.
     webhookProperties.setMaxRequestBytes(1L);
 
+    WebhookService webhookService =
+        new WebhookService(
+            List.of(restTemplateProvider),
+            userConfiguredUrlRestrictions,
+            webhookProperties,
+            oortService,
+            Optional.empty());
+
     String url = apiProvider.baseUrl();
 
     // The StageExecutionImpl constructor mutates the map, so use a mutable map.
@@ -451,6 +491,14 @@ class WebhookServiceTest {
   void testRequestHeadersAndBodyTooBig() throws Exception {
     // Empirically, this is bigger than the headers in this test, and smaller than headers + body.
     webhookProperties.setMaxRequestBytes(235L);
+
+    WebhookService webhookService =
+        new WebhookService(
+            List.of(restTemplateProvider),
+            userConfiguredUrlRestrictions,
+            webhookProperties,
+            oortService,
+            Optional.empty());
 
     String url = apiProvider.baseUrl();
 
@@ -478,6 +526,14 @@ class WebhookServiceTest {
     // Empirically, this is bigger than the headers in this test, and bigger
     // than headers + body.
     webhookProperties.setMaxRequestBytes(500L);
+
+    WebhookService webhookService =
+        new WebhookService(
+            List.of(restTemplateProvider),
+            userConfiguredUrlRestrictions,
+            webhookProperties,
+            oortService,
+            Optional.empty());
 
     String path = "/path/to/some/endpoint";
     String url = apiProvider.baseUrl() + path;
@@ -510,6 +566,14 @@ class WebhookServiceTest {
     // Even with an empty body, even one response header (e.g. Matched-Stub-Id) is too big.
     webhookProperties.setMaxResponseBytes(1L);
 
+    WebhookService webhookService =
+        new WebhookService(
+            List.of(restTemplateProvider),
+            userConfiguredUrlRestrictions,
+            webhookProperties,
+            oortService,
+            Optional.empty());
+
     String path = "/some/path";
     String url = apiProvider.baseUrl() + path;
 
@@ -536,6 +600,14 @@ class WebhookServiceTest {
   void testResponseHeadersAndBodyTooBig() throws Exception {
     // Empirically, this is bigger than the headers in this test, and smaller than headers + body.
     webhookProperties.setMaxResponseBytes(150L);
+
+    WebhookService webhookService =
+        new WebhookService(
+            List.of(restTemplateProvider),
+            userConfiguredUrlRestrictions,
+            webhookProperties,
+            oortService,
+            Optional.empty());
 
     String path = "/some/path";
     String url = apiProvider.baseUrl() + path;
@@ -569,6 +641,14 @@ class WebhookServiceTest {
     // than headers + body.
     webhookProperties.setMaxResponseBytes(500L);
 
+    WebhookService webhookService =
+        new WebhookService(
+            List.of(restTemplateProvider),
+            userConfiguredUrlRestrictions,
+            webhookProperties,
+            oortService,
+            Optional.empty());
+
     String path = "/some/path";
     String url = apiProvider.baseUrl() + path;
 
@@ -597,6 +677,14 @@ class WebhookServiceTest {
   void testDontFollowRedirects() throws Exception {
     webhookProperties.setFollowRedirects(false);
 
+    WebhookService webhookService =
+        new WebhookService(
+            List.of(restTemplateProvider),
+            userConfiguredUrlRestrictions,
+            webhookProperties,
+            oortService,
+            Optional.empty());
+
     String path = "/some/path";
     String url = apiProvider.baseUrl() + path;
 
@@ -621,6 +709,22 @@ class WebhookServiceTest {
   @Test
   void testValidateAccountWithNoAccountProperty() throws Exception {
     webhookProperties.setValidateAccount(true);
+
+    WebhookService webhookService =
+        new WebhookService(
+            List.of(restTemplateProvider),
+            userConfiguredUrlRestrictions,
+            webhookProperties,
+            oortService,
+            Optional.empty());
+
+    WebhookService webhookServiceWithAccountProcessor =
+        new WebhookService(
+            List.of(restTemplateProvider),
+            userConfiguredUrlRestrictions,
+            webhookProperties,
+            oortService,
+            Optional.of(webhookAccountProcessor));
 
     String path = "/some/path";
     String url = apiProvider.baseUrl() + path;
@@ -693,6 +797,22 @@ class WebhookServiceTest {
   @ValueSource(strings = {"", " "})
   void testValidateAccountWithMissingAccount(String account) throws Exception {
     webhookProperties.setValidateAccount(true);
+
+    WebhookService webhookService =
+        new WebhookService(
+            List.of(restTemplateProvider),
+            userConfiguredUrlRestrictions,
+            webhookProperties,
+            oortService,
+            Optional.empty());
+
+    WebhookService webhookServiceWithAccountProcessor =
+        new WebhookService(
+            List.of(restTemplateProvider),
+            userConfiguredUrlRestrictions,
+            webhookProperties,
+            oortService,
+            Optional.of(webhookAccountProcessor));
 
     String path = "/some/path";
     String url = apiProvider.baseUrl() + path;
@@ -770,6 +890,22 @@ class WebhookServiceTest {
   void testValidateAccountWithAccountAndNoAccountProcessor(boolean validAccount) throws Exception {
     webhookProperties.setValidateAccount(true);
 
+    WebhookService webhookService =
+        new WebhookService(
+            List.of(restTemplateProvider),
+            userConfiguredUrlRestrictions,
+            webhookProperties,
+            oortService,
+            Optional.empty());
+
+    WebhookService webhookServiceWithAccountProcessor =
+        new WebhookService(
+            List.of(restTemplateProvider),
+            userConfiguredUrlRestrictions,
+            webhookProperties,
+            oortService,
+            Optional.of(webhookAccountProcessor));
+
     String path = "/some/path";
     String url = apiProvider.baseUrl() + path;
 
@@ -841,6 +977,22 @@ class WebhookServiceTest {
   @ValueSource(booleans = {false, true})
   void testValidateAccountWithAccountAndAccountProcessor(boolean validAccount) throws Exception {
     webhookProperties.setValidateAccount(true);
+
+    WebhookService webhookService =
+        new WebhookService(
+            List.of(restTemplateProvider),
+            userConfiguredUrlRestrictions,
+            webhookProperties,
+            oortService,
+            Optional.empty());
+
+    WebhookService webhookServiceWithAccountProcessor =
+        new WebhookService(
+            List.of(restTemplateProvider),
+            userConfiguredUrlRestrictions,
+            webhookProperties,
+            oortService,
+            Optional.of(webhookAccountProcessor));
 
     String path = "/some/path";
     String url = apiProvider.baseUrl() + path;

--- a/orca/orca-webhook/src/test/java/com/netflix/spinnaker/orca/webhook/service/WebhookServiceTest.java
+++ b/orca/orca-webhook/src/test/java/com/netflix/spinnaker/orca/webhook/service/WebhookServiceTest.java
@@ -212,7 +212,7 @@ class WebhookServiceTest {
   }
 
   @Test
-  void testAllowedRequestsMethodlMatchesButNotUrl() throws Exception {
+  void testAllowedRequestsMethodMatchesButNotUrl() throws Exception {
     webhookProperties.setAllowedRequestsEnabled(true);
     WebhookProperties.AllowedRequest allowedRequest = new WebhookProperties.AllowedRequest();
     allowedRequest.setHttpMethods(List.of("POST"));


### PR DESCRIPTION
via a new property in `webhook.allowedRequests[]` called `matchStrategy` that has valid values:
* `STARTS_WITH`: The url must start with the `urlPrefix` property to be considered valid (the previously implemented strategy, and the default)
* `PATTERN_MATCHES`: The url must match the `urlPattern` property to be considered valid
