### PR TITLE
fix(orca/web/test): make the description of the test match reality

### DIFF
--- a/orca/orca-web/src/test/kotlin/com/netflix/spinnaker/orca/controllers/TaskControllerSqlExecutionRepositoryTest.kt
+++ b/orca/orca-web/src/test/kotlin/com/netflix/spinnaker/orca/controllers/TaskControllerSqlExecutionRepositoryTest.kt
@@ -214,7 +214,7 @@ class TaskControllerSqlExecutionRepositoryTest : JUnit5Minutests {
         Fixture(true)
       }
 
-      testExecutionRetrieval(optimizedDescription(false))
+      testExecutionRetrieval(optimizedDescription(true))
     }
 
     context("test query having explicit query timeouts") {


### PR DESCRIPTION
for "execution retrieval with optimization" in TaskControllerSqlExecutionRepositoryTest. The test already runs with optimization due to Fixture(true).  This makes the description match.  [PR 7319](https://github.com/spinnaker/spinnaker/pull/7319/files#diff-b2455be7a0dc6558a61c7049705a83045dca90d301531a2975ec573798bf80e1R220) is the source of the bug.
