### PR TITLE
chore(clouddriver): give the jvm 8g when compiling

### DIFF
--- a/clouddriver/gradle.properties
+++ b/clouddriver/gradle.properties
@@ -4,5 +4,5 @@ org.gradle.parallel=true
 spinnakerGradleVersion=8.32.1
 
 targetJava17=true
-org.gradle.jvmargs=-Xmx6g -Xms6g
+org.gradle.jvmargs=-Xmx8g -Xms8g
 testJvmMaxMemory=6g


### PR DESCRIPTION
to avoid errors like

Execution failed for task ':clouddriver:clouddriver-yandex:compileGroovy'.
> java.lang.OutOfMemoryError: Java heap space

from https://github.com/spinnaker/spinnaker/actions/runs/16887943215/job/47842437284
