### PR TITLE
fix(gate/web/test): replace deprecated Spring Security DSL in AuthConfigTest

### DIFF
--- a/gate/gate-web/src/test/java/com/netflix/spinnaker/gate/AuthConfigTest.java
+++ b/gate/gate-web/src/test/java/com/netflix/spinnaker/gate/AuthConfigTest.java
@@ -42,6 +42,7 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.session.web.http.DefaultCookieSerializer;
@@ -181,7 +182,7 @@ class AuthConfigTest {
       //
       // Leaving that out makes it easier to test some behavior of AuthConfig.
       defaultCookieSerializer.setSameSite(null);
-      http.formLogin().and().httpBasic();
+      http.formLogin(Customizer.withDefaults()).httpBasic(Customizer.withDefaults());
       authConfig.configure(http);
       return http.build();
     }


### PR DESCRIPTION
Replace deprecated chained API with lambda DSL to fix these warnings:
```
$ ./gradlew gate:gate-web:compileTestJava
  AuthConfigTest.java:184: warning: [removal] formLogin() in HttpSecurity has been deprecated and marked for removal
        http.formLogin().and().httpBasic();
            ^
  AuthConfigTest.java:184: warning: [removal] and() in SecurityConfigurerAdapter has been deprecated and marked for removal
        http.formLogin().and().httpBasic();
                        ^
  AuthConfigTest.java:184: warning: [removal] httpBasic() in HttpSecurity has been deprecated and marked for removal
        http.formLogin().and().httpBasic();
```

FWIW, this is deprecated in spring security 6.1, which came along with [spring boot 3.1.x](https://github.com/spinnaker/spinnaker/pull/7338).  It wasn't deprecated in spring boot 3.0.13.