### PR TITLE
feat(webhooks): allow waitBeforeMonitor and retryStatusCodes fields in preconfigured webhooks

### DIFF
--- a/orca/orca-web/src/test/groovy/com/netflix/spinnaker/orca/controllers/OperationsControllerSpec.groovy
+++ b/orca/orca-web/src/test/groovy/com/netflix/spinnaker/orca/controllers/OperationsControllerSpec.groovy
@@ -618,7 +618,7 @@ class OperationsControllerSpec extends Specification {
     given:
     def preconfiguredProperties = ["url", "customHeaders", "method", "payload", "failFastStatusCodes", "waitForCompletion", "statusUrlResolution",
                                    "statusUrlJsonPath", "statusJsonPath", "progressJsonPath", "successStatuses", "canceledStatuses", "terminalStatuses",
-                                   "signalCancellation", "cancelEndpoint", "cancelMethod", "cancelPayload"]
+                                   "signalCancellation", "cancelEndpoint", "cancelMethod", "cancelPayload", "waitBeforeMonitor", "retryStatusCodes"]
 
     when:
     def preconfiguredWebhooks = controller.preconfiguredWebhooks()
@@ -638,7 +638,7 @@ class OperationsControllerSpec extends Specification {
     given:
     def preconfiguredProperties = ["url", "customHeaders", "method", "payload", "failFastStatusCodes", "waitForCompletion", "statusUrlResolution",
                                    "statusUrlJsonPath", "statusJsonPath", "progressJsonPath", "successStatuses", "canceledStatuses", "terminalStatuses",
-                                   "signalCancellation", "cancelEndpoint", "cancelMethod", "cancelPayload"]
+                                   "signalCancellation", "cancelEndpoint", "cancelMethod", "cancelPayload", "waitBeforeMonitor", "retryStatusCodes"]
     executionLauncher.start(*_) >> { ExecutionType type, Map config ->
       mapper.convertValue(config, PipelineExecutionImpl)
     }
@@ -670,7 +670,7 @@ class OperationsControllerSpec extends Specification {
     given:
     def preconfiguredProperties = ["url", "customHeaders", "method", "payload", "failFastStatusCodes", "waitForCompletion", "statusUrlResolution",
                                    "statusUrlJsonPath", "statusJsonPath", "progressJsonPath", "successStatuses", "canceledStatuses", "terminalStatuses",
-                                   "signalCancellation", "cancelEndpoint", "cancelMethod", "cancelPayload"]
+                                   "signalCancellation", "cancelEndpoint", "cancelMethod", "cancelPayload", "waitBeforeMonitor", "retryStatusCodes"]
     executionLauncher.start(*_) >> { ExecutionType type, Map config ->
       mapper.convertValue(config, PipelineExecutionImpl)
     }
@@ -772,7 +772,7 @@ class OperationsControllerSpec extends Specification {
       url: "a", customHeaders: customHeaders, method: HttpMethod.POST, payload: "b",
       failFastStatusCodes: [500, 501], waitForCompletion: true, statusUrlResolution: WebhookProperties.StatusUrlResolution.webhookResponse,
       statusUrlJsonPath: "c", statusJsonPath: "d", progressJsonPath: "e", successStatuses: "f", canceledStatuses: "g", terminalStatuses: "h", parameters: null, parameterData: null,
-      permissions: permissions, signalCancellation: true, cancelEndpoint: "i", cancelMethod: HttpMethod.POST, cancelPayload: "j"
+      permissions: permissions, signalCancellation: true, cancelEndpoint: "i", cancelMethod: HttpMethod.POST, cancelPayload: "j", waitBeforeMonitor: 5, retryStatusCodes: [404]
     )
   }
 }

