### PR TITLE
fix(orca/redis): actually run the tests

### DIFF
--- a/orca/orca-redis/orca-redis.gradle
+++ b/orca/orca-redis/orca-redis.gradle
@@ -15,3 +15,7 @@ dependencies {
   testImplementation(project(":orca-test-groovy"))
   testImplementation("io.spinnaker.kork:kork-jedis-test")
 }
+
+test {
+  useJUnitPlatform()
+}


### PR DESCRIPTION
I'm not sure why the
```
subprojects {
  if (name != "orca-bom" && name != "orca-api") {
    test {
      minHeapSize = "512m"
      maxHeapSize = "2g"
      maxParallelForks = 4

      testLogging {
        exceptionFormat = "full"
      }
      useJUnitPlatform()
    }
  }
}
```
code from orca/build.gradle isn't sufficient to run (groovy) tests in orca-redis, but apparently it's not.

Adding
```
test {
  useJUnitPlatform()
}
```
to orca-redis does the trick, and gets
```
$ ./gradlew orca:orca-redis:test
```
to run JedisPipelineExecutionRepositorySpec when it didn't before.
<img width="1728" height="943" alt="image" src="https://github.com/user-attachments/assets/21af8f5c-3d57-41c3-b26d-73af10efd369" />