### PR TITLE
feat(orca): plumb additional headers from incoming requests into webhook stages

### DIFF
--- a/clouddriver/clouddriver-core/src/test/java/com/netflix/spinnaker/clouddriver/safety/TrafficGuardTest.java
+++ b/clouddriver/clouddriver-core/src/test/java/com/netflix/spinnaker/clouddriver/safety/TrafficGuardTest.java
@@ -43,6 +43,7 @@ import com.netflix.spinnaker.moniker.Moniker;
 import com.netflix.spinnaker.okhttp.OkHttpClientConfigurationProperties;
 import com.netflix.spinnaker.okhttp.Retrofit2EncodeCorrectionInterceptor;
 import com.netflix.spinnaker.okhttp.SpinnakerRequestHeaderInterceptor;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -127,7 +128,8 @@ public class TrafficGuardTest {
 
     @Bean
     SpinnakerRequestHeaderInterceptor spinnakerRequestHeaderInterceptor() {
-      return new SpinnakerRequestHeaderInterceptor(false);
+      return new SpinnakerRequestHeaderInterceptor(
+          false /* propagateSpinnakerHeaders */, Collections.emptyList() /* additionalHeaders */);
     }
   }
 }

--- a/echo/echo-test/src/main/java/com/netflix/spinnaker/echo/test/config/Retrofit2TestConfig.java
+++ b/echo/echo-test/src/main/java/com/netflix/spinnaker/echo/test/config/Retrofit2TestConfig.java
@@ -24,6 +24,7 @@ import com.netflix.spinnaker.okhttp.OkHttp3MetricsInterceptor;
 import com.netflix.spinnaker.okhttp.OkHttpClientConfigurationProperties;
 import com.netflix.spinnaker.okhttp.Retrofit2EncodeCorrectionInterceptor;
 import com.netflix.spinnaker.okhttp.SpinnakerRequestHeaderInterceptor;
+import java.util.Collections;
 import okhttp3.OkHttpClient;
 import okhttp3.logging.HttpLoggingInterceptor;
 import org.springframework.beans.factory.ObjectFactory;
