### PR TITLE
fix(builds): Fix spinnaker.io publishing when using a GitHub App token

### DIFF
--- a/.github/workflows/spinnaker-release-bom.yml
+++ b/.github/workflows/spinnaker-release-bom.yml
@@ -121,7 +121,8 @@ jobs:
         id: spinnaker-release-bom
         uses: ./.github/actions/spinnaker-release
         with:
-          github-pat: ${{ steps.app-token.outputs.token }}
+          ## https://github.com/octokit/auth-token.js/?tab=readme-ov-file#use-token-for-git-operations Since using a GHA, must prefix with x-access-token apparently.
+          github-pat:  x-access-token:${{ steps.app-token.outputs.token }}
           credentials-json: ${{ secrets.GAR_JSON_KEY }}
           version: ${{ inputs.spinnaker-version }}
           previous-version: ${{ inputs.spinnaker-previous-version }}


### PR DESCRIPTION
Per https://github.com/octokit/auth-token.js/?tab=readme-ov-file#use-token-for-git-operations... should prefix GH App tokens with x-access-token .. 