### PR TITLE
chore(clouddriver): bump json-flattener from 0.14.2 to 0.16.6

### DIFF
--- a/clouddriver/gradle.properties
+++ b/clouddriver/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.parallel=true
 artifactTypes=bitbucket,custom,docker,embedded,front50,gcs,github,gitlab,gitrepo,helm,http,ivy,jenkins,kubernetes,maven,oracle,s3
 commonsCompressVersion=1.21
-jsonFlattenerVersion=0.14.2
+jsonFlattenerVersion=0.16.6
 targetJava17=true
 org.gradle.jvmargs=-Xmx10g -Xms10g
 testJvmMaxMemory=6g


### PR DESCRIPTION
json-flattener 0.16.6 is the newest version whose transitive jackson-databind dependency (2.15.2) is close to clouddriver's current jackson-databind version (2.15.4). Newer json-flattener versions jump to jackson-databind 2.17+ which is too far ahead.

before (0.14.2):
```
  \--- com.github.wnameless.json:json-flattener:0.14.2
       +--- com.fasterxml.jackson.core:jackson-databind:2.13.4.2 -> 2.15.4
       +--- org.apache.commons:commons-text:1.10.0
       \--- com.github.wnameless.json:json-base:2.0.0
```
after (0.16.6):
```
  \--- com.github.wnameless.json:json-flattener:0.16.6
       +--- com.fasterxml.jackson.core:jackson-databind:2.15.2 -> 2.15.4
       +--- org.apache.commons:commons-text:1.10.0
       \--- com.github.wnameless.json:json-base:2.4.3
```