@@ -59,7 +60,8 @@ public class Retrofit2TestConfig {
 
   @Bean
   public SpinnakerRequestHeaderInterceptor getSpinnakerRequestHeaderInterceptor() {
-    return new SpinnakerRequestHeaderInterceptor(false);
+    return new SpinnakerRequestHeaderInterceptor(
+        false /* propagateSpinnakerHeaders */, Collections.emptyList() /* additionalHeaders */);
   }
 
   @Bean

--- a/front50/front50-core/src/test/java/com/netflix/spinnaker/front50/echo/EchoServiceTest.java
+++ b/front50/front50-core/src/test/java/com/netflix/spinnaker/front50/echo/EchoServiceTest.java
@@ -45,6 +45,7 @@ import com.netflix.spinnaker.okhttp.OkHttpClientConfigurationProperties;
 import com.netflix.spinnaker.okhttp.Retrofit2EncodeCorrectionInterceptor;
 import com.netflix.spinnaker.okhttp.SpinnakerRequestHeaderInterceptor;
 import com.netflix.spinnaker.retrofit.Retrofit2ConfigurationProperties;
+import java.util.Collections;
 import java.util.List;
 import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
@@ -128,7 +129,8 @@ public class EchoServiceTest {
 
     @Bean
     public SpinnakerRequestHeaderInterceptor spinnakerRequestHeaderInterceptor() {
-      return new SpinnakerRequestHeaderInterceptor(false);
+      return new SpinnakerRequestHeaderInterceptor(
+          false /* propagateSpinnakerHeaders */, Collections.emptyList() /* additionalHeaders */);
     }
 
     @Bean

--- a/gate/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateConfig.groovy
+++ b/gate/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateConfig.groovy
@@ -30,8 +30,6 @@ import com.netflix.spinnaker.filters.AuthenticatedRequestFilter
 import com.netflix.spinnaker.gate.config.controllers.PipelineControllerConfigProperties
 import com.netflix.spinnaker.gate.converters.JsonHttpMessageConverter
 import com.netflix.spinnaker.gate.converters.YamlHttpMessageConverter
-import com.netflix.spinnaker.gate.filters.ProvidedIdRequestFilter
-import com.netflix.spinnaker.gate.filters.ProvidedIdRequestFilterConfigurationProperties
 import com.netflix.spinnaker.gate.filters.RequestLoggingFilter
 import com.netflix.spinnaker.gate.filters.RequestSheddingFilter
 import com.netflix.spinnaker.gate.filters.ResetAuthenticatedRequestFilter
@@ -42,6 +40,8 @@ import com.netflix.spinnaker.kork.client.ServiceClientProvider
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
 import com.netflix.spinnaker.kork.web.context.AuthenticatedRequestContextProvider
 import com.netflix.spinnaker.kork.web.context.RequestContextProvider
+import com.netflix.spinnaker.kork.web.filters.ProvidedIdRequestFilter
+import com.netflix.spinnaker.kork.web.filters.ProvidedIdRequestFilterConfigurationProperties
 import com.netflix.spinnaker.kork.web.selector.DefaultServiceSelector
 import com.netflix.spinnaker.kork.web.selector.SelectableService
 import com.netflix.spinnaker.kork.web.selector.ServiceSelector

--- a/kork/kork-web/src/main/groovy/com/netflix/spinnaker/okhttp/OkHttpClientConfigurationProperties.groovy
+++ b/kork/kork-web/src/main/groovy/com/netflix/spinnaker/okhttp/OkHttpClientConfigurationProperties.groovy
@@ -32,6 +32,10 @@ class OkHttpClientConfigurationProperties {
   int maxRequests = 100
   int maxRequestsPerHost = 100
 
+  /**
+   * Whether to propagate headers to outgoing HTTP requests.  If false, no
+   * headers are propagated.  Not X-SPINNAKER-*, not additionalHeaders.
+   */
   boolean propagateSpinnakerHeaders = true
 
   /**
@@ -39,6 +43,13 @@ class OkHttpClientConfigurationProperties {
    * Refer https://github.com/spinnaker/spinnaker/issues/7021 for more details
    */
   boolean skipRetrofit2EncodeCorrection = false
+
+  /**
+   * Headers to propagate from the MDC, in addition to the X-SPINNAKER-*
+   * headers.  Each element whose the value in the MDC is non-empty is included
+   * in outgoing HTTP requests.
+   */
+  List<String> additionalHeaders = []
 
   File keyStore
   String keyStoreType = 'PKCS12'

--- a/kork/kork-web/src/main/java/com/netflix/spinnaker/config/OkHttpClientComponents.java
+++ b/kork/kork-web/src/main/java/com/netflix/spinnaker/config/OkHttpClientComponents.java
@@ -79,7 +79,8 @@ public class OkHttpClientComponents {
 
   @Bean
   public SpinnakerRequestHeaderInterceptor spinnakerRequestHeaderInterceptor() {
-    return new SpinnakerRequestHeaderInterceptor(clientProperties.getPropagateSpinnakerHeaders());
+    return new SpinnakerRequestHeaderInterceptor(
+        clientProperties.getPropagateSpinnakerHeaders(), clientProperties.getAdditionalHeaders());
   }
 
   @Bean

--- a/kork/kork-web/src/main/java/com/netflix/spinnaker/kork/web/filters/ProvidedIdRequestFilter.java
+++ b/kork/kork-web/src/main/java/com/netflix/spinnaker/kork/web/filters/ProvidedIdRequestFilter.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.netflix.spinnaker.gate.filters;
+package com.netflix.spinnaker.kork.web.filters;
 
 import java.io.IOException;
 import java.util.Enumeration;

--- a/kork/kork-web/src/main/java/com/netflix/spinnaker/kork/web/filters/ProvidedIdRequestFilterConfigurationProperties.java
+++ b/kork/kork-web/src/main/java/com/netflix/spinnaker/kork/web/filters/ProvidedIdRequestFilterConfigurationProperties.java
@@ -24,6 +24,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "provided-id-request-filter")
 public class ProvidedIdRequestFilterConfigurationProperties {
 
+  private boolean enabled;
+
   /** The headers to include in the MDC. */
   private List<String> headers =
       List.of(Header.REQUEST_ID.getHeader(), Header.EXECUTION_ID.getHeader());

--- a/kork/kork-web/src/main/java/com/netflix/spinnaker/kork/web/filters/ProvidedIdRequestFilterConfigurationProperties.java
+++ b/kork/kork-web/src/main/java/com/netflix/spinnaker/kork/web/filters/ProvidedIdRequestFilterConfigurationProperties.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.netflix.spinnaker.gate.filters;
+package com.netflix.spinnaker.kork.web.filters;
 
 import com.netflix.spinnaker.kork.common.Header;
 import java.util.List;

--- a/orca/orca-api/src/main/java/com/netflix/spinnaker/orca/api/pipeline/models/PipelineExecution.java
+++ b/orca/orca-api/src/main/java/com/netflix/spinnaker/orca/api/pipeline/models/PipelineExecution.java
@@ -156,6 +156,14 @@ public interface PipelineExecution {
    */
   Optional<Long> getTotalSize();
 
+  /**
+   * If provided-id-request-filter.enabled is true, this contains the additional headers that have
+   * non-empty values from the http request that initiated the pipeline execution.
+   */
+  Map<String, String> getAdditionalHeaders();
+
+  void setAdditionalHeaders(Map<String, String> additionalHeaders);
+
   // -------
 
   StageExecution namedStage(String type);

--- a/orca/orca-core/orca-core.gradle
+++ b/orca/orca-core/orca-core.gradle
@@ -43,6 +43,7 @@ dependencies {
   implementation("com.netflix.frigga:frigga")
   implementation("com.netflix.spectator:spectator-api")
   implementation("io.spinnaker.kork:kork-core")
+  implementation("io.spinnaker.kork:kork-web")
   implementation("net.logstash.logback:logstash-logback-encoder")
   implementation("org.springframework.security:spring-security-web")
   implementation("com.fasterxml.jackson.datatype:jackson-datatype-jdk8")

--- a/orca/orca-core/src/main/java/com/netflix/spinnaker/orca/commands/ForceExecutionCancellationCommand.kt
+++ b/orca/orca-core/src/main/java/com/netflix/spinnaker/orca/commands/ForceExecutionCancellationCommand.kt
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory
  *
  * TODO(rz): Fix zombies.
  */
-class ForceExecutionCancellationCommand(
+open class ForceExecutionCancellationCommand(
   private val executionRepository: ExecutionRepository,
   private val clock: Clock
 ) {

--- a/orca/orca-core/src/main/java/com/netflix/spinnaker/orca/config/OrcaConfiguration.java
+++ b/orca/orca-core/src/main/java/com/netflix/spinnaker/orca/config/OrcaConfiguration.java
@@ -26,6 +26,7 @@ import com.netflix.spinnaker.kork.artifacts.artifactstore.ArtifactStoreConfigura
 import com.netflix.spinnaker.kork.core.RetrySupport;
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService;
 import com.netflix.spinnaker.kork.expressions.config.ExpressionProperties;
+import com.netflix.spinnaker.kork.web.filters.ProvidedIdRequestFilterConfigurationProperties;
 import com.netflix.spinnaker.orca.DefaultStageResolver;
 import com.netflix.spinnaker.orca.DynamicStageResolver;
 import com.netflix.spinnaker.orca.DynamicTaskImplementationResolver;
@@ -97,7 +98,8 @@ import rx.schedulers.Schedulers;
   TaskOverrideConfigurationProperties.class,
   ExecutionConfigurationProperties.class,
   ExpressionProperties.class,
-  TaskConfigurationProperties.class
+  TaskConfigurationProperties.class,
+  ProvidedIdRequestFilterConfigurationProperties.class
 })
 public class OrcaConfiguration {
   @Bean

--- a/orca/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/PipelineBuilder.java
+++ b/orca/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/PipelineBuilder.java
@@ -193,5 +193,11 @@ public class PipelineBuilder {
     return this;
   }
 
+  public PipelineBuilder withAdditionalHeaders(Map<String, String> additionalHeaders) {
+    pipeline.setAdditionalHeaders(additionalHeaders);
+
+    return this;
+  }
+
   private final PipelineExecution pipeline;
 }

--- a/orca/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/PipelineExecutionImpl.java
+++ b/orca/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/PipelineExecutionImpl.java
@@ -459,6 +459,18 @@ public class PipelineExecutionImpl implements PipelineExecution, Serializable {
     return Optional.of(totalSize);
   }
 
+  private Map<String, String> additionalHeaders = new HashMap<>();
+
+  @Override
+  public void setAdditionalHeaders(Map<String, String> additionalHeaders) {
+    this.additionalHeaders = additionalHeaders;
+  }
+
+  @Override
+  public Map<String, String> getAdditionalHeaders() {
+    return this.additionalHeaders;
+  }
+
   @Nullable
   public StageExecution namedStage(String type) {
     return stages.stream().filter(it -> it.getType().equals(type)).findFirst().orElse(null);

--- a/orca/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/PipelineExecutionLauncherSpec.groovy
+++ b/orca/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/PipelineExecutionLauncherSpec.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.orca.pipeline
 
+import com.netflix.spinnaker.kork.web.filters.ProvidedIdRequestFilterConfigurationProperties
 import com.netflix.spinnaker.orca.api.pipeline.graph.StageDefinitionBuilder
 import com.netflix.spinnaker.orca.config.ExecutionConfigurationProperties
 import com.netflix.spinnaker.orca.events.BeforeInitialExecutionPersist
@@ -40,6 +41,7 @@ class PipelineExecutionLauncherSpec extends Specification {
   def executionRepository = Mock(ExecutionRepository)
   def pipelineValidator = Stub(PipelineValidator)
   def applicationEventPublisher = Mock(ApplicationEventPublisher)
+  def providedIdRequestFilterConfigurationProperties = new ProvidedIdRequestFilterConfigurationProperties()
 
   ExecutionLauncher create() {
     return new ExecutionLauncher(
@@ -50,7 +52,8 @@ class PipelineExecutionLauncherSpec extends Specification {
       applicationEventPublisher,
       Optional.of(pipelineValidator),
       Optional.<Registry> empty(),
-      new ExecutionConfigurationProperties()
+      new ExecutionConfigurationProperties(),
+      providedIdRequestFilterConfigurationProperties
     )
   }
 
@@ -99,6 +102,7 @@ class PipelineExecutionLauncherSpec extends Specification {
           }
         })
         registerSingleton("executionConfigurationProperties", new ExecutionConfigurationProperties())
+        registerSingleton("providedIdRequestFilterConfigurationProperties", new ProvidedIdRequestFilterConfigurationProperties())
       }
       register(ExecutionLauncher)
       refresh()

--- a/orca/orca-core/src/test/java/com/netflix/spinnaker/orca/testconfig/ExecutionLauncherConfigurationTest.java
+++ b/orca/orca-core/src/test/java/com/netflix/spinnaker/orca/testconfig/ExecutionLauncherConfigurationTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.*;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.kork.common.Header;
+import com.netflix.spinnaker.kork.web.filters.ProvidedIdRequestFilterConfigurationProperties;
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionType;
 import com.netflix.spinnaker.orca.api.pipeline.models.PipelineExecution;
 import com.netflix.spinnaker.orca.config.ExecutionConfigurationProperties;
@@ -56,7 +57,10 @@ import org.springframework.test.context.ContextConfiguration;
 
 @ExtendWith(MockitoExtension.class)
 @ContextConfiguration(
-    classes = ExecutionConfigurationProperties.class,
+    classes = {
+      ExecutionConfigurationProperties.class,
+      ProvidedIdRequestFilterConfigurationProperties.class
+    },
     initializers = ExecutionLauncherConfigurationTest.class)
 @EnableConfigurationProperties
 @SpringBootTest
@@ -72,6 +76,10 @@ public class ExecutionLauncherConfigurationTest extends YamlFileApplicationConte
 
   // autowiring this so that it can mimic how springboot will initialize it at app startup
   @Autowired private ExecutionConfigurationProperties executionConfigurationProperties;
+
+  @Autowired
+  private ProvidedIdRequestFilterConfigurationProperties
+      providedIdRequestFilterConfigurationProperties;
 
   @Override
   protected String getResourceLocation() {
@@ -95,7 +103,8 @@ public class ExecutionLauncherConfigurationTest extends YamlFileApplicationConte
             applicationEventPublisher,
             pipelineValidator,
             registry,
-            executionConfigurationProperties);
+            executionConfigurationProperties,
+            providedIdRequestFilterConfigurationProperties);
   }
 
   @DisplayName(
@@ -138,7 +147,8 @@ public class ExecutionLauncherConfigurationTest extends YamlFileApplicationConte
             applicationEventPublisher,
             pipelineValidator,
             registry,
-            executionConfigurationProperties);
+            executionConfigurationProperties,
+            providedIdRequestFilterConfigurationProperties);
 
     // when
     // deployManifest orchestration type should now be able to run
@@ -232,7 +242,8 @@ public class ExecutionLauncherConfigurationTest extends YamlFileApplicationConte
             applicationEventPublisher,
             pipelineValidator,
             registry,
-            executionConfigurationProperties);
+            executionConfigurationProperties,
+            providedIdRequestFilterConfigurationProperties);
 
     // when
     PipelineExecution pipelineExecution =
@@ -270,7 +281,8 @@ public class ExecutionLauncherConfigurationTest extends YamlFileApplicationConte
             applicationEventPublisher,
             pipelineValidator,
             registry,
-            executionConfigurationProperties);
+            executionConfigurationProperties,
+            providedIdRequestFilterConfigurationProperties);
 
     // when
     PipelineExecution pipelineExecution =
