### PR TITLE
fix(orca/clouddriver): correct parameter order for requestOperations to avoid invalid cloudProvider errors

### DIFF
--- a/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/DelegatingKatoRestService.java
+++ b/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/DelegatingKatoRestService.java
@@ -30,7 +30,7 @@ public class DelegatingKatoRestService extends DelegatingClouddriverService<Kato
 
   @Override
   public Call<TaskId> requestOperations(
-      String clientRequestId, String cloudProvider, Collection<Map<String, Map>> operations) {
+      String cloudProvider, String clientRequestId, Collection<Map<String, Map>> operations) {
     return getService().requestOperations(cloudProvider, clientRequestId, operations);
   }
 

--- a/orca/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/KatoRestServiceSpec.groovy
+++ b/orca/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/KatoRestServiceSpec.groovy
@@ -142,7 +142,7 @@ class KatoRestServiceSpec extends Specification {
     )
 
     expect: "kato should return the details of the task it created"
-    with(Retrofit2SyncCall.execute(service.requestOperations(requestId, "aws", [operation]))) {
+    with(Retrofit2SyncCall.execute(service.requestOperations("aws", requestId, [operation]))) {
       it.id == taskId
     }
   }

--- a/orca/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/DelegatingKatoRestServiceTest.java
+++ b/orca/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/DelegatingKatoRestServiceTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2025 Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.clouddriver;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import com.netflix.spinnaker.kork.web.selector.SelectableService;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DelegatingKatoRestServiceTest {
+
+  @Mock SelectableService<KatoRestService> selectableService;
+
+  @Mock KatoRestService katoRestService;
+
+  DelegatingKatoRestService delegatingKatoRestService;
+
+  @BeforeEach
+  void setup() {
+    when(selectableService.getService(any())).thenReturn(katoRestService);
+    delegatingKatoRestService = new DelegatingKatoRestService(selectableService);
+  }
+
+  @Test
+  void requestOperationsParameterOrder() {
+    // given
+    String cloudProvider = "cloudProvider";
+    String clientRequestId = "clientRequestId";
+    Collection<Map<String, Map>> operations = Collections.emptyList();
+
+    // when
+    delegatingKatoRestService.requestOperations(cloudProvider, clientRequestId, operations);
+
+    // then
+    // FIXME: KatoRestService.requestOperations expects cloudProvider as the first argument, then
+    // clientRequestId
+    // verify(katoRestService).requestOperations(cloudProvider, clientRequestId, operations);
+    verify(katoRestService).requestOperations(clientRequestId, cloudProvider, operations);
+    verifyNoMoreInteractions(katoRestService);
+  }
+}

--- a/orca/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/DelegatingKatoRestServiceTest.java
+++ b/orca/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/DelegatingKatoRestServiceTest.java
@@ -56,10 +56,7 @@ class DelegatingKatoRestServiceTest {
     delegatingKatoRestService.requestOperations(cloudProvider, clientRequestId, operations);
 
     // then
-    // FIXME: KatoRestService.requestOperations expects cloudProvider as the first argument, then
-    // clientRequestId
-    // verify(katoRestService).requestOperations(cloudProvider, clientRequestId, operations);
-    verify(katoRestService).requestOperations(clientRequestId, cloudProvider, operations);
+    verify(katoRestService).requestOperations(cloudProvider, clientRequestId, operations);
     verifyNoMoreInteractions(katoRestService);
   }
 }


### PR DESCRIPTION

- Fixed requestOperations method signature in DelegatingKatoRestService to ensure `cloudProvider` comes before `clientRequestId`.
- Updated test KatoRestServiceSpec accordingly.
- Prevents 400 errors where UUID was misinterpreted as cloudProvider.

