### PR TITLE
fix(orca/clouddriver/retrofit): fix wildcard in the retrofit method parameter

### DIFF
--- a/orca/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/job/DestroyJobForceCacheRefreshTask.groovy
+++ b/orca/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/job/DestroyJobForceCacheRefreshTask.groovy
@@ -44,7 +44,7 @@ class DestroyJobForceCacheRefreshTask implements CloudProviderAware, Task {
     String name = stage.context.jobName
     String region = stage.context.region
 
-    def model = [jobName: name, region: region, account: account, evict: true]
+    def model = [jobName: name, region: region, account: account, evict: true] as Map
     cacheService.forceCacheUpdate(cloudProvider, REFRESH_TYPE, model)
     TaskResult.ofStatus(ExecutionStatus.SUCCEEDED)
   }

--- a/orca/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/loadbalancer/DeleteLoadBalancerForceRefreshTask.groovy
+++ b/orca/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/loadbalancer/DeleteLoadBalancerForceRefreshTask.groovy
@@ -46,7 +46,7 @@ class DeleteLoadBalancerForceRefreshTask implements CloudProviderAware, Task {
     List<String> regions = stage.context.regions
 
     regions.each { region ->
-      def model = [loadBalancerName: name, region: region, account: account, vpcId: vpcId, evict: true]
+      def model = [loadBalancerName: name, region: region, account: account, vpcId: vpcId, evict: true] as Map
       cacheService.forceCacheUpdate(cloudProvider, REFRESH_TYPE, model)
     }
     TaskResult.ofStatus(ExecutionStatus.SUCCEEDED)

--- a/orca/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/loadbalancer/UpsertLoadBalancerForceRefreshTask.groovy
+++ b/orca/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/loadbalancer/UpsertLoadBalancerForceRefreshTask.groovy
@@ -116,7 +116,7 @@ public class UpsertLoadBalancerForceRefreshTask implements CloudProviderAware, R
                 [loadBalancerName: target.name,
                  region          : region,
                  account         : target.credentials,
-                 loadBalancerType: stage.context.loadBalancerType]
+                 loadBalancerType: stage.context.loadBalancerType] as Map
           ))
         }, 3, 1000, false)
 

