### PR TITLE
fix(clouddriver): update kubectl download URL in Debian Packages, Docker image, KubernetesCluster.java

### DIFF
--- a/clouddriver/Dockerfile.slim
+++ b/clouddriver/Dockerfile.slim
@@ -40,7 +40,7 @@ RUN [ $TARGETARCH == 'amd64' ] &&  export GCP_ARCH="x86_64" || export GCP_ARCH="
 # kubectl + AWS IAM authenticator
 RUN for version in $KUBECTL_RELEASES; do \
       release_version=$(echo ${version} | cut -d. -f1,2); \
-      wget -nv https://cdn.dl.k8s.io/release/v${version}/bin/linux/${TARGETARCH}/kubectl -O /usr/local/bin/kubectl-${release_version}; \
+      wget -nv https://dl.k8s.io/release/v${version}/bin/linux/${TARGETARCH}/kubectl -O /usr/local/bin/kubectl-${release_version}; \
       chmod +x /usr/local/bin/kubectl-${release_version}; \
       done \
   && ln -sf "/usr/local/bin/kubectl-$(echo ${KUBECTL_DEFAULT_RELEASE} | cut -d. -f1,2)" /usr/local/bin/kubectl \

--- a/clouddriver/Dockerfile.ubuntu
+++ b/clouddriver/Dockerfile.ubuntu
@@ -37,7 +37,7 @@ RUN if [ "${TARGETARCH}" = "arm64" ]; then \
 # kubectl + AWS IAM authenticator
 RUN for version in $KUBECTL_RELEASES; do \
       release_version=$(echo ${version} | cut -d. -f1,2); \
-      wget -nv https://cdn.dl.k8s.io/release/v${version}/bin/linux/${TARGETARCH}/kubectl -O /usr/local/bin/kubectl-${release_version}; \
+      wget -nv https://dl.k8s.io/release/v${version}/bin/linux/${TARGETARCH}/kubectl -O /usr/local/bin/kubectl-${release_version}; \
       chmod +x /usr/local/bin/kubectl-${release_version}; \
       done \
   && ln -sf "/usr/local/bin/kubectl-$(echo ${KUBECTL_DEFAULT_RELEASE} | cut -d. -f1,2)" /usr/local/bin/kubectl \

--- a/clouddriver/clouddriver-kubernetes/src/integration/java/com/netflix/spinnaker/clouddriver/kubernetes/it/containers/KubernetesCluster.java
+++ b/clouddriver/clouddriver-kubernetes/src/integration/java/com/netflix/spinnaker/clouddriver/kubernetes/it/containers/KubernetesCluster.java
@@ -165,7 +165,7 @@ public class KubernetesCluster {
     if (!kubectl.toFile().exists()) {
       String url =
           String.format(
-              "https://cdn.dl.k8s.io/release/v%s/bin/%s/%s/kubectl", KUBECTL_VERSION, os, arch);
+              "https://dl.k8s.io/release/v%s/bin/%s/%s/kubectl", KUBECTL_VERSION, os, arch);
       System.out.println("Downloading kubectl from " + url);
       downloadFile(kubectl, url);
     }

--- a/clouddriver/clouddriver-web/pkg_scripts/postInstall.sh
+++ b/clouddriver/clouddriver-web/pkg_scripts/postInstall.sh
@@ -21,7 +21,7 @@ install_kubectl() {
   if [ -z "$(which kubectl)" ]; then
     for version in $KUBECTL_RELEASES; do
       release_version=$(echo "${version}" | cut -d. -f1,2); \
-      wget -nv "https://cdn.dl.k8s.io/release/v${version}/bin/linux/amd64/kubectl" -O "/usr/local/bin/kubectl-${release_version}";
+      wget -nv "https://dl.k8s.io/release/v${version}/bin/linux/amd64/kubectl" -O "/usr/local/bin/kubectl-${release_version}";
       chmod +x "/usr/local/bin/kubectl-${release_version}";
     done
     ln -sf "/usr/local/bin/kubectl-$(echo ${KUBECTL_DEFAULT_RELEASE} | cut -d. -f1,2)" /usr/local/bin/kubectl


### PR DESCRIPTION
Resolves the following issue with an incorrect hostname when installing Clouddriver Debian packages:

```
Unpacking spinnaker-clouddriver (2025.4.1) over (2025.2.3) ...
Setting up spinnaker-clouddriver (2025.4.1) ...
wget: unable to resolve host address 'cdn.dl.k8s.io'
dpkg: error processing package spinnaker-clouddriver (--configure):
 installed spinnaker-clouddriver package post-installation script subprocess returned error exit status 4
Errors were encountered while processing:
 spinnaker-clouddriver
needrestart is being skipped since dpkg has failed
E: Sub-process /usr/bin/dpkg returned an error code (1)
! ERROR Error encountered running script. See above output for more
  details.
  ```
  
  **Also fixes:**
  - Slim Docker image
  - Ubuntu Docker image
  - URL in KubernetesCluster.java

This includes the fix from https://github.com/spinnaker/spinnaker/pull/7469 which only fixes the Slim Docker image, and not all other places where the URL is also incorrect.