### PR TITLE
chore(gradle): allocate 10g of heap space

### DIFF
--- a/clouddriver/gradle.properties
+++ b/clouddriver/gradle.properties
@@ -3,5 +3,5 @@ artifactTypes=bitbucket,custom,docker,embedded,front50,gcs,github,gitlab,gitrepo
 commonsCompressVersion=1.21
 
 targetJava17=true
-org.gradle.jvmargs=-Xmx8g -Xms8g
+org.gradle.jvmargs=-Xmx10g -Xms10g
 testJvmMaxMemory=6g


### PR DESCRIPTION
to avoid errors like
```
* What went wrong: Execution failed for task ':clouddriver:clouddriver-titus:compileGroovy'.
> java.lang.OutOfMemoryError: Java heap space
```
from https://github.com/spinnaker/spinnaker/actions/runs/20496243884/job/58896276990
