### PR TITLE
fix(gate-web): Controller fix for RoleController & EcsCloudMetricController after retrofit updates

### DIFF
--- a/gate/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/EcsCloudMetricService.groovy
+++ b/gate/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/EcsCloudMetricService.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.gate.services
 
 import com.netflix.spinnaker.gate.services.internal.ClouddriverService
+import com.netflix.spinnaker.kork.retrofit.Retrofit2SyncCall
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
@@ -31,6 +32,6 @@ class EcsCloudMetricService {
   }
 
   List getEcsAllMetricAlarms() {
-    clouddriver.getEcsAllMetricAlarms()
+    Retrofit2SyncCall.execute(clouddriver.getEcsAllMetricAlarms())
   }
 }

--- a/gate/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/RoleService.groovy
+++ b/gate/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/RoleService.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.gate.services;
 
 import com.netflix.spinnaker.gate.services.internal.ClouddriverService
+import com.netflix.spinnaker.kork.retrofit.Retrofit2SyncCall
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
@@ -31,6 +32,6 @@ class RoleService {
   }
 
   List getRoles(String provider) {
-    clouddriver.getRoles(provider)
+    Retrofit2SyncCall.execute(clouddriver.getRoles(provider))
   }
 }

--- a/gate/gate-web/src/test/java/com/netflix/spinnaker/gate/controllers/EcsCloudMetricControllerTest.java
+++ b/gate/gate-web/src/test/java/com/netflix/spinnaker/gate/controllers/EcsCloudMetricControllerTest.java
@@ -1,0 +1,127 @@
+package com.netflix.spinnaker.gate.controllers;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.gate.controllers.ecs.EcsCloudMetricController;
+import com.netflix.spinnaker.gate.services.EcsCloudMetricService;
+import com.netflix.spinnaker.gate.services.internal.ClouddriverService;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import retrofit2.Call;
+import retrofit2.mock.Calls;
+
+@ExtendWith(MockitoExtension.class)
+public class EcsCloudMetricControllerTest {
+
+  private MockWebServer server;
+  private MockMvc mockMvc;
+
+  @Mock private ClouddriverService clouddriverService;
+
+  private EcsCloudMetricService ecsCloudMetricService;
+
+  private ObjectMapper objectMapper;
+
+  @BeforeEach
+  public void setup() {
+    server = new MockWebServer();
+    ecsCloudMetricService = new EcsCloudMetricService(clouddriverService);
+    EcsCloudMetricController controller = new EcsCloudMetricController();
+    controller.setEcsClusterService(ecsCloudMetricService);
+    mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+    objectMapper = new ObjectMapper();
+  }
+
+  @AfterEach
+  public void tearDown() throws Exception {
+    server.shutdown();
+  }
+
+  @Test
+  public void shouldReturnEmptyResponse() throws Exception {
+    Call<List<Map>> callResponse = Calls.response(new ArrayList<>());
+    List<Map> alarmsList = new ArrayList<>();
+
+    when(clouddriverService.getEcsAllMetricAlarms()).thenReturn(callResponse);
+
+    mockMvc
+        .perform(get("/ecs/cloudMetrics/alarms").contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect((content().json(objectMapper.writeValueAsString(alarmsList))));
+
+    verify(clouddriverService).getEcsAllMetricAlarms();
+  }
+
+  @Test
+  public void shouldReturnNonEmptyResponse() throws Exception {
+    List<Map> alarmsList = new ArrayList<>();
+
+    Map<String, String> alarm1 = new HashMap<>();
+    alarm1.put("accountName", "account1");
+    alarm1.put(
+        "alarmActions",
+        "arn:aws:autoscaling:us-west-2:0000000000000:scalingPolicy:"
+            + "981fc192-4b43-46f7-963a-2c7e6bd9b9ce:autoScalingGroupName/my-ecs-cluster:policyName/"
+            + "ECSManagedAutoScalingPolicy-ea823f38-166f-497d-bc13-5ef1aaca62ad");
+    alarm1.put(
+        "alarmArn",
+        "arn:aws:cloudwatch:us-west-2:0000000000000:alarm:"
+            + "TargetTracking-my-ecs-cluster-AlarmHigh-8d1ecfc9-5e98-4011-8a8b-c5ebfa7742eb");
+    alarm1.put(
+        "alarmName",
+        "TargetTracking-my-ecs-cluster-AlarmHigh-8d1ecfc9-5e98-4011-8a8b-c5ebfa7742eb");
+    alarm1.put("dimensions", "[]");
+    alarm1.put("insufficientDataActions", "[]");
+    alarm1.put("metrics", "[]");
+    alarm1.put("region", "us-west-2");
+
+    Map<String, String> alarm2 = new HashMap<>();
+    alarm2.put("accountName", "account2");
+    alarm2.put(
+        "alarmActions",
+        "arn:aws:autoscaling:us-west-2:11111111111111:scalingPolicy:"
+            + "981fc192-4b43-46f7-963a-2c7e6bd9b9ce:autoScalingGroupName/my-ecs-cluster:policyName/"
+            + "ECSManagedAutoScalingPolicy-ea823f38-166f-497d-bc13-5ef1aaca62ad");
+    alarm2.put(
+        "alarmArn",
+        "arn:aws:cloudwatch:us-west-2:11111111111111:alarm:"
+            + "TargetTracking-my-ecs-cluster-AlarmHigh-8d1ecfc9-5e98-4011-8a8b-c5ebfa7742eb");
+    alarm2.put(
+        "alarmName",
+        "TargetTracking-my-ecs-cluster-AlarmHigh-8d1ecfc9-5e98-4011-8a8b-c5ebfa7742eb");
+    alarm2.put("dimensions", "[]");
+    alarm2.put("insufficientDataActions", "[]");
+    alarm2.put("metrics", "[]");
+    alarm2.put("region", "us-west-2");
+
+    alarmsList.add(alarm1);
+    alarmsList.add(alarm2);
+
+    Call<List<Map>> callResponse = Calls.response(alarmsList);
+    when(clouddriverService.getEcsAllMetricAlarms()).thenReturn(callResponse);
+
+    mockMvc
+        .perform(get("/ecs/cloudMetrics/alarms").contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect((content().json(objectMapper.writeValueAsString(alarmsList))));
+
+    verify(clouddriverService).getEcsAllMetricAlarms();
+  }
+}

--- a/gate/gate-web/src/test/java/com/netflix/spinnaker/gate/controllers/RoleControllerTest.java
+++ b/gate/gate-web/src/test/java/com/netflix/spinnaker/gate/controllers/RoleControllerTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2025 Harness, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.gate.controllers;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.gate.services.RoleService;
+import com.netflix.spinnaker.gate.services.internal.ClouddriverService;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import retrofit2.Call;
+import retrofit2.mock.Calls;
+
+@ExtendWith(MockitoExtension.class)
+public class RoleControllerTest {
+
+  private MockWebServer server;
+  private MockMvc mockMvc;
+
+  @Mock private ClouddriverService clouddriverService;
+
+  private RoleService roleService;
+
+  private ObjectMapper objectMapper;
+
+  @BeforeEach
+  public void setup() {
+    server = new MockWebServer();
+    roleService = new RoleService(clouddriverService);
+    RoleController controller = new RoleController();
+    controller.setRoleService(roleService);
+    mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+    objectMapper = new ObjectMapper();
+  }
+
+  @AfterEach
+  public void tearDown() throws Exception {
+    server.shutdown();
+  }
+
+  @Test
+  public void shouldReturnEmptyResponse() throws Exception {
+    Call<List<Map>> callResponse = Calls.response(new ArrayList<>());
+    List<Map> roleList = new ArrayList<>();
+
+    when(clouddriverService.getRoles("aws")).thenReturn(callResponse);
+
+    mockMvc
+        .perform(get("/roles/aws").contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().json(objectMapper.writeValueAsString(roleList)));
+
+    verify(clouddriverService).getRoles("aws");
+  }
+
+  @Test
+  public void shouldReturnNonEmptyResponse() throws Exception {
+    List<Map> roleList = new ArrayList<>();
+
+    Map<String, String> role1 = new HashMap<>();
+    role1.put("accountName", "my-account-1");
+    role1.put("id", "arn:aws:iam::0000000000000:role/role-ecs");
+    role1.put("name", "role-ecs");
+    role1.put(
+        "trustRelationships",
+        List.of(
+                Map.of(
+                    "type", "Service",
+                    "value", "logs.amazonaws.com"),
+                Map.of(
+                    "type", "Service",
+                    "value", "ecs-tasks.amazonaws.com"))
+            .toString());
+
+    Map<String, String> role2 = new HashMap<>();
+    role2.put("accountName", "my-account-2");
+    role2.put("id", "arn:aws:iam::1111111111111:role/role-ecs");
+    role2.put("name", "role-ecs");
+    role2.put(
+        "trustRelationships",
+        List.of(
+                Map.of(
+                    "type", "Service",
+                    "value", "logs.amazonaws.com"),
+                Map.of(
+                    "type", "Service",
+                    "value", "ecs-tasks.amazonaws.com"))
+            .toString());
+
+    roleList.add(role1);
+    roleList.add(role2);
+
+    Call<List<Map>> callResponse = Calls.response(roleList);
+
+    when(clouddriverService.getRoles("ecs")).thenReturn(callResponse);
+
+    mockMvc
+        .perform(get("/roles/ecs").contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().json(objectMapper.writeValueAsString(roleList)));
+
+    verify(clouddriverService).getRoles("ecs");
+  }
+}


### PR DESCRIPTION
Similar to fix https://github.com/spinnaker/spinnaker/pull/7291 the following error is thrown:

```
{"error":"Internal Server Error","exception":"org.codehaus.groovy.runtime.typehandling.GroovyCastException","message":"Cannot cast object 
'com.netflix.spinnaker.kork.retrofit.ErrorHandlingExecutorCallAdapterFactory$ExecutorCallbackCall@7860644c' with class 
'com.netflix.spinnaker.kork.retrofit.ErrorHandlingExecutorCallAdapterFactory$ExecutorCallbackCall' to class 'java.util.List
```

Adding missing tests as well