@@ -326,7 +338,8 @@ public class ExecutionLauncherConfigurationTest extends YamlFileApplicationConte
             applicationEventPublisher,
             pipelineValidator,
             registry,
-            executionConfigurationProperties);
+            executionConfigurationProperties,
+            providedIdRequestFilterConfigurationProperties);
 
     // when
     PipelineExecution pipelineExecution =
@@ -360,7 +373,8 @@ public class ExecutionLauncherConfigurationTest extends YamlFileApplicationConte
             applicationEventPublisher,
             pipelineValidator,
             registry,
-            executionConfigurationProperties);
+            executionConfigurationProperties,
+            providedIdRequestFilterConfigurationProperties);
 
     // when
     // childPipeline pipeline type should be able to run
@@ -398,7 +412,8 @@ public class ExecutionLauncherConfigurationTest extends YamlFileApplicationConte
             applicationEventPublisher,
             pipelineValidator,
             registry,
-            executionConfigurationProperties);
+            executionConfigurationProperties,
+            providedIdRequestFilterConfigurationProperties);
 
     // when
     // childPipeline pipeline type should be able to run
@@ -436,7 +451,8 @@ public class ExecutionLauncherConfigurationTest extends YamlFileApplicationConte
             applicationEventPublisher,
             pipelineValidator,
             registry,
-            executionConfigurationProperties);
+            executionConfigurationProperties,
+            providedIdRequestFilterConfigurationProperties);
 
     // when
     // childPipeline pipeline type should be able to run

--- a/orca/orca-echo/src/test/java/com/netflix/spinnaker/orca/echo/EchoServiceTest.java
+++ b/orca/orca-echo/src/test/java/com/netflix/spinnaker/orca/echo/EchoServiceTest.java
@@ -39,6 +39,7 @@ import com.netflix.spinnaker.orca.echo.config.EchoConfiguration;
 import com.netflix.spinnaker.orca.front50.Front50Service;
 import com.netflix.spinnaker.orca.pipeline.persistence.InMemoryExecutionRepository;
 import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor;
