### PR TITLE
chore(build/protobuf): upgrade com.google.protobuf plugin 0.8.12 -> 0.9.6

### DIFF
--- a/clouddriver/build.gradle
+++ b/clouddriver/build.gradle
@@ -19,7 +19,7 @@ plugins {
   id 'io.spinnaker.project' apply false
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.kotlin.spring)
-  id "com.google.protobuf" version "0.8.12" apply false
+  alias(libs.plugins.protobuf) apply false
 }
 
 allprojects {

--- a/clouddriver/clouddriver-titus/clouddriver-titus.gradle
+++ b/clouddriver/clouddriver-titus/clouddriver-titus.gradle
@@ -60,11 +60,13 @@ dependencies {
 sourceSets {
   main {
     java {
-      srcDir "${protobuf.generatedFilesBaseDir}/main/grpc"
-      srcDir "${protobuf.generatedFilesBaseDir}/main/java"
+      srcDir "${buildDir}/generated/sources/proto/main/grpc"
+      srcDir "${buildDir}/generated/sources/proto/main/java"
     }
   }
 }
+
+compileJava.dependsOn generateProto
 
 task cleanGenerated(type: Delete) {
   delete "$projectDir/src/generated"

--- a/halyard/build.gradle
+++ b/halyard/build.gradle
@@ -16,7 +16,7 @@
 
 plugins {
   id 'io.spinnaker.project' apply false
-  id 'com.google.protobuf' version "0.8.12" apply false
+  alias(libs.plugins.protobuf) apply false
 }
 
 allprojects {

--- a/halyard/halyard-proto/halyard-proto.gradle
+++ b/halyard/halyard-proto/halyard-proto.gradle
@@ -35,15 +35,10 @@ protobuf {
       task.descriptorSetOptions.includeImports = true
     }
   }
-  generatedFilesBaseDir = "${projectDir}/build-gen/proto"
 }
 
 idea {
   module {
-    sourceDirs += file("${projectDir}/build-gen/proto/main/java")
+    sourceDirs += file("${buildDir}/generated/sources/proto/main/java")
   }
-}
-
-clean {
-  delete "${projectDir}/build-gen"
 }

--- a/halyard/settings.gradle
+++ b/halyard/settings.gradle
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+apply from: "../versions.gradle"
+
 rootProject.name="halyard"
 
 include 'halyard-backup'

--- a/kork/kork-proto/kork-proto.gradle
+++ b/kork/kork-proto/kork-proto.gradle
@@ -1,6 +1,6 @@
 plugins {
   id "java-library"
-  id "com.google.protobuf" version "0.8.12"
+  alias(libs.plugins.protobuf)
 }
 
 dependencies {

--- a/kork/kork-proto/kork-proto.gradle
+++ b/kork/kork-proto/kork-proto.gradle
@@ -18,6 +18,6 @@ protobuf {
 
 idea {
   module {
-    generatedSourceDirs += file("${protobuf.generatedFilesBaseDir}/main/java")
+    generatedSourceDirs += file("${buildDir}/generated/sources/proto/main/java")
   }
 }

--- a/versions.gradle
+++ b/versions.gradle
@@ -33,6 +33,7 @@ dependencyResolutionManagement {
             plugin('kotlin-allopen', 'org.jetbrains.kotlin.plugin.allopen').versionRef('kotlin')
             plugin('kotlin-jvm', 'org.jetbrains.kotlin.jvm').versionRef('kotlin')
             plugin('kotlin-spring', 'org.jetbrains.kotlin.plugin.spring').versionRef('kotlin')
+            plugin('protobuf', 'com.google.protobuf').version('0.8.12')
 
             // Arguments: library(<alias>, <group>, <artifact>)
             // Libraries are directly accessed from the root "libs" catalog in Gradle scripts

--- a/versions.gradle
+++ b/versions.gradle
@@ -33,7 +33,7 @@ dependencyResolutionManagement {
             plugin('kotlin-allopen', 'org.jetbrains.kotlin.plugin.allopen').versionRef('kotlin')
             plugin('kotlin-jvm', 'org.jetbrains.kotlin.jvm').versionRef('kotlin')
             plugin('kotlin-spring', 'org.jetbrains.kotlin.plugin.spring').versionRef('kotlin')
-            plugin('protobuf', 'com.google.protobuf').version('0.8.12')
+            plugin('protobuf', 'com.google.protobuf').version('0.9.6')
 
             // Arguments: library(<alias>, <group>, <artifact>)
             // Libraries are directly accessed from the root "libs" catalog in Gradle scripts


### PR DESCRIPTION
to remove these warnings:

kork
```
$ ./gradlew :kork:kork-proto:build
Starting a Gradle Daemon, 1 busy and 1 stopped Daemons could not be reused, use --status for details

> Task :kork:kork-proto:processResources
Execution optimizations have been disabled for task ':kork:kork-proto:processResources' to ensure correctness due to the following reasons:
  - Gradle detected a problem with the following location: '/Users/dbyron/src/spinnaker/spinnaker/kork/kork-proto/build/extracted-protos/main'. Reason: Task ':kork:kork-proto:processResource>
```

clouddriver
```
$ ./gradlew :clouddriver:clouddriver-titus:build
Starting a Gradle Daemon, 1 busy and 3 stopped Daemons could not be reused, use --status for details

> Task :clouddriver:clouddriver-titus:processResources
Execution optimizations have been disabled for task ':clouddriver:clouddriver-titus:processResources' to ensure correctness due to the following reasons:
  - Gradle detected a problem with the following location: '/Users/dbyron/src/spinnaker/spinnaker/clouddriver/clouddriver-titus/build/extracted-protos/main'. Reason: Task ':clouddriver:cloud>

> Task :clouddriver:clouddriver-titus:processTestResources
Execution optimizations have been disabled for task ':clouddriver:clouddriver-titus:processTestResources' to ensure correctness due to the following reasons:
  - Gradle detected a problem with the following location: '/Users/dbyron/src/spinnaker/spinnaker/clouddriver/clouddriver-titus/build/extracted-protos/test'. Reason: Task ':clouddriver:cloud>
```

halyard
```
$ ./gradlew halyard:halyard-proto:build

> Task :halyard:halyard-proto:processResources
Execution optimizations have been disabled for task ':halyard:halyard-proto:processResources' to ensure correctness due to the following reasons:
  - Gradle detected a problem with the following location: '/Users/dbyron/src/spinnaker/spinnaker/halyard/halyard-proto/build/extracted-protos/main'. Reason: Task ':halyard:halyard-proto:pro>

> Task :halyard:halyard-proto:spotlessMisc
Execution optimizations have been disabled for task ':halyard:halyard-proto:spotlessMisc' to ensure correctness due to the following reasons:
  - Gradle detected a problem with the following location: '/Users/dbyron/src/spinnaker/spinnaker/halyard/halyard-proto'. Reason: Task ':halyard:halyard-proto:spotlessMisc' uses this output >
```

Fixed in plugin v0.9.0 via https://github.com/google/protobuf-gradle-plugin/pull/594, but
use 0.9.6 since it's currently the newest version.  See also https://github.com/google/protobuf-gradle-plugin/issues/553.

Generated protobuf code verified identical before and after upgrade.

Centralize the version along the way.