--- a/orca/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/securitygroup/DeleteSecurityGroupForceRefreshTask.groovy
+++ b/orca/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/securitygroup/DeleteSecurityGroupForceRefreshTask.groovy
@@ -46,7 +46,7 @@ class DeleteSecurityGroupForceRefreshTask implements CloudProviderAware, Task {
     List<String> regions = stage.context.regions
 
     regions.each { region ->
-      def model = [securityGroupName: name, vpcId: vpcId, region: region, account: account, evict: true]
+      def model = [securityGroupName: name, vpcId: vpcId, region: region, account: account, evict: true] as Map
       cacheService.forceCacheUpdate(cloudProvider, REFRESH_TYPE, model)
     }
     TaskResult.ofStatus(ExecutionStatus.SUCCEEDED)

--- a/orca/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/securitygroup/SecurityGroupForceCacheRefreshTask.groovy
+++ b/orca/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/securitygroup/SecurityGroupForceCacheRefreshTask.groovy
@@ -42,7 +42,7 @@ public class SecurityGroupForceCacheRefreshTask implements CloudProviderAware, T
 
     stage.context.targets.each { Map target ->
       cacheService.forceCacheUpdate(
-        cloudProvider, REFRESH_TYPE, [account: target.accountName, securityGroupName: target.name, region: target.region]
+        cloudProvider, REFRESH_TYPE, [account: target.accountName, securityGroupName: target.name, region: target.region] as Map
       )
     }
 

--- a/orca/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/ServerGroupCacheForceRefreshTask.groovy
+++ b/orca/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/ServerGroupCacheForceRefreshTask.groovy
@@ -138,7 +138,7 @@ class ServerGroupCacheForceRefreshTask implements CloudProviderAware, RetryableT
     boolean allUpdatesApplied = true
     refreshableServerGroups.each { Map<String, String> model ->
       try {
-        def response = Retrofit2SyncCall.executeCall(cacheService.forceCacheUpdate(cloudProvider, REFRESH_TYPE, model))
+        def response = Retrofit2SyncCall.executeCall(cacheService.forceCacheUpdate(cloudProvider, REFRESH_TYPE, (Map) model))
         if (response.code() != HttpURLConnection.HTTP_OK) {
           // cache update was not applied immediately; need to poll for completion
           allUpdatesApplied = false

--- a/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/CloudDriverCacheService.java
+++ b/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/CloudDriverCacheService.java
@@ -30,7 +30,7 @@ public interface CloudDriverCacheService {
   Call<ResponseBody> forceCacheUpdate(
       @Path("cloudProvider") String cloudProvider,
       @Path("type") String type,
-      @Body Map<String, ?> data);
+      @Body Map<String, Object> data);
 
   @PUT("/admin/db/truncate/{namespace}")
   Call<Map<String, Object>> clearNamespace(@Path("namespace") String namespace);

--- a/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/DelegatingClouddriverCacheService.java
+++ b/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/DelegatingClouddriverCacheService.java
@@ -37,7 +37,7 @@ public class DelegatingClouddriverCacheService
 
   @Override
   public Call<ResponseBody> forceCacheUpdate(
-      String cloudProvider, String type, Map<String, ?> data) {
+      String cloudProvider, String type, Map<String, Object> data) {
     return getService().forceCacheUpdate(cloudProvider, type, data);
   }
 

--- a/orca/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/loadbalancer/DeleteLoadBalancerForceRefreshTaskSpec.groovy
+++ b/orca/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/loadbalancer/DeleteLoadBalancerForceRefreshTaskSpec.groovy
@@ -45,7 +45,7 @@ class DeleteLoadBalancerForceRefreshTaskSpec extends Specification {
 
     then:
     1 * task.cacheService.forceCacheUpdate(stage.context.cloudProvider, DeleteLoadBalancerForceRefreshTask.REFRESH_TYPE, _) >> {
-      String cloudProvider, String type, Map<String, ? extends Object> body ->
+      String cloudProvider, String type, Map<String, Object> body ->
 
       assert body.loadBalancerName == config.loadBalancerName
       assert body.account == config.credentials

--- a/orca/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/loadbalancer/UpsertLoadBalancerForceRefreshTaskSpec.groovy
+++ b/orca/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/loadbalancer/UpsertLoadBalancerForceRefreshTaskSpec.groovy
@@ -56,7 +56,7 @@ class UpsertLoadBalancerForceRefreshTaskSpec extends Specification {
   void "should force cache refresh server groups via oort when name provided"() {
     when:
     1 * cloudDriverCacheService.forceCacheUpdate('aws', 'LoadBalancer', _) >> {
-      String cloudProvider, String type, Map<String, ? extends Object> body ->
+      String cloudProvider, String type, Map<String, Object> body ->
         assert cloudProvider == "aws"
         assert body.loadBalancerName == "flapjack-frontend"
         assert body.account == "spinnaker"

--- a/orca/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/securitygroup/DeleteSecurityGroupForceRefreshTaskSpec.groovy
+++ b/orca/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/securitygroup/DeleteSecurityGroupForceRefreshTaskSpec.groovy
@@ -45,7 +45,7 @@ class DeleteSecurityGroupForceRefreshTaskSpec extends Specification {
 
     then:
     1 * task.cacheService.forceCacheUpdate(stage.context.cloudProvider, DeleteSecurityGroupForceRefreshTask.REFRESH_TYPE, _) >> {
-      String cloudProvider, String type, Map<String, ? extends Object> body ->
+      String cloudProvider, String type, Map<String, Object> body ->
 
       assert body.securityGroupName == config.securityGroupName
       assert body.vpcId == config.vpcId

--- a/orca/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/securitygroup/SecurityGroupForceCacheRefreshTaskSpec.groovy
+++ b/orca/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/securitygroup/SecurityGroupForceCacheRefreshTaskSpec.groovy
@@ -46,7 +46,7 @@ class SecurityGroupForceCacheRefreshTaskSpec extends Specification {
 
     then:
     1 * task.cacheService.forceCacheUpdate('aws', SecurityGroupForceCacheRefreshTask.REFRESH_TYPE, _) >> {
-      String cloudProvider, String type, Map<String, ? extends Object> body ->
+      String cloudProvider, String type, Map<String, Object> body ->
 
       assert body.securityGroupName == config.name
       assert body.account == config.accountName

--- a/orca/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/ServerGroupCacheForceRefreshTaskSpec.groovy
+++ b/orca/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/ServerGroupCacheForceRefreshTaskSpec.groovy
@@ -74,7 +74,7 @@ class ServerGroupCacheForceRefreshTaskSpec extends Specification {
 
     then:
     1 * task.cacheService.forceCacheUpdate(stage.context.cloudProvider, ServerGroupCacheForceRefreshTask.REFRESH_TYPE, _) >> {
-      String cloudProvider, String type, Map<String, ? extends Object> body ->
+      String cloudProvider, String type, Map<String, Object> body ->
         expectations = body
         Calls.response(Response.success(202, ResponseBody.create(MediaType.parse("application/json"),"[]")))
     }


### PR DESCRIPTION
- retrofit2 doesn't allow parameter type to be a type variable or wildcard so CloudDriverCacheService.forceCacheUpdate method parameter is updated from `@Body Map<String, ?> data` to `@Body Map<String, Object> data`.
- Added a test to demonstrate the issue
- Updated few groovy classes to make sure Groovy doesn't infer any generics while passing the body parameter. 
- Also updated the parameter type in some of the test classes to match the change done at CloudDriverCacheService.forceCacheUpdate method. 

https://github.com/spinnaker/spinnaker/pull/7085 introduced this bug when moving orca to use retrofit2.  [2025.1.0](https://spinnaker.io/changelogs/2025.1.0-changelog/) was the first version of Spinnaker that had this bug.