### PR TITLE
feat(clouddriver/ecs): Implement the account API for ecs accounts

### DIFF
--- a/clouddriver/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/security/ECSCredentialsConfig.java
+++ b/clouddriver/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/security/ECSCredentialsConfig.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.ecs.security;
 
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.netflix.spinnaker.credentials.definition.CredentialsDefinition;
 import java.util.List;
 import lombok.Data;
@@ -26,6 +27,7 @@ public class ECSCredentialsConfig {
   List<Account> accounts;
 
   @Data
+  @JsonTypeName("ecs")
   public static class Account implements CredentialsDefinition {
     private String name;
     private String awsAccount;

--- a/clouddriver/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/security/EcsAccountDefinitionSource.java
+++ b/clouddriver/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/security/EcsAccountDefinitionSource.java
@@ -1,0 +1,27 @@
+package com.netflix.spinnaker.clouddriver.ecs.security;
+
+import com.netflix.spinnaker.clouddriver.security.AccountDefinitionRepository;
+import com.netflix.spinnaker.clouddriver.security.AccountDefinitionSource;
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinitionSource;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+import java.util.Optional;
+
+@Configuration
+@ConditionalOnProperty({"account.storage.enabled", "account.storage.aws.enabled", "account.storage.ecs.enabled"})
+public class EcsAccountDefinitionSource {
+
+  @Bean
+  CredentialsDefinitionSource<ECSCredentialsConfig.Account> ecsAccountSource(
+    AccountDefinitionRepository repository,
+    Optional<List<CredentialsDefinitionSource<ECSCredentialsConfig.Account>>> additionalSources,
+    ECSCredentialsConfig ecsCredentialsConfig) {
+    return new AccountDefinitionSource<>(
+      repository,
+      ECSCredentialsConfig.Account.class,
+      additionalSources.orElseGet(() -> List.of(ecsCredentialsConfig::getAccounts)));
+  }
+}

--- a/clouddriver/clouddriver-ecs/src/test/java/com/netflix/spinnaker/clouddriver/ecs/security/EcsAccountDefinitionSourceTest.java
+++ b/clouddriver/clouddriver-ecs/src/test/java/com/netflix/spinnaker/clouddriver/ecs/security/EcsAccountDefinitionSourceTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2025 Harness, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.ecs.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import com.netflix.spinnaker.clouddriver.security.AccountDefinitionRepository;
+import com.netflix.spinnaker.clouddriver.security.AccountDefinitionSource;
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinitionSource;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class EcsAccountDefinitionSourceTest {
+
+  private EcsAccountDefinitionSource accountDefinitionSource;
+
+  @BeforeEach
+  public void setUp() {
+    accountDefinitionSource = new EcsAccountDefinitionSource();
+  }
+
+  @Test
+  public void testEcsAccountSourceReturnsAccountDefinitions() {
+
+    ECSCredentialsConfig.Account mockAccount = new ECSCredentialsConfig.Account();
+    mockAccount.setName("test-account");
+
+    AccountDefinitionRepository repository = mock(AccountDefinitionRepository.class);
+
+    doReturn(Collections.singletonList(mockAccount))
+        .when(repository).listByType(eq("ecs"));
+
+    ECSCredentialsConfig ecsCredentialsConfig = mock(ECSCredentialsConfig.class);
+    Optional<List<CredentialsDefinitionSource<ECSCredentialsConfig.Account>>> emptyAdditionalSources =
+        Optional.empty();
+
+    CredentialsDefinitionSource<ECSCredentialsConfig.Account> source =
+        accountDefinitionSource.ecsAccountSource(repository, emptyAdditionalSources, ecsCredentialsConfig);
+
+    assertThat(source).isNotNull();
+    assertThat(source).isInstanceOf(AccountDefinitionSource.class);
+
+    List<ECSCredentialsConfig.Account> retrievedAccounts = source.getCredentialsDefinitions();
+
+    assertThat(retrievedAccounts).isNotEmpty();
+    assertThat(retrievedAccounts.get(0).getName()).isEqualTo("test-account");
+  }
+}

--- a/clouddriver/clouddriver-ecs/src/test/java/com/netflix/spinnaker/clouddriver/ecs/security/EcsCredentialsInitializerTest.java
+++ b/clouddriver/clouddriver-ecs/src/test/java/com/netflix/spinnaker/clouddriver/ecs/security/EcsCredentialsInitializerTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2025 Harness, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.ecs.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
+import com.netflix.spinnaker.clouddriver.aws.security.config.AccountsConfiguration;
+import com.netflix.spinnaker.clouddriver.ecs.EcsCloudProvider;
+import com.netflix.spinnaker.clouddriver.names.NamerRegistry;
+import com.netflix.spinnaker.clouddriver.security.AccountCredentials;
+import com.netflix.spinnaker.clouddriver.security.CredentialsInitializerSynchronizable;
+import com.netflix.spinnaker.credentials.CompositeCredentialsRepository;
+import com.netflix.spinnaker.credentials.CredentialsLifecycleHandler;
+import com.netflix.spinnaker.credentials.CredentialsRepository;
+import com.netflix.spinnaker.credentials.MapBackedCredentialsRepository;
+import com.netflix.spinnaker.credentials.definition.AbstractCredentialsLoader;
+import com.netflix.spinnaker.credentials.definition.BasicCredentialsLoader;
+import com.netflix.spinnaker.credentials.definition.CredentialsDefinitionSource;
+import com.netflix.spinnaker.credentials.definition.CredentialsParser;
+
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class EcsCredentialsInitializerTest {
+
+  private EcsCredentialsInitializer initializer;
+
+  @BeforeEach
+  public void setUp() {
+    initializer = new EcsCredentialsInitializer();
+  }
+
+  @Test
+  public void testEcsCredentialsConfigBean() {
+    ECSCredentialsConfig config = initializer.ecsCredentialsConfig();
+    assertThat(config).isNotNull();
+    assertThat(config).isInstanceOf(ECSCredentialsConfig.class);
+  }
+
+  @Test
+  public void testEcsCredentialsRepositoryBean() {
+    CredentialsLifecycleHandler<NetflixECSCredentials> eventHandler = mock(CredentialsLifecycleHandler.class);
+
+    CredentialsRepository<NetflixECSCredentials> repository = initializer.ecsCredentialsRepository(eventHandler);
+
+    assertThat(repository).isNotNull();
+    assertThat(repository).isInstanceOf(MapBackedCredentialsRepository.class);
+    assertThat(repository.getType()).isEqualTo(EcsCloudProvider.ID);
+  }
+
+  @Test
+  public void testEcsCredentialsParserBean() {
+    ECSCredentialsConfig ecsCredentialsConfig = mock(ECSCredentialsConfig.class);
+    CompositeCredentialsRepository<AccountCredentials> compositeCredentialsRepository = mock(CompositeCredentialsRepository.class);
+    CredentialsParser<AccountsConfiguration.Account, NetflixAmazonCredentials> amazonCredentialsParser = mock(CredentialsParser.class);
+    NamerRegistry namerRegistry = mock(NamerRegistry.class);
+
+    CredentialsParser<ECSCredentialsConfig.Account, NetflixECSCredentials> parser = initializer.ecsCredentialsParser(
+        ecsCredentialsConfig,
+        compositeCredentialsRepository,
+        amazonCredentialsParser,
+        namerRegistry
+    );
+
+    assertThat(parser).isNotNull();
+    assertThat(parser).isInstanceOf(EcsCredentialsParser.class);
+  }
+
+  @Test
+  public void testEcsCredentialsLoaderBeanWithProvidedSource() {
+    CredentialsParser<ECSCredentialsConfig.Account, NetflixECSCredentials> credentialsParser = mock(CredentialsParser.class);
+    CredentialsRepository<NetflixECSCredentials> repository = mock(CredentialsRepository.class);
+    ECSCredentialsConfig ecsCredentialsConfig = mock(ECSCredentialsConfig.class);
+    CredentialsDefinitionSource<ECSCredentialsConfig.Account> ecsCredentialsSource = mock(CredentialsDefinitionSource.class);
+
+    AbstractCredentialsLoader<NetflixECSCredentials> loader = initializer.ecsCredentialsLoader(
+        credentialsParser,
+        repository,
+        ecsCredentialsConfig,
+        ecsCredentialsSource
+    );
+
+    assertThat(loader).isNotNull();
+    assertThat(loader).isInstanceOf(BasicCredentialsLoader.class);
+  }
+
+  @Test
+  public void testEcsCredentialsInializerSynchronizable() {
+    AbstractCredentialsLoader<NetflixECSCredentials> credentialsLoader = mock(AbstractCredentialsLoader.class);
+
+    CredentialsInitializerSynchronizable synchronizable = initializer.ecsCredentialsInializerSynchronizable(credentialsLoader);
+
+    assertThat(synchronizable).isNotNull();
+    assertThat(synchronizable).isInstanceOf(CredentialsInitializerSynchronizable.class);
+
+    synchronizable.synchronize();
+
+    verify(credentialsLoader).load();
+  }
+}


### PR DESCRIPTION
Change to allow clouddriver ECS accounts to use the account management API. Additionally to the AWS (implemented by https://github.com/spinnaker/spinnaker/pull/7238) it allows clouddriver to load ECS accounts from the AccountDefinitionRepository used by the account API.

A new config flag needs to be enabled `account.storage.ecs.enabled` ontop of the existing `account.storage.enabled`, `account.storage.aws.enabled`.