### PR TITLE
fix(publishing): Tags cant be semver so prefix with release

### DIFF
--- a/.github/actions/publish-npm/action.yml
+++ b/.github/actions/publish-npm/action.yml
@@ -61,4 +61,4 @@ runs:
       ## We have to do this... since otherwise "latest" tag is applied, and backports
       ## then fail because they'll be on older versions... and you can't tag an older
       ## semver version as "latest".  NPM rejects it.
-      run: npm publish --tag ${{ inputs.version }}
+      run: npm publish --tag release-${{ inputs.version }}


### PR DESCRIPTION
NPM publishing on tags doesn't like a "semver" tag.  OK so we don't use semver, but the semver with a label in front... silly NPM