### PR TITLE
chore(dependency): update bc version from 1.77 to 1.78

### DIFF
--- a/kork/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/kork/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -9,7 +9,7 @@ ext {
     arrow            : "0.13.2",
     aws              : "1.12.261",
     awsv2            : "2.23.7",
-    bouncycastle     : "1.77",
+    bouncycastle     : "1.78", // fixes CVE-2024-34447
     brave            : "5.12.3",
     gcp              : "26.34.0",
     groovy           : "4.0.15",


### PR DESCRIPTION
Fixes for CVE-2024-34447 (Bouncy Castle Java Cryptography API vulnerable to DNS poisoning)

https://github.com/advisories/GHSA-4h8f-2wvx-gg5w
