### PR TITLE
fix(build): actually publish compiled deck-kayenta code

### DIFF
--- a/deck-kayenta/package.json
+++ b/deck-kayenta/package.json
@@ -8,6 +8,9 @@
   },
   "module": "build/dist/index.js",
   "typings": "build/dist/index.d.ts",
+  "files": [
+    "build/dist"
+  ],
   "engines": {
     "node": ">=20.19.4",
     "npm": ">=10.8.2",


### PR DESCRIPTION
Upgrading to Node 20 also upgraded npm, which included a breaking change in how the contents of published packages are determined. `@spinnaker/kayenta` published from `2025.1.0` onwards has not included the `build/dist` directory, meaning imports break.

We hadn't noticed this because in open source there's no write-back mechanism to update `@spinnaker/kayenta` in Deck when a change is merged, so Deck is still using `2.3.0` (a pre-monorepo version). However, internally we do have that mechanism and `2025.1` broke our Deck build 📦 

You can see the difference using `npmfs` - [`2.3.0`](https://npmfs.com/package/@spinnaker/kayenta/2.3.0/), [`2025.0.8`](https://npmfs.com/package/@spinnaker/kayenta/2025.0.8/), [`2025.1.0`](https://npmfs.com/package/@spinnaker/kayenta/2025.1.0/). Notice `build` is not present in the last version.

We do need to add a mechanism to update `deck` when `deck-kayenta` is changed but I'm leaving that for another day.