### PR TITLE
fix(gate/basic): replace deprecated Spring Security DSL with lambda-style configuration

### DIFF
--- a/gate/gate-basic/src/main/java/com/netflix/spinnaker/gate/security/basic/BasicAuthConfig.java
+++ b/gate/gate-basic/src/main/java/com/netflix/spinnaker/gate/security/basic/BasicAuthConfig.java
@@ -25,6 +25,7 @@ import org.springframework.boot.autoconfigure.security.SecurityProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
@@ -58,11 +59,11 @@ public class BasicAuthConfig {
   @Order(2)
   public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
     defaultCookieSerializer.setSameSite(null);
-    http.formLogin()
-        .and()
+    http.formLogin(Customizer.withDefaults())
         .authenticationProvider(authProvider)
-        .httpBasic()
-        .authenticationEntryPoint(new LoginUrlAuthenticationEntryPoint("/login"));
+        .httpBasic(
+            basic ->
+                basic.authenticationEntryPoint(new LoginUrlAuthenticationEntryPoint("/login")));
     authConfig.configure(http);
     return http.build();
   }


### PR DESCRIPTION
Replace deprecated no-arg formLogin(), httpBasic(), and .and() chaining with the lambda DSL introduced as their replacement in Spring Security 6.1 (shipped with Spring Boot 3.1):
```
  warning: [removal] formLogin() in HttpSecurity has been deprecated and marked for removal
  warning: [removal] and() in SecurityConfigurerAdapter has been deprecated and marked for removal
  warning: [removal] httpBasic() in HttpSecurity has been deprecated and marked for removal
```