+import java.util.Collections;
 import java.util.Map;
 import okhttp3.OkHttpClient;
 import org.junit.jupiter.api.Test;
@@ -102,7 +103,8 @@ public class EchoServiceTest {
 
     @Bean
     SpinnakerRequestHeaderInterceptor spinnakerRequestHeaderInterceptor() {
-      return new SpinnakerRequestHeaderInterceptor(false);
+      return new SpinnakerRequestHeaderInterceptor(
+          false /* propagateSpinnakerHeaders */, Collections.emptyList() /* additionalHeaders */);
     }
   }
 }

--- a/orca/orca-queue-tck/src/main/kotlin/com/netflix/spinnaker/orca/q/LogMessageTask.kt
+++ b/orca/orca-queue-tck/src/main/kotlin/com/netflix/spinnaker/orca/q/LogMessageTask.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2025 Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.q
+
+import com.netflix.spinnaker.orca.api.pipeline.Task
+import com.netflix.spinnaker.orca.api.pipeline.TaskResult
+import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
+import org.slf4j.LoggerFactory
+import org.slf4j.MDC
+
+class LogMessageTask : Task {
+  private val log = LoggerFactory.getLogger(javaClass)
+
+  override fun execute(stage: StageExecution): TaskResult {
+    log.info("MDC: ${MDC.getCopyOfContextMap()}")
+    return TaskResult.SUCCEEDED
+  }
+}

--- a/orca/orca-queue/orca-queue.gradle
+++ b/orca/orca-queue/orca-queue.gradle
@@ -36,6 +36,7 @@ dependencies {
 
   testImplementation("io.spinnaker.kork:kork-jedis-test")
   testImplementation("io.spinnaker.kork:kork-retrofit")
+  testImplementation("io.spinnaker.kork:kork-test")
   testImplementation(project(":orca-api-tck"))
   testImplementation(project(":orca-retrofit"))
   testImplementation(project(":orca-test-kotlin"))

--- a/orca/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandler.kt
+++ b/orca/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandler.kt
@@ -475,12 +475,14 @@ class RunTaskHandler(
       if (taskModel.startTime != null) {
         MDC.put("taskStartTime", taskModel.startTime.toString())
       }
+      execution.additionalHeaders.forEach(MDC::put)
 
       block.invoke()
     } finally {
       MDC.remove("stageType")
       MDC.remove("taskType")
       MDC.remove("taskStartTime")
+      execution.additionalHeaders.keys.forEach(MDC::remove)
     }
   }
 

--- a/orca/orca-queue/src/test/resources/logback-test.xml
+++ b/orca/orca-queue/src/test/resources/logback-test.xml
@@ -1,0 +1,34 @@
+<!--
+
+    Copyright 2025 Salesforce, Inc.
+    <p>
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    <p>
+    http://www.apache.org/licenses/LICENSE-2.0
+    <p>
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are  by default assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+    <logger name="org.jooq.tools.LoggerListener" level="DEBUG"/>
+    <logger name="com.netflix.spinnaker.orca.sql.pipeline.persistence" level="DEBUG"/>
+</configuration>

--- a/orca/orca-web/src/test/java/com/netflix/spinnaker/orca/web/testconfig/WebConfigurationTest.java
+++ b/orca/orca-web/src/test/java/com/netflix/spinnaker/orca/web/testconfig/WebConfigurationTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2025 Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.web.testconfig;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import com.netflix.spectator.api.NoopRegistry;
+import com.netflix.spinnaker.config.TaskControllerConfigurationProperties;
+import com.netflix.spinnaker.fiat.shared.FiatService;
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService;
+import com.netflix.spinnaker.orca.capabilities.CapabilitiesService;
+import com.netflix.spinnaker.orca.commands.ForceExecutionCancellationCommand;
+import com.netflix.spinnaker.orca.config.ExecutionConfigurationProperties;
+import com.netflix.spinnaker.orca.pipeline.CompoundExecutionOperator;
+import com.netflix.spinnaker.orca.pipeline.ExecutionLauncher;
+import com.netflix.spinnaker.orca.pipeline.ExecutionRunner;
+import com.netflix.spinnaker.orca.pipeline.StageDefinitionBuilderFactory;
+import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository;
+import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor;
+import com.netflix.spinnaker.orca.pipelinetemplate.PipelineTemplateService;
+import com.netflix.spinnaker.orca.web.config.WebConfiguration;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.context.annotation.UserConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+
+class WebConfigurationTest {
+
+  // WebConfiguration has an @EnableFiatAutoConfig annotation, which brings in
+  // fiat's FiatAuthenticationConfig's class.  FiatAuthenticationConfig has
+  //
+  // @ComponentScan("com.netflix.spinnaker.fiat.shared")
+  //
+  // which creates a FiatAccessDeniedExceptionHandler bean because it has
+  // a @ControllerAdvice annotation.
+  //
+  // FiatAuthenticationConfig also provides a FiatAccessDeniedExceptionHandler
+  // bean.  Until that's fixed, use
+  //
+  // .allowBeanDefinitionOverriding(true).
+  //
+  // Because WebConfiguration also brings in all of orca's controllers, supply
+  // all the beans they depend on.
+  private final ApplicationContextRunner runner =
+      new ApplicationContextRunner()
+          .withBean(NoopRegistry.class)
+          .withAllowBeanDefinitionOverriding(true)
+          .withConfiguration(
+              UserConfigurations.of(TestDependencyConfiguration.class, WebConfiguration.class));
+
+  @Test
+  void metricsInterceptorPresent() {
+    // A basic assertion about a bean that WebConfiguration provides.
+    runner.run(ctx -> assertThat(ctx).hasBean("metricsInterceptor"));
+  }
+
+  static class TestDependencyConfiguration {
+    @Bean
+    ExecutionRepository executionRepository() {
+      return mock(ExecutionRepository.class);
+    }
+
+    @Bean
+    ForceExecutionCancellationCommand forceExecutionCancellationCommand() {
+      return mock(ForceExecutionCancellationCommand.class);
+    }
+
+    @Bean
+    CapabilitiesService capabilitiesService() {
+      return mock(CapabilitiesService.class);
+    }
+
+    @Bean
+    ExecutionLauncher executionLauncher() {
+      return mock(ExecutionLauncher.class);
+    }
+
+    @Bean
+    ContextParameterProcessor contextParameterProcessor() {
+      return mock(ContextParameterProcessor.class);
+    }
+
+    @Bean
+    FiatService fiatService() {
+      return mock(FiatService.class);
+    }
+
+    @Bean
+    DynamicConfigService dynamicConfigService() {
+      return mock(DynamicConfigService.class);
+    }
+
+    @Bean
+    PipelineTemplateService pipelineTemplateService() {
+      return mock(PipelineTemplateService.class);
+    }
+
+    @Bean
+    ExecutionRunner executionRunner() {
+      return mock(ExecutionRunner.class);
+    }
+
+    @Bean
+    CompoundExecutionOperator compoundExecutionOperator() {
+      return mock(CompoundExecutionOperator.class);
+    }
+
+    @Bean
+    StageDefinitionBuilderFactory stageDefinitionBuilderFactory() {
+      return mock(StageDefinitionBuilderFactory.class);
+    }
+
+    @Bean
+    TaskControllerConfigurationProperties taskControllerConfigurationProperties() {
+      return mock(TaskControllerConfigurationProperties.class);
+    }
+
+    @Bean
+    ExecutionConfigurationProperties executionConfigurationProperties() {
+      return mock(ExecutionConfigurationProperties.class);
+    }
+  }
+}

