### PR TITLE
fix(kork/moniker): fix unchecked warnings in FriggaReflectiveNamer

### DIFF
--- a/kork/kork-moniker/src/main/java/com/netflix/spinnaker/moniker/frigga/FriggaReflectiveNamer.java
+++ b/kork/kork-moniker/src/main/java/com/netflix/spinnaker/moniker/frigga/FriggaReflectiveNamer.java
@@ -53,7 +53,7 @@ public class FriggaReflectiveNamer implements Namer<Object> {
   }
 
   private void setName(Object obj, String name) {
-    Class clazz = obj.getClass();
+    Class<?> clazz = obj.getClass();
 
     // First walk up the object hierarchy and try to find some "setName" method to call
     while (clazz != Object.class) {
@@ -88,7 +88,7 @@ public class FriggaReflectiveNamer implements Namer<Object> {
   }
 
   private String getName(Object obj) {
-    Class clazz = obj.getClass();
+    Class<?> clazz = obj.getClass();
 
     // If the object is a String, just return it.
     if (clazz == String.class) {


### PR DESCRIPTION
```
$ ./gradlew kork:kork-moniker:compileJava
> Task :kork:kork-moniker:compileJava
/Users/dbyron/src/spinnaker/spinnaker/kork/kork-moniker/src/main/java/com/netflix/spinnaker/moniker/frigga/FriggaReflectiveNamer.java:61: warning: [unchecked] unchecked call to getDeclaredMethod(String,Class<?>...) as a member of the raw type Class
        Method setName = clazz.getDeclaredMethod("setName", String.class);
                                                ^
/Users/dbyron/src/spinnaker/spinnaker/kork/kork-moniker/src/main/java/com/netflix/spinnaker/moniker/frigga/FriggaReflectiveNamer.java:101: warning: [unchecked] unchecked call to getDeclaredMethod(String,Class<?>...) as a member of the raw type Class
        Method setName = clazz.getDeclaredMethod("getName");
```
