### PR TITLE
fix(logs): Fix log message formatting 

### DIFF
--- a/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/WaitForCapacityMatchTask.java
+++ b/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/WaitForCapacityMatchTask.java
@@ -96,7 +96,10 @@ public class WaitForCapacityMatchTask extends AbstractInstancesCheckTask {
 
       if (serverGroupProperties.getResize().isMatchInstancesSize()) {
         splainer.add(
-            "checking if capacity matches (desired=${desired}, instances.size()=${instances.size()}) ");
+            "checking if capacity matches (desired="
+                + desired
+                + ", instances.size()="
+                + instances.size());
         if (desired == null || desired != instances.size()) {
           splainer.add(
               "short-circuiting out of WaitForCapacityMatchTask because expected and current capacity don't match}");


### PR DESCRIPTION
Most likely a groovy/java change in past - java file string formatting doesn't work this way.