--- a/orca/orca-web/src/test/java/com/netflix/spinnaker/orca/web/testconfig/WebConfigurationTest.java
+++ b/orca/orca-web/src/test/java/com/netflix/spinnaker/orca/web/testconfig/WebConfigurationTest.java
@@ -23,6 +23,7 @@ import com.netflix.spectator.api.NoopRegistry;
 import com.netflix.spinnaker.config.TaskControllerConfigurationProperties;
 import com.netflix.spinnaker.fiat.shared.FiatService;
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService;
+import com.netflix.spinnaker.kork.web.filters.ProvidedIdRequestFilterConfigurationProperties;
 import com.netflix.spinnaker.orca.capabilities.CapabilitiesService;
 import com.netflix.spinnaker.orca.commands.ForceExecutionCancellationCommand;
 import com.netflix.spinnaker.orca.config.ExecutionConfigurationProperties;
@@ -67,6 +68,37 @@ class WebConfigurationTest {
   void metricsInterceptorPresent() {
     // A basic assertion about a bean that WebConfiguration provides.
     runner.run(ctx -> assertThat(ctx).hasBean("metricsInterceptor"));
+  }
+
+  @Test
+  void testProvidedIdRequestFilterBeanCreatedWhenPropertyEnabled() {
+    runner
+        .withPropertyValues("provided-id-request-filter.enabled=true")
+        .run(
+            ctx -> {
+              assertThat(ctx).hasBean("providedIdRequestFilter");
+              assertThat(ctx).hasSingleBean(ProvidedIdRequestFilterConfigurationProperties.class);
+            });
+  }
+
+  @Test
+  void testProvidedIdRequestFilterBeanNotCreatedWhenPropertyDisabled() {
+    runner
+        .withPropertyValues("provided-id-request-filter.enabled=false")
+        .run(
+            ctx -> {
+              assertThat(ctx).doesNotHaveBean("providedIdRequestFilter");
+              assertThat(ctx).hasSingleBean(ProvidedIdRequestFilterConfigurationProperties.class);
+            });
+  }
+
+  @Test
+  void testProvidedIdRequestFilterBeanNotCreatedWhenPropertyNotSet() {
+    runner.run(
+        ctx -> {
+          assertThat(ctx).doesNotHaveBean("providedIdRequestFilter");
+          assertThat(ctx).hasSingleBean(ProvidedIdRequestFilterConfigurationProperties.class);
+        });
   }
 
   static class TestDependencyConfiguration {

--- a/orca/orca-webhook/src/main/java/com/netflix/spinnaker/orca/webhook/config/WebhookProperties.java
+++ b/orca/orca-webhook/src/main/java/com/netflix/spinnaker/orca/webhook/config/WebhookProperties.java
@@ -120,6 +120,12 @@ public class WebhookProperties {
    */
   private boolean validateAccount = false;
 
+  /**
+   * True to include additional headers that ProvidedIdRequestFilter puts in the MDC in outgoing
+   * http requests. Only relevant if ProvidedIdRequestFilter is enabled.
+   */
+  private boolean includeAdditionalHeaders = false;
+
   @Data
   @NoArgsConstructor
   public static class TrustSettings {

--- a/orca/orca-webhook/src/main/java/com/netflix/spinnaker/orca/webhook/service/WebhookAccountProcessor.java
+++ b/orca/orca-webhook/src/main/java/com/netflix/spinnaker/orca/webhook/service/WebhookAccountProcessor.java
@@ -32,9 +32,10 @@ public interface WebhookAccountProcessor {
    * @param account the name of the Spinnaker account associated with the webhook stage (possibly
    *     null or empty)
    * @param accountDetails details about the Spinnaker account (possibly null)
-   * @param customHeaders the custom headers specified in the webhook stage (possibly null)
+   * @param combinedHeaders the custom headers specified in the webhook stage, combined with
+   *     additional headers from ProvidedIdRequestFilter (possibly null).
    * @return the http request headers to send
    */
   HttpHeaders getHeaders(
-      String account, Map<String, Object> accountDetails, Map<String, Object> customHeaders);
+      String account, Map<String, Object> accountDetails, Map<String, Object> combinedHeaders);
 }

--- a/orca/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/service/WebhookServiceSpec.groovy
+++ b/orca/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/service/WebhookServiceSpec.groovy
@@ -17,6 +17,7 @@
 
 package com.netflix.spinnaker.orca.webhook.service
 
+import com.netflix.spinnaker.kork.web.filters.ProvidedIdRequestFilterConfigurationProperties
 import com.netflix.spinnaker.okhttp.OkHttpClientConfigurationProperties
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
 import com.netflix.spinnaker.orca.clouddriver.OortService
@@ -70,11 +71,14 @@ class WebhookServiceSpec extends Specification {
 
   def oortService = Mock(OortService)
 
+  def providedIdRequestFilterConfigurationProperties = new ProvidedIdRequestFilterConfigurationProperties()
+
   @Subject
   def webhookService = new WebhookService(List.of(restTemplateProvider),
                                           userConfiguredUrlRestrictions,
                                           preconfiguredWebhookProperties,
-                                          oortService, Optional.empty())
+                                          oortService, Optional.empty(),
+                                          providedIdRequestFilterConfigurationProperties)
 
   @Unroll
   def "Webhook is being called with correct parameters"() {

--- a/orca/orca-webhook/src/test/java/com/netflix/spinnaker/orca/webhook/config/MtlsConfigurationKeystoreTest.java
+++ b/orca/orca-webhook/src/test/java/com/netflix/spinnaker/orca/webhook/config/MtlsConfigurationKeystoreTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.netflix.spinnaker.config.OkHttp3ClientConfiguration;
 import com.netflix.spinnaker.config.OkHttpClientComponents;
+import com.netflix.spinnaker.kork.web.filters.ProvidedIdRequestFilterConfigurationProperties;
 import com.netflix.spinnaker.orca.pipeline.model.StageExecutionImpl;
 import com.netflix.spinnaker.orca.webhook.service.WebhookService;
 import java.util.HashMap;
@@ -67,6 +68,12 @@ public class MtlsConfigurationKeystoreTest extends MtlsConfigurationTestBase {
       props.setInsecureSkipHostnameVerification(true);
 
       return props;
+    }
+
+    @Bean
+    ProvidedIdRequestFilterConfigurationProperties
+        providedIdRequestFilterConfigurationProperties() {
+      return new ProvidedIdRequestFilterConfigurationProperties();
     }
   }
 

--- a/orca/orca-webhook/src/test/java/com/netflix/spinnaker/orca/webhook/config/MtlsConfigurationPemTest.java
+++ b/orca/orca-webhook/src/test/java/com/netflix/spinnaker/orca/webhook/config/MtlsConfigurationPemTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.netflix.spinnaker.config.OkHttp3ClientConfiguration;
 import com.netflix.spinnaker.config.OkHttpClientComponents;
+import com.netflix.spinnaker.kork.web.filters.ProvidedIdRequestFilterConfigurationProperties;
 import com.netflix.spinnaker.orca.pipeline.model.StageExecutionImpl;
 import com.netflix.spinnaker.orca.webhook.service.WebhookService;
 import java.util.HashMap;
@@ -65,6 +66,12 @@ public class MtlsConfigurationPemTest extends MtlsConfigurationTestBase {
       props.setInsecureSkipHostnameVerification(true);
 
       return props;
+    }
+
+    @Bean
+    ProvidedIdRequestFilterConfigurationProperties
+        providedIdRequestFilterConfigurationProperties() {
+      return new ProvidedIdRequestFilterConfigurationProperties();
     }
   }
 

--- a/orca/orca-webhook/src/test/java/com/netflix/spinnaker/orca/webhook/config/WebhookConfigurationTest.java
+++ b/orca/orca-webhook/src/test/java/com/netflix/spinnaker/orca/webhook/config/WebhookConfigurationTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.mock;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import com.netflix.spinnaker.fiat.shared.FiatService;
+import com.netflix.spinnaker.kork.web.filters.ProvidedIdRequestFilterConfigurationProperties;
 import com.netflix.spinnaker.okhttp.OkHttpClientConfigurationProperties;
 import com.netflix.spinnaker.orca.clouddriver.OortService;
 import com.netflix.spinnaker.orca.config.UserConfiguredUrlRestrictions;
@@ -66,6 +67,7 @@ class WebhookConfigurationTest {
               UserConfigurations.of(
                   WebhookConfiguration.class,
                   OkHttpClientConfigurationProperties.class,
+                  ProvidedIdRequestFilterConfigurationProperties.class,
                   WebhookTestConfiguration.class));
 
   @BeforeEach

--- a/orca/orca-webhook/src/test/java/com/netflix/spinnaker/orca/webhook/service/WebhookServiceTest.java
+++ b/orca/orca-webhook/src/test/java/com/netflix/spinnaker/orca/webhook/service/WebhookServiceTest.java
@@ -39,6 +39,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import com.github.tomakehurst.wiremock.matching.MatchResult;
 import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder;
+import com.netflix.spinnaker.kork.web.filters.ProvidedIdRequestFilterConfigurationProperties;
 import com.netflix.spinnaker.okhttp.OkHttpClientConfigurationProperties;
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
 import com.netflix.spinnaker.orca.clouddriver.OortService;
@@ -51,13 +52,17 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.regex.PatternSyntaxException;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.slf4j.MDC;
 import org.springframework.core.env.Environment;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -95,6 +100,10 @@ class WebhookServiceTest {
 
   private WebhookAccountProcessor webhookAccountProcessor = mock(WebhookAccountProcessor.class);
 
+  private ProvidedIdRequestFilterConfigurationProperties
+      providedIdRequestFilterConfigurationProperties =
+          new ProvidedIdRequestFilterConfigurationProperties();
+
   @BeforeEach
   void init(TestInfo testInfo) throws Exception {
     System.out.println("--------------- Test " + testInfo.getDisplayName());
@@ -120,7 +129,8 @@ class WebhookServiceTest {
             userConfiguredUrlRestrictions,
             webhookProperties,
             oortService,
-            Optional.empty());
+            Optional.empty(),
+            providedIdRequestFilterConfigurationProperties);
 
     String url = "https://localhost"; // arbitrary, but needs to include a resolvable hostname
 
@@ -154,7 +164,8 @@ class WebhookServiceTest {
             userConfiguredUrlRestrictions,
             webhookProperties,
             oortService,
-            Optional.empty());
+            Optional.empty(),
+            providedIdRequestFilterConfigurationProperties);
 
     String path = "/path/to/an/endpoint";
     String url = apiProvider.baseUrl() + path;
@@ -197,7 +208,8 @@ class WebhookServiceTest {
                     userConfiguredUrlRestrictions,
                     webhookProperties,
                     oortService,
-                    Optional.empty()));
+                    Optional.empty(),
+                    providedIdRequestFilterConfigurationProperties));
 
     assertThat(thrown)
         .isInstanceOf(IllegalArgumentException.class)
