### PR TITLE
feat(plugins): Log output of the version requirements when a mismatch

### DIFF
--- a/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/SpinnakerPluginManager.kt
+++ b/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/SpinnakerPluginManager.kt
@@ -118,6 +118,7 @@ open class SpinnakerPluginManager(
 
   override fun loadPluginFromPath(pluginPath: Path): PluginWrapper? {
     val extractedPath = pluginBundleExtractor.extractService(pluginPath, serviceName) ?: return null
+    log.info("loading plugin from path {}", extractedPath)
     return super.loadPluginFromPath(extractedPath)
   }
 


### PR DESCRIPTION
Was debugging a weird semver parsing...and the log messages were NOT helpful.  Just adding some basic logging on parsing of plugins and when version parsing fails, wrap it and output the information.  Could see making the .info a debug potentially.... 