### PR TITLE
chore(clouddriver): log unhandled exceptions with a stack trace during HTTP URL Restrictions check

### DIFF
--- a/clouddriver/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/config/HttpUrlRestrictions.java
+++ b/clouddriver/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/config/HttpUrlRestrictions.java
@@ -31,6 +31,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.security.web.util.matcher.IpAddressMatcher;
 
@@ -60,6 +61,7 @@ import org.springframework.security.web.util.matcher.IpAddressMatcher;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
+@Slf4j
 public class HttpUrlRestrictions {
 
   @Builder.Default
@@ -223,6 +225,7 @@ public class HttpUrlRestrictions {
     } catch (IllegalArgumentException iae) {
       throw iae;
     } catch (Exception ex) {
+      log.error("Unexpected HttpUrlRestrictions Exception: {}", ex.getMessage(), ex);
       throw new IllegalArgumentException("URI not valid: " + url, ex);
     }
   }


### PR DESCRIPTION
When something is missing or unfilled in configuration for an artifact the error is then obscured with a generic "URI not valid: " in http body between orca/rosco and clouddriver, this PR fixes it by providing a full exception message and stack trace.