### PR TITLE
feat(clouddriver/aws): log the endpoint that aws sdk sts clients use

### DIFF
--- a/clouddriver/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/security/AmazonCredentials.java
+++ b/clouddriver/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/security/AmazonCredentials.java
@@ -22,6 +22,7 @@ import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.netflix.spinnaker.clouddriver.aws.AwsConfigurationProperties;
 import com.netflix.spinnaker.clouddriver.security.AbstractAccountCredentials;
 import com.netflix.spinnaker.fiat.model.resources.Permissions;
 import java.util.ArrayList;
@@ -82,7 +83,10 @@ public class AmazonCredentials extends AbstractAccountCredentials<AWSCredentials
         null);
   }
 
-  public AmazonCredentials(AmazonCredentials source, AWSCredentialsProvider credentialsProvider) {
+  public AmazonCredentials(
+      AmazonCredentials source,
+      AWSCredentialsProvider credentialsProvider,
+      AwsConfigurationProperties awsConfigurationProperties) {
     this(
         source.getName(),
         source.getEnvironment(),

--- a/clouddriver/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/security/AmazonCredentials.java
+++ b/clouddriver/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/security/AmazonCredentials.java
@@ -31,7 +31,7 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * Basic set of Amazon credentials that will a provided {@link
+ * Basic set of Amazon credentials that use a provided {@link
  * com.amazonaws.auth.AWSCredentialsProvider} to resolve account credentials. If none provided, the
  * {@link com.amazonaws.auth.DefaultAWSCredentialsProviderChain} will be used. The account's active
  * regions and availability zones can be specified as well.
@@ -52,43 +52,6 @@ public class AmazonCredentials extends AbstractAccountCredentials<AWSCredentials
   private final List<LifecycleHook> lifecycleHooks;
   private final boolean allowPrivateThirdPartyImages;
   private final AWSCredentialsProvider credentialsProvider;
-
-  public static AmazonCredentials fromAWSCredentials(
-      String name,
-      String environment,
-      String accountType,
-      AWSCredentialsProvider credentialsProvider,
-      AmazonClientProvider amazonClientProvider) {
-    return fromAWSCredentials(
-        name, environment, accountType, null, credentialsProvider, amazonClientProvider);
-  }
-
-  public static AmazonCredentials fromAWSCredentials(
-      String name,
-      String environment,
-      String accountType,
-      String defaultKeyPair,
-      AWSCredentialsProvider credentialsProvider,
-      AmazonClientProvider amazonClientProvider) {
-    AWSAccountInfoLookup lookup =
-        new DefaultAWSAccountInfoLookup(credentialsProvider, amazonClientProvider);
-    final String accountId = lookup.findAccountId();
-    final List<AWSRegion> regions = lookup.listRegions();
-    return new AmazonCredentials(
-        name,
-        environment,
-        accountType,
-        accountId,
-        defaultKeyPair,
-        true,
-        regions,
-        null,
-        null,
-        null,
-        null,
-        false,
-        credentialsProvider);
-  }
 
   public AmazonCredentials(
       @JsonProperty("name") String name,

--- a/clouddriver/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/security/AmazonCredentialsInitializer.java
+++ b/clouddriver/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/security/AmazonCredentialsInitializer.java
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.clouddriver.aws.security;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.google.common.base.Strings;
 import com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider;
+import com.netflix.spinnaker.clouddriver.aws.AwsConfigurationProperties;
 import com.netflix.spinnaker.clouddriver.aws.security.config.AccountsConfiguration;
 import com.netflix.spinnaker.clouddriver.aws.security.config.AccountsConfiguration.Account;
 import com.netflix.spinnaker.clouddriver.aws.security.config.AmazonCredentialsParser;
@@ -80,7 +81,8 @@ public class AmazonCredentialsInitializer {
       AWSCredentialsProviderFactory awsCredentialsProviderFactory,
       Class<? extends NetflixAmazonCredentials> credentialsType,
       CredentialsConfig credentialsConfig,
-      AccountsConfiguration accountsConfig) {
+      AccountsConfiguration accountsConfig,
+      AwsConfigurationProperties awsConfigurationProperties) {
     return new AmazonCredentialsParser<>(
         awsCredentialsProvider,
         amazonClientProvider,
@@ -89,7 +91,8 @@ public class AmazonCredentialsInitializer {
         awsCredentialsProviderFactory,
         (Class<NetflixAmazonCredentials>) credentialsType,
         credentialsConfig,
-        accountsConfig);
+        accountsConfig,
+        awsConfigurationProperties);
   }
 
   @Bean

--- a/clouddriver/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/security/AssumeRoleAmazonCredentials.java
+++ b/clouddriver/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/security/AssumeRoleAmazonCredentials.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.clouddriver.aws.security;
 
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.netflix.spinnaker.clouddriver.aws.AwsConfigurationProperties;
 import com.netflix.spinnaker.fiat.model.resources.Permissions;
 import java.util.List;
 import java.util.Objects;
@@ -39,7 +40,8 @@ public class AssumeRoleAmazonCredentials extends AmazonCredentials {
       String assumeRole,
       String sessionName,
       Integer sessionDurationSeconds,
-      String externalId) {
+      String externalId,
+      AwsConfigurationProperties awsConfigurationProperties) {
     String assumeRoleValue = Objects.requireNonNull(assumeRole, "assumeRole");
     if (!assumeRoleValue.startsWith("arn:")) {
 
@@ -62,7 +64,8 @@ public class AssumeRoleAmazonCredentials extends AmazonCredentials {
             Objects.requireNonNull(sessionName, "sessionName"),
             sessionDurationSeconds,
             accountId,
-            externalId);
+            externalId,
+            awsConfigurationProperties);
   }
 
   /** The role to assume on the target account. */
@@ -108,11 +111,25 @@ public class AssumeRoleAmazonCredentials extends AmazonCredentials {
         assumeRole,
         sessionName,
         sessionDurationSeconds,
-        externalId);
+        externalId,
+        null /* awsConfigurationProperties */);
   }
 
+  /**
+   * Construct a new AssumeRoleAmazonCredentials object by copying an existing one. Even though
+   * AssumeRoleAmazonCredentials objects have (via AmazonCredentials) both a credentialsProvider and
+   * awsConfigurationProperties, this method takes those as separate arguments in case the existing
+   * object doesn't have them, which is the case when it was constructed via deserialization. This
+   * is what AmazonCredentialsParser does.
+   *
+   * @param copy the object to copy
+   * @param credentialsProvider a credentials provider
+   * @param awsConfigurationProperties configuration properties
+   */
   public AssumeRoleAmazonCredentials(
-      AssumeRoleAmazonCredentials copy, AWSCredentialsProvider credentialsProvider) {
+      AssumeRoleAmazonCredentials copy,
+      AWSCredentialsProvider credentialsProvider,
+      AwsConfigurationProperties awsConfigurationProperties) {
     this(
         copy.getName(),
         copy.getEnvironment(),
@@ -130,7 +147,8 @@ public class AssumeRoleAmazonCredentials extends AmazonCredentials {
         copy.getAssumeRole(),
         copy.getSessionName(),
         copy.getSessionDurationSeconds(),
-        copy.getExternalId());
+        copy.getExternalId(),
+        awsConfigurationProperties);
   }
 
   AssumeRoleAmazonCredentials(
@@ -150,7 +168,8 @@ public class AssumeRoleAmazonCredentials extends AmazonCredentials {
       String assumeRole,
       String sessionName,
       Integer sessionDurationSeconds,
-      String externalId) {
+      String externalId,
+      AwsConfigurationProperties awsConfigurationProperties) {
     super(
         name,
         environment,
@@ -170,7 +189,8 @@ public class AssumeRoleAmazonCredentials extends AmazonCredentials {
             assumeRole,
             sessionName == null ? DEFAULT_SESSION_NAME : sessionName,
             sessionDurationSeconds,
-            externalId));
+            externalId,
+            awsConfigurationProperties));
     this.assumeRole = assumeRole;
     this.sessionName = sessionName == null ? DEFAULT_SESSION_NAME : sessionName;
     this.sessionDurationSeconds = sessionDurationSeconds;

--- a/clouddriver/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/security/NetflixAmazonCredentials.java
+++ b/clouddriver/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/security/NetflixAmazonCredentials.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.clouddriver.aws.security;
 
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.netflix.spinnaker.clouddriver.aws.AwsConfigurationProperties;
 import com.netflix.spinnaker.fiat.model.resources.Permissions;
 import java.util.List;
 import lombok.Getter;
@@ -93,8 +94,21 @@ public class NetflixAmazonCredentials extends AmazonCredentials {
         && (flag != null ? flag : true));
   }
 
+  /**
+   * Construct a new NetflixAmazonCredentials object by copying an existing one. Even though
+   * NetflixAmazonCredentials objects have (via AmazonCredentials) both a credentialsProvider and
+   * awsConfigurationProperties, this method takes those as separate arguments in case the existing
+   * object doesn't have them, which is the case when it was constructed via deserialization. This
+   * is what AmazonCredentialsParser does.
+   *
+   * @param copy the object to copy
+   * @param credentialsProvider a credentials provider
+   * @param awsConfigurationProperties configuration properties
+   */
   public NetflixAmazonCredentials(
-      NetflixAmazonCredentials copy, AWSCredentialsProvider credentialsProvider) {
+      NetflixAmazonCredentials copy,
+      AWSCredentialsProvider credentialsProvider,
+      AwsConfigurationProperties awsConfigurationProperties) {
     this(
         copy.getName(),
         copy.getEnvironment(),

--- a/clouddriver/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/security/NetflixAssumeRoleAmazonCredentials.java
+++ b/clouddriver/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/security/NetflixAssumeRoleAmazonCredentials.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.clouddriver.aws.security;
 
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.netflix.spinnaker.clouddriver.aws.AwsConfigurationProperties;
 import com.netflix.spinnaker.fiat.model.resources.Permissions;
 import java.util.List;
 import lombok.Getter;
@@ -90,11 +91,25 @@ public class NetflixAssumeRoleAmazonCredentials extends NetflixAmazonCredentials
         sessionName,
         sessionDurationSeconds,
         lambdaEnabled,
-        externalId);
+        externalId,
+        null /* awsConfigurationProperties */);
   }
 
+  /**
+   * Construct a new NetflixAssumeRoleAmazonCredentials object by copying an existing one. Even
+   * though NetflixAssumeRoleAmazonCredentials objects have (via AmazonCredentials) both a
+   * credentialsProvider and awsConfigurationProperties, this method takes those as separate
+   * arguments in case the existing object doesn't have them, which is the case when it was
+   * constructed via deserialization. This is what AmazonCredentialsParser does.
+   *
+   * @param copy the object to copy
+   * @param credentialsProvider a credentials provider
+   * @param awsConfigurationProperties configuration properties
+   */
   public NetflixAssumeRoleAmazonCredentials(
-      NetflixAssumeRoleAmazonCredentials copy, AWSCredentialsProvider credentialsProvider) {
+      NetflixAssumeRoleAmazonCredentials copy,
+      AWSCredentialsProvider credentialsProvider,
+      AwsConfigurationProperties awsConfigurationProperties) {
     this(
         copy.getName(),
         copy.getEnvironment(),
@@ -122,7 +137,8 @@ public class NetflixAssumeRoleAmazonCredentials extends NetflixAmazonCredentials
         copy.getSessionName(),
         copy.getSessionDurationSeconds(),
         copy.isLambdaEnabled(),
-        copy.getExternalId());
+        copy.getExternalId(),
+        awsConfigurationProperties);
   }
 
   NetflixAssumeRoleAmazonCredentials(
@@ -152,7 +168,8 @@ public class NetflixAssumeRoleAmazonCredentials extends NetflixAmazonCredentials
       String sessionName,
       Integer sessionDurationSeconds,
       Boolean lambdaEnabled,
-      String externalId) {
+      String externalId,
+      AwsConfigurationProperties awsConfigurationProperties) {
     super(
         name,
         environment,
@@ -172,7 +189,8 @@ public class NetflixAssumeRoleAmazonCredentials extends NetflixAmazonCredentials
             assumeRole,
             sessionName == null ? AssumeRoleAmazonCredentials.DEFAULT_SESSION_NAME : sessionName,
             sessionDurationSeconds,
-            externalId),
+            externalId,
+            awsConfigurationProperties),
         edda,
         eddaEnabled,
         discovery,

