### PR TITLE
fix(build/test): disable JVM class data sharing to remove warning on j

### DIFF
--- a/spinnaker-gradle-project/spinnaker-project-plugin/src/main/groovy/com/netflix/spinnaker/gradle/baseproject/SpinnakerBaseProjectConventionsPlugin.groovy
+++ b/spinnaker-gradle-project/spinnaker-project-plugin/src/main/groovy/com/netflix/spinnaker/gradle/baseproject/SpinnakerBaseProjectConventionsPlugin.groovy
@@ -13,6 +13,7 @@ import org.gradle.api.plugins.JavaPluginConvention
 import org.gradle.api.publish.maven.plugins.MavenPublishPlugin
 import org.gradle.api.tasks.Delete
 import org.gradle.api.tasks.javadoc.Javadoc
+import org.gradle.api.tasks.testing.Test
 import org.gradle.jvm.tasks.Jar
 
 @CompileStatic
@@ -35,6 +36,16 @@ class SpinnakerBaseProjectConventionsPlugin implements Plugin<Project> {
         sourceJar.from(convention.sourceSets.getByName('main').allSource)
         project.artifacts.add('archives', sourceJar)
       }
+
+      // Disable JVM class data sharing in test workers to avoid this warning on startup
+      //
+      // "Sharing is only supported for boot loader classes because bootstrap classpath has been appended"
+      //
+      // This has a minor startup performance cost (~13ms per JVM invocation), but it seems worth it to clean up the noise.
+      //
+      // See also https://stackoverflow.com/questions/54205486/how-to-avoid-sharing-is-only-supported-for-boot-loader-classes-because-bootstra
+      project.tasks.withType(Test).configureEach { it.jvmArgs('-Xshare:off') }
+
       // Nebula insists on building Javadoc, but we don't do anything with it
       // and it seems to cause lots of errors.
       project.tasks.withType(Javadoc) { (it as Javadoc).setFailOnError(false) }


### PR DESCRIPTION
For example:
```
> Task :gate:gate-web:test
OpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended
```
but this occurs in test tasks across all microservices.

Adds -Xshare:off to all Test task JVM args via the shared SpinnakerBaseProjectConventionsPlugin.  See
https://stackoverflow.com/questions/54205486/how-to-avoid-sharing-is-only-supported-for-boot-loader-classes-because-bootstra for background.

[Benchmark](https://github.com/user-attachments/files/26641296/benchmark_cds.py) (100 iterations, alternating, Zulu JDK 17.0.11):
```
  With Class Data Sharing:  avg=252ms  p50=257ms  p95=281ms
  Without:                  avg=265ms  p50=267ms  p95=300ms
  Diff:                     ~13ms per JVM startup
```
This is potentially controversial since it is slows things down (slightly).  I think the reduction is noise on stdout, and generally getting closer to no warnings is worth it.  If we ever do get there, we can fail builds if warnings do get introduced.