--- a/orca/orca-webhook/src/main/java/com/netflix/spinnaker/orca/webhook/config/WebhookProperties.java
+++ b/orca/orca-webhook/src/main/java/com/netflix/spinnaker/orca/webhook/config/WebhookProperties.java
@@ -214,6 +214,8 @@ public class WebhookProperties {
     public String cancelEndpoint;
     public HttpMethod cancelMethod;
     public String cancelPayload;
+    public Integer waitBeforeMonitor;
+    public List<Integer> retryStatusCodes;
 
     public List<String> getPreconfiguredProperties() {
       return ALL_FIELDS.stream()

--- a/orca/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/config/PreconfiguredWebhookSpec.groovy
+++ b/orca/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/config/PreconfiguredWebhookSpec.groovy
@@ -36,7 +36,7 @@ class PreconfiguredWebhookSpec extends Specification {
     then:
     fields == ["url", "customHeaders", "method", "payload", "failFastStatusCodes", "waitForCompletion", "statusUrlResolution", "statusUrlJsonPath",
       "statusJsonPath", "progressJsonPath", "successStatuses", "canceledStatuses", "terminalStatuses",
-      "signalCancellation", "cancelEndpoint", "cancelMethod", "cancelPayload"]
+      "signalCancellation", "cancelEndpoint", "cancelMethod", "cancelPayload", "waitBeforeMonitor", "retryStatusCodes"]
   }
 
   def "getPreconfiguredFields should return empty list if no stage configuration fields are populated"() {
@@ -86,7 +86,8 @@ class PreconfiguredWebhookSpec extends Specification {
       failFastStatusCodes: [500, 501], waitForCompletion: true, statusUrlResolution: webhookResponse,
       statusUrlJsonPath: "statusUrlJsonPath", statusJsonPath: "statusJsonPath", progressJsonPath: "progressJsonPath",
       successStatuses: "successStatuses", canceledStatuses: "canceledStatuses", terminalStatuses: "terminalStatuses",
-      signalCancellation: true, cancelEndpoint: "cancelEndpoint", cancelMethod: HttpMethod.POST, cancelPayload: "cancelPayload"
+      signalCancellation: true, cancelEndpoint: "cancelEndpoint", cancelMethod: HttpMethod.POST, cancelPayload: "cancelPayload",
+      waitBeforeMonitor: 5, retryStatusCodes: [404]
     )
   }
 }

--- a/orca/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/pipeline/PreconfiguredWebhookStageSpec.groovy
+++ b/orca/orca-webhook/src/test/groovy/com/netflix/spinnaker/orca/webhook/pipeline/PreconfiguredWebhookStageSpec.groovy
@@ -68,7 +68,10 @@ class PreconfiguredWebhookStageSpec extends Specification {
       signalCancellation: true,
       cancelEndpoint: "i",
       cancelMethod: HttpMethod.POST,
-      cancelPayload: "j"
+      cancelPayload: "j",
+      retryStatusCodes: [404],
+      waitBeforeMonitor: 5,
+      waitTime: 5
     ]
   }
 
@@ -93,7 +96,9 @@ class PreconfiguredWebhookStageSpec extends Specification {
       signalCancellation: true,
       cancelEndpoint: "i",
       cancelMethod: HttpMethod.POST,
-      cancelPayload: "j"
+      cancelPayload: "j",
+      retryStatusCodes: null,
+      waitBeforeMonitor: null
     ])
 
     when:
@@ -121,7 +126,9 @@ class PreconfiguredWebhookStageSpec extends Specification {
       signalCancellation: true,
       cancelEndpoint: "i",
       cancelMethod: HttpMethod.POST,
-      cancelPayload: "j"
+      cancelPayload: "j",
+      retryStatusCodes: null,
+      waitBeforeMonitor: null
     ]
   }
 
@@ -132,7 +139,7 @@ class PreconfiguredWebhookStageSpec extends Specification {
       label: label, description: description, type: type, url: "a", customHeaders: customHeaders, method: HttpMethod.POST, payload: "b",
       failFastStatusCodes: [500, 501], waitForCompletion: true, statusUrlResolution: WebhookProperties.StatusUrlResolution.locationHeader,
       statusUrlJsonPath: "c", statusJsonPath: "d", progressJsonPath: "e", successStatuses: "f", canceledStatuses: "g", terminalStatuses: "h",
-      signalCancellation: true, cancelEndpoint: "i", cancelMethod: HttpMethod.POST, cancelPayload: "j"
+      signalCancellation: true, cancelEndpoint: "i", cancelMethod: HttpMethod.POST, cancelPayload: "j", retryStatusCodes: [404], waitBeforeMonitor: 5
     )
   }
 }


### PR DESCRIPTION
Hi,

A small PR to add waitBeforeMonitor and retryStatusCodes fields in preconfigured webhooks. We use these are they weren't allowed.

Thanks!