### PR TITLE
perf(gate/header): skip login of service account users when using header authentication

### DIFF
--- a/gate/gate-core/src/main/java/com/netflix/spinnaker/gate/model/front50/ServiceAccountPojo.java
+++ b/gate/gate-core/src/main/java/com/netflix/spinnaker/gate/model/front50/ServiceAccountPojo.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026 Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.model.front50;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * A simple POJO representing a service account with just the name field. This is a subset of
+ * front50's ServiceAccount class (which implements Timestamped) and is used to deserialize
+ * responses from front50's /serviceAccounts endpoint when only the name is needed.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ServiceAccountPojo {
+  private String name;
+}

--- a/gate/gate-core/src/main/java/com/netflix/spinnaker/gate/services/internal/Front50Service.java
+++ b/gate/gate-core/src/main/java/com/netflix/spinnaker/gate/services/internal/Front50Service.java
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.gate.services.internal;
 
 import com.netflix.spinnaker.fiat.model.resources.ServiceAccount;
+import com.netflix.spinnaker.gate.model.front50.ServiceAccountPojo;
 import com.netflix.spinnaker.kork.plugins.SpinnakerPluginDescriptor;
 import java.util.List;
 import java.util.Map;
@@ -149,6 +150,9 @@ public interface Front50Service {
 
   @GET("serviceAccounts")
   Call<List<ServiceAccount>> getServiceAccounts();
+
+  @GET("serviceAccounts")
+  List<ServiceAccountPojo> getServiceAccountsPojo();
 
   @GET("deliveries")
   Call<List<Map>> getDeliveries();

--- a/gate/gate-header/gate-header.gradle
+++ b/gate/gate-header/gate-header.gradle
@@ -2,4 +2,7 @@ dependencies {
   implementation project(":gate-core")
   implementation "io.spinnaker.kork:kork-core"
   implementation "io.spinnaker.kork:kork-security" // for deprecated User class
+  implementation "io.spinnaker.kork:kork-retrofit"
+  implementation "io.spinnaker.kork:kork-annotations"
+  implementation "com.github.ben-manes.caffeine:caffeine"
 }

--- a/gate/gate-header/src/main/java/com/netflix/spinnaker/gate/security/header/HeaderAuthConfig.java
+++ b/gate/gate-header/src/main/java/com/netflix/spinnaker/gate/security/header/HeaderAuthConfig.java
@@ -18,8 +18,10 @@ package com.netflix.spinnaker.gate.security.header;
 
 import com.netflix.spinnaker.gate.security.AllowedAccountsSupport;
 import com.netflix.spinnaker.gate.services.PermissionService;
+import com.netflix.spinnaker.gate.services.internal.Front50Service;
 import com.netflix.spinnaker.kork.common.Header;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -36,6 +38,7 @@ import org.springframework.security.web.context.HttpSessionSecurityContextReposi
  */
 @ConditionalOnProperty("header.enabled")
 @Configuration
+@EnableConfigurationProperties(HeaderAuthProperties.class)
 public class HeaderAuthConfig {
 
   @Bean
@@ -100,7 +103,10 @@ public class HeaderAuthConfig {
 
   @Bean
   public AuthenticationProvider authenticationProvider(
-      PermissionService permissionService, AllowedAccountsSupport allowedAccountsSupport) {
+      PermissionService permissionService,
+      AllowedAccountsSupport allowedAccountsSupport,
+      Front50Service front50Service,
+      HeaderAuthProperties headerAuthProperties) {
     // PreAuthenticatedAuthenticationProvider provides tokens of type
     // PreAuthenticatedAuthenticationToken.  Because our
     // RequestHeaderAuthenticationFilter sets an authenticationDetailsSource to
@@ -126,7 +132,8 @@ public class HeaderAuthConfig {
     // To try to rock the boat as little as possible, generate kork-security
     // User objects via gate's own user details service
     provider.setPreAuthenticatedUserDetailsService(
-        new HeaderAuthenticationUserDetailsService(permissionService, allowedAccountsSupport));
+        new HeaderAuthenticationUserDetailsService(
+            permissionService, allowedAccountsSupport, front50Service, headerAuthProperties));
     return provider;
   }
 

--- a/gate/gate-header/src/main/java/com/netflix/spinnaker/gate/security/header/HeaderAuthProperties.java
+++ b/gate/gate-header/src/main/java/com/netflix/spinnaker/gate/security/header/HeaderAuthProperties.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2026 Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.security.header;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("header")
+@Data
+public class HeaderAuthProperties {
+  private long serviceAccountCacheTimeoutMinutes = 60;
+}

--- a/gate/gate-header/src/main/java/com/netflix/spinnaker/gate/security/header/HeaderAuthenticationUserDetailsService.java
+++ b/gate/gate-header/src/main/java/com/netflix/spinnaker/gate/security/header/HeaderAuthenticationUserDetailsService.java
@@ -16,13 +16,23 @@
 
 package com.netflix.spinnaker.gate.security.header;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.netflix.spinnaker.gate.model.front50.ServiceAccountPojo;
 import com.netflix.spinnaker.gate.security.AllowedAccountsSupport;
 import com.netflix.spinnaker.gate.services.PermissionService;
+import com.netflix.spinnaker.gate.services.internal.Front50Service;
+import com.netflix.spinnaker.kork.annotations.VisibleForTesting;
 import com.netflix.spinnaker.kork.core.RetrySupport;
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerServerException;
 import com.netflix.spinnaker.security.User;
 import java.time.Duration;
 import java.util.Collection;
+import java.util.List;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -38,17 +48,34 @@ import org.springframework.security.web.authentication.preauth.PreAuthenticatedG
 public class HeaderAuthenticationUserDetailsService
     extends PreAuthenticatedGrantedAuthoritiesUserDetailsService {
 
+  private static final Logger log =
+      LoggerFactory.getLogger(HeaderAuthenticationUserDetailsService.class);
+  private static final String SERVICE_ACCOUNTS_CACHE_KEY = "serviceAccounts";
+
   private final PermissionService permissionService;
 
   private final AllowedAccountsSupport allowedAccountsSupport;
 
+  private final Front50Service front50Service;
+
+  private final Cache<String, List<ServiceAccountPojo>> serviceAccountCache;
+
   private final RetrySupport retrySupport = new RetrySupport();
 
   public HeaderAuthenticationUserDetailsService(
-      PermissionService permissionService, AllowedAccountsSupport allowedAccountsSupport) {
+      PermissionService permissionService,
+      AllowedAccountsSupport allowedAccountsSupport,
+      Front50Service front50Service,
+      HeaderAuthProperties headerAuthProperties) {
     super();
     this.permissionService = permissionService;
     this.allowedAccountsSupport = allowedAccountsSupport;
+    this.front50Service = front50Service;
+    this.serviceAccountCache =
+        Caffeine.newBuilder()
+            .expireAfterWrite(
+                headerAuthProperties.getServiceAccountCacheTimeoutMinutes(), TimeUnit.MINUTES)
+            .build();
   }
 
   /**
@@ -68,27 +95,32 @@ public class HeaderAuthenticationUserDetailsService
   protected UserDetails createUserDetails(
       Authentication token, Collection<? extends GrantedAuthority> authorities) {
 
-    // Log the user in.  This invalidates the cache in gate, and logs the user
-    // in to fiat.  What this actually means is:
-    // - load roles for this user from fiat's provider
-    // - persist the permissions for this user
-    //
-    // This way, subsequent calls to fiat to retrieve permissions for the user
-    // are guaranteed to get them.  Without this, there are potentially races
-    // with role syncing in fiat.
-    retrySupport.retry(
-        () -> {
-          permissionService.login(token.getName());
-          return null;
-        },
-        5,
-        Duration.ofMillis(2000),
-        false);
+    String email = token.getName();
+
+    // Service accounts are already logged in, skip permissionService.login()
+    if (!isServiceAccount(email)) {
+      // Log the user in.  This invalidates the cache in gate, and logs the user
+      // in to fiat.  What this actually means is:
+      // - load roles for this user from fiat's provider
+      // - persist the permissions for this user
+      //
+      // This way, subsequent calls to fiat to retrieve permissions for the user
+      // are guaranteed to get them.  Without this, there are potentially races
+      // with role syncing in fiat.
+      retrySupport.retry(
+          () -> {
+            permissionService.login(email);
+            return null;
+          },
+          5,
+          Duration.ofMillis(2000),
+          false);
+    }
 
     User user = new User();
 
     // Part of UserDetails
-    user.setEmail(token.getName());
+    user.setEmail(email);
 
     // Neither firstName nor lastName are available in header auth (i.e. via
     // X-SPINNAKER-USER).
@@ -101,8 +133,40 @@ public class HeaderAuthenticationUserDetailsService
     // roles aren't available in header auth, so don't bother setting them, and
     // pass an empty collection to filterAllowedAccounts
     user.setAllowedAccounts(
-        allowedAccountsSupport.filterAllowedAccounts(token.getName(), Set.of() /* roles */));
+        allowedAccountsSupport.filterAllowedAccounts(email, Set.of() /* roles */));
 
     return user;
+  }
+
+  /**
+   * Determines if the given email belongs to a service account by checking against Front50's
+   * service accounts list. Uses a Caffeine cache to avoid repeated Front50 calls.
+   *
+   * @param email the user's email address
+   * @return true if the email matches a service account, false otherwise
+   */
+  @VisibleForTesting
+  boolean isServiceAccount(String email) {
+    if (email == null) {
+      return false;
+    }
+    try {
+      List<ServiceAccountPojo> serviceAccounts =
+          serviceAccountCache.get(
+              SERVICE_ACCOUNTS_CACHE_KEY, key -> front50Service.getServiceAccountsPojo());
+      // Caffeine's get() with a loading function should never return null - it will either return
+      // a value or throw an exception. This null check is defensive programming.
+      if (serviceAccounts == null) {
+        log.warn(
+            "Unexpected null result from service account cache - this should never happen. "
+                + "Returning false for email: {}",
+            email);
+        return false;
+      }
+      return serviceAccounts.stream().anyMatch(sa -> email.equalsIgnoreCase(sa.getName()));
+    } catch (SpinnakerServerException e) {
+      log.warn("Could not get list of service accounts.", e);
+      return false;
+    }
   }
 }

