### PR TITLE
chore(build): remove gradle warnings

### DIFF
--- a/halyard/halyard-web/halyard-web.gradle
+++ b/halyard/halyard-web/halyard-web.gradle
@@ -42,7 +42,7 @@ dependencies {
 
 def cliScript = project.tasks.create('createCliStartScripts', CreateStartScripts) {
   dependsOn(project.tasks.startScripts)
-  mainClassName = 'com.netflix.spinnaker.halyard.cli.Main'
+  mainClass.set('com.netflix.spinnaker.halyard.cli.Main')
   applicationName = 'hal'
   outputDir = project.tasks.startScripts.outputDir
   classpath = project.tasks.startScripts.classpath

--- a/kayenta/kayenta-judge/kayenta-judge.gradle
+++ b/kayenta/kayenta-judge/kayenta-judge.gradle
@@ -17,7 +17,7 @@ dependencies {
 }
 
 task scalaTest(dependsOn: ['testClasses'], type: JavaExec) {
-  main = 'org.scalatest.tools.Runner'
+  mainClass.set('org.scalatest.tools.Runner')
   args = ['-R', 'build/classes/scala/test', '-o']
   classpath = sourceSets.test.runtimeClasspath
 }

--- a/kayenta/kayenta-mannwhitney/kayenta-mannwhitney.gradle
+++ b/kayenta/kayenta-mannwhitney/kayenta-mannwhitney.gradle
@@ -13,7 +13,7 @@ dependencies {
 }
 
 task scalaTest(dependsOn: ['testClasses'], type: JavaExec) {
-    main = 'org.scalatest.tools.Runner'
+    mainClass.set('org.scalatest.tools.Runner')
     args = ['-R', 'build/classes/scala/test', '-o']
     classpath = sourceSets.test.runtimeClasspath
 }

--- a/keel/keel-web/keel-web.gradle
+++ b/keel/keel-web/keel-web.gradle
@@ -74,6 +74,6 @@ dependencies {
 }
 
 application {
-  mainClassName = "com.netflix.spinnaker.keel.MainKt"
+  mainClass.set("com.netflix.spinnaker.keel.MainKt")
   applicationName("keel")
 }


### PR DESCRIPTION
```
$ ./gradlew kork:kork-retrofit:test

Deprecated Gradle features were used in this build, making it incompatible with Gradle 8.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

See https://docs.gradle.org/7.6.1/userguide/command_line_interface.html#sec:command_line_warnings
```
and
```
$ ./gradlew kork:kork-retrofit:test --warning-mode=all
> Configure project :halyard:halyard-web
The CreateStartScripts.mainClassName property has been deprecated. This is scheduled to be removed in Gradle 8.0. Please use the mainClass property instead. See
https://docs.gradle.org/7.6.1/dsl/org.gradle.jvm.application.tasks.CreateStartScripts.html#org.gradle.jvm.application.tasks.CreateStartScripts:mainClassName for more details.
        at halyard_web_6cizb2sm2gvgz1qjp7m4d6s4a$_run_closure4.doCall(/Users/dbyron/src/spinnaker/spinnaker/halyard/halyard-web/halyard-web.gradle:45)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
> Configure project :kayenta:kayenta-judge
The JavaExec.main property has been deprecated. This is scheduled to be removed in Gradle 8.0. Please use the mainClass property instead. See
https://docs.gradle.org/7.6.1/dsl/org.gradle.api.tasks.JavaExec.html#org.gradle.api.tasks.JavaExec:main for more details.
        at kayenta_judge_3w2tlszjxmhx4fsy67gwh2pq9$_run_closure2.doCall(/Users/dbyron/src/spinnaker/spinnaker/kayenta/kayenta-judge/kayenta-judge.gradle:20)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
> Configure project :keel:keel-web
The JavaApplication.setMainClassName(String) method has been deprecated. This is scheduled to be removed in Gradle 8.0. Use #getMainClass().set(...) instead. See
https://docs.gradle.org/7.6.1/dsl/org.gradle.api.plugins.JavaApplication.html#org.gradle.api.plugins.JavaApplication:mainClass for more details.
        at keel_web_3kjz5ug3uxlsm868rxqf9rfjc$_run_closure4.doCall(/Users/dbyron/src/spinnaker/spinnaker/keel/keel-web/keel-web.gradle:77)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
```
kayenta-mannwhitney has the same JavaExec.main deprecation as kayenta-judge but gradle deduplicates the warning.
