### PR TITLE
fix(spin): Fix spin cli docker publishing to GHCR

### DIFF
--- a/.github/workflows/spin.yml
+++ b/.github/workflows/spin.yml
@@ -130,4 +130,5 @@ jobs:
           release-train: ${{ steps.version.outputs.release-train}}
           build-url: ${{ steps.version.outputs.build-url }}
           push: ${{ github.event_name != 'pull_request' }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           gar-json-key: ${{ secrets.GAR_JSON_KEY }}


### PR DESCRIPTION
Spin was ONLY published on release and used a custom set of passed logins vs. rosco which passed to the build then to docker and thus got auth secrets.  Spin didn't pass the GHCR auth secret (GITHUB_TOKEN).  This should fix this.