### PR TITLE
fix(halyard/retrofit2): fix daemon service getTask API definition

### DIFF
--- a/halyard/halyard-cli/halyard-cli.gradle
+++ b/halyard/halyard-cli/halyard-cli.gradle
@@ -33,6 +33,7 @@ dependencies {
   testImplementation 'org.spockframework:spock-core'
   testImplementation 'org.springframework:spring-test'
   testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
+  testImplementation "com.github.tomakehurst:wiremock-jre8-standalone"
 }
 
 apply plugin: 'application'

--- a/halyard/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/Daemon.java
+++ b/halyard/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/Daemon.java
@@ -43,6 +43,7 @@ import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.RunningServiceDetails;
 import com.netflix.spinnaker.kork.retrofit.ErrorHandlingExecutorCallAdapterFactory;
 import com.netflix.spinnaker.kork.retrofit.util.RetrofitUtils;
 import com.netflix.spinnaker.okhttp.Retrofit2EncodeCorrectionInterceptor;
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -1232,7 +1233,12 @@ public class Daemon {
   }
 
   static <C, T> DaemonTask<C, T> getTask(String uuid) {
-    return getService().getTask(uuid);
+    try {
+      return objectMapper.readValue(
+          getService().getTask(uuid).string(), new TypeReference<DaemonTask<C, T>>() {});
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to parse response for the task with UUID: " + uuid, e);
+    }
   }
 
   public static void interruptTask(String uuid) {

--- a/halyard/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/DaemonService.java
+++ b/halyard/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/DaemonService.java
@@ -33,6 +33,7 @@ import com.netflix.spinnaker.halyard.core.tasks.v1.ShallowTaskList;
 import com.netflix.spinnaker.halyard.deploy.deployment.v1.DeployOption;
 import java.util.List;
 import java.util.Map;
+import okhttp3.ResponseBody;
 import retrofit2.http.Body;
 import retrofit2.http.DELETE;
 import retrofit2.http.GET;
@@ -55,7 +56,7 @@ public interface DaemonService {
   Void interruptTask(@Path("uuid") String uuid, @Body String _ignore);
 
   @GET("v1/tasks/{uuid}/")
-  <C, T> DaemonTask<C, T> getTask(@Path("uuid") String uuid);
+  ResponseBody getTask(@Path("uuid") String uuid);
 
   @PUT("v1/backup/create")
   DaemonTask<Halconfig, Object> createBackup(@Body String _ignore);

--- a/halyard/halyard-cli/src/test/java/com/netflix/spinnaker/halyard/cli/services/v1/DaemonServiceTest.java
+++ b/halyard/halyard-cli/src/test/java/com/netflix/spinnaker/halyard/cli/services/v1/DaemonServiceTest.java
@@ -1,0 +1,67 @@
+package com.netflix.spinnaker.halyard.cli.services.v1;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import com.netflix.spinnaker.halyard.core.DaemonResponse;
+import com.netflix.spinnaker.halyard.core.problem.v1.Problem;
+import com.netflix.spinnaker.halyard.core.problem.v1.ProblemBuilder;
+import com.netflix.spinnaker.halyard.core.problem.v1.ProblemSet;
+import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTask;
+import com.netflix.spinnaker.kork.retrofit.ErrorHandlingExecutorCallAdapterFactory;
+import com.netflix.spinnaker.kork.retrofit.util.RetrofitUtils;
+import okhttp3.OkHttpClient;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import retrofit2.Retrofit;
+import retrofit2.converter.jackson.JacksonConverterFactory;
+
+public class DaemonServiceTest {
+  @RegisterExtension
+  private static final WireMockExtension wmDaemon =
+      WireMockExtension.newInstance().options(wireMockConfig().dynamicPort()).build();
+
+  private static final ObjectMapper objectMapper = new ObjectMapper();
+  private static DaemonService daemonService;
+
+  @BeforeAll
+  public static void setUp() {
+    daemonService =
+        new Retrofit.Builder()
+            .baseUrl(RetrofitUtils.getBaseUrl(wmDaemon.baseUrl()))
+            .client(new OkHttpClient())
+            .addCallAdapterFactory(ErrorHandlingExecutorCallAdapterFactory.getInstance())
+            .addConverterFactory(JacksonConverterFactory.create())
+            .build()
+            .create(DaemonService.class);
+  }
+
+  @Test
+  public void testGetTask() throws JsonProcessingException {
+    DaemonTask task = new DaemonTask<>("testTask", 1000);
+    Problem problem = new ProblemBuilder(Problem.Severity.FATAL, "some exception").build();
+    DaemonResponse response = new DaemonResponse<>(null, new ProblemSet(problem));
+    task.setResponse(response);
+
+    wmDaemon.stubFor(
+        get(urlEqualTo("/v1/tasks/" + task.getUuid() + "/"))
+            .willReturn(
+                aResponse().withStatus(200).withBody(objectMapper.writeValueAsString(task))));
+
+    // FIXME: retrofit2 does not support type variables in method return types, fix getTask() method
+    // in DaemonService
+    Throwable thrown = catchThrowable(() -> daemonService.getTask(task.getUuid()));
+    assertThat(thrown)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(
+            "Method return type must not include a type variable or wildcard: com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTask<C, T>");
+  }
+}


### PR DESCRIPTION
- Retrofit2 does not support type variables in method return type. So `DaemonService.getTask()` is failing with the following error:
```
Method return type must not include a type variable or
  wildcard: com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTask<C, T>
for method DaemonService.getTask 
```

- This PR fixes the issue by manually deserializing the ResponseBody so that retrofit2 doesn't need to know the actual generic types at compile time. 

- Added a test to demonstrate the issue.