### PR TITLE
fix(orca/web): properly deserialize webhook status code

### DIFF
--- a/orca/orca-web/src/test/java/com/netflix/spinnaker/orca/HttpStatusCodeSpringObjectMapperTest.java
+++ b/orca/orca-web/src/test/java/com/netflix/spinnaker/orca/HttpStatusCodeSpringObjectMapperTest.java
@@ -1,13 +1,32 @@
+/*
+ * Copyright 2025 OpsMx, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.orca;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import com.netflix.spinnaker.orca.notifications.NotificationClusterLock;
 import com.netflix.spinnaker.orca.pipeline.persistence.ExecutionRepository;
 import com.netflix.spinnaker.orca.q.pending.PendingExecutionService;
 import com.netflix.spinnaker.orca.webhook.pipeline.WebhookStage;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -31,15 +50,54 @@ class HttpStatusCodeSpringObjectMapperTest {
   @MockBean NotificationClusterLock notificationClusterLock;
 
   @Test
-  void shouldFailToDeserializeStringStatusCode() {
+  void shouldFailToDeserializeInvalidStringStatusCode() {
     String json = """
       {
-        "statusCode": "OK"
+        "statusCode": "InvalidStatusCode"
       }
       """;
 
     assertThrows(
         InvalidFormatException.class,
         () -> objectMapper.readValue(json, WebhookStage.WebhookMonitorResponseStageData.class));
+  }
+
+  @Test
+  void shouldFailToDeserializeInvalidIntStatusCode() {
+    String json = """
+      {
+        "statusCode": 20
+      }
+      """;
+
+    assertThrows(
+        JsonMappingException.class,
+        () -> objectMapper.readValue(json, WebhookStage.WebhookMonitorResponseStageData.class));
+  }
+
+  @Test
+  void shouldDeserializeStringStatusCode() throws JsonProcessingException {
+    String json = """
+      {
+        "statusCode": "OK"
+      }
+      """;
+
+    WebhookStage.WebhookMonitorResponseStageData monitor =
+        objectMapper.readValue(json, WebhookStage.WebhookMonitorResponseStageData.class);
+    Assertions.assertThat(monitor.getStatusCode().is2xxSuccessful()).isTrue();
+  }
+
+  @Test
+  void shouldDeserializeIntStatusCode() throws JsonProcessingException {
+    String json = """
+      {
+        "statusCode": 200
+      }
+      """;
+
+    WebhookStage.WebhookMonitorResponseStageData monitor =
+        objectMapper.readValue(json, WebhookStage.WebhookMonitorResponseStageData.class);
+    Assertions.assertThat(monitor.getStatusCode().is2xxSuccessful()).isTrue();
   }
 }


### PR DESCRIPTION
Seeing below error with 2025.4.0 release. This because the `WebhookStage.WebhookMonitorResponseStageData.class.statusCode` field's type is changed to `HttpStatusCode` from `HttpStatus` as part Sringboot 3.0.13 migration (see https://github.com/spinnaker/spinnaker/pull/7057/files#diff-9cb623dde54bbb3431d90ce3b50969c26327fd89484530b14fa194159c8af67bR156). 

`HttpStatusCode` is an interface that models an HTTP status by its numeric value.
During deserialization, Jackson has no symbolic mapping like it does for enums, so it expects a numeric value.
When the JSON contains "OK", Jackson attempts to coerce it into an integer and fails.
This is why the error mentions int even though the field type is `HttpStatusCode`.

### Stacktrace:
```
Caused by: com.fasterxml.jackson.databind.exc.InvalidFormatException: Cannot deserialize value of type `int` from String "OK": not a valid `int` value
 at [Source: UNKNOWN; byte offset: #UNKNOWN] (through reference chain: com.netflix.spinnaker.orca.webhook.pipeline.WebhookStage$StageData["webhook"]->com.netflix.spinnaker.orca.webhook.pipeline.WebhookStage$WebhookResponseStageData["monitor"]->com.netflix.spinnaker.orca.webhook.pipeline.WebhookStage$WebhookMonitorResponseStageData["statusCode"])
	at com.fasterxml.jackson.databind.exc.InvalidFormatException.from(InvalidFormatException.java:67)
	at com.fasterxml.jackson.databind.DeserializationContext.weirdStringException(DeserializationContext.java:1996)
	at com.fasterxml.jackson.databind.DeserializationContext.handleWeirdStringValue(DeserializationContext.java:1224)
	at com.fasterxml.jackson.databind.deser.std.StdDeserializer._parseIntPrimitive(StdDeserializer.java:772)
	at com.fasterxml.jackson.databind.deser.std.StdDeserializer._deserializeFromString(StdDeserializer.java:288)
	at com.fasterxml.jackson.databind.deser.BeanDeserializerBase.deserializeFromString(BeanDeserializerBase.java:1500)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer._deserializeOther(BeanDeserializer.java:197)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:187)
	at com.fasterxml.jackson.databind.deser.impl.MethodProperty.deserializeAndSet(MethodProperty.java:129)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.vanillaDeserialize(BeanDeserializer.java:314)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:177)
	at com.fasterxml.jackson.databind.deser.impl.MethodProperty.deserializeAndSet(MethodProperty.java:129)
```

### Changes:
- Added tests to demonstrate http status code deserialisation issue.
- Properly deserialized webhook status code 