### PR TITLE
fix(build): produce production build of Deck

### DIFF
--- a/deck/build.gradle
+++ b/deck/build.gradle
@@ -28,6 +28,9 @@ task modules(type: YarnTask) {
   dependsOn "yarn"
 
   yarnCommand = ["modules"]
+  environment = [
+    "NODE_ENV": "production",
+  ]
 }
 
 task eslintPluginCompile(type: YarnTask) {


### PR DESCRIPTION
`NODE_ENV` is set to `production` for the `webpack` build but not for the `rollup` builds triggered by running `yarn modules`. This results in a partial development React build.

Set `NODE_ENV` when running `yarn modules` too so we get a full production build.

**Before**
<img width="473" height="199" alt="image" src="https://github.com/user-attachments/assets/b72fb91e-7db5-42b1-a317-09a3b4c48831" />

**After**
<img width="481" height="119" alt="image" src="https://github.com/user-attachments/assets/7e429000-93a8-45f6-adda-9544de477bd8" />