--- a/clouddriver/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/security/NetflixSTSAssumeRoleSessionCredentialsProvider.java
+++ b/clouddriver/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/security/NetflixSTSAssumeRoleSessionCredentialsProvider.java
@@ -22,6 +22,7 @@ import com.amazonaws.auth.AWSSessionCredentialsProvider;
 import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
 import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
 import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClient;
+import com.netflix.spinnaker.clouddriver.aws.AwsConfigurationProperties;
 import com.netflix.spinnaker.clouddriver.aws.security.sdkclient.SpinnakerAwsRegionProvider;
 import java.io.Closeable;
 import lombok.extern.slf4j.Slf4j;
@@ -42,7 +43,8 @@ public class NetflixSTSAssumeRoleSessionCredentialsProvider
       String roleSessionName,
       Integer sessionDurationSeconds,
       String accountId,
-      String externalId) {
+      String externalId,
+      AwsConfigurationProperties awsConfigurationProperties) {
 
     this.accountId = accountId;
     this.roleArn = roleArn;
@@ -71,6 +73,10 @@ public class NetflixSTSAssumeRoleSessionCredentialsProvider
           new EndpointConfiguration("sts.cn-north-1.amazonaws.com.cn", this.region));
     } else {
       stsClientBuilder.withRegion(this.region);
+    }
+
+    if (awsConfigurationProperties.getClient().getLogEndpoints()) {
+      stsClientBuilder.withRequestHandlers(new LogEndpointRequestHandler());
     }
 
     STSAssumeRoleSessionCredentialsProvider.Builder stsSessionProviderBuilder =

