### PR TITLE
chore(gate/web/test): mock ApplicationService to prevent noisy log output

### DIFF
--- a/gate/gate-web/src/test/groovy/com/netflix/spinnaker/gate/config/GateCorsAllowedOriginConfigSpec.groovy
+++ b/gate/gate-web/src/test/groovy/com/netflix/spinnaker/gate/config/GateCorsAllowedOriginConfigSpec.groovy
@@ -17,6 +17,8 @@
 package com.netflix.spinnaker.gate.config
 
 import com.netflix.spinnaker.gate.Main
+import com.netflix.spinnaker.gate.services.ApplicationService
+import org.spockframework.spring.SpringBean
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
@@ -34,6 +36,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ActiveProfiles('alloworigincors')
 @TestPropertySource(properties = ["spring.config.location=classpath:gate-test.yml"])
 class GateCorsAllowedOriginConfigSpec extends Specification {
+
+  /**
+   * To prevent the background thread that refreshes the applications cache, which makes calls to
+   * clouddriver and front50 that fail and pollute the logs because those services are not available.
+   */
+  @SpringBean ApplicationService applicationService = Mock()
 
   @Autowired
   private MockMvc mvc

--- a/gate/gate-web/src/test/groovy/com/netflix/spinnaker/gate/config/GateCorsRegexConfigSpec.groovy
+++ b/gate/gate-web/src/test/groovy/com/netflix/spinnaker/gate/config/GateCorsRegexConfigSpec.groovy
@@ -17,6 +17,8 @@
 package com.netflix.spinnaker.gate.config
 
 import com.netflix.spinnaker.gate.Main
+import com.netflix.spinnaker.gate.services.ApplicationService
+import org.spockframework.spring.SpringBean
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
@@ -34,6 +36,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ActiveProfiles('regexcors')
 @TestPropertySource(properties = ["spring.config.location=classpath:gate-test.yml"])
 class GateCorsRegexConfigSpec extends Specification {
+
+  /**
+   * To prevent the background thread that refreshes the applications cache, which makes calls to
+   * clouddriver and front50 that fail and pollute the logs because those services are not available.
+   */
+  @SpringBean ApplicationService applicationService = Mock()
 
   @Autowired
   private MockMvc mvc

--- a/gate/gate-web/src/test/groovy/com/netflix/spinnaker/gate/controllers/BuildControllerSpec.groovy
+++ b/gate/gate-web/src/test/groovy/com/netflix/spinnaker/gate/controllers/BuildControllerSpec.groovy
@@ -18,6 +18,7 @@
 package com.netflix.spinnaker.gate.controllers
 
 import com.netflix.spinnaker.gate.Main
+import com.netflix.spinnaker.gate.services.ApplicationService
 import com.netflix.spinnaker.gate.services.internal.IgorService
 import groovy.json.JsonSlurper
 import org.spockframework.spring.SpringBean
@@ -41,6 +42,11 @@ class BuildControllerSpec extends Specification {
 
   @Autowired
   private MockMvc mockMvc
+  /**
+   * To prevent the background thread that refreshes the applications cache, which makes calls to
+   * clouddriver and front50 that fail and pollute the logs because those services are not available.
+   */
+  @SpringBean ApplicationService applicationService = Mock()
   @SpringBean IgorService igorService = Mock()
   @Shared def MASTER = 'MASTER'
   @Shared def BUILD_NUMBER = 123

--- a/gate/gate-web/src/test/groovy/com/netflix/spinnaker/gate/security/basic/BasicAuthSpec.groovy
+++ b/gate/gate-web/src/test/groovy/com/netflix/spinnaker/gate/security/basic/BasicAuthSpec.groovy
@@ -22,8 +22,10 @@ import com.netflix.spinnaker.gate.security.FormLoginRequestBuilder
 import com.netflix.spinnaker.gate.security.GateSystemTest
 import com.netflix.spinnaker.gate.security.YamlFileApplicationContextInitializer
 import com.netflix.spinnaker.gate.services.AccountLookupService
+import com.netflix.spinnaker.gate.services.ApplicationService
 import com.netflix.spinnaker.gate.services.internal.ClouddriverService
 import groovy.util.logging.Slf4j
+import org.spockframework.spring.SpringBean
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
@@ -53,6 +55,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 @TestPropertySource("/basic-auth.properties")
 class BasicAuthSpec extends Specification {
+
+  /**
+   * To prevent the background thread that refreshes the applications cache, which makes calls to
+   * clouddriver and front50 that fail and pollute the logs because those services are not available.
+   */
+  @SpringBean ApplicationService applicationService = Mock()
 
   @Autowired
   MockMvc mockMvc

--- a/gate/gate-web/src/test/groovy/com/netflix/spinnaker/gate/security/ldap/LdapAuthSpec.groovy
+++ b/gate/gate-web/src/test/groovy/com/netflix/spinnaker/gate/security/ldap/LdapAuthSpec.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.gate.security.ldap
 
 import com.netflix.spinnaker.gate.Main
 import com.netflix.spinnaker.gate.config.RedisTestConfig
+import com.netflix.spinnaker.gate.services.ApplicationService
 import com.netflix.spinnaker.gate.security.FormLoginRequestBuilder
 import com.netflix.spinnaker.gate.security.GateSystemTest
 import com.netflix.spinnaker.gate.security.YamlFileApplicationContextInitializer
@@ -25,6 +26,7 @@ import com.netflix.spinnaker.gate.security.ldap.LdapSsoConfig.LdapConfigProps
 import com.netflix.spinnaker.gate.services.AccountLookupService
 import com.netflix.spinnaker.gate.services.internal.ClouddriverService.AccountDetails
 import groovy.util.logging.Slf4j
+import org.spockframework.spring.SpringBean
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
@@ -55,6 +57,12 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 )
 @AutoConfigureMockMvc
 class LdapAuthSpec extends Specification {
+
+  /**
+   * To prevent the background thread that refreshes the applications cache, which makes calls to
+   * clouddriver and front50 that fail and pollute the logs because those services are not available.
+   */
+  @SpringBean ApplicationService applicationService = Mock()
 
   @Autowired
   MockMvc mockMvc

--- a/gate/gate-web/src/test/java/com/netflix/spinnaker/gate/SAMLConfigurationIntegrationTest.java
+++ b/gate/gate-web/src/test/java/com/netflix/spinnaker/gate/SAMLConfigurationIntegrationTest.java
@@ -26,6 +26,7 @@ import com.netflix.spinnaker.fiat.model.resources.Account;
 import com.netflix.spinnaker.fiat.model.resources.Role;
 import com.netflix.spinnaker.fiat.shared.FiatService;
 import com.netflix.spinnaker.gate.security.saml.SecuritySamlProperties;
+import com.netflix.spinnaker.gate.services.ApplicationService;
 import com.netflix.spinnaker.gate.services.internal.ClouddriverService;
 import com.netflix.spinnaker.gate.services.internal.Front50Service;
 import java.io.IOException;
@@ -92,6 +93,13 @@ import retrofit2.mock.Calls;
     },
     classes = Main.class)
 class SAMLConfigurationIntegrationTest {
+
+  /**
+   * To prevent the background thread that refreshes the applications cache, which makes calls to
+   * clouddriver and front50 that fail and pollute the logs because those services are not
+   * available.
+   */
+  @MockBean ApplicationService applicationService;
 
   @MockBean ClouddriverService clouddriverService;
 

--- a/gate/gate-web/src/test/java/com/netflix/spinnaker/gate/config/GateSwaggerConfigTest.java
+++ b/gate/gate-web/src/test/java/com/netflix/spinnaker/gate/config/GateSwaggerConfigTest.java
@@ -24,10 +24,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.netflix.spinnaker.gate.Main;
+import com.netflix.spinnaker.gate.services.ApplicationService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
@@ -37,6 +39,13 @@ import org.springframework.test.web.servlet.MockMvc;
 @ActiveProfiles("swaggertest")
 @TestPropertySource(properties = {"spring.config.location=classpath:gate-test.yml"})
 public class GateSwaggerConfigTest {
+
+  /**
+   * To prevent the background thread that refreshes the applications cache, which makes calls to
+   * clouddriver and front50 that fail and pollute the logs because those services are not
+   * available.
+   */
+  @MockBean ApplicationService applicationService;
 
   @Autowired private MockMvc mockMvc;
 

--- a/gate/gate-web/src/test/java/com/netflix/spinnaker/gate/config/GateWebConfigAuthenticatedRequestFilterTest.java
+++ b/gate/gate-web/src/test/java/com/netflix/spinnaker/gate/config/GateWebConfigAuthenticatedRequestFilterTest.java
@@ -27,6 +27,7 @@ import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppC
 
 import ch.qos.logback.classic.Level;
 import com.netflix.spinnaker.gate.Main;
+import com.netflix.spinnaker.gate.services.ApplicationService;
 import com.netflix.spinnaker.kork.common.Header;
 import com.netflix.spinnaker.kork.test.log.MemoryAppender;
 import com.netflix.spinnaker.security.AuthenticatedRequest;
@@ -37,6 +38,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
@@ -83,6 +85,13 @@ public class GateWebConfigAuthenticatedRequestFilterTest {
       };
     }
   }
+
+  /**
+   * To prevent the background thread that refreshes the applications cache, which makes calls to
+   * clouddriver and front50 that fail and pollute the logs because those services are not
+   * available.
+   */
+  @MockBean ApplicationService applicationService;
 
   @Autowired
   @Qualifier("authenticatedRequestFilter")

--- a/gate/gate-web/src/test/java/com/netflix/spinnaker/gate/controllers/ArtifactControllerTest.java
+++ b/gate/gate-web/src/test/java/com/netflix/spinnaker/gate/controllers/ArtifactControllerTest.java
@@ -28,6 +28,7 @@ import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppC
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spinnaker.gate.Main;
+import com.netflix.spinnaker.gate.services.ApplicationService;
 import com.netflix.spinnaker.gate.services.internal.ClouddriverService;
 import com.netflix.spinnaker.gate.services.internal.ClouddriverServiceSelector;
 import java.io.InputStream;
@@ -55,6 +56,13 @@ public class ArtifactControllerTest {
   private static final String ARTIFACT_DATA = "Some data";
 
   private MockMvc mockMvc;
+
+  /**
+   * To prevent the background thread that refreshes the applications cache, which makes calls to
+   * clouddriver and front50 that fail and pollute the logs because those services are not
+   * available.
+   */
+  @MockBean private ApplicationService applicationService;
 
   @MockBean private ClouddriverServiceSelector mockClouddriverServiceSelector;
 

--- a/gate/gate-web/src/test/java/com/netflix/spinnaker/gate/controllers/CredentialsControllerTest.java
+++ b/gate/gate-web/src/test/java/com/netflix/spinnaker/gate/controllers/CredentialsControllerTest.java
@@ -35,6 +35,7 @@ import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import com.netflix.spinnaker.gate.Main;
 import com.netflix.spinnaker.gate.health.DownstreamServicesHealthIndicator;
+import com.netflix.spinnaker.gate.services.ApplicationService;
 import com.netflix.spinnaker.gate.services.internal.ClouddriverService;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -74,6 +75,13 @@ public class CredentialsControllerTest {
   @Autowired private WebApplicationContext webApplicationContext;
 
   @Autowired ObjectMapper objectMapper;
+
+  /**
+   * To prevent the background thread that refreshes the applications cache, which makes calls to
+   * clouddriver and front50 that fail and pollute the logs because those services are not
+   * available.
+   */
+  @MockBean ApplicationService applicationService;
 
   /** To prevent periodic calls to service's /health endpoints */
   @MockBean DownstreamServicesHealthIndicator downstreamServicesHealthIndicator;

--- a/gate/gate-web/src/test/java/com/netflix/spinnaker/gate/controllers/ImageControllerTest.java
+++ b/gate/gate-web/src/test/java/com/netflix/spinnaker/gate/controllers/ImageControllerTest.java
@@ -22,6 +22,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppContextSetup;
 
 import com.netflix.spinnaker.gate.Main;
+import com.netflix.spinnaker.gate.services.ApplicationService;
 import com.netflix.spinnaker.gate.services.ImageService;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
@@ -41,6 +42,13 @@ class ImageControllerTest {
   private MockMvc webAppMockMvc;
 
   @Autowired private WebApplicationContext webApplicationContext;
+
+  /**
+   * To prevent the background thread that refreshes the applications cache, which makes calls to
+   * clouddriver and front50 that fail and pollute the logs because those services are not
+   * available.
+   */
+  @MockBean ApplicationService applicationService;
 
   @MockBean ImageService imageService;
 


### PR DESCRIPTION
Tests that boot the full gate context via @SpringBootTest(classes = Main.class) were triggering ApplicationService's background cache refresh thread, which attempts to connect to clouddriver and front50. Since those services aren't available in test, this produced large connection-refused stack traces that polluted the test output:
```
  ERROR c.n.s.gate.services.ApplicationService : [] Falling back to application cache
  SpinnakerNetworkException: java.net.ConnectException: Failed to connect to localhost/[0:0:0:0:0:0:0:1]:8080
      at ...ApplicationService$Front50ApplicationListRetriever...
  SpinnakerNetworkException: java.net.ConnectException: Failed to connect to localhost/[0:0:0:0:0:0:0:1]:7002
      at ...ApplicationService$ClouddriverApplicationListRetriever...
```
Add @MockBean/@SpringBean for ApplicationService to all affected tests.
