### PR TITLE
fix(gate/web): return 200 instead of 500 for void orca endpoints

### DIFF
--- a/gate/gate-core/src/main/java/com/netflix/spinnaker/gate/services/TaskService.java
+++ b/gate/gate-core/src/main/java/com/netflix/spinnaker/gate/services/TaskService.java
@@ -73,9 +73,9 @@ public class TaskService {
     return Retrofit2SyncCall.execute(getOrcaServiceSelector().select().getTask(id));
   }
 
-  public Map deleteTask(final String id) {
+  public void deleteTask(final String id) {
     setApplicationForTask(id);
-    return Retrofit2SyncCall.execute(getOrcaServiceSelector().select().deleteTask(id));
+    Retrofit2SyncCall.execute(getOrcaServiceSelector().select().deleteTask(id));
   }
 
   public Map getTaskDetails(final String taskDetailsId, String selectorKey) {
@@ -83,14 +83,14 @@ public class TaskService {
         getClouddriverServiceSelector().select().getTaskDetails(taskDetailsId));
   }
 
-  public Map cancelTask(final String id) {
+  public void cancelTask(final String id) {
     setApplicationForTask(id);
-    return Retrofit2SyncCall.execute(getOrcaServiceSelector().select().cancelTask(id, ""));
+    Retrofit2SyncCall.execute(getOrcaServiceSelector().select().cancelTask(id, ""));
   }
 
-  public Map cancelTasks(final List<String> taskIds) {
+  public void cancelTasks(final List<String> taskIds) {
     setApplicationForTask(taskIds.get(0));
-    return Retrofit2SyncCall.execute(getOrcaServiceSelector().select().cancelTasks(taskIds));
+    Retrofit2SyncCall.execute(getOrcaServiceSelector().select().cancelTasks(taskIds));
   }
 
   public Map createAndWaitForCompletion(Map body, int maxPolls, int intervalMs) {

--- a/gate/gate-core/src/main/java/com/netflix/spinnaker/gate/services/internal/OrcaService.java
+++ b/gate/gate-core/src/main/java/com/netflix/spinnaker/gate/services/internal/OrcaService.java
@@ -51,15 +51,15 @@ public interface OrcaService {
 
   @Headers("Accept: application/json")
   @DELETE("tasks/{id}")
-  Call<Map> deleteTask(@Path("id") String id);
+  Call<Void> deleteTask(@Path("id") String id);
 
   @Headers("Accept: application/json")
   @PUT("tasks/{id}/cancel")
-  Call<Map> cancelTask(@Path("id") String id, @Body String ignored);
+  Call<Void> cancelTask(@Path("id") String id, @Body String ignored);
 
   @Headers("Accept: application/json")
   @PUT("tasks/cancel")
-  Call<Map> cancelTasks(@Body List<String> taskIds);
+  Call<Void> cancelTasks(@Body List<String> taskIds);
 
   @Headers("Accept: application/json")
   @GET("pipelines")

--- a/gate/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ApplicationController.groovy
+++ b/gate/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ApplicationController.groovy
@@ -201,7 +201,7 @@ class ApplicationController {
   @Deprecated
   @Operation(summary = "Cancel task")
   @RequestMapping(value = "/{application}/tasks/{id}/cancel", method = RequestMethod.PUT)
-  Map cancelTask(@PathVariable("id") String id) {
+  void cancelTask(@PathVariable("id") String id) {
     taskService.cancelTask(id)
   }
 

--- a/gate/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/TaskController.groovy
+++ b/gate/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/TaskController.groovy
@@ -38,7 +38,7 @@ class TaskController {
 
   @Operation(summary = "Delete task")
   @RequestMapping(value = "/{id}", method = RequestMethod.DELETE)
-  Map deleteTask(@PathVariable("id") String id) {
+  void deleteTask(@PathVariable("id") String id) {
     taskService.deleteTask(id)
   }
 
@@ -50,13 +50,13 @@ class TaskController {
 
   @Operation(summary = "Cancel task")
   @RequestMapping(value = "/{id}/cancel", method = RequestMethod.PUT)
-  Map cancelTask(@PathVariable("id") String id) {
+  void cancelTask(@PathVariable("id") String id) {
     taskService.cancelTask(id)
   }
 
   @Operation(summary = "Cancel tasks")
   @RequestMapping(value = "/cancel", method = RequestMethod.PUT)
-  Map cancelTasks(@RequestParam List<String> ids) {
+  void cancelTasks(@RequestParam List<String> ids) {
     taskService.cancelTasks(ids)
   }
 

--- a/gate/gate-web/src/test/java/com/netflix/spinnaker/gate/controllers/ApplicationControllerWireMockTest.java
+++ b/gate/gate-web/src/test/java/com/netflix/spinnaker/gate/controllers/ApplicationControllerWireMockTest.java
@@ -99,7 +99,6 @@ class ApplicationControllerWireMockTest {
   @Test
   void cancelTaskWithEmptyOrcaResponse() throws Exception {
     // Orca's PUT /tasks/{id}/cancel returns void, so the response body is empty.
-    // FIXME: Gate should return 200 with an empty body, not 500.
     stubOrcaGetTask();
     wmOrca.stubFor(
         WireMock.put(urlPathEqualTo("/tasks/" + TASK_ID + "/cancel"))
@@ -112,12 +111,7 @@ class ApplicationControllerWireMockTest {
                 .header(USER.getHeader(), USERNAME)
                 .characterEncoding(StandardCharsets.UTF_8.toString()))
         .andDo(print())
-        .andExpect(status().isInternalServerError())
-        .andExpect(
-            status()
-                .reason(
-                    "Failed to process response body: No content to map due to end-of-input\n"
-                        + " at [Source: (okhttp3.ResponseBody$BomAwareReader); line: 1, column: 0]"))
+        .andExpect(status().isOk())
         .andExpect(content().string(""));
   }
 

--- a/gate/gate-web/src/test/java/com/netflix/spinnaker/gate/controllers/TaskControllerTest.java
+++ b/gate/gate-web/src/test/java/com/netflix/spinnaker/gate/controllers/TaskControllerTest.java
@@ -100,7 +100,6 @@ class TaskControllerTest {
   @Test
   void deleteTaskWithEmptyOrcaResponse() throws Exception {
     // Orca's DELETE /tasks/{id} returns void, so the response body is empty.
-    // FIXME: Gate should return 200 with an empty body, not 500.
     stubOrcaGetTask();
     wmOrca.stubFor(
         WireMock.delete(urlPathEqualTo("/tasks/" + TASK_ID))
@@ -113,19 +112,13 @@ class TaskControllerTest {
                 .header(USER.getHeader(), USERNAME)
                 .characterEncoding(StandardCharsets.UTF_8.toString()))
         .andDo(print())
-        .andExpect(status().isInternalServerError())
-        .andExpect(
-            status()
-                .reason(
-                    "Failed to process response body: No content to map due to end-of-input\n"
-                        + " at [Source: (okhttp3.ResponseBody$BomAwareReader); line: 1, column: 0]"))
+        .andExpect(status().isOk())
         .andExpect(content().string(""));
   }
 
   @Test
   void cancelTaskWithEmptyOrcaResponse() throws Exception {
     // Orca's PUT /tasks/{id}/cancel returns void, so the response body is empty.
-    // FIXME: Gate should return 200 with an empty body, not 500.
     stubOrcaGetTask();
     wmOrca.stubFor(
         WireMock.put(urlPathEqualTo("/tasks/" + TASK_ID + "/cancel"))
@@ -138,19 +131,13 @@ class TaskControllerTest {
                 .header(USER.getHeader(), USERNAME)
                 .characterEncoding(StandardCharsets.UTF_8.toString()))
         .andDo(print())
-        .andExpect(status().isInternalServerError())
-        .andExpect(
-            status()
-                .reason(
-                    "Failed to process response body: No content to map due to end-of-input\n"
-                        + " at [Source: (okhttp3.ResponseBody$BomAwareReader); line: 1, column: 0]"))
+        .andExpect(status().isOk())
         .andExpect(content().string(""));
   }
 
   @Test
   void cancelTasksWithEmptyOrcaResponse() throws Exception {
     // Orca's PUT /tasks/cancel returns void, so the response body is empty.
-    // FIXME: Gate should return 200 with an empty body, not 500.
     stubOrcaGetTask();
     wmOrca.stubFor(
         WireMock.put(urlPathEqualTo("/tasks/cancel"))
@@ -165,12 +152,7 @@ class TaskControllerTest {
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .characterEncoding(StandardCharsets.UTF_8.toString()))
         .andDo(print())
-        .andExpect(status().isInternalServerError())
-        .andExpect(
-            status()
-                .reason(
-                    "Failed to process response body: No content to map due to end-of-input\n"
-                        + " at [Source: (okhttp3.ResponseBody$BomAwareReader); line: 1, column: 0]"))
+        .andExpect(status().isOk())
         .andExpect(content().string(""));
   }
 


### PR DESCRIPTION
orca's deleteTask, cancelTask, and cancelTasks endpoints return an empty response body. Change gate's OrcaService from Call<Map> to Call<Void> for these endpoints, and update TaskService, TaskController, and ApplicationController to return void instead of Map, so gate responds with 200.

The gate retrofit2 upgrade (https://github.com/spinnaker/gate/pull/1866, first released in [Spinnaker version 1.37.0](https://spinnaker.io/changelogs/1.37.0-changelog/)) is the source of these bugs. https://github.com/spinnaker/gate/pull/1883 fixes some similar bugs (first released in [1.38.0](https://spinnaker.io/changelogs/1.38.0-changelog/) / [2025.0.0](https://spinnaker.io/changelogs/2025.0.0-changelog/)).