### PR TITLE
fix(kork/sql): remove warnings

### DIFF
--- a/kork/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/JooqSqlCommentAppender.kt
+++ b/kork/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/JooqSqlCommentAppender.kt
@@ -17,14 +17,14 @@ package com.netflix.spinnaker.kork.sql
 
 import com.netflix.spinnaker.security.AuthenticatedRequest
 import org.jooq.ExecuteContext
-import org.jooq.impl.DefaultExecuteListener
+import org.jooq.ExecuteListener
 import org.slf4j.MDC
 
 /**
  * Appends contextual information about the source of a SQL query for
  * debugging purposes.
  */
-class JooqSqlCommentAppender : DefaultExecuteListener() {
+class JooqSqlCommentAppender : ExecuteListener {
 
   override fun renderEnd(ctx: ExecuteContext) {
     val comments: ArrayList<String> = ArrayList()

--- a/kork/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/JooqToSpringExceptionTransformer.kt
+++ b/kork/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/JooqToSpringExceptionTransformer.kt
@@ -25,10 +25,9 @@ import org.springframework.jdbc.support.SQLErrorCodeSQLExceptionTranslator
 class JooqToSpringExceptionTransformer : ExecuteListener {
 
   override fun exception(ctx: ExecuteContext) {
-    if (ctx.sqlException() != null) {
-      val dialect = ctx.configuration().dialect()
-      val translator = SQLErrorCodeSQLExceptionTranslator(dialect.name)
-      ctx.exception(translator.translate("jOOQ", ctx.sql(), ctx.sqlException()))
-    }
+    val sqlException = ctx.sqlException() ?: return
+    val dialect = ctx.configuration().dialect()
+    val translator = SQLErrorCodeSQLExceptionTranslator(dialect.name)
+    ctx.exception(translator.translate("jOOQ", ctx.sql(), sqlException))
   }
 }

--- a/kork/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/JooqToSpringExceptionTransformer.kt
+++ b/kork/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/JooqToSpringExceptionTransformer.kt
@@ -16,14 +16,14 @@
 package com.netflix.spinnaker.kork.sql
 
 import org.jooq.ExecuteContext
-import org.jooq.impl.DefaultExecuteListener
+import org.jooq.ExecuteListener
 import org.springframework.jdbc.support.SQLErrorCodeSQLExceptionTranslator
 import org.springframework.jdbc.support.SQLStateSQLExceptionTranslator
 
 /**
  * Converts raw JDBC exceptions exposed by jOOQ into Spring-compatible exceptions.
  */
-class JooqToSpringExceptionTransformer : DefaultExecuteListener() {
+class JooqToSpringExceptionTransformer : ExecuteListener {
 
   override fun exception(ctx: ExecuteContext) {
     if (ctx.sqlException() != null) {

--- a/kork/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/JooqToSpringExceptionTransformer.kt
+++ b/kork/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/JooqToSpringExceptionTransformer.kt
@@ -18,7 +18,6 @@ package com.netflix.spinnaker.kork.sql
 import org.jooq.ExecuteContext
 import org.jooq.ExecuteListener
 import org.springframework.jdbc.support.SQLErrorCodeSQLExceptionTranslator
-import org.springframework.jdbc.support.SQLStateSQLExceptionTranslator
 
 /**
  * Converts raw JDBC exceptions exposed by jOOQ into Spring-compatible exceptions.
@@ -28,11 +27,7 @@ class JooqToSpringExceptionTransformer : ExecuteListener {
   override fun exception(ctx: ExecuteContext) {
     if (ctx.sqlException() != null) {
       val dialect = ctx.configuration().dialect()
-      val translator = if (dialect != null) {
-        SQLErrorCodeSQLExceptionTranslator(dialect.name)
-      } else {
-        SQLStateSQLExceptionTranslator()
-      }
+      val translator = SQLErrorCodeSQLExceptionTranslator(dialect.name)
       ctx.exception(translator.translate("jOOQ", ctx.sql(), ctx.sqlException()))
     }
   }

--- a/kork/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/config/DefaultSqlConfiguration.kt
+++ b/kork/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/config/DefaultSqlConfiguration.kt
@@ -124,7 +124,7 @@ class DefaultSqlConfiguration {
 
     validateDefaultTargetDataSources(targets.values)
 
-    val dataSources = targets.map { it.key.toLowerCase() to it.value.dataSource }.toMap()
+    val dataSources = targets.map { it.key.lowercase() to it.value.dataSource }.toMap()
     val dataSource = NamedDataSourceRouter()
     dataSource.setTargetDataSources(dataSources as Map<Any, Any>)
     dataSource.setDataSourceLookup(StaticDataSourceLookup(dataSources))

--- a/kork/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/config/DefaultSqlConfiguration.kt
+++ b/kork/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/config/DefaultSqlConfiguration.kt
@@ -125,8 +125,11 @@ class DefaultSqlConfiguration {
 
     validateDefaultTargetDataSources(targets.values)
 
-    val dataSources = targets.map { it.key.lowercase() to it.value.dataSource }.toMap()
+    val dataSources: Map<String, DataSource> = targets.map { it.key.lowercase() to it.value.dataSource }.toMap()
     val dataSource = NamedDataSourceRouter()
+    // Safe: Map<String, DataSource> is a Map<Any, Any> at runtime due to erasure,
+    // but Kotlin's invariant Map key type prevents a direct assignment.
+    @Suppress("UNCHECKED_CAST")
     dataSource.setTargetDataSources(dataSources as Map<Any, Any>)
     dataSource.setDataSourceLookup(StaticDataSourceLookup(dataSources))
     dataSource.setDefaultTargetDataSource(

--- a/kork/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/config/DefaultSqlConfiguration.kt
+++ b/kork/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/config/DefaultSqlConfiguration.kt
@@ -78,7 +78,8 @@ class DefaultSqlConfiguration {
   fun secondaryLiquibase(properties: SqlProperties, @Value("\${sql.read-only:false}") sqlReadOnly: Boolean): SpringLiquibase =
     SpringLiquibaseProxy(properties.secondaryMigration, sqlReadOnly)
 
-  @Suppress("ThrowsCount", "UndocumentedPublicFunction")
+  // Remove DEPRECATION suppression once SqlProperties.connectionPool is removed
+  @Suppress("ThrowsCount", "UndocumentedPublicFunction", "DEPRECATION")
   @DependsOn("liquibase")
   @Bean
   fun dataSource(dataSourceFactory: DataSourceFactory, properties: SqlProperties): DataSource {

--- a/kork/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/config/SqlProperties.kt
+++ b/kork/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/config/SqlProperties.kt
@@ -56,6 +56,8 @@ data class SqlProperties(
    * Convenience method for accessing all connection pool properties, backwards-compatible with deprecated
    * [connectionPool] configuration.
    */
+  // Remove DEPRECATION suppression once SqlProperties.connectionPool is removed
+  @Suppress("DEPRECATION")
   fun getDefaultConnectionPoolProperties(): ConnectionPoolProperties {
     if (connectionPools.isEmpty()) {
       if (connectionPool == null) {

--- a/kork/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/migration/SpringLiquibaseProxy.kt
+++ b/kork/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/migration/SpringLiquibaseProxy.kt
@@ -72,10 +72,14 @@ class SpringLiquibaseProxy(
 
   private fun createDataSource(): DataSource =
     sqlMigrationProperties.run {
+      // SingleConnectionDataSource's constructor params are marked non-null by
+      // the @NonNullApi package annotation
+      // (https://github.com/spring-projects/spring-framework/blob/v6.0.21/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/package-info.java),
+      // but the constructor delegates to @Nullable setters and null is valid at
+      // runtime (e.g. for databases that don't require auth).
+      @Suppress("NULLABILITY_MISMATCH_BASED_ON_JAVA_ANNOTATIONS")
       val ds = SingleConnectionDataSource(jdbcUrl, user, password, true)
-      if (driver != null) {
-        ds.setDriverClassName(driver)
-      }
+      driver?.let { ds.setDriverClassName(it) }
       ds
     }
 }

--- a/kork/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/routing/NamedDatabaseContextHolder.kt
+++ b/kork/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/routing/NamedDatabaseContextHolder.kt
@@ -23,7 +23,7 @@ object NamedDatabaseContextHolder {
   private val context: ThreadLocal<String> = ThreadLocal()
 
   fun set(name: String) {
-    context.set(name.toLowerCase())
+    context.set(name.lowercase())
   }
 
   fun get(): String? = context.get()

--- a/kork/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/routing/StaticDataSourceLookup.kt
+++ b/kork/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/routing/StaticDataSourceLookup.kt
@@ -17,6 +17,7 @@ package com.netflix.spinnaker.kork.sql.routing
 
 import javax.sql.DataSource
 import org.springframework.jdbc.datasource.lookup.DataSourceLookup
+import org.springframework.jdbc.datasource.lookup.DataSourceLookupFailureException
 
 /**
  * Lookup a [DataSource] by name from a static set.
@@ -28,6 +29,9 @@ class StaticDataSourceLookup(
   private val dataSources: Map<String, DataSource>
 ) : DataSourceLookup {
 
-  override fun getDataSource(dataSourceName: String): DataSource? =
+  override fun getDataSource(dataSourceName: String): DataSource =
     dataSources[dataSourceName]
+      ?: throw DataSourceLookupFailureException(
+        "No DataSource with name '$dataSourceName' registered"
+      )
 }

--- a/kork/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/telemetry/JooqSlowQueryLogger.kt
+++ b/kork/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/telemetry/JooqSlowQueryLogger.kt
@@ -17,7 +17,7 @@ package com.netflix.spinnaker.kork.sql.telemetry
 
 import java.util.concurrent.TimeUnit
 import org.jooq.ExecuteContext
-import org.jooq.impl.DefaultExecuteListener
+import org.jooq.ExecuteListener
 import org.jooq.tools.StopWatch
 import org.slf4j.LoggerFactory
 
@@ -26,7 +26,7 @@ import org.slf4j.LoggerFactory
  */
 class JooqSlowQueryLogger(
   slowQuerySecondsThreshold: Long = 1
-) : DefaultExecuteListener() {
+) : ExecuteListener {
 
   private lateinit var watch: StopWatch
 
@@ -34,12 +34,10 @@ class JooqSlowQueryLogger(
   private val slowQueryThreshold = TimeUnit.SECONDS.toNanos(slowQuerySecondsThreshold)
 
   override fun executeStart(ctx: ExecuteContext) {
-    super.executeStart(ctx)
     watch = StopWatch()
   }
 
   override fun executeEnd(ctx: ExecuteContext) {
-    super.executeEnd(ctx)
     if (watch.split() > slowQueryThreshold) {
       log.warn("Slow SQL (${watch.splitToMillis()}ms):\n${ctx.query()}")
     }


### PR DESCRIPTION
```
> Task :kork:kork-sql:compileKotlin
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/JooqSqlCommentAppender.kt:20:22 'DefaultExecuteListener' is deprecated. Deprecated in Java
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/JooqSqlCommentAppender.kt:27:32 'DefaultExecuteListener' is deprecated. Deprecated in Java
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/JooqToSpringExceptionTransformer.kt:19:22 'DefaultExecuteListener' is deprecated. Deprecated in Java
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/JooqToSpringExceptionTransformer.kt:26:42 'DefaultExecuteListener' is deprecated. Deprecated in Java
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/JooqToSpringExceptionTransformer.kt:31:28 Condition 'dialect != null' is always 'true'
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/JooqToSpringExceptionTransformer.kt:36:61 Type mismatch: inferred type is SQLException? but SQLException was expected
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/config/DefaultSqlConfiguration.kt:85:63 'connectionPool: ConnectionPoolProperties?' is deprecated. use named connection pools instead
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/config/DefaultSqlConfiguration.kt:90:22 'connectionPool: ConnectionPoolProperties?' is deprecated. use named connection pools instead
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/config/DefaultSqlConfiguration.kt:94:60 'connectionPool: ConnectionPoolProperties?' is deprecated. use named connection pools instead
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/config/DefaultSqlConfiguration.kt:127:44 'toLowerCase(): String' is deprecated. Use lowercase() instead.
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/config/DefaultSqlConfiguration.kt:129:49 Unchecked cast: Map<String, DataSource> to Map<Any, Any>
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/config/SqlProperties.kt:61:11 'connectionPool: ConnectionPoolProperties?' is deprecated. use named connection pools instead
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/config/SqlProperties.kt:64:14 'connectionPool: ConnectionPoolProperties?' is deprecated. use named connection pools instead
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/migration/SpringLiquibaseProxy.kt:75:43 Type mismatch: inferred type is String? but String was expected
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/migration/SpringLiquibaseProxy.kt:75:52 Type mismatch: inferred type is String? but String was expected
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/migration/SpringLiquibaseProxy.kt:75:58 Type mismatch: inferred type is String? but String was expected
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/migration/SpringLiquibaseProxy.kt:77:31 Type mismatch: inferred type is String? but String was expected
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/routing/NamedDatabaseContextHolder.kt:26:22 'toLowerCase(): String' is deprecated. Use lowercase() instead.
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/routing/StaticDataSourceLookup.kt:31:3 Override 'fun getDataSource(dataSourceName: String): DataSource?' has incorrect nullability in its signature comparing with overridden 'fun getDataSource(dataSourceName: String): DataSource'This warning will become an error soon. See https://youtrack.jetbrains.com/issue/KT-36770 for details
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/telemetry/JooqSlowQueryLogger.kt:20:22 'DefaultExecuteListener' is deprecated. Deprecated in Java
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/telemetry/JooqSlowQueryLogger.kt:29:5 'DefaultExecuteListener' is deprecated. Deprecated in Java
```