### PR TITLE
feat(clouddriver/aws): Implement the account API for aws accounts

### DIFF
--- a/clouddriver/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/security/config/AccountsConfiguration.java
+++ b/clouddriver/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/security/config/AccountsConfiguration.java
@@ -21,6 +21,7 @@ import static lombok.EqualsAndHashCode.Include;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.netflix.spinnaker.clouddriver.security.AccessControlledAccountDefinition;
 import com.netflix.spinnaker.fiat.model.resources.Permissions;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -57,8 +58,8 @@ public class AccountsConfiguration {
     @Include private Boolean enabled;
     @Include private List<CredentialsConfig.Region> regions;
     @Include private List<String> defaultSecurityGroups;
-    private List<String> requiredGroupMembership;
-    @Include private Permissions.Builder permissions;
+    private List<String> requiredGroupMembership = new ArrayList<>();
+    @Include private Permissions.Builder permissions = new Permissions.Builder();
     @Include private String edda;
     @Include private Boolean eddaEnabled;
     @Include private Boolean lambdaEnabled;

--- a/clouddriver/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/security/config/AmazonAccountDefinitionSourceConfiguration.java
+++ b/clouddriver/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/security/config/AmazonAccountDefinitionSourceConfiguration.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.security.config;
+
+import com.netflix.spinnaker.clouddriver.security.AccountDefinitionRepository;
+import com.netflix.spinnaker.clouddriver.security.AccountDefinitionSource;
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinitionSource;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConditionalOnProperty({"account.storage.enabled", "account.storage.aws.enabled"})
+public class AmazonAccountDefinitionSourceConfiguration {
+  @Bean
+  public CredentialsDefinitionSource<AccountsConfiguration.Account> amazonAccountSource(
+      AccountDefinitionRepository repository,
+      Optional<List<CredentialsDefinitionSource<AccountsConfiguration.Account>>> additionalSources,
+      AccountsConfiguration accountProperties) {
+    return new AccountDefinitionSource<>(
+        repository,
+        AccountsConfiguration.Account.class,
+        additionalSources.orElseGet(() -> List.of(accountProperties::getAccounts)));
+  }
+}

--- a/clouddriver/clouddriver-aws/src/test/java/com/netflix/spinnaker/testconfig/AmazonCredentialsInitializerTest.java
+++ b/clouddriver/clouddriver-aws/src/test/java/com/netflix/spinnaker/testconfig/AmazonCredentialsInitializerTest.java
@@ -66,9 +66,7 @@ public class AmazonCredentialsInitializerTest {
             UserConfigurations.of(TestExternalAccountStorageDependencyConfiguration.class))
         .run(
             ctx -> {
-              // FIXME: once implemented, an AccountDefinitionSource bean is present in the context
-              // assertThat(ctx).hasSingleBean(AccountDefinitionSource.class);
-              assertThat(ctx).doesNotHaveBean(AccountDefinitionSource.class);
+              assertThat(ctx).hasSingleBean(AccountDefinitionSource.class);
             });
   }
 


### PR DESCRIPTION
This change allows clouddriver AWS accounts to use the account management API. Specifically, it allows clouddriver to load AWS accounts from the AccountDefinitionRepository used by the account API.

The new config flag `account.storage.aws.enabled`, in addition to the existing config flag `account.storage.enabled`, control when this feature is enabled.  Both are false by default.