### PR TITLE
fix(build): Call Deck/Deck Kayenta workflows via API to work around NPM Trusted Publishing validation

### DIFF
--- a/.github/workflows/spinnaker-release.yml
+++ b/.github/workflows/spinnaker-release.yml
@@ -94,17 +94,41 @@ jobs:
       version-override: ${{ needs.version.outputs.version }}
   deck:
     needs: version
-    uses: ./.github/workflows/deck.yml
-    secrets: inherit
-    with:
-      publish-debs: true
-      version-override: ${{ needs.version.outputs.version }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Deck Release
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.SPINNAKERBOT_PERSONAL_ACCESS_TOKEN }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'deck.yml',
+              ref: '${{ github.ref_name }}',
+              inputs: {
+                'publish-debs': true,
+                'version-override': '${{ needs.version.outputs.version }}'
+              }
+            });
   deck-kayenta:
     needs: version
-    uses: ./.github/workflows/deck-kayenta.yml
-    secrets: inherit
-    with:
-      version-override: ${{ needs.version.outputs.version }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Deck Kayenta Release
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.SPINNAKERBOT_PERSONAL_ACCESS_TOKEN }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'deck-kayenta.yml',
+              ref: '${{ github.ref_name }}',
+              inputs: {
+                'version-override': '${{ needs.version.outputs.version }}'
+              }
+            });
   echo:
     needs: version
     uses: ./.github/workflows/echo.yml


### PR DESCRIPTION
NPM Trusted Publishing is incompatible with composite/reusable workflows, as the callee workflow identifies as the caller.

Example set of OIDC token claims from a test workflow called by a parent workflow (note the difference between the `workflow_ref` and `job_workflow_ref` keys:

```
{
  "actor": "jcavanagh",
  "actor_id": "784689",
  "aud": "npm:registry.npmjs.org",
  "base_ref": "",
  "check_run_id": "62445116680",
  "event_name": "workflow_dispatch",
  "exp": 1770186035,
  "head_ref": "",
  "iat": 1770185735,
  "iss": "https://token.actions.githubusercontent.com/",
  "job_workflow_ref": "jcavanagh/spinnaker-monorepo-public/.github/workflows/id-token-callee.yml@refs/heads/main",
  "job_workflow_sha": "4cca28382b580ebc8f20e3a68a9c8b6221666f16",
  "jti": "86a1e622-556b-46f9-8c50-48791700cd50",
  "nbf": 1770185435,
  "ref": "refs/heads/main",
  "ref_protected": "false",
  "ref_type": "branch",
  "repository": "jcavanagh/spinnaker-monorepo-public",
  "repository_id": "557469356",
  "repository_owner": "jcavanagh",
  "repository_owner_id": "784689",
  "repository_visibility": "private",
  "run_attempt": "1",
  "run_id": "21660812912",
  "run_number": "12",
  "runner_environment": "github-hosted",
  "sha": "4cca28382b580ebc8f20e3a68a9c8b6221666f16",
  "sub": "repo:jcavanagh/spinnaker-monorepo-public:ref:refs/heads/main",
  "workflow": "ID Token Caller",
  "workflow_ref": "jcavanagh/spinnaker-monorepo-public/.github/workflows/id-token-caller.yml@refs/heads/main",
  "workflow_sha": "4cca28382b580ebc8f20e3a68a9c8b6221666f16"
}
```

When called via `workflow_dispatch` via the API, the workflow will identify as itself:

```
{
  "actor": "jcavanagh",
  "actor_id": "784689",
  "aud": "npm:registry.npmjs.org",
  "base_ref": "",
  "check_run_id": "62445328533",
  "event_name": "workflow_dispatch",
  "exp": 1770186210,
  "head_ref": "",
  "iat": 1770185910,
  "iss": "https://token.actions.githubusercontent.com/",
  "job_workflow_ref": "jcavanagh/spinnaker-monorepo-public/.github/workflows/id-token-callee.yml@refs/heads/main",
  "job_workflow_sha": "d064f8b1b8341623a024684f37cd2f6aa191e6f7",
  "jti": "aeebd645-c1df-4cc3-8594-f567f2a2328a",
  "nbf": 1770185610,
  "ref": "refs/heads/main",
  "ref_protected": "false",
  "ref_type": "branch",
  "repository": "jcavanagh/spinnaker-monorepo-public",
  "repository_id": "557469356",
  "repository_owner": "jcavanagh",
  "repository_owner_id": "784689",
  "repository_visibility": "private",
  "run_attempt": "1",
  "run_id": "21660886789",
  "run_number": "4",
  "runner_environment": "github-hosted",
  "sha": "d064f8b1b8341623a024684f37cd2f6aa191e6f7",
  "sub": "repo:jcavanagh/spinnaker-monorepo-public:ref:refs/heads/main",
  "workflow": "ID Token Callee",
  "workflow_ref": "jcavanagh/spinnaker-monorepo-public/.github/workflows/id-token-callee.yml@refs/heads/main",
  "workflow_sha": "d064f8b1b8341623a024684f37cd2f6aa191e6f7"
}
```