### PR TITLE
fix(orca/retrofit2): error @Param must not come after @Query

### DIFF
--- a/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/CloudDriverService.java
+++ b/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/CloudDriverService.java
@@ -80,7 +80,7 @@ public class CloudDriverService {
     ResponseBody responseBody =
         Retrofit2SyncCall.execute(
             oortService.getServerGroupFromCluster(
-                app, account, cluster, serverGroup, region, cloudProvider));
+                app, account, cluster, serverGroup, cloudProvider, region));
     return readBody(responseBody, ServerGroup.class);
   }
 

--- a/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/DelegatingOortService.java
+++ b/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/DelegatingOortService.java
@@ -72,10 +72,10 @@ public class DelegatingOortService extends DelegatingClouddriverService<OortServ
       String account,
       String cluster,
       String serverGroup,
-      String region,
-      String cloudProvider) {
+      String cloudProvider,
+      String region) {
     return getService()
-        .getServerGroupFromCluster(app, account, cluster, serverGroup, region, cloudProvider);
+        .getServerGroupFromCluster(app, account, cluster, serverGroup, cloudProvider, region);
   }
 
   @Override

--- a/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/OortService.java
+++ b/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/OortService.java
@@ -49,8 +49,8 @@ public interface OortService {
       @Path("account") String account,
       @Path("cluster") String cluster,
       @Path("serverGroup") String serverGroup,
-      @Query("region") String region,
-      @Path("cloudProvider") String cloudProvider);
+      @Path("cloudProvider") String cloudProvider,
+      @Query("region") String region);
 
   @GET("applications/{app}/clusters/{account}/{cluster}/{cloudProvider}/serverGroups/{serverGroup}")
   Call<List<ServerGroup>> getServerGroupsFromClusterTyped(

--- a/orca/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/OortServiceTest.java
+++ b/orca/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/OortServiceTest.java
@@ -16,10 +16,12 @@
 
 package com.netflix.spinnaker.orca.clouddriver;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
+import com.netflix.spinnaker.kork.retrofit.Retrofit2SyncCall;
+import okhttp3.ResponseBody;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -52,13 +54,11 @@ class OortServiceTest {
                     "/applications/spinnaker/clusters/myAccount/myCluster/aws/serverGroups/myServerGroup?region=us-west-2"))
             .willReturn(WireMock.aResponse().withStatus(HttpStatus.OK.value()).withBody("{}")));
 
-    // FIXME: fix parameter order
-    assertThatThrownBy(
-            () ->
-                oortService.getServerGroupFromCluster(
-                    "spinnaker", "myAccount", "myCluster", "myServerGroup", "aws", "us-west-2"))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage(
-            "A @Path parameter must not come after a @Query. (parameter #6)\n    for method OortService.getServerGroupFromCluster");
+    ResponseBody responseBody =
+        Retrofit2SyncCall.execute(
+            oortService.getServerGroupFromCluster(
+                "spinnaker", "myAccount", "myCluster", "myServerGroup", "aws", "us-west-2"));
+
+    assertThat(responseBody).isNotNull();
   }
 }


### PR DESCRIPTION
related PRs:
- https://github.com/spinnaker/spinnaker/pull/7183

using ripgrep to find missed params:
`rg --multiline '@Query\("\w+"\).*\n.*@Path'`

output:
```java
orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/OortService.java
52:      @Query("region") String region,
53:      @Path("cloudProvider") String cloudProvider);

```

Added a test to reproduce the error:

```java
A @Path parameter must not come after a @Query. (parameter #6)
    for method OortService.getServerGroupFromCluster
java.lang.IllegalArgumentException: A @Path parameter must not come after a @Query. (parameter #6)
    for method OortService.getServerGroupFromCluster
	at retrofit2.Utils.methodError(Utils.java:53)
	at retrofit2.Utils.methodError(Utils.java:43)
	at retrofit2.Utils.parameterError(Utils.java:62)
	at retrofit2.RequestFactory$Builder.parseParameterAnnotation(RequestFactory.java:376)
	at retrofit2.RequestFactory$Builder.parseParameter(RequestFactory.java:306)
	at retrofit2.RequestFactory$Builder.build(RequestFactory.java:193)
	at retrofit2.RequestFactory.parseAnnotations(RequestFactory.java:67)
	at retrofit2.ServiceMethod.parseAnnotations(ServiceMethod.java:26)
	at retrofit2.Retrofit.loadServiceMethod(Retrofit.java:192)
	at retrofit2.Retrofit$1.invoke(Retrofit.java:149)
	at jdk.proxy3/jdk.proxy3.$Proxy17.getServerGroupFromCluster(Unknown Source)
	at com.netflix.spinnaker.orca.clouddriver.OortServiceTest.getServerGroupFromClusterPathMustNotComeAfterQuery(OortServiceTest.java:59)
```