### PR TITLE
fix(kork/retrofit): remove unchecked, deprecation warnings

### DIFF
--- a/kork/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerHttpException.java
+++ b/kork/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerHttpException.java
@@ -16,8 +16,10 @@
 
 package com.netflix.spinnaker.kork.retrofit.exceptions;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.netflix.spinnaker.kork.annotations.NullableByDefault;
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
 import java.util.Map;
 import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
@@ -34,6 +36,8 @@ import retrofit2.Retrofit;
 @NullableByDefault
 @Slf4j
 public class SpinnakerHttpException extends SpinnakerServerException {
+
+  private static final Type ERROR_BODY_TYPE = new TypeReference<Map<String, Object>>() {}.getType();
 
   private HttpHeaders headers;
 
@@ -161,8 +165,8 @@ public class SpinnakerHttpException extends SpinnakerServerException {
       return null;
     }
 
-    Converter<ResponseBody, Map> converter =
-        retrofit.responseBodyConverter(Map.class, new Annotation[0]);
+    Converter<ResponseBody, Map<String, Object>> converter =
+        retrofit.responseBodyConverter(ERROR_BODY_TYPE, new Annotation[0]);
     try {
       return converter.convert(retrofit2Response.errorBody());
     } catch (Exception e) {

--- a/kork/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/Retrofit2SyncCallTest.java
+++ b/kork/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/Retrofit2SyncCallTest.java
@@ -33,7 +33,7 @@ class Retrofit2SyncCallTest {
 
   @Test
   void testExecuteSuccess() throws IOException {
-    Call<String> mockCall = mock(Call.class);
+    Call<String> mockCall = mock();
     String responseBody = "testing";
     when(mockCall.execute()).thenReturn(Response.success(responseBody));
     String execute = Retrofit2SyncCall.execute(mockCall);
@@ -42,12 +42,12 @@ class Retrofit2SyncCallTest {
 
   @Test
   void testExecuteThrowException() throws IOException {
-    Call<String> mockCall = mock(Call.class);
+    Call<String> mockCall = mock();
     IOException ioException = new IOException("exception test");
     when(mockCall.execute()).thenThrow(ioException);
 
     HttpUrl url = HttpUrl.parse("http://arbitrary-url");
-    Request mockRequest = mock(Request.class);
+    Request mockRequest = mock();
     when(mockCall.request()).thenReturn(mockRequest);
     when(mockRequest.url()).thenReturn(url);
 

--- a/kork/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerHttpExceptionTest.java
+++ b/kork/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerHttpExceptionTest.java
@@ -35,7 +35,7 @@ class SpinnakerHttpExceptionTest {
     final String validJsonResponseBodyString = "{\"name\":\"test\"}";
     ResponseBody responseBody =
         ResponseBody.create(
-            MediaType.parse("application/json" + "; charset=utf-8"), validJsonResponseBodyString);
+            validJsonResponseBodyString, MediaType.parse("application/json" + "; charset=utf-8"));
     retrofit2.Response response =
         retrofit2.Response.error(HttpStatus.NOT_FOUND.value(), responseBody);
 

--- a/kork/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerRetrofitExceptionHandlersTest.java
+++ b/kork/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerRetrofitExceptionHandlersTest.java
@@ -205,7 +205,7 @@ class SpinnakerRetrofitExceptionHandlersTest {
           retrofit2.Response.error(
               status,
               ResponseBody.create(
-                  MediaType.parse("application/json"), "{ \"message\": \"arbitrary message\" }"));
+                  "{ \"message\": \"arbitrary message\" }", MediaType.parse("application/json")));
 
       Retrofit retrofit =
           new Retrofit.Builder()

--- a/kork/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerRetrofitExceptionHandlersTest.java
+++ b/kork/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerRetrofitExceptionHandlersTest.java
@@ -153,8 +153,8 @@ class SpinnakerRetrofitExceptionHandlersTest {
     class WebSecurityConfig implements WebMvcConfigurer {
       @Bean
       protected SecurityFilterChain configure(HttpSecurity http) throws Exception {
-        http.csrf().disable().headers().disable();
-        http.authorizeRequests().anyRequest().permitAll();
+        http.csrf(csrf -> csrf.disable()).headers(headers -> headers.disable());
+        http.authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
         return http.build();
       }
     }


### PR DESCRIPTION
```
> Task :kork:kork-retrofit:compileJava
/Users/dbyron/src/spinnaker/spinnaker/kork/kork-retrofit/src/main/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerHttpException.java:167: warning: [unchecked] unchecked conversion
      return converter.convert(retrofit2Response.errorBody());
                              ^
  required: Map<String,Object>
  found:    Map
1 warning
```
```
> Task :kork:kork-retrofit:compileTestJava
/Users/dbyron/src/spinnaker/spinnaker/kork/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerHttpExceptionTest.java:37: warning: [deprecation] create(MediaType,String) in ResponseBod>
        ResponseBody.create(
                    ^
/Users/dbyron/src/spinnaker/spinnaker/kork/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerRetrofitExceptionHandlersTest.java:207: warning: [deprecation] create(MediaType,String) i>
              ResponseBody.create(
                          ^
/Users/dbyron/src/spinnaker/spinnaker/kork/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/Retrofit2SyncCallTest.java:36: warning: [unchecked] unchecked conversion
    Call<String> mockCall = mock(Call.class);
                                ^
  required: Call<String>
  found:    Call
/Users/dbyron/src/spinnaker/spinnaker/kork/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/Retrofit2SyncCallTest.java:45: warning: [unchecked] unchecked conversion
    Call<String> mockCall = mock(Call.class);
                                ^
  required: Call<String>
  found:    Call
4 warnings
```
```
> Task :kork:kork-retrofit:compileTestJava
/Users/dbyron/src/spinnaker/spinnaker/kork/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerRetrofitExceptionHandlersTest.java:156: warning: [removal] csrf() in HttpSecurity has been deprecated and marked for removal
        http.csrf().disable().headers().disable();
            ^
/Users/dbyron/src/spinnaker/spinnaker/kork/kork-retrofit/src/test/java/com/netflix/spinnaker/kork/retrofit/exceptions/SpinnakerRetrofitExceptionHandlersTest.java:156: warning: [removal] headers() in HttpSecurity has been deprecated and marked for removal
        http.csrf().disable().headers().disable();
```
