### PR TITLE
fix(kork/core): remove yaml-related deprecation warnings

### DIFF
--- a/kork/kork-core/src/main/java/com/netflix/spinnaker/kork/yaml/YamlHelper.java
+++ b/kork/kork-core/src/main/java/com/netflix/spinnaker/kork/yaml/YamlHelper.java
@@ -67,8 +67,8 @@ public class YamlHelper {
       LoaderOptions opts = getLoaderOptions();
 
       Constructor constructor = new Constructor(opts);
-      Representer representer = new Representer();
       DumperOptions dumperOpts = new DumperOptions();
+      Representer representer = new Representer(dumperOpts);
       Resolver resolver = new Resolver(); // default tag resolver
 
       return new Yaml(constructor, representer, dumperOpts, opts, resolver);
@@ -89,13 +89,13 @@ public class YamlHelper {
       LoaderOptions opts = getLoaderOptions();
 
       SafeConstructor constructor = new SafeConstructor(opts);
-      Representer representer = new Representer();
       DumperOptions dumperOpts = new DumperOptions();
+      Representer representer = new Representer(dumperOpts);
 
       return new Yaml(constructor, representer, dumperOpts, opts);
     }
 
-    return new Yaml(new SafeConstructor());
+    return new Yaml(new SafeConstructor(new LoaderOptions()));
   }
 
   /**
@@ -110,12 +110,13 @@ public class YamlHelper {
       LoaderOptions opts = getLoaderOptions();
 
       SafeConstructor constructor = new SafeConstructor(opts);
-      Representer representer = new Representer();
+      Representer representer = new Representer(dumperOptions);
 
       return new Yaml(constructor, representer, dumperOptions, opts);
     }
 
-    return new Yaml(new SafeConstructor(), new Representer(), dumperOptions);
+    return new Yaml(
+        new SafeConstructor(new LoaderOptions()), new Representer(dumperOptions), dumperOptions);
   }
 
   /**

--- a/kork/kork-core/src/test/java/com/netflix/spinnaker/kork/yaml/YamlHelperTest.java
+++ b/kork/kork-core/src/test/java/com/netflix/spinnaker/kork/yaml/YamlHelperTest.java
@@ -164,7 +164,8 @@ class YamlHelperTest {
     String doc = yamlWithNAliases(56);
     assertThatThrownBy(
             () ->
-                YamlHelper.newYamlRepresenter(new Constructor(Object.class), new Representer())
+                YamlHelper.newYamlRepresenter(
+                        new Constructor(Object.class), new Representer(new DumperOptions()))
                     .load(doc))
         .isInstanceOf(YAMLException.class)
         .hasMessage("Number of aliases for non-scalar nodes exceeds the specified max=55");
@@ -174,7 +175,8 @@ class YamlHelperTest {
   public void aliasLimitIsNotExceededYamlRepresenter() {
     String okString = yamlWithNAliases(50);
     Object result =
-        YamlHelper.newYamlRepresenter(new Constructor(Object.class), new Representer())
+        YamlHelper.newYamlRepresenter(
+                new Constructor(Object.class), new Representer(new DumperOptions()))
             .load(okString);
     assertThat(result).isNotNull();
   }
@@ -185,7 +187,8 @@ class YamlHelperTest {
     String bigString = yamlWithNCodePoints(1025);
     assertThatThrownBy(
             () ->
-                YamlHelper.newYamlRepresenter(new Constructor(Object.class), new Representer())
+                YamlHelper.newYamlRepresenter(
+                        new Constructor(Object.class), new Representer(new DumperOptions()))
                     .load(bigString))
         .isInstanceOf(YAMLException.class)
         .hasMessage("The incoming YAML document exceeds the limit: 1024 code points.");
@@ -195,7 +198,8 @@ class YamlHelperTest {
   public void codePointLimitIsNotExceededYamlRepresenter() {
     String okString = yamlWithNCodePoints(1000);
     Object result =
-        YamlHelper.newYamlRepresenter(new Constructor(Object.class), new Representer())
+        YamlHelper.newYamlRepresenter(
+                new Constructor(Object.class), new Representer(new DumperOptions()))
             .load(okString);
     assertThat(result).isNotNull();
   }


### PR DESCRIPTION
in YamlHelper / YamlHelperTest.
```
$ ./gradlew kork:kork-core:compileJava

> Task :kork:kork-core:compileJava
/Users/dbyron/src/spinnaker/spinnaker/kork/kork-core/src/main/java/com/netflix/spinnaker/kork/yaml/YamlHelper.java:70: warning: [deprecation] Representer() in Representer has been deprecated
      Representer representer = new Representer();
                                ^
/Users/dbyron/src/spinnaker/spinnaker/kork/kork-core/src/main/java/com/netflix/spinnaker/kork/yaml/YamlHelper.java:92: warning: [deprecation] Representer() in Representer has been deprecated
      Representer representer = new Representer();
                                ^
/Users/dbyron/src/spinnaker/spinnaker/kork/kork-core/src/main/java/com/netflix/spinnaker/kork/yaml/YamlHelper.java:98: warning: [deprecation] SafeConstructor() in SafeConstructor has been deprecated
    return new Yaml(new SafeConstructor());
                    ^
/Users/dbyron/src/spinnaker/spinnaker/kork/kork-core/src/main/java/com/netflix/spinnaker/kork/yaml/YamlHelper.java:113: warning: [deprecation] Representer() in Representer has been deprecated
      Representer representer = new Representer();
                                ^
/Users/dbyron/src/spinnaker/spinnaker/kork/kork-core/src/main/java/com/netflix/spinnaker/kork/yaml/YamlHelper.java:118: warning: [deprecation] SafeConstructor() in SafeConstructor has been deprecated
    return new Yaml(new SafeConstructor(), new Representer(), dumperOptions);
                    ^
/Users/dbyron/src/spinnaker/spinnaker/kork/kork-core/src/main/java/com/netflix/spinnaker/kork/yaml/YamlHelper.java:118: warning: [deprecation] Representer() in Representer has been deprecated
    return new Yaml(new SafeConstructor(), new Representer(), dumperOptions);
                                           ^
```
```
$ ./gradlew kork:kork-core:compileTestJava

> Task :kork:kork-core:compileTestJava
/Users/dbyron/src/spinnaker/spinnaker/kork/kork-core/src/test/java/com/netflix/spinnaker/kork/yaml/YamlHelperTest.java:167: warning: [deprecation] Representer() in Representer has been deprecated
                YamlHelper.newYamlRepresenter(new Constructor(Object.class), new Representer())
                                                                             ^
/Users/dbyron/src/spinnaker/spinnaker/kork/kork-core/src/test/java/com/netflix/spinnaker/kork/yaml/YamlHelperTest.java:177: warning: [deprecation] Representer() in Representer has been deprecated
        YamlHelper.newYamlRepresenter(new Constructor(Object.class), new Representer())
                                                                     ^
/Users/dbyron/src/spinnaker/spinnaker/kork/kork-core/src/test/java/com/netflix/spinnaker/kork/yaml/YamlHelperTest.java:188: warning: [deprecation] Representer() in Representer has been deprecated
                YamlHelper.newYamlRepresenter(new Constructor(Object.class), new Representer())
                                                                             ^
/Users/dbyron/src/spinnaker/spinnaker/kork/kork-core/src/test/java/com/netflix/spinnaker/kork/yaml/YamlHelperTest.java:198: warning: [deprecation] Representer() in Representer has been deprecated
        YamlHelper.newYamlRepresenter(new Constructor(Object.class), new Representer())
                                                                     ^
```
Use Representer(DumperOptions) and SafeConstructor(LoaderOptions) instead
of the no-arg constructors deprecated since SnakeYAML 1.31.
