### PR TITLE
fix(kayentadeck): Fix NPM publishing to NOT tag by latest. 

### DIFF
--- a/.github/actions/publish-npm/action.yml
+++ b/.github/actions/publish-npm/action.yml
@@ -58,4 +58,7 @@ runs:
         NODE_ENV: production
       shell: bash
       working-directory: ${{ inputs.project }}
-      run: npm publish
+      ## We have to do this... since otherwise "latest" tag is applied, and backports
+      ## then fail because they'll be on older versions... and you can't tag an older
+      ## semver version as "latest".  NPM rejects it.
+      run: npm publish --tag ${{ inputs.version }}


### PR DESCRIPTION
This prevents us from hitting an issue where backports fail to publish due to being older versions.  Specifically the NPM publishing by default if tags are NOT set uses a "latest' tag on every publish.  The result is that when you publish an older release, which shows up as a lower revision, NPM rejects that tag since it's older breaking publishing.  This is a VERY simple "just use the version" vs. "latest" approach.  IF we want a more advanced option, can consider it - I just went simple on this one.