### PR TITLE
chore(kork/sql/test): remove warnings + clean up test output

### DIFF
--- a/kork/kork-sql/src/test/kotlin/com/netflix/spinnaker/kork/sql/SpringStartupTests.kt
+++ b/kork/kork-sql/src/test/kotlin/com/netflix/spinnaker/kork/sql/SpringStartupTests.kt
@@ -24,18 +24,14 @@ import org.jooq.impl.DSL.table
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.beans.factory.getBeansOfType
+//import org.springframework.beans.factory.getBeansOfType
 import org.springframework.boot.actuate.health.HealthIndicator
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.Import
-import org.springframework.test.context.TestPropertySource
 import org.springframework.test.context.junit.jupiter.SpringExtension
-import strikt.api.expectThat
-import strikt.assertions.isA
-import strikt.assertions.isEqualTo
-import strikt.assertions.isNotNull
+import org.assertj.core.api.Assertions.assertThat
 
 @ExtendWith(SpringExtension::class)
 @SpringBootTest(
@@ -62,17 +58,17 @@ internal class SpringStartupTests {
 
   @Test
   fun `uses SqlHealthIndicator`() {
-    expectThat(dbHealthIndicator).isA<SqlHealthIndicator>()
+    assertThat(dbHealthIndicator).isInstanceOf(SqlHealthIndicator::class.java)
 
-    expectThat(
+    assertThat(
       jooq
         .insertInto(table("healthcheck"), listOf(field("id")))
         .values(true).execute()
     ).isEqualTo(1)
 
-    expectThat(applicationContext.getBeansOfType(DSLContext::class.java).size).isEqualTo(1)
-    expectThat(applicationContext.getBean("jooq")).isNotNull()
-    expectThat(applicationContext.getBean("liquibase")).isNotNull()
+    assertThat(applicationContext.getBeansOfType(DSLContext::class.java)).hasSize(1)
+    assertThat(applicationContext.getBean("jooq")).isNotNull()
+    assertThat(applicationContext.getBean("liquibase")).isNotNull()
   }
 }
 

--- a/kork/kork-sql/src/test/kotlin/com/netflix/spinnaker/kork/sql/SqlConfigurationTests.kt
+++ b/kork/kork-sql/src/test/kotlin/com/netflix/spinnaker/kork/sql/SqlConfigurationTests.kt
@@ -31,10 +31,7 @@ import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.Import
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.junit.jupiter.SpringExtension
-import strikt.api.expectThat
-import strikt.assertions.isA
-import strikt.assertions.isEqualTo
-import strikt.assertions.isNotNull
+import org.assertj.core.api.Assertions.assertThat
 
 internal class SqlConfigurationTests {
 
@@ -55,14 +52,12 @@ internal class SqlConfigurationTests {
 
     @Test
     fun `should have 2 JOOQ configured one for each H2 and MySQL`() {
-      expectThat(applicationContext.getBeansOfType(DSLContext::class.java).size).isEqualTo(2)
-      expectThat(sqlProperties.connectionPools.size).isEqualTo(2)
-      expectThat(applicationContext.getBean("jooq")).isNotNull()
-      expectThat(applicationContext.getBean("jooq")).isA<DSLContext>()
-      expectThat(applicationContext.getBean("secondaryJooq")).isNotNull()
-      expectThat(applicationContext.getBean("secondaryJooq")).isA<DSLContext>()
-      expectThat(applicationContext.getBean("liquibase")).isNotNull()
-      expectThat(applicationContext.getBean("secondaryLiquibase")).isNotNull()
+      assertThat(applicationContext.getBeansOfType(DSLContext::class.java)).hasSize(2)
+      assertThat(sqlProperties.connectionPools).hasSize(2)
+      assertThat(applicationContext.getBean("jooq")).isNotNull().isInstanceOf(DSLContext::class.java)
+      assertThat(applicationContext.getBean("secondaryJooq")).isNotNull().isInstanceOf(DSLContext::class.java)
+      assertThat(applicationContext.getBean("liquibase")).isNotNull()
+      assertThat(applicationContext.getBean("secondaryLiquibase")).isNotNull()
     }
   }
 
@@ -83,11 +78,10 @@ internal class SqlConfigurationTests {
 
     @Test
     fun `should have 1 JOOQ configured for MYSQL`() {
-      expectThat(applicationContext.getBeansOfType(DSLContext::class.java).size).isEqualTo(1)
-      expectThat(sqlProperties.connectionPools.size).isEqualTo(2)
-      expectThat(applicationContext.getBean("jooq")).isNotNull()
-      expectThat(applicationContext.getBean("jooq")).isA<DSLContext>()
-      expectThat(applicationContext.getBean("liquibase")).isNotNull()
+      assertThat(applicationContext.getBeansOfType(DSLContext::class.java)).hasSize(1)
+      assertThat(sqlProperties.connectionPools).hasSize(2)
+      assertThat(applicationContext.getBean("jooq")).isNotNull().isInstanceOf(DSLContext::class.java)
+      assertThat(applicationContext.getBean("liquibase")).isNotNull()
     }
   }
 }

--- a/kork/kork-sql/src/test/resources/logback-test.xml
+++ b/kork/kork-sql/src/test/resources/logback-test.xml
@@ -1,0 +1,33 @@
+<!--
+
+    Copyright 2026 Salesforce, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+    <!-- tone down logging here to clean up noise on stdout during spring context shutdown -->
+    <logger name="com.zaxxer.hikari.HikariDataSource" level="warn"/>
+
+</configuration>


### PR DESCRIPTION
to avoid:
```
> Task :kork:kork-sql:test
2026-04-11T22:30:14.161-07:00  INFO 49552 --- [ionShutdownHook] com.zaxxer.hikari.HikariDataSource       : default - Shutdown initiated...
2026-04-11T22:30:14.161-07:00  INFO 49552 --- [ionShutdownHook] com.zaxxer.hikari.HikariDataSource       : default - Shutdown completed.
```
and
```
> Task :kork:kork-sql:compileTestKotlin
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-sql/src/test/kotlin/com/netflix/spinnaker/kork/sql/SpringStartupTests.kt:74:5 Unsafe use of a nullable receiver of type DescribeableBuilder<Any>
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-sql/src/test/kotlin/com/netflix/spinnaker/kork/sql/SpringStartupTests.kt:75:5 Unsafe use of a nullable receiver of type DescribeableBuilder<Any>
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-sql/src/test/kotlin/com/netflix/spinnaker/kork/sql/SqlConfigurationTests.kt:60:7 Unsafe use of a nullable receiver of type DescribeableBuilder<Any>
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-sql/src/test/kotlin/com/netflix/spinnaker/kork/sql/SqlConfigurationTests.kt:62:7 Unsafe use of a nullable receiver of type DescribeableBuilder<Any>
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-sql/src/test/kotlin/com/netflix/spinnaker/kork/sql/SqlConfigurationTests.kt:64:7 Unsafe use of a nullable receiver of type DescribeableBuilder<Any>
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-sql/src/test/kotlin/com/netflix/spinnaker/kork/sql/SqlConfigurationTests.kt:65:7 Unsafe use of a nullable receiver of type DescribeableBuilder<Any>
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-sql/src/test/kotlin/com/netflix/spinnaker/kork/sql/SqlConfigurationTests.kt:88:7 Unsafe use of a nullable receiver of type DescribeableBuilder<Any>
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-sql/src/test/kotlin/com/netflix/spinnaker/kork/sql/SqlConfigurationTests.kt:90:7 Unsafe use of a nullable receiver of type DescribeableBuilder<Any>
```
