### PR TITLE
fix(orca/retrofit2): fix path and query params order issue

### DIFF
--- a/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/DelegatingKatoRestService.java
+++ b/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/DelegatingKatoRestService.java
@@ -31,7 +31,7 @@ public class DelegatingKatoRestService extends DelegatingClouddriverService<Kato
   @Override
   public Call<TaskId> requestOperations(
       String clientRequestId, String cloudProvider, Collection<Map<String, Map>> operations) {
-    return getService().requestOperations(clientRequestId, cloudProvider, operations);
+    return getService().requestOperations(cloudProvider, clientRequestId, operations);
   }
 
   @Override
@@ -40,7 +40,7 @@ public class DelegatingKatoRestService extends DelegatingClouddriverService<Kato
       String cloudProvider,
       String operationName,
       OperationContext operation) {
-    return getService().submitOperation(clientRequestId, cloudProvider, operationName, operation);
+    return getService().submitOperation(cloudProvider, operationName, clientRequestId, operation);
   }
 
   @Override

--- a/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/KatoRestService.java
+++ b/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/KatoRestService.java
@@ -30,15 +30,15 @@ public interface KatoRestService {
 
   @POST("{cloudProvider}/ops")
   Call<TaskId> requestOperations(
-      @Query("clientRequestId") String clientRequestId,
       @Path("cloudProvider") String cloudProvider,
+      @Query("clientRequestId") String clientRequestId,
       @Body Collection<Map<String, Map>> operations);
 
   @POST("{cloudProvider}/ops/{operationName}")
   Call<ResponseBody> submitOperation(
-      @Query("clientRequestId") String clientRequestId,
       @Path("cloudProvider") String cloudProvider,
       @Path("operationName") String operationName,
+      @Query("clientRequestId") String clientRequestId,
       @Body OperationContext operation);
 
   @PATCH("{cloudProvider}/task/{id}")

--- a/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/KatoService.java
+++ b/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/KatoService.java
@@ -57,7 +57,7 @@ public class KatoService {
         () ->
             Retrofit2SyncCall.execute(
                 katoRestService.requestOperations(
-                    requestId(operations), cloudProvider, operations)),
+                    cloudProvider, requestId(operations), operations)),
         3,
         Duration.ofSeconds(1),
         false);
@@ -69,7 +69,7 @@ public class KatoService {
     try (ResponseBody responseBody =
         Retrofit2SyncCall.execute(
             katoRestService.submitOperation(
-                requestId(operation), cloudProvider, operation.getOperationType(), operation))) {
+                cloudProvider, operation.getOperationType(), requestId(operation), operation))) {
 
       taskId = objectMapper.readValue(responseBody.byteStream(), TaskId.class);
     } catch (Exception e) {

--- a/orca/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/KatoRestServiceSpec.groovy
+++ b/orca/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/KatoRestServiceSpec.groovy
@@ -141,12 +141,9 @@ class KatoRestServiceSpec extends Specification {
             )
     )
 
-    when:
-    Retrofit2SyncCall.execute(service.requestOperations(requestId, "aws", [operation]))
-
-    //FIXME: This exception shouldn't be thrown. Fix the order of @Path and @Query parameters in the service method.
-    then: "an IllegalArgumentException is thrown"
-    def e = thrown(IllegalArgumentException)
-    e.message.contains("@Path parameter must not come after a @Query")
+    expect: "kato should return the details of the task it created"
+    with(Retrofit2SyncCall.execute(service.requestOperations(requestId, "aws", [operation]))) {
+      it.id == taskId
+    }
   }
 }

--- a/orca/orca-clouddriver/src/test/kotlin/com/netflix/spinnaker/orca/clouddriver/pipeline/KubernetesPreconfiguredJobSpec.kt
+++ b/orca/orca-clouddriver/src/test/kotlin/com/netflix/spinnaker/orca/clouddriver/pipeline/KubernetesPreconfiguredJobSpec.kt
@@ -86,7 +86,7 @@ class KubernetesPreconfiguredJobSpec : JUnit5Minutests {
             .contains("\"ref\":\"/pipelines")
         }
 
-        verify(timeout = 2000) { katoRestService.requestOperations(any(), "kubernetes", match { it.toString().contains("alias=preconfiguredJob") }) }
+        verify(timeout = 2000) { katoRestService.requestOperations("kubernetes", any(), match { it.toString().contains("alias=preconfiguredJob") }) }
       }
     }
   }


### PR DESCRIPTION
- This PR fixes the issue of "@Path parameter must not come after a @Query" in KatoRestService for a couple of service methods.
- Added a test to demonstrate the issue