--- a/gate/gate-header/src/test/java/com/netflix/spinnaker/gate/security/header/HeaderAuthenticationUserDetailsServiceTest.java
+++ b/gate/gate-header/src/test/java/com/netflix/spinnaker/gate/security/header/HeaderAuthenticationUserDetailsServiceTest.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2026 Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.security.header;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import com.netflix.spinnaker.gate.model.front50.ServiceAccountPojo;
+import com.netflix.spinnaker.gate.security.AllowedAccountsSupport;
+import com.netflix.spinnaker.gate.services.PermissionService;
+import com.netflix.spinnaker.gate.services.internal.Front50Service;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
+
+class HeaderAuthenticationUserDetailsServiceTest {
+
+  private PermissionService permissionService = mock(PermissionService.class);
+  private AllowedAccountsSupport allowedAccountsSupport = mock(AllowedAccountsSupport.class);
+  private Front50Service front50Service = mock(Front50Service.class);
+  private HeaderAuthProperties headerAuthProperties = new HeaderAuthProperties();
+  private HeaderAuthenticationUserDetailsService userDetailsService =
+      new HeaderAuthenticationUserDetailsService(
+          permissionService, allowedAccountsSupport, front50Service, headerAuthProperties);
+
+  @BeforeEach
+  void setUp() {
+    when(allowedAccountsSupport.filterAllowedAccounts(anyString(), any()))
+        .thenReturn(Collections.emptySet());
+  }
+
+  @Test
+  void testServiceAccountDoesNotCallFiatLogin() {
+    String serviceAccountEmail = "pipegensvc@salesforce.com";
+    ServiceAccountPojo serviceAccount = new ServiceAccountPojo(serviceAccountEmail);
+    when(front50Service.getServiceAccountsPojo()).thenReturn(List.of(serviceAccount));
+
+    PreAuthenticatedAuthenticationToken token =
+        new PreAuthenticatedAuthenticationToken(serviceAccountEmail, null);
+
+    userDetailsService.createUserDetails(token, Collections.emptyList());
+
+    // Verify permissionService.login() is NOT called for service accounts
+    verify(permissionService, never()).login(anyString());
+  }
+
+  @Test
+  void testRegularUserCallsFiatLogin() {
+    String regularUserEmail = "regularuser@salesforce.com";
+    when(front50Service.getServiceAccountsPojo()).thenReturn(Collections.emptyList());
+
+    PreAuthenticatedAuthenticationToken token =
+        new PreAuthenticatedAuthenticationToken(regularUserEmail, null);
+
+    userDetailsService.createUserDetails(token, Collections.emptyList());
+
+    // Verify permissionService.login() IS called for regular users
+    verify(permissionService).login(regularUserEmail);
+  }
+
+  @Test
+  void testCachedServiceAccountLookup() {
+    // With caching, two calls to gate should result in one call to
+    // front50Service.getServiceAccountsPojo()
+
+    String serviceAccountEmail = "pipegensvc@salesforce.com";
+    ServiceAccountPojo serviceAccount = new ServiceAccountPojo(serviceAccountEmail);
+    when(front50Service.getServiceAccountsPojo()).thenReturn(List.of(serviceAccount));
+
+    PreAuthenticatedAuthenticationToken token1 =
+        new PreAuthenticatedAuthenticationToken(serviceAccountEmail, null);
+    PreAuthenticatedAuthenticationToken token2 =
+        new PreAuthenticatedAuthenticationToken(serviceAccountEmail, null);
+
+    // First call - cache miss
+    userDetailsService.createUserDetails(token1, Collections.emptyList());
+    verify(front50Service, times(1)).getServiceAccountsPojo();
+
+    // Second call - cache hit
+    userDetailsService.createUserDetails(token2, Collections.emptyList());
+
+    // Verify front50Service.getServiceAccountsPojo() was called only once total
+    verifyNoMoreInteractions(front50Service);
+  }
+
+  @Test
+  void testIsServiceAccountReturnsFalseForNullEmail() {
+    boolean result = userDetailsService.isServiceAccount(null);
+
+    assertThat(result).isFalse();
+    verify(front50Service, never()).getServiceAccountsPojo();
+  }
+
+  @Test
+  void testIsServiceAccountCaseInsensitive() {
+    String serviceAccountEmail = "PipeGenSvc@Salesforce.com";
+    ServiceAccountPojo serviceAccount = new ServiceAccountPojo("pipegensvc@salesforce.com");
+    when(front50Service.getServiceAccountsPojo()).thenReturn(List.of(serviceAccount));
+
+    boolean result = userDetailsService.isServiceAccount(serviceAccountEmail);
+
+    assertThat(result).isTrue();
+    verify(front50Service).getServiceAccountsPojo();
+  }
+
+  @Test
+  void testIsServiceAccountReturnsFalseWhenNotInList() {
+    String regularUserEmail = "regularuser@salesforce.com";
+    ServiceAccountPojo serviceAccount = new ServiceAccountPojo("pipegensvc@salesforce.com");
+    when(front50Service.getServiceAccountsPojo()).thenReturn(List.of(serviceAccount));
+
+    boolean result = userDetailsService.isServiceAccount(regularUserEmail);
+
+    assertThat(result).isFalse();
+    verify(front50Service).getServiceAccountsPojo();
+  }
+
+  @Test
+  void testIsServiceAccountHandlesEmptyServiceAccountList() {
+    when(front50Service.getServiceAccountsPojo()).thenReturn(Collections.emptyList());
+
+    boolean result = userDetailsService.isServiceAccount("test@salesforce.com");
+
+    assertThat(result).isFalse();
+    verify(front50Service).getServiceAccountsPojo();
+  }
+
+  @Test
+  void testIsServiceAccountWithMultipleServiceAccounts() {
+    String serviceAccountEmail = "pipegensvc@salesforce.com";
+    ServiceAccountPojo serviceAccount1 = new ServiceAccountPojo("otherservice@salesforce.com");
+    ServiceAccountPojo serviceAccount2 = new ServiceAccountPojo(serviceAccountEmail);
+    ServiceAccountPojo serviceAccount3 = new ServiceAccountPojo("anotherservice@salesforce.com");
+    when(front50Service.getServiceAccountsPojo())
+        .thenReturn(List.of(serviceAccount1, serviceAccount2, serviceAccount3));
+
+    boolean result = userDetailsService.isServiceAccount(serviceAccountEmail);
+
+    assertThat(result).isTrue();
+    verify(front50Service).getServiceAccountsPojo();
+  }
+
+  @Test
+  void testCreateUserDetailsReturnsUserWithEmail() {
+    String email = "user@salesforce.com";
+    when(front50Service.getServiceAccountsPojo()).thenReturn(Collections.emptyList());
+
+    PreAuthenticatedAuthenticationToken token =
+        new PreAuthenticatedAuthenticationToken(email, null);
+
+    org.springframework.security.core.userdetails.UserDetails result =
+        userDetailsService.createUserDetails(token, Collections.emptyList());
+
+    assertThat(result).isNotNull();
+    assertThat(result).isInstanceOf(com.netflix.spinnaker.security.User.class);
+    com.netflix.spinnaker.security.User user = (com.netflix.spinnaker.security.User) result;
+    assertThat(user.getEmail()).isEqualTo(email);
+  }
+
+  @Test
+  void testCreateUserDetailsCallsFilterAllowedAccounts() {
+    String email = "user@salesforce.com";
+    when(front50Service.getServiceAccountsPojo()).thenReturn(Collections.emptyList());
+
+    PreAuthenticatedAuthenticationToken token =
+        new PreAuthenticatedAuthenticationToken(email, null);
+
+    userDetailsService.createUserDetails(token, Collections.emptyList());
+
+    verify(allowedAccountsSupport).filterAllowedAccounts(email, Collections.emptySet());
+  }
+
+  @Test
+  void testCacheExpirationAfterTimeout() {
+    String serviceAccountEmail = "pipegensvc@salesforce.com";
+    ServiceAccountPojo serviceAccount = new ServiceAccountPojo(serviceAccountEmail);
+
+    // Use a very short cache timeout (0 minutes) for testing
+    headerAuthProperties.setServiceAccountCacheTimeoutMinutes(0);
+    HeaderAuthenticationUserDetailsService userDetailsServiceWithShortTimeout =
+        new HeaderAuthenticationUserDetailsService(
+            permissionService, allowedAccountsSupport, front50Service, headerAuthProperties);
+
+    when(front50Service.getServiceAccountsPojo()).thenReturn(List.of(serviceAccount));
+
+    PreAuthenticatedAuthenticationToken token1 =
+        new PreAuthenticatedAuthenticationToken(serviceAccountEmail, null);
+
+    // First call - cache miss
+    userDetailsServiceWithShortTimeout.createUserDetails(token1, Collections.emptyList());
+    verify(front50Service, times(1)).getServiceAccountsPojo();
+
+    PreAuthenticatedAuthenticationToken token2 =
+        new PreAuthenticatedAuthenticationToken(serviceAccountEmail, null);
+
+    // Second call - cache expired (using 0 timeout, so immediate expiration), should call Front50
+    // again
+    userDetailsServiceWithShortTimeout.createUserDetails(token2, Collections.emptyList());
+    verify(front50Service, times(2)).getServiceAccountsPojo();
+  }
+}