--- a/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/security/AmazonBasicCredentialsLoaderSpec.groovy
+++ b/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/security/AmazonBasicCredentialsLoaderSpec.groovy
@@ -20,6 +20,7 @@ package com.netflix.spinnaker.clouddriver.aws.security
 import com.amazonaws.SDKGlobalConfiguration
 import com.amazonaws.auth.AWSCredentialsProvider
 import com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider
+import com.netflix.spinnaker.clouddriver.aws.AwsConfigurationProperties
 import com.netflix.spinnaker.clouddriver.aws.security.config.AmazonCredentialsParser
 import com.netflix.spinnaker.clouddriver.aws.security.config.CredentialsConfig
 import com.netflix.spinnaker.clouddriver.aws.security.config.AccountsConfiguration
@@ -143,7 +144,9 @@ class AmazonBasicCredentialsLoaderSpec extends Specification{
       credentialsProviderFactory,
       NetflixAmazonCredentials.class,
       credentialsConfig,
-      accountsConfig)
+      accountsConfig,
+      new AwsConfigurationProperties()
+    )
 
     def loader = new AmazonBasicCredentialsLoader<Account, NetflixAmazonCredentials>(
       amazonCredentialsSource, ci, credentialsRepository, credentialsConfig, accountsConfig, defaultAccountConfigurationProperties

--- a/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/security/AmazonClientProviderSpec.groovy
+++ b/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/security/AmazonClientProviderSpec.groovy
@@ -21,6 +21,7 @@ import com.amazonaws.auth.BasicAWSCredentials
 import com.amazonaws.services.autoscaling.AmazonAutoScaling
 import com.amazonaws.services.autoscaling.model.DescribeAutoScalingGroupsRequest
 import com.amazonaws.services.ec2.AmazonEC2
+import com.netflix.spinnaker.clouddriver.aws.AwsConfigurationProperties
 import com.netflix.spinnaker.clouddriver.aws.TestCredential
 import org.apache.http.Header
 import org.apache.http.HttpEntity
@@ -38,8 +39,9 @@ class AmazonClientProviderSpec extends Specification {
       getCredentials() >> new BasicAWSCredentials('foo', 'bar')
   }
 
-  @Shared NetflixAmazonCredentials credentialsWithEdda = new NetflixAmazonCredentials(TestCredential.named('test', [edda: 'foo']), credentialsProvider)
-  @Shared NetflixAmazonCredentials credentialsNoEdda = new NetflixAmazonCredentials(TestCredential.named('test'), credentialsProvider)
+  @Shared AwsConfigurationProperties awsConfigurationProperties = new AwsConfigurationProperties()
+  @Shared NetflixAmazonCredentials credentialsWithEdda = new NetflixAmazonCredentials(TestCredential.named('test', [edda: 'foo']), credentialsProvider, awsConfigurationProperties)
+  @Shared NetflixAmazonCredentials credentialsNoEdda = new NetflixAmazonCredentials(TestCredential.named('test'), credentialsProvider, awsConfigurationProperties)
 
   void "client proxies to edda when available"() {
     setup:

--- a/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/security/config/CredentialsLoaderSpec.groovy
+++ b/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/security/config/CredentialsLoaderSpec.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.clouddriver.aws.security.config
 
 import com.amazonaws.auth.AWSCredentialsProvider
+import com.netflix.spinnaker.clouddriver.aws.AwsConfigurationProperties
 import com.netflix.spinnaker.clouddriver.aws.security.AWSAccountInfoLookup
 import com.netflix.spinnaker.clouddriver.aws.security.AWSAccountInfoLookupFactory
 import com.netflix.spinnaker.clouddriver.aws.security.AWSCredentialsProviderFactory
@@ -27,9 +28,13 @@ import com.netflix.spinnaker.clouddriver.aws.security.NetflixAssumeRoleAmazonCre
 import com.netflix.spinnaker.clouddriver.aws.security.config.AccountsConfiguration.Account
 import com.netflix.spinnaker.clouddriver.aws.security.config.CredentialsConfig.LifecycleHook
 import com.netflix.spinnaker.clouddriver.aws.security.config.CredentialsConfig.Region
+import spock.lang.Shared
 import spock.lang.Specification
 
 class CredentialsLoaderSpec extends Specification {
+
+    @Shared
+    AwsConfigurationProperties awsConfigurationProperties = new AwsConfigurationProperties()
 
     def 'basic test with defaults'() {
         setup:
@@ -62,7 +67,8 @@ class CredentialsLoaderSpec extends Specification {
           credentialsProviderFactory,
           NetflixAmazonCredentials.class,
           config,
-          accountsConfig)
+          accountsConfig,
+          awsConfigurationProperties)
 
         when:
         List<NetflixAmazonCredentials> creds = ci.load(config)
@@ -108,7 +114,8 @@ class CredentialsLoaderSpec extends Specification {
           credentialsProviderFactory,
           NetflixAmazonCredentials.class,
           config,
-          accountsConfig)
+          accountsConfig,
+          awsConfigurationProperties)
 
         when:
         List<NetflixAmazonCredentials> creds = ci.load(config)
@@ -146,7 +153,8 @@ class CredentialsLoaderSpec extends Specification {
           credentialsProviderFactory,
           NetflixAmazonCredentials.class,
           config,
-          accountsConfig)
+          accountsConfig,
+          awsConfigurationProperties)
 
         when:
         List<AmazonCredentials> creds = ci.load(config)
@@ -187,7 +195,8 @@ class CredentialsLoaderSpec extends Specification {
           credentialsProviderFactory,
           NetflixAmazonCredentials.class,
           config,
-          accountsConfig)
+          accountsConfig,
+          awsConfigurationProperties)
 
         when:
         List<AmazonCredentials> creds = ci.load(config)
