### PR TITLE
fix(igor/web): remove some deprecation warnings

### DIFF
--- a/igor/igor-web/src/main/java/com/netflix/spinnaker/igor/config/GoogleCloudBuildProperties.java
+++ b/igor/igor-web/src/main/java/com/netflix/spinnaker/igor/config/GoogleCloudBuildProperties.java
@@ -30,7 +30,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.boot.context.properties.bind.ConstructorBinding;
 
 @ConfigurationProperties(prefix = "gcb")
 @Data

--- a/igor/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildTest.java
+++ b/igor/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gcb/GoogleCloudBuildTest.java
@@ -96,7 +96,8 @@ public class GoogleCloudBuildTest {
   static class WebSecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-      http.authorizeHttpRequests().anyRequest().permitAll().and().csrf().disable();
+      http.authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+          .csrf(csrf -> csrf.disable());
       return http.build();
     }
   }


### PR DESCRIPTION
```
GoogleCloudBuildTest.java:99: warning: [removal] authorizeHttpRequests() in HttpSecurity has been deprecated and marked for removal
GoogleCloudBuildTest.java:99: warning: [removal] and() in AuthorizeHttpRequestsConfigurer.AuthorizationManagerRequestMatcherRegistry has been deprecated and marked for removal
GoogleCloudBuildTest.java:99: warning: [removal] csrf() in HttpSecurity has been deprecated and marked for removal
```
and
```
GoogleCloudBuildProperties.java: warning: [removal] ConstructorBinding in org.springframework.boot.context.properties
has been deprecated and marked for removal
```