--- a/gate/gate-web/src/test/java/com/netflix/spinnaker/gate/HeaderAuthWiremockTest.java
+++ b/gate/gate-web/src/test/java/com/netflix/spinnaker/gate/HeaderAuthWiremockTest.java
@@ -107,13 +107,19 @@ public class HeaderAuthWiremockTest {
   static WireMockExtension wmFiat =
       WireMockExtension.newInstance().options(wireMockConfig().dynamicPort()).build();
 
+  @RegisterExtension
+  static WireMockExtension wmFront50 =
+      WireMockExtension.newInstance().options(wireMockConfig().dynamicPort()).build();
+
   @Autowired FiatPermissionEvaluator fiatPermissionEvaluator;
 
   @DynamicPropertySource
   static void registerUrls(DynamicPropertyRegistry registry) {
     // Configure wiremock's random ports into gate
     System.out.println("wiremock fiat url: " + wmFiat.baseUrl());
+    System.out.println("wiremock front50 url: " + wmFront50.baseUrl());
     registry.add("services.fiat.base-url", wmFiat::baseUrl);
+    registry.add("services.front50.base-url", wmFront50::baseUrl);
   }
 
   @BeforeEach
@@ -205,5 +211,55 @@ public class HeaderAuthWiremockTest {
         .containsExactly(TEST_REQUEST_ID);
 
     return response.body();
+  }
+
+  @Test
+  void testHeaderAuthHandlesFront50Exception() throws Exception {
+    // Test that when Front50 returns an error for /serviceAccounts, header auth
+    // handles it gracefully and still allows the user to authenticate
+    String serviceAccountEmail = "pipegensvc@salesforce.com";
+    URI uri = new URI("http://localhost:" + port + "/auth/rawUser");
+
+    HttpRequest request =
+        HttpRequest.newBuilder(uri)
+            .GET()
+            .header(USER.getHeader(), serviceAccountEmail)
+            .header(REQUEST_ID.getHeader(), TEST_REQUEST_ID)
+            .build();
+
+    // Configure Front50 to return a 500 error for /serviceAccounts
+    wmFront50.stubFor(
+        WireMock.get(urlPathEqualTo("/serviceAccounts"))
+            .willReturn(aResponse().withStatus(HttpStatus.INTERNAL_SERVER_ERROR.value())));
+
+    // Configure Fiat for the login call (which should still happen even if Front50 fails)
+    String encodedUserId = URLEncoder.encode(serviceAccountEmail, StandardCharsets.UTF_8);
+    wmFiat.stubFor(
+        WireMock.post(urlMatching("/roles/" + encodedUserId))
+            .willReturn(aResponse().withStatus(HttpStatus.OK.value())));
+
+    // Configure Fiat for permissions call
+    UserPermission.View userPermissionView =
+        new UserPermission.View()
+            .setName(serviceAccountEmail)
+            .setAdmin(false)
+            .setAccounts(Set.of())
+            .setRoles(Set.of());
+
+    String userPermissionViewJson = objectMapper.writeValueAsString(userPermissionView);
+
+    wmFiat.stubFor(
+        WireMock.get(urlMatching("/authorize/" + encodedUserId))
+            .willReturn(
+                aResponse().withStatus(HttpStatus.OK.value()).withBody(userPermissionViewJson)));
+
+    // The request should succeed even though Front50 returned an error
+    callGate(request, 200);
+
+    // Verify Front50 was called
+    wmFront50.verify(getRequestedFor(urlPathEqualTo("/serviceAccounts")));
+
+    // Verify Fiat was still called (user was logged in)
+    wmFiat.verify(postRequestedFor(urlPathEqualTo("/roles/" + encodedUserId)));
   }
 }


