### PR TITLE
chore(kork/test): close the jedis pool before shutting down redis

### DIFF
--- a/kork/kork-jedis-test/src/main/java/com/netflix/spinnaker/kork/jedis/EmbeddedRedis.java
+++ b/kork/kork-jedis-test/src/main/java/com/netflix/spinnaker/kork/jedis/EmbeddedRedis.java
@@ -26,6 +26,11 @@ public class EmbeddedRedis implements AutoCloseable {
   }
 
   public void destroy() {
+    // Close the JedisPool before stopping the container so that QUIT commands reach the
+    // still-running Redis server.
+    if (jedis != null) {
+      jedis.close();
+    }
     redisContainer.stop();
   }
 


### PR DESCRIPTION
to avoid errors like:
```
2026-03-24 12:57:52.446  WARN 21584 --- [ionShutdownHook] redis.clients.jedis.JedisFactory         : [] Error while QUIT
redis.clients.jedis.exceptions.JedisConnectionException: Unexpected end of stream.
```
