### PR TITLE
fix(echo/rest): make it possible to send events to URLs with no trailing slash

### DIFF
--- a/echo/echo-rest/src/main/java/com/netflix/spinnaker/echo/events/RestEventListener.java
+++ b/echo/echo-rest/src/main/java/com/netflix/spinnaker/echo/events/RestEventListener.java
@@ -91,7 +91,7 @@ class RestEventListener implements EventListener {
                   processEventWithCircuitBreaker(event, service);
                 } else {
                   Map<String, Object> eventMap = transformEventToMap(event, service);
-                  restEventService.sendEvent(eventMap, service);
+                  restEventService.sendEvent(service.getConfig().getUrl(), eventMap, service);
                 }
               } catch (Exception e) {
                 handleError(event, service, e);

--- a/echo/echo-rest/src/main/java/com/netflix/spinnaker/echo/events/RestEventService.java
+++ b/echo/echo-rest/src/main/java/com/netflix/spinnaker/echo/events/RestEventService.java
@@ -45,7 +45,8 @@ public class RestEventService {
    */
   public void sendEventWithCircuitBreaker(
       Map<String, Object> eventMap, RestUrls.Service service, CircuitBreaker circuitBreaker) {
-    circuitBreaker.executeRunnable(() -> sendEvent(eventMap, service));
+    circuitBreaker.executeRunnable(
+        () -> sendEvent(service.getConfig().getUrl(), eventMap, service));
   }
 
   /**
@@ -54,9 +55,11 @@ public class RestEventService {
    * @param event The event data to be sent.
    * @param service The REST service to which the event should be sent.
    */
-  public void sendEvent(Map<String, Object> event, RestUrls.Service service) {
+  public void sendEvent(String url, Map<String, Object> event, RestUrls.Service service) {
     retrySupport.retry(
-        () -> Retrofit2SyncCall.execute(service.getClient().recordEvent(event)),
+        () ->
+            Retrofit2SyncCall.execute(
+                service.getClient().recordEvent(service.getConfig().getUrl(), event)),
         service.getConfig().getRetryCount(),
         Duration.ofMillis(200),
         false);

--- a/echo/echo-rest/src/main/java/com/netflix/spinnaker/echo/rest/RestService.java
+++ b/echo/echo-rest/src/main/java/com/netflix/spinnaker/echo/rest/RestService.java
@@ -21,9 +21,10 @@ import okhttp3.ResponseBody;
 import retrofit2.Call;
 import retrofit2.http.Body;
 import retrofit2.http.POST;
+import retrofit2.http.Url;
 
 public interface RestService {
 
-  @POST(".")
-  Call<ResponseBody> recordEvent(@Body Map<String, Object> event);
+  @POST
+  Call<ResponseBody> recordEvent(@Url String url, @Body Map<String, Object> event);
 }

--- a/echo/echo-rest/src/test/groovy/com/netflix/spinnaker/echo/config/RestConfigSpec.groovy
+++ b/echo/echo-rest/src/test/groovy/com/netflix/spinnaker/echo/config/RestConfigSpec.groovy
@@ -72,7 +72,7 @@ class RestConfigSpec extends Specification {
     RestUrls restUrls = configureRestServices(endpoint, EmptyHeadersFile)
 
     when:
-    Retrofit2SyncCall.execute(restUrls.getServices().get(0).getClient().recordEvent([:]))
+    Retrofit2SyncCall.execute(restUrls.getServices().get(0).getClient().recordEvent(wireMockServer.baseUrl(), [:]))
 
     then:
     headers.get().get("Authorization") == "Basic dGVzdHVzZXI6dGVzdHBhc3N3b3Jk"
@@ -88,7 +88,7 @@ class RestConfigSpec extends Specification {
     RestUrls restUrls = configureRestServices(endpoint, EmptyHeadersFile)
 
     when:
-    Retrofit2SyncCall.execute(restUrls.getServices().get(0).getClient().recordEvent([:]))
+    Retrofit2SyncCall.execute(restUrls.getServices().get(0).getClient().recordEvent(wireMockServer.baseUrl(), [:]))
 
     then:
     headers.get().get("Authorization") == "FromConfig"
@@ -113,7 +113,7 @@ class RestConfigSpec extends Specification {
     RestUrls restUrls = configureRestServices(endpoint, headersFromFile)
 
     when:
-    Retrofit2SyncCall.execute(restUrls.getServices().get(0).getClient().recordEvent([:]))
+    Retrofit2SyncCall.execute(restUrls.getServices().get(0).getClient().recordEvent(wireMockServer.baseUrl(), [:]))
 
     then:
     headers.get().get("Authorization") == "FromFile"

--- a/echo/echo-rest/src/test/java/com/netflix/spinnaker/echo/events/RestEventListenerTest.java
+++ b/echo/echo-rest/src/test/java/com/netflix/spinnaker/echo/events/RestEventListenerTest.java
@@ -17,6 +17,8 @@
 package com.netflix.spinnaker.echo.events;
 
 import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spectator.api.NoopRegistry;
@@ -98,7 +100,7 @@ class RestEventListenerTest {
 
     Map<String, Object> expectedEvent = listener.getMapper().convertValue(event, Map.class);
 
-    Mockito.when(restService.recordEvent(anyMap()))
+    Mockito.when(restService.recordEvent(anyString(), anyMap()))
         .thenAnswer(
             invoke ->
                 Calls.response(ResponseBody.create(MediaType.parse("application/json"), "{}")));
@@ -107,6 +109,7 @@ class RestEventListenerTest {
 
     Mockito.verify(restService, Mockito.times(1))
         .recordEvent(
+            eq(config.getUrl()),
             Mockito.argThat(
                 it -> {
                   Map<String, Object> expected = new HashMap<>();
@@ -128,7 +131,7 @@ class RestEventListenerTest {
 
     Map<String, Object> expectedEvent = listener.getMapper().convertValue(event, Map.class);
 
-    Mockito.when(restService.recordEvent(anyMap()))
+    Mockito.when(restService.recordEvent(anyString(), anyMap()))
         .thenAnswer(
             invoke ->
                 Calls.response(ResponseBody.create(MediaType.parse("application/json"), "{}")));
@@ -137,6 +140,7 @@ class RestEventListenerTest {
 
     Mockito.verify(restService, Mockito.times(1))
         .recordEvent(
+            eq(config.getUrl()),
             Mockito.argThat(
                 it -> {
                   Map<String, Object> expected = new HashMap<>();
@@ -161,7 +165,7 @@ class RestEventListenerTest {
 
     Map<String, Object> expectedEvent = listener.getMapper().convertValue(event, Map.class);
 
-    Mockito.when(restService.recordEvent(anyMap()))
+    Mockito.when(restService.recordEvent(anyString(), anyMap()))
         .thenAnswer(
             invoke ->
                 Calls.response(ResponseBody.create(MediaType.parse("application/json"), "{}")));
@@ -170,6 +174,7 @@ class RestEventListenerTest {
 
     Mockito.verify(restService, Mockito.times(1))
         .recordEvent(
+            eq(config.getUrl()),
             Mockito.argThat(
                 it -> {
                   Map<String, Object> expected = new HashMap<>();
@@ -192,14 +197,14 @@ class RestEventListenerTest {
 
     Map<String, Object> expectedEvent = listener.getMapper().convertValue(event, Map.class);
 
-    Mockito.when(restService.recordEvent(anyMap()))
+    Mockito.when(restService.recordEvent(anyString(), anyMap()))
         .thenAnswer(
             invoke ->
                 Calls.response(ResponseBody.create(MediaType.parse("application/json"), "{}")));
 
     listener.processEvent(event);
 
-    Mockito.verify(restService, Mockito.times(1)).recordEvent(expectedEvent);
+    Mockito.verify(restService, Mockito.times(1)).recordEvent(config.getUrl(), expectedEvent);
   }
 
   @Test
@@ -220,19 +225,19 @@ class RestEventListenerTest {
 
     Map<String, Object> expectedEvent = listener.getMapper().convertValue(event, Map.class);
 
-    Mockito.when(restService.recordEvent(anyMap()))
+    Mockito.when(restService.recordEvent(anyString(), anyMap()))
         .thenAnswer(
             invoke ->
                 Calls.response(ResponseBody.create(MediaType.parse("application/json"), "{}")));
-    Mockito.when(restService2.recordEvent(anyMap()))
+    Mockito.when(restService2.recordEvent(anyString(), anyMap()))
         .thenAnswer(
             invoke ->
                 Calls.response(ResponseBody.create(MediaType.parse("application/json"), "{}")));
 
     listener.processEvent(event);
 
-    Mockito.verify(restService, Mockito.times(1)).recordEvent(expectedEvent);
-    Mockito.verify(restService2, Mockito.times(1)).recordEvent(expectedEvent);
+    Mockito.verify(restService, Mockito.times(1)).recordEvent(config.getUrl(), expectedEvent);
+    Mockito.verify(restService2, Mockito.times(1)).recordEvent(config.getUrl(), expectedEvent);
   }
 
   @Test()
@@ -254,16 +259,17 @@ class RestEventListenerTest {
 
     Map<String, Object> expectedEvent = listener.getMapper().convertValue(event, Map.class);
 
-    Mockito.when(restService.recordEvent(expectedEvent))
+    Mockito.when(restService.recordEvent(config.getUrl(), expectedEvent))
         .thenThrow(new RuntimeException("test exception"));
-    Mockito.when(restService2.recordEvent(expectedEvent))
+    Mockito.when(restService2.recordEvent(config.getUrl(), expectedEvent))
         .thenReturn(Calls.response(ResponseBody.create(MediaType.parse("application/json"), "{}")));
 
     listener.processEvent(event);
 
-    Mockito.verify(restService, Mockito.times(3)).recordEvent(expectedEvent);
-    Assertions.assertThrows(RuntimeException.class, () -> restService.recordEvent(expectedEvent));
-    Mockito.verify(restService2, Mockito.times(1)).recordEvent(expectedEvent);
+    Mockito.verify(restService, Mockito.times(3)).recordEvent(config.getUrl(), expectedEvent);
+    Assertions.assertThrows(
+        RuntimeException.class, () -> restService.recordEvent(config.getUrl(), expectedEvent));
+    Mockito.verify(restService2, Mockito.times(1)).recordEvent(config.getUrl(), expectedEvent);
   }
 
   @Test
@@ -280,14 +286,14 @@ class RestEventListenerTest {
 
     Map<String, Object> expectedEvent = listener.getMapper().convertValue(event, Map.class);
 
-    Mockito.when(restService.recordEvent(anyMap()))
+    Mockito.when(restService.recordEvent(anyString(), anyMap()))
         .thenAnswer(
             invoke ->
                 Calls.response(ResponseBody.create(MediaType.parse("application/json"), "{}")));
 
     listener.processEvent(event);
 
-    Mockito.verify(restService, Mockito.times(1)).recordEvent(expectedEvent);
+    Mockito.verify(restService, Mockito.times(1)).recordEvent(config.getUrl(), expectedEvent);
   }
 
   /**
@@ -309,7 +315,7 @@ class RestEventListenerTest {
 
     Map<String, Object> expectedEvent = listener.getMapper().convertValue(event, Map.class);
 
-    Mockito.when(restService.recordEvent(anyMap()))
+    Mockito.when(restService.recordEvent(anyString(), anyMap()))
         .thenAnswer(
             invoke ->
                 Calls.response(ResponseBody.create(MediaType.parse("application/json"), "{}")));
@@ -318,7 +324,7 @@ class RestEventListenerTest {
 
     Assertions.assertEquals(
         "sendEvent", restEventService.getCircuitBreakerInstance(service).getName());
-    Mockito.verify(restService, Mockito.times(1)).recordEvent(expectedEvent);
+    Mockito.verify(restService, Mockito.times(1)).recordEvent(config.getUrl(), expectedEvent);
   }
 
   @Test
@@ -356,7 +362,7 @@ class RestEventListenerTest {
     listener.processEvent(event);
 
     Mockito.verify(objectMapper, Mockito.times(0)).convertValue(event, Map.class);
-    Mockito.verify(restService, Mockito.times(0)).recordEvent(expectedEvent);
+    Mockito.verify(restService, Mockito.times(0)).recordEvent(config.getUrl(), expectedEvent);
     Assertions.assertThrows(
         CallNotPermittedException.class, mockedCircuitBreaker::acquirePermission);
   }
@@ -375,16 +381,17 @@ class RestEventListenerTest {
 
     Map<String, Object> expectedEvent = listener.getMapper().convertValue(event, Map.class);
 
-    Mockito.when(restService.recordEvent(expectedEvent))
+    Mockito.when(restService.recordEvent(config.getUrl(), expectedEvent))
         .thenThrow(new RuntimeException("test exception"));
 
     listener.processEvent(event);
 
-    Mockito.verify(restService, Mockito.times(1)).recordEvent(expectedEvent);
+    Mockito.verify(restService, Mockito.times(1)).recordEvent(config.getUrl(), expectedEvent);
     Assertions.assertEquals(
         CircuitBreaker.State.OPEN,
         circuitBreakerRegistry.circuitBreaker("circuitBreakerTest").getState());
-    Assertions.assertThrows(RuntimeException.class, () -> restService.recordEvent(expectedEvent));
+    Assertions.assertThrows(
+        RuntimeException.class, () -> restService.recordEvent(config.getUrl(), expectedEvent));
 
     // reset RestService mock to correctly evaluate that recordEvent is not being called
     Mockito.reset(restService);
@@ -394,7 +401,7 @@ class RestEventListenerTest {
     Map<String, Object> newExpectedEvent = listener.getMapper().convertValue(newEvent, Map.class);
 
     listener.processEvent(newEvent); // process new event
-    Mockito.verify(restService, Mockito.times(0)).recordEvent(newExpectedEvent);
+    Mockito.verify(restService, Mockito.times(0)).recordEvent(config.getUrl(), newExpectedEvent);
   }
 
   @Test
@@ -420,7 +427,7 @@ class RestEventListenerTest {
 
     // RestEventListener.transformEventToMap() threw exception and returned null map
     // It shouldn't try to send an empty event
-    Mockito.verify(restService, Mockito.times(0)).recordEvent(expectedEvent);
+    Mockito.verify(restService, Mockito.times(0)).recordEvent(config.getUrl(), expectedEvent);
     Assertions.assertThrows(
         IllegalArgumentException.class, () -> objectMapper.convertValue(event, Map.class));
   }
@@ -450,7 +457,7 @@ class RestEventListenerTest {
 
     // RestEventListener.transformEventToMap() threw exception and returned null map
     // It shouldn't try to send an empty event
-    Mockito.verify(restService, Mockito.times(0)).recordEvent(expectedEvent);
+    Mockito.verify(restService, Mockito.times(0)).recordEvent(config.getUrl(), expectedEvent);
     Assertions.assertEquals(
         CircuitBreaker.State.CLOSED,
         circuitBreakerRegistry.circuitBreaker("circuitBreakerTest").getState());
@@ -483,9 +490,9 @@ class RestEventListenerTest {
     Map<String, Object> expectedEvent = listener.getMapper().convertValue(event, Map.class);
 
     // first service throws Exception when recording event
-    Mockito.when(restService.recordEvent(expectedEvent))
+    Mockito.when(restService.recordEvent(config.getUrl(), expectedEvent))
         .thenThrow(new RuntimeException("test exception"));
-    Mockito.when(restService2.recordEvent(anyMap()))
+    Mockito.when(restService2.recordEvent(anyString(), anyMap()))
         .thenAnswer(
             invoke ->
                 Calls.response(ResponseBody.create(MediaType.parse("application/json"), "{}")));
@@ -493,9 +500,10 @@ class RestEventListenerTest {
     listener.processEvent(event);
 
     // verify it tried to recordEvent for both services
-    Mockito.verify(restService, Mockito.times(1)).recordEvent(expectedEvent);
-    Assertions.assertThrows(RuntimeException.class, () -> restService.recordEvent(expectedEvent));
-    Mockito.verify(restService2, Mockito.times(1)).recordEvent(expectedEvent);
+    Mockito.verify(restService, Mockito.times(1)).recordEvent(config.getUrl(), expectedEvent);
+    Assertions.assertThrows(
+        RuntimeException.class, () -> restService.recordEvent(config.getUrl(), expectedEvent));
+    Mockito.verify(restService2, Mockito.times(1)).recordEvent(config2.getUrl(), expectedEvent);
 
     // circuitBreakerTest should be open
     Assertions.assertEquals(
@@ -511,7 +519,7 @@ class RestEventListenerTest {
     newEvent.setContent(Map.of("tres", "cuatro"));
     Map<String, Object> newExpectedEvent = listener.getMapper().convertValue(newEvent, Map.class);
 
-    Mockito.when(restService2.recordEvent(anyMap()))
+    Mockito.when(restService2.recordEvent(anyString(), anyMap()))
         .thenAnswer(
             invoke ->
                 Calls.response(ResponseBody.create(MediaType.parse("application/json"), "{}")));
@@ -519,7 +527,7 @@ class RestEventListenerTest {
     listener.processEvent(newEvent); // process new event
 
     // first service cannot record event because of OPEN circuit breaker
-    Mockito.verify(restService, Mockito.times(0)).recordEvent(newExpectedEvent);
-    Mockito.verify(restService2, Mockito.times(1)).recordEvent(newExpectedEvent);
+    Mockito.verify(restService, Mockito.times(0)).recordEvent(config.getUrl(), newExpectedEvent);
+    Mockito.verify(restService2, Mockito.times(1)).recordEvent(config2.getUrl(), newExpectedEvent);
   }
 }

--- a/echo/echo-rest/src/test/java/com/netflix/spinnaker/echo/events/RestEventServiceTest.java
+++ b/echo/echo-rest/src/test/java/com/netflix/spinnaker/echo/events/RestEventServiceTest.java
@@ -33,7 +33,6 @@ import com.netflix.spinnaker.echo.config.RestUrls;
 import com.netflix.spinnaker.echo.rest.RestService;
 import com.netflix.spinnaker.kork.core.RetrySupport;
 import com.netflix.spinnaker.kork.retrofit.ErrorHandlingExecutorCallAdapterFactory;
-import com.netflix.spinnaker.kork.retrofit.util.RetrofitUtils;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
 import java.util.Map;
@@ -60,14 +59,14 @@ public class RestEventServiceTest {
     port = wireMockServer.port();
     WireMock.configureFor("localhost", port);
 
-    stubFor(post(urlEqualTo("/api/")).willReturn(aResponse().withStatus(200)));
+    stubFor(post(urlEqualTo("/api")).willReturn(aResponse().withStatus(200)));
 
     baseUrl = baseUrl.replaceFirst("PORT", String.valueOf(port));
 
     // Create the RestService
     RestService restService =
         new Retrofit.Builder()
-            .baseUrl(RetrofitUtils.getBaseUrl(baseUrl))
+            .baseUrl("http://not-used.com")
             .client(new OkHttpClient())
             .addCallAdapterFactory(ErrorHandlingExecutorCallAdapterFactory.getInstance())
             .addConverterFactory(JacksonConverterFactory.create())
@@ -98,7 +97,7 @@ public class RestEventServiceTest {
     service =
         RestUrls.Service.builder()
             .client(restService)
-            .config(new RestProperties.RestEndpointConfiguration())
+            .config(new RestProperties.RestEndpointConfiguration().setUrl(baseUrl))
             .build();
   }
 
@@ -109,7 +108,7 @@ public class RestEventServiceTest {
 
   @Test
   void testSendEvent() {
-    restEventService.sendEvent(eventMap, service);
-    verify(1, postRequestedFor(urlEqualTo("/api/")));
+    restEventService.sendEvent(service.getConfig().getUrl(), eventMap, service);
+    verify(1, postRequestedFor(urlEqualTo("/api")));
   }
 }

--- a/echo/echo-rest/src/test/java/com/netflix/spinnaker/echo/rest/RestServiceTest.java
+++ b/echo/echo-rest/src/test/java/com/netflix/spinnaker/echo/rest/RestServiceTest.java
@@ -39,6 +39,7 @@ import retrofit2.Retrofit;
 import retrofit2.converter.jackson.JacksonConverterFactory;
 import retrofit2.http.Body;
 import retrofit2.http.POST;
+import retrofit2.http.Url;
 
 public class RestServiceTest {
   WireMockServer wireMockServer;
@@ -53,7 +54,7 @@ public class RestServiceTest {
     port = wireMockServer.port();
     WireMock.configureFor("localhost", port);
 
-    stubFor(post(urlEqualTo("/api/")).willReturn(aResponse().withStatus(200)));
+    stubFor(post(urlEqualTo("/api")).willReturn(aResponse().withStatus(200)));
 
     stubFor(post(urlEqualTo("/")).willReturn(aResponse().withStatus(200)));
 
@@ -88,13 +89,13 @@ public class RestServiceTest {
   @Test
   void testRestService_withPostMappingDot() {
 
-    Retrofit2SyncCall.execute(restService.recordEvent2(Map.of()));
+    Retrofit2SyncCall.execute(restService.recordEvent2(baseUrl, Map.of()));
 
-    // FIXME: the configuration specifies http://localhost:<port>/api (with no
-    // trailing slash), so it's not correct to use a trailing slash in the
-    // request, as servers may interpret that differently.
-    verify(1, postRequestedFor(urlEqualTo("/api/")));
-    verify(0, postRequestedFor(urlEqualTo("/api")));
+    // The configuration specifies http://localhost:<port>/api (with no trailing
+    // slash), so verify that the request used that URL, and not one with a
+    // trailing slash.
+    verify(0, postRequestedFor(urlEqualTo("/api/")));
+    verify(1, postRequestedFor(urlEqualTo("/api")));
     verify(0, postRequestedFor(urlEqualTo("/")));
   }
 
@@ -102,7 +103,7 @@ public class RestServiceTest {
     @POST("/")
     Call<Void> recordEvent(@Body Map<String, Object> event);
 
-    @POST(".")
-    Call<Void> recordEvent2(@Body Map<String, Object> event);
+    @POST
+    Call<Void> recordEvent2(@Url String url, @Body Map<String, Object> event);
   }
 }

--- a/echo/echo-rest/src/test/java/com/netflix/spinnaker/echo/rest/RestServiceTest.java
+++ b/echo/echo-rest/src/test/java/com/netflix/spinnaker/echo/rest/RestServiceTest.java
@@ -75,7 +75,7 @@ public class RestServiceTest {
   }
 
   @Test
-  void testRetService_withPostMappingSingleSlash() {
+  void testRestService_withPostMappingSingleSlash() {
 
     Retrofit2SyncCall.execute(restService.recordEvent(Map.of()));
 
@@ -86,12 +86,15 @@ public class RestServiceTest {
   }
 
   @Test
-  void testRetService_withPostMappingDot() {
+  void testRestService_withPostMappingDot() {
 
     Retrofit2SyncCall.execute(restService.recordEvent2(Map.of()));
 
-    // @POST(".") rightly results in calling "http://localhost:<port>/api/"
+    // FIXME: the configuration specifies http://localhost:<port>/api (with no
+    // trailing slash), so it's not correct to use a trailing slash in the
+    // request, as servers may interpret that differently.
     verify(1, postRequestedFor(urlEqualTo("/api/")));
+    verify(0, postRequestedFor(urlEqualTo("/api")));
     verify(0, postRequestedFor(urlEqualTo("/")));
   }
 


### PR DESCRIPTION
The move to retrofit2 made it impossible to send events to URLs with no trailing slash.  https://github.com/spinnaker/echo/pull/1476 changed POST("/") to POST(".") and ensured the base URL ends with a trailing slash with RetrofitUtils.getBaseUrl.  retrofit2 rejects baseUrls that don't end with a trailing slash though, so we need a different solution.

echo moved to retrofit2 in http://github.com/spinnaker/echo/pull/1466, so this fix needs to go to release-2025.0.x, release-2025.1.x (and release-1.37.x in http://github.com/spinnaker/echo if we change plans and decide to release 1.37.next).