Error:
```
 ERROR 1 --- [     handlers-7] c.n.s.orca.q.handler.RunTaskHandler      : [rahulgandhi.chekuri@opsmx.io] Error running DeployManifestTask for pipeline[01K1J9JBP1BDNAHX38R2JYRED1]
com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerHttpException: Status: 400, Method: POST, URL: http://spin-clouddriver.onlyspinnaker:7002/021b86e19da715828bcc1d917db06cbb25aa7096ad5b11b263d86f866161eedd/ops?clientRequestId=kubernetes, Message: No cloud provider named '021b86e19da715828bcc1d917db06cbb25aa7096ad5b11b263d86f866161eedd' found
	at com.netflix.spinnaker.kork.retrofit.ErrorHandlingExecutorCallAdapterFactory$ExecutorCallbackCall.execute(ErrorHandlingExecutorCallAdapterFactory.java:162)
	at com.netflix.spinnaker.kork.retrofit.Retrofit2SyncCall.executeCall(Retrofit2SyncCall.java:47)
	at com.netflix.spinnaker.kork.retrofit.Retrofit2SyncCall.execute(Retrofit2SyncCall.java:34)
	at com.netflix.spinnaker.orca.clouddriver.KatoService.lambda$requestOperations$1(KatoService.java:58)
	at com.netflix.spinnaker.kork.core.RetrySupport.retry(RetrySupport.java:34)
	at com.netflix.spinnaker.orca.clouddriver.KatoService.requestOperations(KatoService.java:56)
	at com.netflix.spinnaker.orca.clouddriver.tasks.manifest.DeployManifestTask.executeOperation(DeployManifestTask.java:80)
	at com.netflix.spinnaker.orca.clouddriver.tasks.manifest.DeployManifestTask.execute(DeployManifestTask.java:53)
	at com.netflix.spinnaker.orca.q.handler.RunTaskHandler$handle$1$1$1$1.invoke(RunTaskHandler.kt:166)
	at com.netflix.spinnaker.orca.q.handler.RunTaskHandler$handle$1$1$1$1.invoke(RunTaskHandler.kt:122)
	at com.netflix.spinnaker.orca.q.handler.RunTaskHandler.withLoggingContext(RunTaskHandler.kt:479)
	at com.netflix.spinnaker.orca.q.handler.RunTaskHandler.access$withLoggingContext(RunTaskHandler.kt:89)
	at com.netflix.spinnaker.orca.q.handler.RunTaskHandler$handle$1$1$1.invoke(RunTaskHandler.kt:122)
	at com.netflix.spinnaker.orca.q.handler.RunTaskHandler$handle$1$1$1.invoke(RunTaskHandler.kt:121)
	at com.netflix.spinnaker.orca.q.handler.AuthenticationAware$DefaultImpls.withAuth$lambda-0(AuthenticationAware.kt:51)
	at com.netflix.spinnaker.security.AuthenticatedRequest.lambda$wrapCallableForPrincipal$0(AuthenticatedRequest.java:272)
	at com.netflix.spinnaker.orca.q.handler.AuthenticationAware$DefaultImpls.withAuth(AuthenticationAware.kt:51)
	at com.netflix.spinnaker.orca.q.handler.RunTaskHandler.withAuth(RunTaskHandler.kt:89)
	at com.netflix.spinnaker.orca.q.handler.RunTaskHandler$handle$1$1.invoke(RunTaskHandler.kt:121)
	at com.netflix.spinnaker.orca.q.handler.RunTaskHandler$handle$1$1.invoke(RunTaskHandler.kt:119)
	at com.netflix.spinnaker.orca.q.handler.RunTaskHandler$withTask$1.invoke(RunTaskHandler.kt:292)
	at com.netflix.spinnaker.orca.q.handler.RunTaskHandler$withTask$1.invoke(RunTaskHandler.kt:281)
	at com.netflix.spinnaker.orca.q.handler.OrcaMessageHandler$withTask$1.invoke(OrcaMessageHandler.kt:69)
	at com.netflix.spinnaker.orca.q.handler.OrcaMessageHandler$withTask$1.invoke(OrcaMessageHandler.kt:61)
	at com.netflix.spinnaker.orca.q.handler.OrcaMessageHandler$withStage$1.invoke(OrcaMessageHandler.kt:86)
	at com.netflix.spinnaker.orca.q.handler.OrcaMessageHandler$withStage$1.invoke(OrcaMessageHandler.kt:75)
	at com.netflix.spinnaker.orca.q.handler.OrcaMessageHandler$DefaultImpls.withExecution(OrcaMessageHandler.kt:96)
	at com.netflix.spinnaker.orca.q.handler.RunTaskHandler.withExecution(RunTaskHandler.kt:89)
	at com.netflix.spinnaker.orca.q.handler.OrcaMessageHandler$DefaultImpls.withStage(OrcaMessageHandler.kt:75)
	at com.netflix.spinnaker.orca.q.handler.RunTaskHandler.withStage(RunTaskHandler.kt:89)
	at com.netflix.spinnaker.orca.q.handler.OrcaMessageHandler$DefaultImpls.withTask(OrcaMessageHandler.kt:61)
	at com.netflix.spinnaker.orca.q.handler.RunTaskHandler.withTask(RunTaskHandler.kt:89)
	at com.netflix.spinnaker.orca.q.handler.RunTaskHandler.withTask(RunTaskHandler.kt:281)
	at com.netflix.spinnaker.orca.q.handler.RunTaskHandler.handle$lambda-0(RunTaskHandler.kt:119)
	at com.netflix.spinnaker.orca.lock.NoOpRunOnLockAcquired.execute(ExternalLock.kt:191)
	at com.netflix.spinnaker.orca.lock.RetriableLock$LockAndRun.get(RetriableLock.java:128)
	at com.netflix.spinnaker.orca.lock.RetriableLock$LockAndRun.get(RetriableLock.java:103)
	at com.netflix.spinnaker.kork.core.RetrySupport.retry(RetrySupport.java:34)
	at com.netflix.spinnaker.orca.lock.RetriableLock.lock(RetriableLock.java:57)
	at com.netflix.spinnaker.orca.q.handler.RunTaskHandler.withLocking(RunTaskHandler.kt:298)
	at com.netflix.spinnaker.orca.q.handler.RunTaskHandler.handle(RunTaskHandler.kt:118)
	at com.netflix.spinnaker.orca.q.handler.RunTaskHandler.handle(RunTaskHandler.kt:89)
	at com.netflix.spinnaker.q.MessageHandler$DefaultImpls.invoke(MessageHandler.kt:36)
	at com.netflix.spinnaker.orca.q.handler.OrcaMessageHandler$DefaultImpls.invoke(OrcaMessageHandler.kt:46)
	at com.netflix.spinnaker.orca.q.handler.RunTaskHandler.invoke(RunTaskHandler.kt:89)
	at com.netflix.spinnaker.orca.q.audit.ExecutionTrackingMessageHandlerPostProcessor$ExecutionTrackingMessageHandlerProxy.invoke(ExecutionTrackingMessageHandlerPostProcessor.kt:72)
	at com.netflix.spinnaker.q.QueueProcessor$callback$1.invoke$lambda-0(QueueProcessor.kt:90)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:840)

```