@@ -224,7 +233,8 @@ class CredentialsLoaderSpec extends Specification {
           credentialsProviderFactory,
           NetflixAmazonCredentials.class,
           config,
-          accountsConfig)
+          accountsConfig,
+          awsConfigurationProperties)
 
         when:
         List<AmazonCredentials> creds = ci.load(config)
@@ -282,7 +292,8 @@ class CredentialsLoaderSpec extends Specification {
           credentialsProviderFactory,
           NetflixAmazonCredentials.class,
           config,
-          accountsConfig)
+          accountsConfig,
+          awsConfigurationProperties)
 
         when:
         List<NetflixAmazonCredentials> creds = ci.load(config)
@@ -332,7 +343,8 @@ class CredentialsLoaderSpec extends Specification {
           credentialsProviderFactory,
           NetflixAssumeRoleAmazonCredentials.class,
           config,
-          accountsConfig)
+          accountsConfig,
+          awsConfigurationProperties)
 
         when:
         ci.load(config)
@@ -387,7 +399,8 @@ class CredentialsLoaderSpec extends Specification {
       credentialsProviderFactory,
       NetflixAssumeRoleAmazonCredentials.class,
       config,
-      accountsConfig)
+      accountsConfig,
+      awsConfigurationProperties)
 
     when:
     List<NetflixAssumeRoleAmazonCredentials> creds = ci.load(config)
