### PR TITLE
fix(OAuth2): Remove quotes as it is causing URI issues while redirecting

### DIFF
--- a/halyard/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/SpringConfig.java
+++ b/halyard/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/SpringConfig.java
@@ -85,8 +85,7 @@ class SpringConfig {
 
     if (oauth2.getClient().getPreEstablishedRedirectUri() != null
         && !oauth2.getClient().getPreEstablishedRedirectUri().isEmpty()) {
-      registration.put(
-          "redirect-uri", "\"" + oauth2.getClient().getPreEstablishedRedirectUri() + "\"");
+      registration.put("redirect-uri", oauth2.getClient().getPreEstablishedRedirectUri());
     }
     prvdr.put("token-uri", oauth2.getClient().getAccessTokenUri());
     prvdr.put("authorization-uri", oauth2.getClient().getUserAuthorizationUri());

--- a/halyard/halyard-deploy/src/test/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/GateSpringSecurity5OAuth2ProfileFactoryTest.java
+++ b/halyard/halyard-deploy/src/test/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/GateSpringSecurity5OAuth2ProfileFactoryTest.java
@@ -127,7 +127,7 @@ class GateSpringSecurity5OAuth2ProfileFactoryTest {
             .getGoogle()
             .get("redirect-uri"));
     assertEquals(
-        "\"https://my-real-gate-address.com:8084/login\"",
+        "https://my-real-gate-address.com:8084/login",
         config
             .getSpring()
             .getSecurity()


### PR DESCRIPTION
Quotes around the `redirect-uri ` were causing authentication failures because the value did not exactly match the redirect URI configured on the IdP side. These quotes have been removed to ensure proper matching and successful authentication.

For more details, please refer to the background issue below:
https://github.com/spinnaker/spinnaker/issues/7377

https://github.com/spinnaker/spinnaker/pull/7052 introduced the bug, first released in version [2025.2.0](https://spinnaker.io/changelogs/2025.2.0-changelog/).