### PR TITLE
fix(front50/s3): always configure region in s3 client, when specified

### DIFF
--- a/front50/front50-s3/front50-s3.gradle
+++ b/front50/front50-s3/front50-s3.gradle
@@ -34,4 +34,5 @@ dependencies {
   implementation "software.amazon.awssdk:sqs"
 
   testImplementation project(":front50-test")
+  testImplementation("org.assertj:assertj-core")
 }

--- a/front50/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3BucketProperties.java
+++ b/front50/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3BucketProperties.java
@@ -21,10 +21,6 @@ import com.netflix.spinnaker.front50.model.S3StorageService.ServerSideEncryption
 public class S3BucketProperties {
   private String bucket;
   private String region;
-  // regionOverride allows the aws client to override the region in s3 request signatures
-  // some s3 compatible solutions allow non-aws region identifiers to be used
-  private String regionOverride;
-  private String signerOverride;
   private String endpoint;
   private String proxyHost;
   private String proxyPort;
@@ -48,22 +44,6 @@ public class S3BucketProperties {
 
   public void setRegion(String region) {
     this.region = region;
-  }
-
-  public String getRegionOverride() {
-    return regionOverride;
-  }
-
-  public void setRegionOverride(String regionOverride) {
-    this.regionOverride = regionOverride;
-  }
-
-  public String getSignerOverride() {
-    return signerOverride;
-  }
-
-  public void setSignerOverride(String signerOverride) {
-    this.signerOverride = signerOverride;
   }
 
   public String getEndpoint() {

--- a/front50/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3ClientFactory.java
+++ b/front50/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3ClientFactory.java
@@ -72,13 +72,9 @@ public class S3ClientFactory {
 
     if (!StringUtils.isEmpty(s3Properties.getEndpoint())) {
       s3Builder.endpointOverride(URI.create(s3Properties.getEndpoint()));
-
-      if (!StringUtils.isEmpty(s3Properties.getRegionOverride())) {
-        s3Builder.region(Region.of(s3Properties.getRegionOverride()));
-      }
-    } else {
-      Optional.ofNullable(s3Properties.getRegion()).map(Region::of).ifPresent(s3Builder::region);
     }
+
+    Optional.ofNullable(s3Properties.getRegion()).map(Region::of).ifPresent(s3Builder::region);
 
     return s3Builder.build();
   }

--- a/front50/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3Properties.java
+++ b/front50/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3Properties.java
@@ -82,15 +82,6 @@ public abstract class S3Properties extends S3BucketProperties {
   }
 
   @Override
-  public String getRegionOverride() {
-    if (isFailoverEnabled()) {
-      return failover.getRegionOverride();
-    }
-
-    return super.getRegionOverride();
-  }
-
-  @Override
   public String getEndpoint() {
     if (isFailoverEnabled()) {
       return failover.getEndpoint();

--- a/front50/front50-s3/src/test/java/com/netflix/spinnaker/front50/config/S3ClientFactoryTest.java
+++ b/front50/front50-s3/src/test/java/com/netflix/spinnaker/front50/config/S3ClientFactoryTest.java
@@ -1,0 +1,24 @@
+package com.netflix.spinnaker.front50.config;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.core.exception.SdkClientException;
+
+public class S3ClientFactoryTest {
+
+  @Test
+  void create_shouldNotThrowSdkClientException_whenRegionIsProvidedWithEndpoint() {
+    AwsCredentialsProvider mockProvider = mock(AwsCredentialsProvider.class);
+    S3Properties props = new S3MetadataStorageProperties();
+    props.setRegion("us-west-2");
+    props.setEndpoint("https://minio-host:9000");
+    // FIXME: this should not throw an exception
+    assertThatThrownBy(() -> S3ClientFactory.create(mockProvider, props))
+        .isInstanceOf(SdkClientException.class)
+        .hasMessageContaining(
+            "Unable to load region from system settings. Region must be specified either via environment variable (AWS_REGION) or  system property (aws.region)");
+  }
+}

--- a/front50/front50-s3/src/test/java/com/netflix/spinnaker/front50/config/S3ClientFactoryTest.java
+++ b/front50/front50-s3/src/test/java/com/netflix/spinnaker/front50/config/S3ClientFactoryTest.java
@@ -1,11 +1,11 @@
 package com.netflix.spinnaker.front50.config;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.Mockito.mock;
 
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
-import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.services.s3.S3Client;
 
 public class S3ClientFactoryTest {
 
@@ -15,10 +15,7 @@ public class S3ClientFactoryTest {
     S3Properties props = new S3MetadataStorageProperties();
     props.setRegion("us-west-2");
     props.setEndpoint("https://minio-host:9000");
-    // FIXME: this should not throw an exception
-    assertThatThrownBy(() -> S3ClientFactory.create(mockProvider, props))
-        .isInstanceOf(SdkClientException.class)
-        .hasMessageContaining(
-            "Unable to load region from system settings. Region must be specified either via environment variable (AWS_REGION) or  system property (aws.region)");
+    S3Client client = S3ClientFactory.create(mockProvider, props);
+    assertThat(client.serviceClientConfiguration().region().id()).isEqualTo("us-west-2");
   }
 }


### PR DESCRIPTION
- While upgrading front50 to aws sdk v2 in https://github.com/spinnaker/spinnaker/pull/7250, it was mistakenly assumed that the regionOverride was meant for the s3 compatible storage but in reality it was meant only for signerOverride in sdk v1. So with the existing code, for s3 compatible storages, region won't be set and will cause the following error:
```
software.amazon.awssdk.regions.providers.SystemSettingsRegionProvider@629bee3b: 
Unable to load region from system settings. Region must be specified either via environment variable (AWS_REGION) or  system property (aws.region)
```
- This PR fixes the issue by assigning region to S3Builder even for S3 compatible storages.
- A test is added to demonstrate the issue.
