### PR TITLE
fix(fiat): ensure authenticated user is set in SecurityContext always

### DIFF
--- a/fiat/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatAuthenticationConfig.java
+++ b/fiat/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatAuthenticationConfig.java
@@ -96,14 +96,13 @@ public class FiatAuthenticationConfig {
 
   @Bean
   public SecurityFilterChain fiatSecurityFilterChain(
-      HttpSecurity http, FiatStatus fiatStatus, AuthenticationConverter authenticationConverter)
-      throws Exception {
+      HttpSecurity http, AuthenticationConverter authenticationConverter) throws Exception {
 
     http.servletApi(Customizer.withDefaults())
         .exceptionHandling(Customizer.withDefaults())
         .anonymous(Customizer.withDefaults())
         .addFilterBefore(
-            new FiatAuthenticationFilter(fiatStatus, authenticationConverter),
+            new FiatAuthenticationFilter(authenticationConverter),
             AnonymousAuthenticationFilter.class)
         .csrf()
         .disable();

--- a/fiat/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatAuthenticationFilter.java
+++ b/fiat/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatAuthenticationFilter.java
@@ -31,26 +31,21 @@ import org.springframework.security.web.authentication.AuthenticationConverter;
 @Slf4j
 public class FiatAuthenticationFilter extends HttpFilter {
 
-  private final FiatStatus fiatStatus;
   private final AuthenticationConverter authenticationConverter;
 
-  public FiatAuthenticationFilter(
-      FiatStatus fiatStatus, AuthenticationConverter authenticationConverter) {
-    this.fiatStatus = fiatStatus;
+  public FiatAuthenticationFilter(AuthenticationConverter authenticationConverter) {
     this.authenticationConverter = authenticationConverter;
   }
 
   @Override
   protected void doFilter(HttpServletRequest req, HttpServletResponse res, FilterChain chain)
       throws IOException, ServletException {
+    SecurityContext ctx = SecurityContextHolder.createEmptyContext();
+    Authentication auth = authenticationConverter.convert(req);
+    ctx.setAuthentication(auth);
+    SecurityContextHolder.setContext(ctx);
+    log.debug("Set SecurityContext to user: {}", auth.getPrincipal().toString());
 
-    if (fiatStatus.isEnabled()) {
-      SecurityContext ctx = SecurityContextHolder.createEmptyContext();
-      Authentication auth = authenticationConverter.convert(req);
-      ctx.setAuthentication(auth);
-      SecurityContextHolder.setContext(ctx);
-      log.debug("Set SecurityContext to user: {}", auth.getPrincipal().toString());
-    }
     chain.doFilter(req, res);
   }
 }

--- a/orca/orca-web/src/test/java/com/netflix/spinnaker/orca/OperationsControllerIT.java
+++ b/orca/orca-web/src/test/java/com/netflix/spinnaker/orca/OperationsControllerIT.java
@@ -105,8 +105,7 @@ class OperationsControllerIT {
     assertThat(execution.getStages()).hasSize(1);
     assertThat(execution.getStages().get(0).getType()).isEqualTo("wait");
     assertThat(execution.getTrigger().getType()).isEqualTo("manual");
-    assertThat(execution.getAuthentication().getUser())
-        .isEqualTo("anonymousUser"); // FIXME: this should be same as X-SPINNAKER-USER
+    assertThat(execution.getAuthentication().getUser()).isEqualTo("rahul-chekuri");
   }
 
   @TestConfiguration


### PR DESCRIPTION
This issues showed up in release 2025.3.0. 
Like we see in the below screenshot, we started seeing _(anonymousUser)_ beside user name in tasks and pipeline executions
![Screenshot from 2025-12-08 16-11-33](https://github.com/user-attachments/assets/047ad3f1-f487-4da9-a611-5e919edc9945)

### Changes:

-  test(orca/web): reproduce anonymous pipeline trigger user