### PR DESCRIPTION
Before this PR, header auth in gate (implemented in https://github.com/spinnaker/spinnaker/pull/7109) calls [permissionService.login](https://github.com/spinnaker/spinnaker/blob/e83241968f76d83adebd0e516a73d0e383fce5a4/gate/gate-header/src/main/java/com/netflix/spinnaker/gate/security/header/HeaderAuthenticationUserDetailsService.java#L81), which becomes a [POST to fiat's /roles/{userId} endpoint](https://github.com/spinnaker/spinnaker/blob/e83241968f76d83adebd0e516a73d0e383fce5a4/gate/gate-core/src/main/java/com/netflix/spinnaker/gate/services/PermissionService.java#L82) (via [FiatService.loginUser](https://github.com/spinnaker/spinnaker/blob/e83241968f76d83adebd0e516a73d0e383fce5a4/fiat/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatService.java#L101)). This effectively means that every call to gate that uses header auth causes a call to fiat. This is a lot more traffic than happens using oauth. [The logic there](https://github.com/spinnaker/spinnaker/blob/e83241968f76d83adebd0e516a73d0e383fce5a4/gate/gate-oauth2/src/main/java/com/netflix/spinnaker/gate/security/oauth2/OAuthUserInfoServiceHelper.java#L192-L193) is similar, but there's no call to fiat for service accounts.

This PR adds similar logic for header auth, skipping login with fiat for service accounts. It determines service accounts by periodically calling front50 and caching the results in memory.  There's a new configuration property `header.serviceAccountCacheTimeoutMinutes` that defaults to 60 to control this behavior.
