### PR TITLE
fix(fiat): make prefix permissions case-insensitive

### DIFF
--- a/fiat/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/ResourcePrefixPermissionSource.java
+++ b/fiat/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/ResourcePrefixPermissionSource.java
@@ -68,8 +68,7 @@ public class ResourcePrefixPermissionSource<T extends Resource.AccessControlled>
       }
 
       String prefixWithoutStar = prefix.substring(0, prefix.length() - 1);
-      prefixWithoutStar = prefixWithoutStar.toUpperCase();
-      return resource.getName().startsWith(prefixWithoutStar);
+      return resource.getName().toUpperCase().startsWith(prefixWithoutStar.toUpperCase());
     }
   }
 


### PR DESCRIPTION
### Problem
Application creation restrictions that rely on Fiat prefix-based permissions were case-sensitive. Mixed-case app names could bypass or misapply CREATE permissions defined via auth.permissions.source.application.prefix. This broke scenarios like "only infra teams can create any app" when app names weren’t consistently cased.

### What's fixed
In this PR, we normalize both prefix patterns and resource names before matching so prefix permissions (including `*` and exact-name entries) are evaluated case-insensitively.

### Why this matters
Ensures `restrictApplicationCreation` + prefix-configured `CREATE` permissions are enforced regardless of app name casing. Prevents unintended authorization gaps where application creation was allowed/denied incorrectly due to case mismatches.