@@ -444,7 +457,8 @@ class CredentialsLoaderSpec extends Specification {
       credentialsProviderFactory,
       NetflixAssumeRoleAmazonCredentials.class,
       config,
-      accountsConfig)
+      accountsConfig,
+      awsConfigurationProperties)
 
     when:
     List<NetflixAssumeRoleAmazonCredentials> creds = ci.load(config)

--- a/clouddriver/clouddriver-aws/src/test/java/com/netflix/spinnaker/clouddriver/aws/security/config/AmazonCredentialsParserTest.java
+++ b/clouddriver/clouddriver-aws/src/test/java/com/netflix/spinnaker/clouddriver/aws/security/config/AmazonCredentialsParserTest.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import com.amazonaws.auth.AWSCredentialsProvider;
+import com.netflix.spinnaker.clouddriver.aws.AwsConfigurationProperties;
 import com.netflix.spinnaker.clouddriver.aws.security.AWSAccountInfoLookup;
 import com.netflix.spinnaker.clouddriver.aws.security.AWSAccountInfoLookupFactory;
 import com.netflix.spinnaker.clouddriver.aws.security.AWSCredentialsProviderFactory;
@@ -47,6 +48,9 @@ import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.io.TempDir;
 
 class AmazonCredentialsParserTest {
+
+  private final AwsConfigurationProperties awsConfigurationProperties =
+      new AwsConfigurationProperties();
 
   @BeforeEach
   void init(TestInfo testInfo) {
@@ -116,7 +120,8 @@ class AmazonCredentialsParserTest {
             credentialsProviderFactory,
             NetflixAmazonCredentials.class,
             config,
-            accountsConfig);
+            accountsConfig,
+            awsConfigurationProperties);
 
     when(lookup.findAccountId()).thenReturn(regularAccountId);
 
@@ -201,7 +206,8 @@ class AmazonCredentialsParserTest {
             credentialsProviderFactory,
             NetflixAmazonCredentials.class,
             config,
-            accountsConfig);
+            accountsConfig,
+            awsConfigurationProperties);
 
     doReturn(accountId).when(lookup).findAccountId();
     doReturn(List.of()).when(lookup).listRegions(List.of());

