### PR TITLE
perf(front50): fetch pipeline by id in StartPipelineTask

### DIFF
--- a/orca/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/StartPipelineTask.groovy
+++ b/orca/orca-front50/src/main/groovy/com/netflix/spinnaker/orca/front50/tasks/StartPipelineTask.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.orca.front50.tasks
 
 import com.netflix.spinnaker.kork.exceptions.ConfigurationException
 import com.netflix.spinnaker.kork.retrofit.Retrofit2SyncCall
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerHttpException
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus
 import com.netflix.spinnaker.orca.api.pipeline.Task
 import com.netflix.spinnaker.orca.api.pipeline.models.PipelineExecution
@@ -34,6 +35,8 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 import javax.annotation.Nonnull
+
+import static java.net.HttpURLConnection.HTTP_NOT_FOUND
 
 @Component
 @Slf4j
@@ -66,10 +69,9 @@ class StartPipelineTask implements Task {
     Boolean isStrategy = stage.context.pipelineParameters?.strategy ?: false
     String pipelineId = isStrategy ? stage.context.pipelineId : stage.context.pipeline
 
-    List<Map<String, Object>> pipelines = isStrategy ?
-        Retrofit2SyncCall.execute(front50Service.getStrategies(application)) :
-        Retrofit2SyncCall.execute(front50Service.getPipelines(application, false))
-    Map<String, Object> pipelineConfig = pipelines.find { it.id == pipelineId }
+    Map<String, Object> pipelineConfig = isStrategy
+      ? Retrofit2SyncCall.execute(front50Service.getStrategies(application)).find { it.id == pipelineId }
+      : getPipelineById(pipelineId)
 
     if (!pipelineConfig) {
       throw new ConfigurationException("The referenced ${isStrategy ? 'custom strategy' : 'pipeline'} cannot be located (${pipelineId})")
@@ -139,5 +141,25 @@ class StartPipelineTask implements Task {
     }
 
     return null
+  }
+
+
+  /**
+   * Fetches a pipeline from front50 if it exists.
+   * Returns a null if the pipeline doesn't exist in front50
+   * @param id id of the pipeline to be fetched from front50
+   * @return fetched pipeline if it exists, null otherwise
+   */
+  private Map<String, Object> getPipelineById(String id) {
+    try {
+      return Retrofit2SyncCall.execute(front50Service.getPipeline(id))
+    } catch (SpinnakerHttpException e) {
+      // Return a null if pipeline with the id not found
+      if (e.responseCode == HTTP_NOT_FOUND) {
+        log.debug("Existing pipeline with id {} not found. Returning null.", id)
+        return null
+      }
+      throw e
+    }
   }
 }

--- a/orca/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/tasks/StartPipelineTaskSpec.groovy
+++ b/orca/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/tasks/StartPipelineTaskSpec.groovy
@@ -16,11 +16,18 @@
 
 package com.netflix.spinnaker.orca.front50.tasks
 
-
+import com.netflix.spinnaker.kork.exceptions.ConfigurationException
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerHttpException
+import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus
 import com.netflix.spinnaker.orca.api.pipeline.ExecutionPreprocessor
 import com.netflix.spinnaker.orca.front50.DependentPipelineStarter
 import com.netflix.spinnaker.orca.front50.Front50Service
 import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor
+import okhttp3.MediaType
+import okhttp3.ResponseBody
+import retrofit2.Response
+import retrofit2.Retrofit
+import retrofit2.converter.jackson.JacksonConverterFactory
 import retrofit2.mock.Calls
 import spock.lang.Specification
 import spock.lang.Subject
@@ -29,6 +36,7 @@ import spock.lang.Unroll
 import static com.netflix.spinnaker.orca.api.pipeline.models.PipelineExecution.*
 import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.pipeline
 import static com.netflix.spinnaker.orca.test.model.ExecutionBuilder.stage
