### PR TITLE
fix(release): Fix release publishing notes to spinnaker.io

### DIFF
--- a/.github/workflows/spinnaker-release-bom.yml
+++ b/.github/workflows/spinnaker-release-bom.yml
@@ -112,6 +112,10 @@ jobs:
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            spinnaker.io
+            spinnaker
 
       - name: Create Spinnaker release BoM and changelog
         id: spinnaker-release-bom


### PR DESCRIPTION
https://github.com/marketplace/actions/create-github-app-token#repositories per this - it was scoped JUST to spinnaker repo preventing PR to spinnaker.io repo.  This should address this.