### PR TITLE
fix(kork/sql-test):  remove deprecation warnings

### DIFF
--- a/kork/kork-sql-test/kork-sql-test.gradle
+++ b/kork/kork-sql-test/kork-sql-test.gradle
@@ -7,6 +7,11 @@ dependencies {
   api("org.testcontainers:mysql")
   api("org.testcontainers:postgresql")
 
+  // jOOQ's org.jooq.conf.Settings uses jakarta.xml.bind annotations but
+  // declares jakarta.xml.bind-api as optional.  Without this, javac warns:
+  // unknown enum constant XmlAccessType.FIELD
+  compileOnly("jakarta.xml.bind:jakarta.xml.bind-api")
+
   testImplementation "org.junit.jupiter:junit-jupiter-api"
 
   testRuntimeOnly "com.mysql:mysql-connector-j"

--- a/kork/kork-sql-test/src/main/java/com/netflix/spinnaker/kork/sql/test/SqlTestUtil.java
+++ b/kork/kork-sql-test/src/main/java/com/netflix/spinnaker/kork/sql/test/SqlTestUtil.java
@@ -16,7 +16,8 @@
 package com.netflix.spinnaker.kork.sql.test;
 
 import static org.jooq.SQLDialect.H2;
-import static org.jooq.conf.RenderNameStyle.AS_IS;
+import static org.jooq.conf.RenderNameCase.AS_IS;
+import static org.jooq.conf.RenderQuotedNames.NEVER;
 import static org.jooq.impl.DSL.currentSchema;
 import static org.jooq.impl.DSL.query;
 import static org.jooq.impl.DSL.truncateTable;
@@ -31,12 +32,12 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import liquibase.ContextExpression;
-import liquibase.LabelExpression;
+import liquibase.Contexts;
+import liquibase.GlobalConfiguration;
+import liquibase.Labels;
 import liquibase.Liquibase;
 import liquibase.changelog.ChangeLogParameters;
 import liquibase.changelog.DatabaseChangeLog;
-import liquibase.configuration.GlobalConfiguration;
-import liquibase.configuration.LiquibaseConfiguration;
 import liquibase.database.DatabaseFactory;
 import liquibase.database.jvm.JdbcConnection;
 import liquibase.exception.DatabaseException;
@@ -200,7 +201,7 @@ public class SqlTestUtil {
     config.setSQLDialect(dialect);
 
     if (dialect == H2) {
-      config.settings().withRenderNameStyle(AS_IS);
+      config.settings().withRenderQuotedNames(NEVER).withRenderNameCase(AS_IS);
     }
 
     DSLContext context = new DefaultDSLContext(config);
@@ -223,8 +224,10 @@ public class SqlTestUtil {
           Comparator.comparing(String::toString),
           new ClassLoaderResourceAccessor(),
           new ContextExpression(),
-          new LabelExpression(),
-          false);
+          new Labels(),
+          false,
+          0,
+          Integer.MAX_VALUE);
 
       migrate =
           new Liquibase(
@@ -238,7 +241,7 @@ public class SqlTestUtil {
     }
 
     try {
-      migrate.update(dbName);
+      migrate.update(new Contexts(dbName));
     } catch (LiquibaseException e) {
       throw new DatabaseInitializationFailed(e);
     }
@@ -249,8 +252,9 @@ public class SqlTestUtil {
   public static void cleanupDb(DSLContext context) {
     String schema = context.select(currentSchema()).fetch().getValue(0, 0).toString();
 
-    GlobalConfiguration configuration =
-        LiquibaseConfiguration.getInstance().getConfiguration(GlobalConfiguration.class);
+    String changeLogTableName = GlobalConfiguration.DATABASECHANGELOG_TABLE_NAME.getCurrentValue();
+    String changeLogLockTableName =
+        GlobalConfiguration.DATABASECHANGELOGLOCK_TABLE_NAME.getCurrentValue();
 
     List<Query> commands = new ArrayList<>();
     if (context.dialect() == SQLDialect.MYSQL) {
@@ -261,8 +265,8 @@ public class SqlTestUtil {
             table ->
                 table.getTableType().isTable()
                     && table.getSchema().getName().equals(schema)
-                    && !table.getName().equals(configuration.getDatabaseChangeLogTableName())
-                    && !table.getName().equals(configuration.getDatabaseChangeLogLockTableName()))
+                    && !table.getName().equals(changeLogTableName)
+                    && !table.getName().equals(changeLogLockTableName))
         .forEach(
             table -> {
               switch (context.dialect()) {

--- a/kork/kork-sql-test/src/main/java/com/netflix/spinnaker/kork/sql/test/SqlTestUtil.java
+++ b/kork/kork-sql-test/src/main/java/com/netflix/spinnaker/kork/sql/test/SqlTestUtil.java
@@ -31,17 +31,20 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import liquibase.ContextExpression;
-import liquibase.Contexts;
 import liquibase.GlobalConfiguration;
 import liquibase.Labels;
 import liquibase.Liquibase;
+import liquibase.Scope;
 import liquibase.changelog.ChangeLogParameters;
 import liquibase.changelog.DatabaseChangeLog;
+import liquibase.command.CommandScope;
+import liquibase.command.core.UpdateCommandStep;
+import liquibase.command.core.helpers.DbUrlConnectionCommandStep;
 import liquibase.database.DatabaseFactory;
 import liquibase.database.jvm.JdbcConnection;
 import liquibase.exception.DatabaseException;
-import liquibase.exception.LiquibaseException;
 import liquibase.exception.SetupException;
 import liquibase.resource.ClassLoaderResourceAccessor;
 import org.jooq.DSLContext;
@@ -240,9 +243,28 @@ public class SqlTestUtil {
       throw new DatabaseInitializationFailed(e);
     }
 
+    // Liquibase.update() is deprecated; use the CommandScope API instead.
+    // See https://contribute.liquibase.com/code/api/command-commandscope/
+    // The argument wiring and Scope.child call below mirror the deprecated
+    // Liquibase.update(Contexts, LabelExpression, boolean) and
+    // Liquibase.runInScope methods in liquibase-core 4.24.0.
     try {
-      migrate.update(new Contexts(dbName));
-    } catch (LiquibaseException e) {
+      Scope.child(
+          Map.of(
+              Scope.Attr.database.name(), migrate.getDatabase(),
+              Scope.Attr.resourceAccessor.name(), migrate.getResourceAccessor()),
+          () -> {
+            CommandScope updateCommand = new CommandScope(UpdateCommandStep.COMMAND_NAME);
+            updateCommand.addArgumentValue(
+                DbUrlConnectionCommandStep.DATABASE_ARG, migrate.getDatabase());
+            updateCommand.addArgumentValue(
+                UpdateCommandStep.CHANGELOG_ARG, migrate.getDatabaseChangeLog());
+            updateCommand.addArgumentValue(
+                UpdateCommandStep.CHANGELOG_FILE_ARG, migrate.getChangeLogFile());
+            updateCommand.addArgumentValue(UpdateCommandStep.CONTEXTS_ARG, dbName);
+            updateCommand.execute();
+          });
+    } catch (Exception e) {
       throw new DatabaseInitializationFailed(e);
     }
 


### PR DESCRIPTION
```
$ ./gradlew :kork:kork-sql-test:compileJava
warning: unknown enum constant XmlAccessType.FIELD
  reason: class file for jakarta.xml.bind.annotation.XmlAccessType not found
/Users/dbyron/src/spinnaker/spinnaker/kork/kork-sql-test/src/main/java/com/netflix/spinnaker/kork/sql/test/SqlTestUtil.java:19: warning: [deprecation] RenderNameStyle in org.jooq.conf has been deprecated
import static org.jooq.conf.RenderNameStyle.AS_IS;
                           ^
/Users/dbyron/src/spinnaker/spinnaker/kork/kork-sql-test/src/main/java/com/netflix/spinnaker/kork/sql/test/SqlTestUtil.java:19: warning: [deprecation] RenderNameStyle in org.jooq.conf has been deprecated
import static org.jooq.conf.RenderNameStyle.AS_IS;
                           ^
/Users/dbyron/src/spinnaker/spinnaker/kork/kork-sql-test/src/main/java/com/netflix/spinnaker/kork/sql/test/SqlTestUtil.java:19: warning: [deprecation] RenderNameStyle in org.jooq.conf has been deprecated
import static org.jooq.conf.RenderNameStyle.AS_IS;
                           ^
warning: unknown enum constant XmlAccessType.FIELD
  reason: class file for jakarta.xml.bind.annotation.XmlAccessType not found
/Users/dbyron/src/spinnaker/spinnaker/kork/kork-sql-test/src/main/java/com/netflix/spinnaker/kork/sql/test/SqlTestUtil.java:203: warning: [deprecation] withRenderNameStyle(RenderNameStyle) in Settings has been deprecated
      config.settings().withRenderNameStyle(AS_IS);
                       ^
/Users/dbyron/src/spinnaker/spinnaker/kork/kork-sql-test/src/main/java/com/netflix/spinnaker/kork/sql/test/SqlTestUtil.java:218: warning: [deprecation] includeAll(String,boolean,IncludeAllFilter,boolean,Comparator<String>,ResourceAccessor,ContextExpression,LabelExpression,boolean) in DatabaseChangeLog has been deprecated
      changeLog.includeAll(
               ^
/Users/dbyron/src/spinnaker/spinnaker/kork/kork-sql-test/src/main/java/com/netflix/spinnaker/kork/sql/test/SqlTestUtil.java:241: warning: [deprecation] update(String) in Liquibase has been deprecated
      migrate.update(dbName);
             ^
/Users/dbyron/src/spinnaker/spinnaker/kork/kork-sql-test/src/main/java/com/netflix/spinnaker/kork/sql/test/SqlTestUtil.java:252: warning: [deprecation] GlobalConfiguration in liquibase.configuration has been deprecated
    GlobalConfiguration configuration =
    ^
/Users/dbyron/src/spinnaker/spinnaker/kork/kork-sql-test/src/main/java/com/netflix/spinnaker/kork/sql/test/SqlTestUtil.java:253: warning: [deprecation] GlobalConfiguration in liquibase.configuration has been deprecated
        LiquibaseConfiguration.getInstance().getConfiguration(GlobalConfiguration.class);
                                                              ^
/Users/dbyron/src/spinnaker/spinnaker/kork/kork-sql-test/src/main/java/com/netflix/spinnaker/kork/sql/test/SqlTestUtil.java:253: warning: [deprecation] getInstance() in LiquibaseConfiguration has been deprecated
        LiquibaseConfiguration.getInstance().getConfiguration(GlobalConfiguration.class);
                              ^
/Users/dbyron/src/spinnaker/spinnaker/kork/kork-sql-test/src/main/java/com/netflix/spinnaker/kork/sql/test/SqlTestUtil.java:253: warning: [deprecation] <T>getConfiguration(Class<T>) in LiquibaseConfiguration has been deprecated
        LiquibaseConfiguration.getInstance().getConfiguration(GlobalConfiguration.class);
                                            ^
  where T is a type-variable:
    T extends ConfigurationContainer declared in method <T>getConfiguration(Class<T>)
/Users/dbyron/src/spinnaker/spinnaker/kork/kork-sql-test/src/main/java/com/netflix/spinnaker/kork/sql/test/SqlTestUtil.java:264: warning: [deprecation] getDatabaseChangeLogTableName() in GlobalConfiguration has been deprecated
                    && !table.getName().equals(configuration.getDatabaseChangeLogTableName())
                                                            ^
/Users/dbyron/src/spinnaker/spinnaker/kork/kork-sql-test/src/main/java/com/netflix/spinnaker/kork/sql/test/SqlTestUtil.java:265: warning: [deprecation] getDatabaseChangeLogLockTableName() in GlobalConfiguration has been deprecated
                    && !table.getName().equals(configuration.getDatabaseChangeLogLockTableName()))
                                                            ^
```