@@ -221,7 +233,8 @@ class WebhookServiceTest {
             userConfiguredUrlRestrictions,
             webhookProperties,
             oortService,
-            Optional.empty());
+            Optional.empty(),
+            providedIdRequestFilterConfigurationProperties);
 
     String path = "/path/to/an/endpoint";
     String url = apiProvider.baseUrl() + path;
@@ -262,7 +275,8 @@ class WebhookServiceTest {
             userConfiguredUrlRestrictions,
             webhookProperties,
             oortService,
-            Optional.empty());
+            Optional.empty(),
+            providedIdRequestFilterConfigurationProperties);
 
     String path = "/path/to/an/endpoint";
     String url = apiProvider.baseUrl() + path;
@@ -299,7 +313,8 @@ class WebhookServiceTest {
                     userConfiguredUrlRestrictions,
                     webhookProperties,
                     oortService,
-                    Optional.empty()));
+                    Optional.empty(),
+                    providedIdRequestFilterConfigurationProperties));
 
     assertThat(thrown)
         .isInstanceOf(IllegalArgumentException.class)
@@ -326,7 +341,8 @@ class WebhookServiceTest {
                     userConfiguredUrlRestrictions,
                     webhookProperties,
                     oortService,
-                    Optional.empty()));
+                    Optional.empty(),
+                    providedIdRequestFilterConfigurationProperties));
 
     assertThat(thrown)
         .isInstanceOf(PatternSyntaxException.class)