--- a/clouddriver/clouddriver-aws/src/test/java/com/netflix/spinnaker/testconfig/AmazonCredentialsInitializerTest.java
+++ b/clouddriver/clouddriver-aws/src/test/java/com/netflix/spinnaker/testconfig/AmazonCredentialsInitializerTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 import com.netflix.spectator.api.NoopRegistry;
+import com.netflix.spinnaker.clouddriver.aws.AwsConfigurationProperties;
 import com.netflix.spinnaker.clouddriver.aws.security.AWSAccountInfoLookup;
 import com.netflix.spinnaker.clouddriver.aws.security.AWSAccountInfoLookupFactory;
 import com.netflix.spinnaker.clouddriver.aws.security.AWSCredentialsProviderFactory;
@@ -47,6 +48,7 @@ public class AmazonCredentialsInitializerTest {
   private final ApplicationContextRunner runner =
       new ApplicationContextRunner()
           .withBean(NoopRegistry.class)
+          .withBean(AwsConfigurationProperties.class)
           .withConfiguration(
               UserConfigurations.of(AwsComponents.class, TestCommonDependencyConfiguration.class));
 

--- a/clouddriver/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/security/NetflixECSCredentials.java
+++ b/clouddriver/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/security/NetflixECSCredentials.java
@@ -22,7 +22,7 @@ public class NetflixECSCredentials extends NetflixAmazonCredentials {
   private static final String CLOUD_PROVIDER = "ecs";
 
   public NetflixECSCredentials(NetflixAmazonCredentials copy) {
-    super(copy, copy.getCredentialsProvider());
+    super(copy, copy.getCredentialsProvider(), null /* awsConfigurationProperties */);
   }
 
   @Override


### PR DESCRIPTION
when the existing config flag `aws.client.logEndpoints` is true.  It defaults to false.  https://github.com/spinnaker/spinnaker/pull/7239 added that config flag.
