### PR TITLE
fix(gate/api-tck/test): remove noisy startup errors from GateFixtureTest output

### DIFF
--- a/gate/gate-api-tck/gate-api-tck.gradle
+++ b/gate/gate-api-tck/gate-api-tck.gradle
@@ -5,6 +5,8 @@ dependencies {
   implementation("io.spinnaker.kork:kork-jedis-test")
   implementation("org.springframework.session:spring-session-data-redis")
 
+  testImplementation(project(":gate-core"))
+
   api("org.springframework.boot:spring-boot-starter-test")
   api("dev.minutest:minutest")
 }

--- a/gate/gate-api-tck/src/test/kotlin/com/netflix/spinnaker/gate/api/test/GateFixtureTest.kt
+++ b/gate/gate-api-tck/src/test/kotlin/com/netflix/spinnaker/gate/api/test/GateFixtureTest.kt
@@ -16,8 +16,13 @@
 
 package com.netflix.spinnaker.gate.api.test
 
+import com.netflix.spinnaker.gate.health.DownstreamServicesHealthIndicator
+import com.netflix.spinnaker.gate.services.ApplicationService
+import com.netflix.spinnaker.gate.services.DefaultProviderLookupService
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.TestPropertySource
 
 class GateFixtureTest : JUnit5Minutests {
 
@@ -31,5 +36,33 @@ class GateFixtureTest : JUnit5Minutests {
     }
   }
 
-  private inner class Fixture : GateFixture()
+  // Disable plugin caches that log during startup even though no plugins are configured:
+  //   INFO [TaskScheduler-2] RemotePluginInfoReleaseCache : Cached 0 remote plugin configurations.
+  //   INFO [TaskScheduler-1] DeckPluginCache : Cached 0 deck plugins
+  @TestPropertySource(properties = [
+    "spinnaker.extensibility.remote-plugins.enabled=false",
+    "spinnaker.extensibility.deck-proxy.enabled=false"
+  ])
+  private inner class Fixture : GateFixture() {
+    // Mock beans that attempt to connect to downstream services on startup.
+    // Without these mocks the test logs connection errors like:
+    //   ERROR [TaskScheduler-4] DownstreamServicesHealthIndicator : Exception received during
+    //     health check of service: clouddriver, java.net.ConnectException: Failed to connect
+    //     to localhost/[0:0:0:0:0:0:0:1]:7002 (url: http://localhost:7002/health)
+    @MockBean
+    lateinit var downstreamServicesHealthIndicator: DownstreamServicesHealthIndicator
+
+    //   ERROR [pool-2-thread-2] ApplicationService : Falling back to application cache
+    //     SpinnakerNetworkException: java.net.ConnectException: Failed to connect to
+    //     localhost/[0:0:0:0:0:0:0:1]:7002
+    @MockBean
+    lateinit var applicationService: ApplicationService
+
+    //   ERROR [TaskScheduler-2] DefaultProviderLookupService : Unable to refresh account
+    //     details cache
+    //     SpinnakerNetworkException: java.net.ConnectException: Failed to connect to
+    //     localhost/[0:0:0:0:0:0:0:1]:7002
+    @MockBean
+    lateinit var defaultProviderLookupService: DefaultProviderLookupService
+  }
 }


### PR DESCRIPTION
Mock beans and disable features that produce spurious errors and log messages during the gate-api-tck test. These fire because the Spring context starts background tasks that try to reach downstream services that aren't running in the test environment.

Mocked beans and the errors they prevent:
```
  DownstreamServicesHealthIndicator:
    ERROR DownstreamServicesHealthIndicator : Exception received during
      health check of service: clouddriver, java.net.ConnectException:
      Failed to connect to localhost/[0:0:0:0:0:0:0:1]:7002

  ApplicationService:
    ERROR ApplicationService : Falling back to application cache
      SpinnakerNetworkException: java.net.ConnectException: Failed to
      connect to localhost/[0:0:0:0:0:0:0:1]:7002

  DefaultProviderLookupService:
    ERROR DefaultProviderLookupService : Unable to refresh account
      details cache
      SpinnakerNetworkException: java.net.ConnectException: Failed to
      connect to localhost/[0:0:0:0:0:0:0:1]:7002
```
Disabled properties and the messages they prevent:
```
  spinnaker.extensibility.remote-plugins.enabled=false:
    INFO RemotePluginInfoReleaseCache : Cached 0 remote plugin configurations.

  spinnaker.extensibility.deck-proxy.enabled=false:
    INFO DeckPluginCache : Cached 0 deck plugins
```

Make the changes in GateFixtureTest instead of GateFixture in case there are implementations of GateFixture outside the Spinnaker codebase that depend on these beans/features being enabled.