### PR TITLE
fix(orca/retrofit2): fix orca bakeservice api

### DIFF
--- a/kork/kork-retrofit2/src/main/java/com/netflix/spinnaker/kork/retrofit/Retrofit2ServiceFactory.java
+++ b/kork/kork-retrofit2/src/main/java/com/netflix/spinnaker/kork/retrofit/Retrofit2ServiceFactory.java
@@ -26,6 +26,7 @@ import com.netflix.spinnaker.kork.retrofit.util.RetrofitUtils;
 import java.util.List;
 import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
+import retrofit2.Converter;
 import retrofit2.Retrofit;
 import retrofit2.converter.jackson.JacksonConverterFactory;
 
@@ -55,6 +56,20 @@ public class Retrofit2ServiceFactory implements ServiceClientFactory {
         .baseUrl(RetrofitUtils.getBaseUrl(serviceEndpoint.getBaseUrl()))
         .client(okHttpClient)
         .addConverterFactory(JacksonConverterFactory.create(objectMapper))
+        .addCallAdapterFactory(ErrorHandlingExecutorCallAdapterFactory.getInstance())
+        .build()
+        .create(type);
+  }
+
+  @Override
+  public <T> T create(
+      Class<T> type, ServiceEndpoint serviceEndpoint, Converter.Factory converterFactory) {
+    OkHttpClient okHttpClient = clientProvider.getClient(serviceEndpoint);
+
+    return new Retrofit.Builder()
+        .baseUrl(RetrofitUtils.getBaseUrl(serviceEndpoint.getBaseUrl()))
+        .client(okHttpClient)
+        .addConverterFactory(converterFactory)
         .addCallAdapterFactory(ErrorHandlingExecutorCallAdapterFactory.getInstance())
         .build()
         .create(type);

--- a/kork/kork-web/kork-web.gradle
+++ b/kork/kork-web/kork-web.gradle
@@ -35,6 +35,7 @@ dependencies {
     transitive = false
   }
   implementation "io.zipkin.brave:brave-instrumentation-okhttp3"
+  implementation "com.squareup.retrofit2:retrofit"
 
   compileOnly "org.springframework.boot:spring-boot-starter-actuator"
 

--- a/kork/kork-web/src/main/java/com/netflix/spinnaker/config/DefaultServiceClientProvider.java
+++ b/kork/kork-web/src/main/java/com/netflix/spinnaker/config/DefaultServiceClientProvider.java
@@ -27,6 +27,7 @@ import com.netflix.spinnaker.kork.exceptions.SystemException;
 import java.util.List;
 import okhttp3.Interceptor;
 import org.springframework.stereotype.Component;
+import retrofit2.Converter;
 
 /** Provider that returns a suitable service client capable of making http calls. */
 @NonnullByDefault
@@ -61,6 +62,13 @@ public class DefaultServiceClientProvider implements ServiceClientProvider {
       List<Interceptor> interceptors) {
     ServiceClientFactory serviceClientFactory = findProvider(type, serviceEndpoint);
     return serviceClientFactory.create(type, serviceEndpoint, objectMapper, interceptors);
+  }
+
+  @Override
+  public <T> T getService(
+      Class<T> type, ServiceEndpoint serviceEndpoint, Converter.Factory converterFactory) {
+    ServiceClientFactory serviceClientFactory = findProvider(type, serviceEndpoint);
+    return serviceClientFactory.create(type, serviceEndpoint, converterFactory);
   }
 
   private ServiceClientFactory findProvider(Class<?> type, ServiceEndpoint service) {

--- a/kork/kork-web/src/main/java/com/netflix/spinnaker/kork/client/ServiceClientFactory.java
+++ b/kork/kork-web/src/main/java/com/netflix/spinnaker/kork/client/ServiceClientFactory.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spinnaker.config.ServiceEndpoint;
 import java.util.List;
 import okhttp3.Interceptor;
+import retrofit2.Converter;
 
 /** Factory to build a client for a service. */
 public interface ServiceClientFactory {
@@ -51,6 +52,18 @@ public interface ServiceClientFactory {
       ServiceEndpoint serviceEndpoint,
       ObjectMapper objectMapper,
       List<Interceptor> interceptors);
+
+  /**
+   * Builds a concrete client capable of making HTTP calls.
+   *
+   * @param type client type
+   * @param serviceEndpoint endpoint configuration
+   * @param converterFactory custom converter factory for conversion
+   * @param <T> type of client , usually an interface with all the remote method definitions.
+   * @return an implementation of the type of client given.
+   */
+  public <T> T create(
+      Class<T> type, ServiceEndpoint serviceEndpoint, Converter.Factory converterFactory);
 
   /**
    * Decide if this factory can support the endpoint provided.

--- a/kork/kork-web/src/main/java/com/netflix/spinnaker/kork/client/ServiceClientProvider.java
+++ b/kork/kork-web/src/main/java/com/netflix/spinnaker/kork/client/ServiceClientProvider.java
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.config.ServiceEndpoint;
 import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
 import java.util.List;
 import okhttp3.Interceptor;
+import retrofit2.Converter;
 
 @NonnullByDefault
 public interface ServiceClientProvider {
@@ -46,6 +47,18 @@ public interface ServiceClientProvider {
    */
   public <T> T getService(
       Class<T> type, ServiceEndpoint serviceEndpoint, ObjectMapper objectMapper);
+
+  /**
+   * Returns the concrete retrofit service client
+   *
+   * @param type retrofit interface type
+   * @param serviceEndpoint endpoint definition
+   * @param converterFactory custom converter factory for conversion
+   * @param <T> type of client , usually an interface with all the remote method definitions.
+   * @return the retrofit interface implementation
+   */
+  public <T> T getService(
+      Class<T> type, ServiceEndpoint serviceEndpoint, Converter.Factory converterFactory);
 
   /**
    * Returns the concrete retrofit service client

--- a/orca/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/config/BakeryConfiguration.groovy
+++ b/orca/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/config/BakeryConfiguration.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.orca.bakery.config
 
 import com.netflix.spinnaker.config.DefaultServiceEndpoint
 import com.netflix.spinnaker.kork.client.ServiceClientProvider
+import com.netflix.spinnaker.kork.retrofit.util.CustomConverterFactory
 import com.netflix.spinnaker.orca.bakery.BakerySelector
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
 import org.springframework.boot.context.properties.EnableConfigurationProperties
@@ -63,7 +64,10 @@ class BakeryConfiguration {
   }
 
   BakeryService buildService(String url, ServiceClientProvider serviceClientProvider) {
-    return serviceClientProvider.getService(BakeryService, new DefaultServiceEndpoint("bakery", url), bakeryConfiguredObjectMapper());
+    return serviceClientProvider.getService(
+        BakeryService,
+        new DefaultServiceEndpoint("bakery", url),
+        CustomConverterFactory.create(bakeryConfiguredObjectMapper()));
   }
 
   @Bean

--- a/orca/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/api/BakeryServiceSpec.groovy
+++ b/orca/orca-bakery/src/test/groovy/com/netflix/spinnaker/orca/bakery/api/BakeryServiceSpec.groovy
@@ -169,7 +169,7 @@ class BakeryServiceSpec extends Specification {
 
     then:
     with(actualRequest) {
-      //FIXME: inputArtifact is not supposed to be null. Fix @Body param in BakeryService.bakeManifest
+      //FIXME: inputArtifact is not supposed to be null
       inputArtifact == null
       outputName == context.outputName
       outputArtifactName == outputArtifactNamePassed


### PR DESCRIPTION
- This PR addressed the issue reported in Spinnaker slack channel - https://spinnakerteam.slack.com/archives/C0DPVDMQE/p1755855361456079

- Due to @ Body param being a base class, when passing a subclass, retrofit2 doesn't serealize to subclass with the default Jackson Converter.Factory. So updated Retrofit2ServiceFactory to accept a custom Convertor.Factory.

- Added a test to demonstrate the issue.

