### PR TITLE
fix(spin-cli): update spin-cli to handle new oauth2 endpoint

### DIFF
--- a/spin/config/auth/oauth2/config.go
+++ b/spin/config/auth/oauth2/config.go
@@ -26,6 +26,7 @@ type Config struct {
 	ClientId     string        `json:"clientId" yaml:"clientId"`
 	ClientSecret string        `json:"clientSecret" yaml:"clientSecret"`
 	Scopes       []string      `json:"scopes" yaml:"scopes"`
+	Provider     string        `json:"provider" yaml:"provider"`
 	CachedToken  *oauth2.Token `json:"cachedToken,omitempty" yaml:"cachedToken,omitempty"`
 }
 


### PR DESCRIPTION
The changes to OAuth in `2025.2` broke `spin-cli` authentication, because it hardcodes `/login` at the end of the Gate endpoint. Add a new config flag for provider, to construct a correct URL if provided.