@@ -351,7 +367,8 @@ class WebhookServiceTest {
             userConfiguredUrlRestrictions,
             webhookProperties,
             oortService,
-            Optional.empty());
+            Optional.empty(),
+            providedIdRequestFilterConfigurationProperties);
 
     String path = "/abcABC-def123/to/an/endpoint";
     String url = apiProvider.baseUrl() + path;
@@ -392,7 +409,8 @@ class WebhookServiceTest {
             userConfiguredUrlRestrictions,
             webhookProperties,
             oortService,
-            Optional.empty());
+            Optional.empty(),
+            providedIdRequestFilterConfigurationProperties);
 
     String path = "/path/to/an/endpoint";
     String url = apiProvider.baseUrl() + path;
@@ -432,7 +450,8 @@ class WebhookServiceTest {
             userConfiguredUrlRestrictions,
             webhookProperties,
             oortService,
-            Optional.empty());
+            Optional.empty(),
+            providedIdRequestFilterConfigurationProperties);
 
     String path = "/path/to/another/endpoint";
     String url = apiProvider.baseUrl() + path;
@@ -468,7 +487,8 @@ class WebhookServiceTest {
             userConfiguredUrlRestrictions,
             webhookProperties,
             oortService,
-            Optional.empty());
+            Optional.empty(),
+            providedIdRequestFilterConfigurationProperties);
 
     String url = apiProvider.baseUrl();
 
@@ -498,7 +518,8 @@ class WebhookServiceTest {
             userConfiguredUrlRestrictions,
             webhookProperties,
             oortService,
-            Optional.empty());
+            Optional.empty(),
+            providedIdRequestFilterConfigurationProperties);
 
     String url = apiProvider.baseUrl();
 
@@ -533,7 +554,8 @@ class WebhookServiceTest {
             userConfiguredUrlRestrictions,
             webhookProperties,
             oortService,
-            Optional.empty());
+            Optional.empty(),
+            providedIdRequestFilterConfigurationProperties);
 
     String path = "/path/to/some/endpoint";
     String url = apiProvider.baseUrl() + path;
@@ -572,7 +594,8 @@ class WebhookServiceTest {
             userConfiguredUrlRestrictions,
             webhookProperties,
             oortService,
-            Optional.empty());
+            Optional.empty(),
+            providedIdRequestFilterConfigurationProperties);
 
     String path = "/some/path";
     String url = apiProvider.baseUrl() + path;
@@ -607,7 +630,8 @@ class WebhookServiceTest {
             userConfiguredUrlRestrictions,
             webhookProperties,
             oortService,
-            Optional.empty());
+            Optional.empty(),
+            providedIdRequestFilterConfigurationProperties);
 
     String path = "/some/path";
     String url = apiProvider.baseUrl() + path;
@@ -647,7 +671,8 @@ class WebhookServiceTest {
             userConfiguredUrlRestrictions,
             webhookProperties,
             oortService,
-            Optional.empty());
+            Optional.empty(),
+            providedIdRequestFilterConfigurationProperties);
 
     String path = "/some/path";
     String url = apiProvider.baseUrl() + path;
@@ -683,7 +708,8 @@ class WebhookServiceTest {
             userConfiguredUrlRestrictions,
             webhookProperties,
             oortService,
-            Optional.empty());
+            Optional.empty(),
+            providedIdRequestFilterConfigurationProperties);
 
     String path = "/some/path";
     String url = apiProvider.baseUrl() + path;
@@ -716,7 +742,8 @@ class WebhookServiceTest {
             userConfiguredUrlRestrictions,
             webhookProperties,
             oortService,
-            Optional.empty());
+            Optional.empty(),
+            providedIdRequestFilterConfigurationProperties);
 
     WebhookService webhookServiceWithAccountProcessor =
         new WebhookService(
@@ -724,7 +751,8 @@ class WebhookServiceTest {
             userConfiguredUrlRestrictions,
             webhookProperties,
             oortService,
-            Optional.of(webhookAccountProcessor));
+            Optional.of(webhookAccountProcessor),
+            providedIdRequestFilterConfigurationProperties);
 
     String path = "/some/path";
     String url = apiProvider.baseUrl() + path;
@@ -804,7 +832,8 @@ class WebhookServiceTest {
             userConfiguredUrlRestrictions,
             webhookProperties,
             oortService,
-            Optional.empty());
+            Optional.empty(),
+            providedIdRequestFilterConfigurationProperties);
 
     WebhookService webhookServiceWithAccountProcessor =
         new WebhookService(
@@ -812,7 +841,8 @@ class WebhookServiceTest {
             userConfiguredUrlRestrictions,
             webhookProperties,
             oortService,
-            Optional.of(webhookAccountProcessor));
+            Optional.of(webhookAccountProcessor),
+            providedIdRequestFilterConfigurationProperties);
 
     String path = "/some/path";
     String url = apiProvider.baseUrl() + path;
@@ -896,7 +926,8 @@ class WebhookServiceTest {
             userConfiguredUrlRestrictions,
             webhookProperties,
             oortService,
-            Optional.empty());
+            Optional.empty(),
+            providedIdRequestFilterConfigurationProperties);
 
     WebhookService webhookServiceWithAccountProcessor =
         new WebhookService(
@@ -904,7 +935,8 @@ class WebhookServiceTest {
             userConfiguredUrlRestrictions,
             webhookProperties,
             oortService,
-            Optional.of(webhookAccountProcessor));
+            Optional.of(webhookAccountProcessor),
+            providedIdRequestFilterConfigurationProperties);
 
     String path = "/some/path";
     String url = apiProvider.baseUrl() + path;
@@ -984,7 +1016,8 @@ class WebhookServiceTest {
             userConfiguredUrlRestrictions,
             webhookProperties,
             oortService,
-            Optional.empty());
+            Optional.empty(),
+            providedIdRequestFilterConfigurationProperties);
 
     WebhookService webhookServiceWithAccountProcessor =
         new WebhookService(
@@ -992,7 +1025,8 @@ class WebhookServiceTest {
             userConfiguredUrlRestrictions,
             webhookProperties,
             oortService,
-            Optional.of(webhookAccountProcessor));
+            Optional.of(webhookAccountProcessor),
+            providedIdRequestFilterConfigurationProperties);
 
     String path = "/some/path";
     String url = apiProvider.baseUrl() + path;
@@ -1082,5 +1116,108 @@ class WebhookServiceTest {
       // And there's no http request
       apiProvider.verify(0, RequestPatternBuilder.allRequests());
     }
