### PR TITLE
fix(orca): set the status correctly when cancelling a pipeline execution

### DIFF
--- a/orca/orca-core-tck/src/main/groovy/com/netflix/spinnaker/orca/pipeline/persistence/PipelineExecutionRepositoryTck.groovy
+++ b/orca/orca-core-tck/src/main/groovy/com/netflix/spinnaker/orca/pipeline/persistence/PipelineExecutionRepositoryTck.groovy
@@ -724,8 +724,7 @@ abstract class PipelineExecutionRepositoryTck<T extends ExecutionRepository> ext
     where:
     pipelineStatus  | firstStageStatus  | secondStageStatus || expectedPipelineStatus
     NOT_STARTED     | NOT_STARTED       | NOT_STARTED       || CANCELED
-    // FIXME: cancelling a pipeline like this should result in a pipeline status of CANCELED
-    RUNNING         | SUCCEEDED         | NOT_STARTED       || RUNNING
+    RUNNING         | SUCCEEDED         | NOT_STARTED       || CANCELED
     SUCCEEDED       | SUCCEEDED         | SUCCEEDED         || SUCCEEDED
     TERMINAL        | SUCCEEDED         | TERMINAL          || TERMINAL
   }


### PR DESCRIPTION
The exact details to reproduce this race are unfortunately lost to time.  We've been running this code at Salesforce since April 2021 though, so it's got some good miles on it.  It also still seems like a reasonable fix.
