### PR TITLE
fix(gate/web): add Retrofit2SyncCall.execute to SubnetController.allByCloudProvider

### DIFF
--- a/gate/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/SubnetController.groovy
+++ b/gate/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/SubnetController.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.gate.controllers
 
 import com.netflix.spinnaker.gate.services.internal.ClouddriverServiceSelector
+import com.netflix.spinnaker.kork.retrofit.Retrofit2SyncCall
 import io.swagger.v3.oas.annotations.Operation
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.web.bind.annotation.*
@@ -31,6 +32,6 @@ class SubnetController {
   @Operation(summary = "Retrieve a list of subnets for a given cloud provider")
   @RequestMapping(value = "/{cloudProvider}", method = RequestMethod.GET)
   List<Map> allByCloudProvider(@PathVariable String cloudProvider) {
-    clouddriverServiceSelector.select().getSubnets(cloudProvider)
+    Retrofit2SyncCall.execute(clouddriverServiceSelector.select().getSubnets(cloudProvider))
   }
 }

--- a/gate/gate-web/src/test/java/com/netflix/spinnaker/gate/controllers/SubnetControllerTest.java
+++ b/gate/gate-web/src/test/java/com/netflix/spinnaker/gate/controllers/SubnetControllerTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2025 Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.gate.controllers;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import com.netflix.spinnaker.gate.services.internal.ClouddriverService;
+import com.netflix.spinnaker.gate.services.internal.ClouddriverServiceSelector;
+import java.util.List;
+import java.util.Map;
+import org.codehaus.groovy.runtime.typehandling.GroovyCastException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
+import retrofit2.Retrofit;
+import retrofit2.converter.jackson.JacksonConverterFactory;
+
+@SpringBootTest(classes = SubnetController.class)
+class SubnetControllerTest {
+
+  @Autowired SubnetController subnetController;
+
+  @MockBean private ClouddriverServiceSelector clouddriverServiceSelector;
+
+  private ClouddriverService clouddriverService;
+
+  /** See https://wiremock.org/docs/junit-jupiter/#advanced-usage---programmatic */
+  @RegisterExtension
+  static WireMockExtension wmClouddriver =
+      WireMockExtension.newInstance().options(wireMockConfig().dynamicPort()).build();
+
+  private ObjectMapper objectMapper = new ObjectMapper();
+
+  @BeforeEach
+  void setup(TestInfo testInfo) {
+    System.out.println("--------------- Test " + testInfo.getDisplayName());
+
+    clouddriverService =
+        new Retrofit.Builder()
+            .baseUrl(wmClouddriver.baseUrl())
+            .addConverterFactory(JacksonConverterFactory.create())
+            .build()
+            .create(ClouddriverService.class);
+
+    when(clouddriverServiceSelector.select()).thenReturn(clouddriverService);
+  }
+
+  @Test
+  void testAllByCloudProvider() throws Exception {
+    // given
+    String cloudProvider = "cloudProvider";
+    List<Map> expectedSubnets = List.of(Map.of("subnet-a", "subnet-a-value"));
+
+    wmClouddriver.stubFor(
+        WireMock.get(urlPathEqualTo("/subnets/" + cloudProvider))
+            .willReturn(
+                aResponse()
+                    .withStatus(HttpStatus.OK.value())
+                    .withBody(objectMapper.writeValueAsString(expectedSubnets))));
+
+    // then
+
+    // FIXME: this is supposed to work, perhaps something like:
+    //
+    // List<Map> actualSubnets = subnetController.allByCloudProvider(cloudProvider);
+    //
+    // assertThat(actualSubnets).isEqualTo(expectedSubnets);
+    // wmClouddriver.verify(getRequestedFor(urlPathEqualTo("/subnets/" + cloudProvider)));
+    assertThatThrownBy(() -> subnetController.allByCloudProvider(cloudProvider))
+        .isInstanceOf(GroovyCastException.class)
+        .hasMessageContaining("with class 'retrofit2.OkHttpCall' to class 'java.util.List'");
+  }
+}

--- a/gate/gate-web/src/test/java/com/netflix/spinnaker/gate/controllers/SubnetControllerTest.java
+++ b/gate/gate-web/src/test/java/com/netflix/spinnaker/gate/controllers/SubnetControllerTest.java
@@ -16,9 +16,10 @@
 package com.netflix.spinnaker.gate.controllers;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -28,7 +29,6 @@ import com.netflix.spinnaker.gate.services.internal.ClouddriverService;
 import com.netflix.spinnaker.gate.services.internal.ClouddriverServiceSelector;
 import java.util.List;
 import java.util.Map;
-import org.codehaus.groovy.runtime.typehandling.GroovyCastException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
@@ -84,15 +84,10 @@ class SubnetControllerTest {
                     .withBody(objectMapper.writeValueAsString(expectedSubnets))));
 
     // then
+    List<Map> actualSubnets = subnetController.allByCloudProvider(cloudProvider);
 
-    // FIXME: this is supposed to work, perhaps something like:
-    //
-    // List<Map> actualSubnets = subnetController.allByCloudProvider(cloudProvider);
-    //
-    // assertThat(actualSubnets).isEqualTo(expectedSubnets);
-    // wmClouddriver.verify(getRequestedFor(urlPathEqualTo("/subnets/" + cloudProvider)));
-    assertThatThrownBy(() -> subnetController.allByCloudProvider(cloudProvider))
-        .isInstanceOf(GroovyCastException.class)
-        .hasMessageContaining("with class 'retrofit2.OkHttpCall' to class 'java.util.List'");
+    // when
+    assertThat(actualSubnets).isEqualTo(expectedSubnets);
+    wmClouddriver.verify(getRequestedFor(urlPathEqualTo("/subnets/" + cloudProvider)));
   }
 }


### PR DESCRIPTION
since it's meant to be a synchronous call.  This also removes the type mismatch, e.g.:
```
org.codehaus.groovy.runtime.typehandling.GroovyCastException: Cannot cast object 'com.netflix.spinnaker.kork.retrofit.ErrorHandlingExecutorCallAdapterFactory$ExecutorCallbackCall@7da3df22' with class 'com.netflix.spinnaker.kork.retrofit.ErrorHandlingExecutorCallAdapterFactory$ExecutorCallbackCall' to class 'java.util.List'
	at org.codehaus.groovy.runtime.typehandling.DefaultTypeTransformation.continueCastOnSAM(DefaultTypeTransformation.java:424) ~[groovy-4.0.15.jar:4.0.15]
	at org.codehaus.groovy.runtime.typehandling.DefaultTypeTransformation.continueCastOnNumber(DefaultTypeTransformation.java:335) ~[groovy-4.0.15.jar:4.0.15]
	at org.codehaus.groovy.runtime.typehandling.DefaultTypeTransformation.continueCastOnCollection(DefaultTypeTransformation.java:293) ~[groovy-4.0.15.jar:4.0.15]
	at org.codehaus.groovy.runtime.typehandling.DefaultTypeTransformation.castToType(DefaultTypeTransformation.java:242) ~[groovy-4.0.15.jar:4.0.15]
	at org.codehaus.groovy.vmplugin.v8.IndyInterface.fromCache(IndyInterface.java:321) ~[groovy-4.0.15.jar:4.0.15]
	at com.netflix.spinnaker.gate.controllers.SubnetController.allByCloudProvider(SubnetController.groovy:34) ~[gate-web-2025.1.2.jar:2025.1.2]
```