### PR TITLE
fix(rosco/helmfile): fix command line arguments list when multiple values files are provided

### DIFF
--- a/rosco/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/helmfile/HelmfileTemplateUtils.java
+++ b/rosco/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/helmfile/HelmfileTemplateUtils.java
@@ -31,7 +31,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
@@ -109,15 +108,18 @@ public class HelmfileTemplateUtils extends HelmBakeTemplateUtils<HelmfileBakeMan
     }
 
     Map<String, Object> overrides = request.getOverrides();
-    if (!overrides.isEmpty()) {
+    if (overrides != null && !overrides.isEmpty()) {
       List<String> overrideList = buildOverrideList(overrides);
       command.add("--set");
       command.add(String.join(",", overrideList));
     }
 
     if (!valuePaths.isEmpty()) {
-      command.add("--values");
-      command.add(valuePaths.stream().map(Path::toString).collect(Collectors.joining(",")));
+      valuePaths.forEach(
+          path -> {
+            command.add("--values");
+            command.add(path.toString());
+          });
     }
 
     result.setCommand(command);


### PR DESCRIPTION
Addresses issue https://github.com/spinnaker/spinnaker/issues/7344 with tests this time.