### PR TITLE
fix(spinnaker-gradle-project/publishing): replace deprecated JacksonFactory with GsonFactory

### DIFF
--- a/spinnaker-gradle-project/spinnaker-project-plugin/src/main/groovy/com/netflix/spinnaker/gradle/publishing/artifactregistry/ArtifactRegistryDebPublishTask.java
+++ b/spinnaker-gradle-project/spinnaker-project-plugin/src/main/groovy/com/netflix/spinnaker/gradle/publishing/artifactregistry/ArtifactRegistryDebPublishTask.java
@@ -1,7 +1,7 @@
 package com.netflix.spinnaker.gradle.publishing.artifactregistry;
 
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
-import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.services.artifactregistry.v1beta2.ArtifactRegistryScopes;
 import com.google.api.services.artifactregistry.v1beta2.model.ImportAptArtifactsGcsSource;
 import com.google.api.services.artifactregistry.v1beta2.model.ImportAptArtifactsRequest;
@@ -148,7 +148,7 @@ class ArtifactRegistryDebPublishTask extends DefaultTask {
     InterruptedException {
 
     ArtifactRegistry artifactRegistryClient = new ArtifactRegistry(
-      GoogleNetHttpTransport.newTrustedTransport(), JacksonFactory.getDefaultInstance(), new HttpCredentialsAdapter(
+      GoogleNetHttpTransport.newTrustedTransport(), GsonFactory.getDefaultInstance(), new HttpCredentialsAdapter(
         resolveCredentials()
       )
     );


### PR DESCRIPTION
to remove this deprecation warning:
```
> Task :spinnaker-gradle-project:spinnaker-project-plugin:compileGroovy
/Users/dbyron/src/spinnaker/spinnaker/spinnaker-gradle-project/spinnaker-project-plugin/src/main/groovy/com/netflix/spinnaker/gradle/publishing/artifactregistry/ArtifactRegistryDebPublishTask.java:151: warning: [deprecation] JacksonFactory in com.google.api.client.json.jackson2 has been deprecated
      GoogleNetHttpTransport.newTrustedTransport(), JacksonFactory.getDefaultInstance(), new HttpCredentialsAdapter(
                                                    ^
1 warning
```