+  }
+
+  @ParameterizedTest(
+      name =
+          "{index} => testIncludeAdditionalHeaders: enableProvidedIdRequestFilter = {0}, includeAdditionalHeaders = {2}, mdcValues = {3}, customHeaders = {4}")
+  @MethodSource("additionalHeadersTests")
+  // Ideally I'd cover some more dimensions here...no values present in the MDC,
+  // some values present in the MDC, all values present in the MDC, + null
+  // custom headers
+  void testIncludeAdditionalHeaders(
+      boolean enableProvidedIdRequestFilter,
+      List<String> additionalHeaderNames,
+      boolean includeAdditionalHeaders,
+      Map<String, String> mdcValues,
+      Map<String, String> customHeaders,
+      Map<String, String> expectedHeaders) {
+    // Put the specifed values in the MDC
+    mdcValues.forEach(MDC::put);
+
+    providedIdRequestFilterConfigurationProperties.setEnabled(enableProvidedIdRequestFilter);
+    providedIdRequestFilterConfigurationProperties.setAdditionalHeaders(additionalHeaderNames);
+
+    webhookProperties.setIncludeAdditionalHeaders(includeAdditionalHeaders);
+
+    WebhookService webhookService =
+        new WebhookService(
+            List.of(restTemplateProvider),
+            userConfiguredUrlRestrictions,
+            webhookProperties,
+            oortService,
+            Optional.empty(),
+            providedIdRequestFilterConfigurationProperties);
+
+    String path = "/some/path";
+    String url = apiProvider.baseUrl() + path;
+
+    // The StageExecutionImpl constructor mutates the map, so use a mutable map.
+    String account = "my-account";
+    Map<String, Object> webhookStageData =
+        new HashMap<>(Map.of("url", url, "method", HttpMethod.GET, "account", account));
+    if (customHeaders != null) {
+      webhookStageData.put("customHeaders", customHeaders);
+    }
+
+    StageExecution stage =
+        new StageExecutionImpl(null, "webhook", "test-webhook-stage", webhookStageData);
+
+    String responseBodyString = "test response body";
+    apiProvider.stubFor(
+        get(urlMatching(path))
+            .willReturn(
+                aResponse().withStatus(HttpStatus.OK.value()).withBody(responseBodyString)));
+
+    // when
+    ResponseEntity<Object> result = webhookService.callWebhook(stage);
+
+    // then
+    RequestPatternBuilder builder = getRequestedFor(urlPathEqualTo(path));
+    expectedHeaders.forEach(
+        (String expectedHeader, String expectedValue) -> {
+          builder.withHeader(expectedHeader, equalTo(expectedValue));
+          builder.andMatching(
+              r -> MatchResult.of(r.getHeaders().getHeader(expectedHeader).isSingleValued()));
+        });
+    apiProvider.verify(builder);
+  }
+
+  private static Stream<Arguments> additionalHeadersTests() {
+    List<String> additionalHeaderNames = List.of("X-foo", "X-bar");
+    Map<String, String> additionalHeaders = Map.of("X-foo", "foo-value", "X-bar", "bar-value");
+    Map<String, String> customHeaders =
+        Map.of("X-foo", "custom-foo-value", "X-custom-header", "custom-header-value");
+
+    // With the feature disabled, expect custom headers
+
+    // With all the additional headers in the MDC, and all the custom headers,
+    // expect this combination
+    Map<String, String> expectedHeaders =
+        Map.of(
+            "X-foo", "foo-value", "X-bar", "bar-value", "X-custom-header", "custom-header-value");
+
+    // With customHeaders null or empty, expect the info from the MDC.
+
+    // With only partial info in the MDC, still expect that the values for
+    // additional header names from customHeaders are dropped.
+    Map<String, String> partialMdc = Map.of("X-bar", "bar-value");
+    Map<String, String> partialExpectedHeaders =
+        Map.of("X-bar", "bar-value", "X-custom-header", "custom-header-value");
+
+    return Stream.of(
+        Arguments.of(
+            false, additionalHeaderNames, false, additionalHeaders, customHeaders, customHeaders),
+        Arguments.of(
+            false, additionalHeaderNames, true, additionalHeaders, customHeaders, customHeaders),
+        Arguments.of(
+            true, additionalHeaderNames, false, additionalHeaders, customHeaders, customHeaders),
+        Arguments.of(
+            true, additionalHeaderNames, true, additionalHeaders, customHeaders, expectedHeaders),
+        Arguments.of(true, additionalHeaderNames, true, additionalHeaders, null, additionalHeaders),
+        Arguments.of(
+            true, additionalHeaderNames, true, additionalHeaders, Map.of(), additionalHeaders),
+        Arguments.of(
+            true, additionalHeaderNames, true, partialMdc, customHeaders, partialExpectedHeaders));
   }
 }

--- a/rosco/rosco-core/src/test/java/com/netflix/spinnaker/rosco/services/ClouddriverServiceTest.java
+++ b/rosco/rosco-core/src/test/java/com/netflix/spinnaker/rosco/services/ClouddriverServiceTest.java
@@ -37,6 +37,7 @@ import com.netflix.spinnaker.okhttp.OkHttpClientConfigurationProperties;
 import com.netflix.spinnaker.okhttp.Retrofit2EncodeCorrectionInterceptor;
 import com.netflix.spinnaker.okhttp.SpinnakerRequestHeaderInterceptor;
 import com.netflix.spinnaker.retrofit.Retrofit2ConfigurationProperties;
+import java.util.Collections;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -98,7 +99,8 @@ public class ClouddriverServiceTest {
   static class TestConfig {
     @Bean
     public SpinnakerRequestHeaderInterceptor spinnakerRequestHeaderInterceptor() {
-      return new SpinnakerRequestHeaderInterceptor(false);
+      return new SpinnakerRequestHeaderInterceptor(
+          false /* propagateSpinnakerHeaders */, Collections.emptyList() /* additionalHeaders */);
     }
   }
 }


### PR DESCRIPTION
These changes:

* enable ProvidedIdRequestFilter in orca, getting incoming additional headers (e.g. X-FOO and X-BAR into the MDC, configured with (for example):
```
    provided-id-request-filter:
      enabled: true
      additionalHeaders:
        - X-FOO
        - X-BAR
```
* add an additionalHeaders property to the pipeline execution context, populated with additional headers from ProvidedIdRequestFilter (if provided-id-request-filter.enabled is true)
* add additional headers from the pipeline execution context into the MDC of running tasks
* include additional headers from the MDC in outgoing http requests that webhook stages make if new config property `webhook.includeAdditionalHeaders` is true (it defaults to false).

Together with mTLS (external to gate) and [header auth](https://github.com/spinnaker/spinnaker/pull/7109) + ProvidedIdRequestFilter in gate, this is a mechanism to get trusted headers from outside Spinnaker into the http requests that webhook stages make, which provides extra context to the receivers of those requests.

release notes: https://github.com/spinnaker/spinnaker.io/pull/533