### PR TITLE
fix(kork/secrets-k8s/test): allow KubernetesSecretsEngineTest to pass outside a k8s cluster

### DIFF
--- a/kork/kork-secrets-k8s/src/main/java/com/netflix/spinnaker/kork/secrets/engines/KubernetesSecretEngine.java
+++ b/kork/kork-secrets-k8s/src/main/java/com/netflix/spinnaker/kork/secrets/engines/KubernetesSecretEngine.java
@@ -71,6 +71,11 @@ public class KubernetesSecretEngine implements SecretEngine {
     this.apiClient = new CoreV1Api(apiClient);
   }
 
+  /** Constructor for testing — caller must provide the apiClient via {@link #setApiClient}. */
+  KubernetesSecretEngine(String namespace) {
+    this.namespace = namespace;
+  }
+
   public String identifier() {
     return IDENTIFIER;
   }

--- a/kork/kork-secrets-k8s/src/main/java/com/netflix/spinnaker/kork/secrets/engines/KubernetesSecretEngine.java
+++ b/kork/kork-secrets-k8s/src/main/java/com/netflix/spinnaker/kork/secrets/engines/KubernetesSecretEngine.java
@@ -28,7 +28,6 @@ import io.kubernetes.client.util.Namespaces;
 import java.io.IOException;
 import java.util.Optional;
 import java.util.Set;
-import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
@@ -39,26 +38,29 @@ import org.springframework.stereotype.Component;
     value = "spinnaker.secrets.kubernetes.enabled",
     havingValue = "true",
     matchIfMissing = false)