+import static java.net.HttpURLConnection.HTTP_NOT_FOUND
 
 class StartPipelineTaskSpec extends Specification {
 
@@ -43,14 +51,16 @@ class StartPipelineTaskSpec extends Specification {
   @Unroll
   def "should trigger the dependent pipeline with the correct context and parentPipelineStageId"() {
     given:
-    def pipelineConfig = [id: "testStrategyId", application: "orca", name: "testStrategy"]
-    1 * front50Service.getStrategies(_) >> Calls.response([pipelineConfig])
+    def pipelineConfig = [id: "testPipelineId", application: "orca", name: "testPipeline"]
+    if (strategyValue) {
+      1 * front50Service.getStrategies(_) >> Calls.response([pipelineConfig])
+    } else 1 * front50Service.getPipeline(_) >> Calls.response(pipelineConfig)
     def stage = stage {
       type = "whatever"
       context = [
-        pipelineId        : "testStrategyId",
+        pipelineId        : "testPipelineId",
         pipelineParameters: [
-          strategy: true,
+          strategy: strategyValue,
           zone    : "north-pole-1",
         ],
         deploymentDetails : [
@@ -84,32 +94,91 @@ class StartPipelineTaskSpec extends Specification {
         application = "orca"
       }
     }
-    gotContext == [
-      strategy         : true,
-      zone             : "north-pole-1",
-      amiName          : "testAMI",
-      imageId          : "testImageId",
-      deploymentDetails: [
-        [
-          ami      : "testAMI",
-          imageName: "testImageName",
-          imageId  : "testImageId",
-          zone     : "north-pole-1",
+    if (strategyValue) {
+      gotContext == [
+        strategy         : strategyValue,
+        zone             : "north-pole-1",
+        amiName          : "testAMI",
+        imageId          : "testImageId",
+        deploymentDetails: [
+          [
+            ami      : "testAMI",
+            imageName: "testImageName",
+            imageId  : "testImageId",
+            zone     : "north-pole-1",
+          ]
         ]
       ]
-    ]
+    } else {
+      gotContext == [
+        strategy         : strategyValue,
+        zone             : "north-pole-1",
+        amiName          : "testAMI",
+        imageId          : "testImageId"
+      ]
+    }
     parentPipelineStageId == stage.id
 
     authenticatedUser?.user == expectedAuthenticatedUsername
     authenticatedUser?.allowedAccounts?.toList() == expectedAuthenticatedAllowedAccounts
 
     where:
-    authentication || expectedAuthenticatedUsername || expectedAuthenticatedAllowedAccounts
-    null           || null                       || null
+    authentication || expectedAuthenticatedUsername || expectedAuthenticatedAllowedAccounts || strategyValue
+    null           || null                          || null                                 || true
+    null           || null                          || null                                 || false
     new AuthenticationDetails(
       "authenticated_user",
       "account1"
-    )              || "authenticated_user"       || ["account1"]
+    )              || "authenticated_user"          || ["account1"]                         || true
+    new AuthenticationDetails(
+      "authenticated_user",
+      "account1"
+    )              || "authenticated_user"          || ["account1"]                         || false
 
+  }
+
+  def "should fail if dependent pipeline not found"() {
+    given:
+    def pipelineConfig = [id: "testPipelineId", application: "app", name: "testPipeline"]
+    1 * front50Service.getPipeline("testPipelineId") >> Calls.response(pipelineConfig)
+    1 * front50Service.getPipeline("invalidPipelineId") >> { throw makeSpinnakerHttpException(HTTP_NOT_FOUND) }
+    def stage = stage {
+      type = "whatever"
+      context = [
+        pipeline: "testPipelineId",
+        user    : "testUser"
+      ]
+    }
+
+    when:
+    def result = task.execute(stage)
+
+    then:
+    result.status == ExecutionStatus.SUCCEEDED
+
+    when:
+    stage.context.pipeline = "invalidPipelineId"
+    task.execute(stage)
+
+    then:
+    def error = thrown(ConfigurationException)
+    error.getMessage() == "The referenced pipeline cannot be located (invalidPipelineId)"
+  }
+
+  static SpinnakerHttpException makeSpinnakerHttpException(int status, String message = "{ \"message\": \"arbitrary message\" }") {
+    String url = "https://oort";
+    Response retrofit2Response =
+      Response.error(
+        status,
+        ResponseBody.create(
+          MediaType.parse("application/json"), message))
+
+    Retrofit retrofit =
+      new Retrofit.Builder()
+        .baseUrl(url)
+        .addConverterFactory(JacksonConverterFactory.create())
+        .build()
+
+    return new SpinnakerHttpException(retrofit2Response, retrofit)
   }
 }


### PR DESCRIPTION
Hi,

I'm working with @dbyron-sf to try and port some of their changes over from the salesforce fork.

This PR improves the performance of the `StartPipelineTask` to fetch pipelines by ID rather than the whole lot. Updated original testing to include happy path tests for triggering pipelines as well.

Thanks!