### PR TITLE
fix(orca/retrofit2): fix wildcard in parameter type in echo's retrofit2 client's api interface method

### DIFF
--- a/orca/orca-echo/orca-echo.gradle
+++ b/orca/orca-echo/orca-echo.gradle
@@ -30,7 +30,14 @@ dependencies {
   implementation("io.spinnaker.fiat:fiat-api")
   implementation("io.spinnaker.kork:kork-retrofit")
 
+  testImplementation("io.spinnaker.kork:kork-retrofit2")
+  testImplementation("org.springframework.boot:spring-boot-starter-test")
   testImplementation("com.squareup.retrofit2:retrofit-mock")
+  testImplementation("org.springframework:spring-test")
+  testImplementation("com.github.tomakehurst:wiremock-jre8-standalone")
+  testImplementation("org.assertj:assertj-core")
+  testImplementation("org.junit.jupiter:junit-jupiter-api")
+  testImplementation("org.junit.jupiter:junit-jupiter-params")
   testRuntimeOnly("net.bytebuddy:byte-buddy")
 }
 

--- a/orca/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/EchoService.groovy
+++ b/orca/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/EchoService.groovy
@@ -28,7 +28,7 @@ import retrofit2.http.Path
 interface EchoService {
 
   @POST(".")
-  Call<ResponseBody> recordEvent(@Body Map<String, Object> notification)
+  Call<Void> recordEvent(@Body Map<String, Object> notification)
 
   @GET("events/recent/{type}/{since}/")
   Call<ResponseBody> getEvents(@Path("type") String type, @Path("since") Long since)

--- a/orca/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/EchoService.groovy
+++ b/orca/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/EchoService.groovy
@@ -28,7 +28,7 @@ import retrofit2.http.Path
 interface EchoService {
 
   @POST(".")
-  Call<ResponseBody> recordEvent(@Body Map<String, ?> notification)
+  Call<ResponseBody> recordEvent(@Body Map<String, Object> notification)
 
   @GET("events/recent/{type}/{since}/")
   Call<ResponseBody> getEvents(@Path("type") String type, @Path("since") Long since)

--- a/orca/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/spring/EchoNotifyingExecutionListener.groovy
+++ b/orca/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/spring/EchoNotifyingExecutionListener.groovy
@@ -62,14 +62,14 @@ class EchoNotifyingExecutionListener implements ExecutionListener {
         }
         AuthenticatedRequest.allowAnonymous({
           Retrofit2SyncCall.execute(
-            echoService.recordEvent(
+            echoService.recordEvent([
               details: [
                 source     : "orca",
                 type       : "orca:${execution.type}:starting".toString(),
                 application: execution.application,
               ],
               content: buildContent(execution)
-            )
+            ] as Map)
           )
         })
       }
@@ -92,14 +92,14 @@ class EchoNotifyingExecutionListener implements ExecutionListener {
         }
         AuthenticatedRequest.allowAnonymous({
           Retrofit2SyncCall.execute(
-            echoService.recordEvent(
+            echoService.recordEvent([
               details: [
                 source     : "orca",
                 type       : "orca:${execution.type}:${wasSuccessful ? "complete" : "failed"}".toString(),
                 application: execution.application,
               ],
               content: buildContent(execution)
-            )
+            ] as Map)
           )
         })
       }