-@Setter
 public class KubernetesSecretEngine implements SecretEngine {
   private static final String IDENTIFIER = "k8s";
   private static final String SECRET_NAME = "n";
   private static final String SECRET_KEY = "k";
   private static final String SECRET_NAMESPACE = "ns";
-  private CoreV1Api apiClient;
-  private String namespace;
+  private final CoreV1Api apiClient;
+  private final String namespace;
 
   /*
   There is NOT a great way to "test" this namespace sane default WITHOUT running in a container in k8s.  As such, do the best we can to capture
   defaults in the executions via integration tests.
    */
   KubernetesSecretEngine() {
+    String tempNamespace;
     try {
-      namespace = Namespaces.getPodNamespace();
+      tempNamespace = Namespaces.getPodNamespace();
     } catch (Exception e) {
       log.warn(
           "WARNING!  Unable to determine the namespace.  This LIKELY means we're not in a container!  Defaulting to 'default'");
+      tempNamespace = "default";
     }
+
+    this.namespace = tempNamespace;
 
     ApiClient apiClient = null;
     try {
@@ -71,9 +73,10 @@ public class KubernetesSecretEngine implements SecretEngine {
     this.apiClient = new CoreV1Api(apiClient);
   }
 
-  /** Constructor for testing — caller must provide the apiClient via {@link #setApiClient}. */
-  KubernetesSecretEngine(String namespace) {
+  /** Constructor for testing */
+  KubernetesSecretEngine(String namespace, CoreV1Api apiClient) {
     this.namespace = namespace;
+    this.apiClient = apiClient;
   }
 
   public String identifier() {

--- a/kork/kork-secrets-k8s/src/test/java/com/netflix/spinnaker/kork/secrets/engines/KubernetesSecretsEngineTest.java
+++ b/kork/kork-secrets-k8s/src/test/java/com/netflix/spinnaker/kork/secrets/engines/KubernetesSecretsEngineTest.java
@@ -38,7 +38,9 @@ import org.testcontainers.utility.DockerImageName;
 @Testcontainers
 public class KubernetesSecretsEngineTest {
 
-  private KubernetesSecretEngine secretEngine = new KubernetesSecretEngine();
+  private static final String NAMESPACE = "default";
+
+  private KubernetesSecretEngine secretEngine;
 
   K3sContainer k3s = new K3sContainer(DockerImageName.parse("rancher/k3s:v1.35.3-k3s1"));
   CoreV1Api coreV1Api;
@@ -51,13 +53,14 @@ public class KubernetesSecretsEngineTest {
                 KubeConfig.loadKubeConfig(new StringReader(k3s.getKubeConfigYaml())))
             .build();
     coreV1Api = new CoreV1Api(client);
+    secretEngine = new KubernetesSecretEngine(NAMESPACE);
     secretEngine.setApiClient(coreV1Api);
   }
 
   @Test
   void testThatCanGetBasicScret() throws Exception {
     String expectedSecretValue = RandomStringUtils.randomAlphanumeric(16);
-    createSecretInNamespace(expectedSecretValue, "default", "somesecret", "secret");
+    createSecretInNamespace(expectedSecretValue, NAMESPACE, "somesecret", "secret");
     byte[] secretValue =
         secretEngine.decrypt(EncryptedSecret.parse("encrypted:k8s!n:somesecret!k:secret"));
     assertThat(new String(secretValue)).isEqualTo(expectedSecretValue);

--- a/kork/kork-secrets-k8s/src/test/java/com/netflix/spinnaker/kork/secrets/engines/KubernetesSecretsEngineTest.java
+++ b/kork/kork-secrets-k8s/src/test/java/com/netflix/spinnaker/kork/secrets/engines/KubernetesSecretsEngineTest.java
@@ -53,8 +53,7 @@ public class KubernetesSecretsEngineTest {
                 KubeConfig.loadKubeConfig(new StringReader(k3s.getKubeConfigYaml())))
             .build();
     coreV1Api = new CoreV1Api(client);
-    secretEngine = new KubernetesSecretEngine(NAMESPACE);
-    secretEngine.setApiClient(coreV1Api);
+    secretEngine = new KubernetesSecretEngine(NAMESPACE, coreV1Api);
   }
 
   @Test


### PR DESCRIPTION
followup to https://github.com/spinnaker/spinnaker/pull/7603.

The [default KubernetesSecretEngine() constructor](https://github.com/spinnaker/spinnaker/blob/91c7367c4e1bcf2e8bb723fa25d3f77dff56b8cf/kork/kork-secrets-k8s/src/main/java/com/netflix/spinnaker/kork/secrets/engines/KubernetesSecretEngine.java#L55) eagerly calls Config.defaultClient(), which throws IllegalArgumentException when no valid kubeconfig exists on the host, and results in test failures:
```
$ ./gradlew kork:kork-secrets-k8s:test --tests KubernetesSecretsEngineTest

> Task :kork:kork-secrets-k8s:test FAILED

KubernetesSecretsEngineTest > testThatCanGetBasicScret() FAILED
    java.lang.IllegalArgumentException at KubernetesSecretsEngineTest.java:41

KubernetesSecretsEngineTest > testThatCanGetBasicScretInAnotherNamespace() FAILED
    java.lang.IllegalArgumentException at KubernetesSecretsEngineTest.java:41
```
with a stack trace:
```
java.lang.IllegalArgumentException: No server in kubeconfig
	at io.kubernetes.client.util.ClientBuilder.kubeconfig(ClientBuilder.java:280)
	at io.kubernetes.client.util.ClientBuilder.getClientBuilder(ClientBuilder.java:129)
	at io.kubernetes.client.util.ClientBuilder.standard(ClientBuilder.java:108)
	at io.kubernetes.client.util.ClientBuilder.standard(ClientBuilder.java:100)
	at io.kubernetes.client.util.Config.defaultClient(Config.java:114)
	at com.netflix.spinnaker.kork.secrets.engines.KubernetesSecretEngine.<init>(KubernetesSecretEngine.java:65)
	at com.netflix.spinnaker.kork.secrets.engines.KubernetesSecretsEngineTest.<init>(KubernetesSecretsEngineTest.java:41)
```
The test overrides the API client anyway, so this isn't really important.

Add a package-private constructor that accepts a namespace without calling Config.defaultClient(), and move secretEngine initialization into @BeforeEach where the K3s-provided client is available.