--- a/orca/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/spring/EchoNotifyingStageListener.groovy
+++ b/orca/orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/spring/EchoNotifyingStageListener.groovy
@@ -144,7 +144,7 @@ class EchoNotifyingStageListener implements StageListener {
         MDC.put(Header.EXECUTION_ID.header, stage.execution.id)
         MDC.put(Header.USER.header, stage.execution?.authentication?.user ?: "anonymous")
         AuthenticatedRequest.allowAnonymous({
-          Retrofit2SyncCall.execute(echoService.recordEvent(event))
+          Retrofit2SyncCall.execute(echoService.recordEvent(event as Map))
         })
       } finally {
         MDC.remove(Header.EXECUTION_ID.header)

--- a/orca/orca-echo/src/test/java/com/netflix/spinnaker/orca/echo/EchoServiceTest.java
+++ b/orca/orca-echo/src/test/java/com/netflix/spinnaker/orca/echo/EchoServiceTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2025 OpsMx, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.echo;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import com.netflix.spectator.api.NoopRegistry;
+import com.netflix.spinnaker.config.DefaultServiceClientProvider;
+import com.netflix.spinnaker.config.okhttp3.DefaultOkHttpClientBuilderProvider;
+import com.netflix.spinnaker.config.okhttp3.OkHttpClientProvider;
+import com.netflix.spinnaker.fiat.shared.FiatClientConfigurationProperties;
+import com.netflix.spinnaker.fiat.shared.FiatStatus;
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService;
+import com.netflix.spinnaker.kork.retrofit.Retrofit2ServiceFactory;
+import com.netflix.spinnaker.kork.retrofit.Retrofit2SyncCall;
+import com.netflix.spinnaker.okhttp.OkHttpClientConfigurationProperties;
+import com.netflix.spinnaker.okhttp.Retrofit2EncodeCorrectionInterceptor;
+import com.netflix.spinnaker.okhttp.SpinnakerRequestHeaderInterceptor;
+import com.netflix.spinnaker.orca.echo.config.EchoConfiguration;
+import com.netflix.spinnaker.orca.front50.Front50Service;
+import com.netflix.spinnaker.orca.pipeline.persistence.InMemoryExecutionRepository;
+import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor;
+import java.util.Map;
+import okhttp3.OkHttpClient;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+@SpringBootTest(
+    classes = {
+      EchoConfiguration.class,
+      OkHttpClientProvider.class,
+      Retrofit2EncodeCorrectionInterceptor.class,
+      DefaultServiceClientProvider.class,
+      EchoServiceTest.TestConfig.class,
+      Retrofit2ServiceFactory.class,
+      DefaultOkHttpClientBuilderProvider.class,
+      OkHttpClient.class,
+      OkHttpClientConfigurationProperties.class,
+      ObjectMapper.class,
+      FiatStatus.class,
+      NoopRegistry.class,
+      DynamicConfigService.NoopDynamicConfig.class,
+      FiatClientConfigurationProperties.class,
+      InMemoryExecutionRepository.class,
+      ContextParameterProcessor.class
+    })
+public class EchoServiceTest {
+
+  @RegisterExtension
+  static WireMockExtension wmEcho50 =
+      WireMockExtension.newInstance().options(wireMockConfig().dynamicPort()).build();
+
+  @Autowired EchoService echoService;
+
+  @DynamicPropertySource
+  static void registerUrls(DynamicPropertyRegistry registry) {
+    System.out.println("wiremock echo url: " + wmEcho50.baseUrl());
+    registry.add("echo.base-url", wmEcho50::baseUrl);
+  }
+
+  @Test
+  public void testEchoService() {
+    wmEcho50.stubFor(
+        WireMock.post(urlMatching("/")).willReturn(aResponse().withStatus(HttpStatus.OK.value())));
+    // FIXME: Fix the wildcard type in the recordEvent method
+    Throwable thrown =
+        catchThrowable(
+            () -> Retrofit2SyncCall.execute(echoService.recordEvent(Map.of("type", "testEvent"))));
+    assertThat(thrown)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(
+            "Parameter type must not include a type variable or wildcard: java.util.Map<java.lang.String, ?> (parameter #1)");
+  }
+
+  @Configuration
+  static class TestConfig {
+
+    @MockBean Front50Service front50Service;
+
+    @Bean
+    SpinnakerRequestHeaderInterceptor spinnakerRequestHeaderInterceptor() {
+      return new SpinnakerRequestHeaderInterceptor(false);
+    }
+  }
+}

--- a/orca/orca-echo/src/test/java/com/netflix/spinnaker/orca/echo/EchoServiceTest.java
+++ b/orca/orca-echo/src/test/java/com/netflix/spinnaker/orca/echo/EchoServiceTest.java
@@ -19,8 +19,6 @@ package com.netflix.spinnaker.orca.echo;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.client.WireMock;
@@ -91,14 +89,10 @@ public class EchoServiceTest {
   public void testEchoService() {
     wmEcho50.stubFor(
         WireMock.post(urlMatching("/")).willReturn(aResponse().withStatus(HttpStatus.OK.value())));
-    // FIXME: Fix the wildcard type in the recordEvent method
-    Throwable thrown =
-        catchThrowable(
-            () -> Retrofit2SyncCall.execute(echoService.recordEvent(Map.of("type", "testEvent"))));
-    assertThat(thrown)
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining(
-            "Parameter type must not include a type variable or wildcard: java.util.Map<java.lang.String, ?> (parameter #1)");
+
+    Retrofit2SyncCall.execute(echoService.recordEvent(Map.of("type", "testEvent")));
+
+    wmEcho50.verify(1, WireMock.postRequestedFor(urlMatching("/")));
   }
 
   @Configuration


### PR DESCRIPTION
- With retrofit2, parameter type must not include a type variable or wildcard so EchoService.recordEvent method parameter is updated. 
- Changed from 
`recordEvent(@Body Map<String, ?> notification)` 
to 
`recordEvent(@Body Map<String, Object> notification)`
- Added a test to demonstrate the issue
- Also changed the method return type to match the actual return of API 