### PR TITLE
fix(kork/plugins): remove warnings

### DIFF
--- a/kork/build.gradle
+++ b/kork/build.gradle
@@ -48,8 +48,19 @@ subprojects {
 
   if (it.name != "kork-bom" && it.name != "spinnaker-dependencies") {
     apply plugin: 'java-library'
+    apply plugin: 'jacoco'
     test {
       useJUnitPlatform()
+      jacoco {
+        enabled = project.hasProperty('testCoverage')
+      }
+    }
+    jacocoTestReport {
+      dependsOn test
+      reports {
+        xml.required = true
+        html.required = true
+      }
     }
     dependencies {
       annotationProcessor(platform(project(":spinnaker-dependencies")))

--- a/kork/kork-plugins-tck/src/main/kotlin/com/netflix/spinnaker/kork/plugins/tck/PluginsTck.kt
+++ b/kork/kork-plugins-tck/src/main/kotlin/com/netflix/spinnaker/kork/plugins/tck/PluginsTck.kt
@@ -70,7 +70,7 @@ abstract class PluginsTck<T : PluginsTckFixture> : JUnit5Minutests {
 /**
  * DSL for constructing a service fixture within a Minutest suite.
  */
-inline fun <PF, reified F> TestContextBuilder<PF, F>.serviceFixture(
+inline fun <PF, reified F : Any> TestContextBuilder<PF, F>.serviceFixture(
   crossinline factory: (Unit).(testDescriptor: TestDescriptor) -> F
 ) {
   fixture { testDescriptor ->

--- a/kork/kork-plugins-tck/src/main/kotlin/com/netflix/spinnaker/kork/plugins/testplugin/GeneratedTestPlugin.kt
+++ b/kork/kork-plugins-tck/src/main/kotlin/com/netflix/spinnaker/kork/plugins/testplugin/GeneratedTestPlugin.kt
@@ -33,7 +33,7 @@ class GeneratedTestPlugin {
    */
   var name: String = "Generated"
     set(value) {
-      field = value.capitalize()
+      field = value.replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() }
     }
 
   /**
@@ -49,7 +49,7 @@ class GeneratedTestPlugin {
   /**
    * The plugin ID of the generated plugin.
    */
-  var pluginId: String = "spinnaker.${name.toLowerCase()}-testplugin"
+  var pluginId: String = "spinnaker.${name.lowercase()}-testplugin"
   internal var sources: MutableList<SourceFile> = mutableListOf()
   internal var pluginClass: SourceFile? = null
 

--- a/kork/kork-plugins-tck/src/main/kotlin/com/netflix/spinnaker/kork/plugins/testplugin/TestPluginBuilderSupport.kt
+++ b/kork/kork-plugins-tck/src/main/kotlin/com/netflix/spinnaker/kork/plugins/testplugin/TestPluginBuilderSupport.kt
@@ -60,7 +60,7 @@ class TestPluginBuilderSupport(
   /**
    * The fully resolved plugin ID.
    */
-  val pluginId = "spinnaker.${name.toLowerCase()}testplugin"
+  val pluginId = "spinnaker.${name.lowercase()}testplugin"
 
   /**
    * Compiles the generated sources of a plugin.
@@ -191,7 +191,7 @@ class TestPluginBuilderSupport(
 
     import com.netflix.spinnaker.kork.plugins.api.ExtensionConfiguration;
 
-    @ExtensionConfiguration("spinnaker.${name.toLowerCase()}-test-extension")
+    @ExtensionConfiguration("spinnaker.${name.lowercase()}-test-extension")
     public class ${name}TestExtensionConfiguration {
       private String foo;
     }

--- a/kork/kork-plugins-tck/src/main/kotlin/com/netflix/spinnaker/kork/plugins/testplugin/builders.kt
+++ b/kork/kork-plugins-tck/src/main/kotlin/com/netflix/spinnaker/kork/plugins/testplugin/builders.kt
@@ -29,7 +29,7 @@ fun testPlugin(init: GeneratedTestPlugin.() -> Unit): GeneratedTestPlugin =
 fun basicGeneratedPlugin(pluginName: String? = null, version: String? = null): GeneratedTestPlugin =
   testPlugin {
     if (pluginName != null) {
-      name = pluginName.capitalize()
+      name = pluginName.replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() }
     }
 
     if (version != null) {

--- a/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/ExtensionBeanDefinitionRegistryPostProcessor.kt
+++ b/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/ExtensionBeanDefinitionRegistryPostProcessor.kt
@@ -87,7 +87,7 @@ class ExtensionBeanDefinitionRegistryPostProcessor(
       }
 
       val bean = pluginManager.extensionFactory.create(extensionClass)
-      val beanName = "${extensionClass.simpleName.decapitalize()}SystemExtension"
+      val beanName = "${extensionClass.simpleName.replaceFirstChar { it.lowercase() }}SystemExtension"
 
       beanFactory.registerSingleton(beanName, bean)
 
@@ -122,7 +122,7 @@ class ExtensionBeanDefinitionRegistryPostProcessor(
           extensionClassInstance
         }
 
-        val beanName = "${plugin.pluginId.replace(".", "")}${extensionClass.simpleName.capitalize()}"
+        val beanName = "${plugin.pluginId.replace(".", "")}${extensionClass.simpleName.replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() }}"
 
         beanFactory.registerSingleton(beanName, bean)
 

--- a/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/ExtensionBeanDefinitionRegistryPostProcessor.kt
+++ b/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/ExtensionBeanDefinitionRegistryPostProcessor.kt
@@ -41,7 +41,7 @@ class ExtensionBeanDefinitionRegistryPostProcessor(
   private val pluginInfoReleaseProvider: PluginInfoReleaseProvider,
   private val springPluginStatusProvider: SpringPluginStatusProvider,
   private val applicationEventPublisher: ApplicationEventPublisher,
-  private val invocationAspects: List<InvocationAspect<*>>
+  private val invocationAspects: List<InvocationAspect<InvocationState>>
 ) : BeanDefinitionRegistryPostProcessor {
 
   private val log by lazy { LoggerFactory.getLogger(javaClass) }
@@ -115,7 +115,7 @@ class ExtensionBeanDefinitionRegistryPostProcessor(
         val bean = if (extensionClassInstance is SpinnakerExtensionPoint) {
           ExtensionInvocationProxy.proxy(
             extensionClassInstance,
-            invocationAspects as List<InvocationAspect<InvocationState>>,
+            invocationAspects,
             plugin.descriptor as SpinnakerPluginDescriptor
           )
         } else {

--- a/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/SpinnakerPluginManager.kt
+++ b/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/SpinnakerPluginManager.kt
@@ -127,7 +127,7 @@ open class SpinnakerPluginManager(
   }
 
   override fun createPluginRepository(): PluginRepository = CompoundPluginRepository()
-    .add(PluginRefPluginRepository(getPluginsRoot()), this::isDevelopment)
+    .add(PluginRefPluginRepository(pluginsRoots.single()), this::isDevelopment)
     .add(super.createPluginRepository())
 
   override fun getPluginFactory(): PluginFactory = spinnakerPluginFactory

--- a/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/dsl.kt
+++ b/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/dsl.kt
@@ -54,7 +54,7 @@ internal enum class ClassKind {
   PLUGIN,
   EXTENSION;
 
-  override fun toString(): String = super.toString().toLowerCase()
+  override fun toString(): String = super.toString().lowercase()
 }
 
 internal fun Class<*>.createWithConstructor(

--- a/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/dsl.kt
+++ b/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/dsl.kt
@@ -120,7 +120,7 @@ internal fun Class<*>.createWithConstructor(
 
 internal fun Class<*>.newInstanceSafely(kind: ClassKind): Any =
   try {
-    newInstance()
+    getDeclaredConstructor().newInstance()
   } catch (ie: InstantiationException) {
     throw IntegrationException("Failed to instantiate $kind '${declaringClass.simpleName}'", ie)
   } catch (iae: IllegalAccessException) {

--- a/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/dsl.kt
+++ b/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/dsl.kt
@@ -16,7 +16,6 @@
 package com.netflix.spinnaker.kork.plugins
 
 import com.netflix.spinnaker.kork.exceptions.IntegrationException
-import com.netflix.spinnaker.kork.plugins.api.ExtensionConfiguration
 import com.netflix.spinnaker.kork.plugins.api.PluginConfiguration
 import com.netflix.spinnaker.kork.plugins.api.PluginSdks
 import com.netflix.spinnaker.kork.plugins.config.ConfigFactory
@@ -78,6 +77,7 @@ internal fun Class<*>.createWithConstructor(
 
   val ctor = declaredConstructors.first()
 
+  @Suppress("DEPRECATION") // ExtensionConfiguration is deprecated in favor of PluginConfiguration
   val args = ctor.parameterTypes.map { paramType ->
     when {
       paramType == PluginWrapper::class.java && classKind == ClassKind.PLUGIN -> pluginWrapper
@@ -98,11 +98,11 @@ internal fun Class<*>.createWithConstructor(
           paramType.getAnnotation(PluginConfiguration::class.java).value
         )
       }
-      paramType.isAnnotationPresent(ExtensionConfiguration::class.java) -> {
+      paramType.isAnnotationPresent(com.netflix.spinnaker.kork.plugins.api.ExtensionConfiguration::class.java) -> {
         configFactory.createExtensionConfig(
           paramType,
           pluginWrapper?.descriptor?.pluginId,
-          paramType.getAnnotation(ExtensionConfiguration::class.java).value
+          paramType.getAnnotation(com.netflix.spinnaker.kork.plugins.api.ExtensionConfiguration::class.java).value
         )
       }
       else -> {

--- a/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/pluginref/PluginRef.kt
+++ b/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/pluginref/PluginRef.kt
@@ -76,7 +76,7 @@ data class PluginRef(
      * Returns whether or not the provided [path] is a valid [PluginRef].
      */
     fun isPluginRef(path: Path?): Boolean =
-      path != null && Files.isRegularFile(path) && path.toString().toLowerCase().endsWith(EXTENSION)
+      path != null && Files.isRegularFile(path) && path.toString().lowercase().endsWith(EXTENSION)
 
     /**
      * Loads the given [path] as a [PluginRef].

--- a/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/proxy/aspects/InvocationAspect.kt
+++ b/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/proxy/aspects/InvocationAspect.kt
@@ -25,7 +25,7 @@ import java.lang.reflect.Method
  * An aspect to use with [ExtensionInvocationProxy], allows for storing state about an invocation
  * and accessing that state on [error] and [after] the invocation.
  */
-interface InvocationAspect<I : InvocationState> {
+interface InvocationAspect<out I : InvocationState> {
 
   /**
    * Determines if the instance supports the specified [InvocationState] type.
@@ -51,7 +51,7 @@ interface InvocationAspect<I : InvocationState> {
    *
    * @param invocationState The state object created via [before]
    */
-  fun after(invocationState: I)
+  fun after(invocationState: @UnsafeVariance I)
 
   /**
    * If the method invocation threw an InvocationTargetException, apply some additional processing if
@@ -60,7 +60,7 @@ interface InvocationAspect<I : InvocationState> {
    * @param e InvocationTargetException which is thrown via
    * @param invocationState The invocationState object created via [before]
    */
-  fun error(e: InvocationTargetException, invocationState: I)
+  fun error(e: InvocationTargetException, invocationState: @UnsafeVariance I)
 
   /**
    * Called last and always called, regardless of invocation success or failure.
@@ -69,5 +69,5 @@ interface InvocationAspect<I : InvocationState> {
    *
    * @param invocationState The invocationState object created via [before]
    */
-  fun finally(invocationState: I) { /* default implementation */ }
+  fun finally(invocationState: @UnsafeVariance I) { /* default implementation */ }
 }

--- a/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/proxy/aspects/MetricInvocationAspect.kt
+++ b/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/proxy/aspects/MetricInvocationAspect.kt
@@ -175,7 +175,7 @@ class MetricInvocationAspect(
     enum class Result {
       SUCCESS, FAILURE;
 
-      override fun toString(): String = name.toLowerCase()
+      override fun toString(): String = name.lowercase()
     }
   }
 }

--- a/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/sdk/PluginSdksImpl.kt
+++ b/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/sdk/PluginSdksImpl.kt
@@ -47,7 +47,7 @@ class PluginSdksImpl(
         if (!type.isAssignableFrom(it.javaClass)) {
           throw IntegrationException("Requested unknown serivce SDK type, but '${it.javaClass.simpleName}' is available")
         }
-        it as T
+        type.cast(it)
       }
       ?: throw SystemException("No service SDK is configured for this service")
 

--- a/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/sdk/httpclient/Ok3HttpClientRegistry.kt
+++ b/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/sdk/httpclient/Ok3HttpClientRegistry.kt
@@ -73,7 +73,7 @@ class Ok3HttpClientRegistry(
   }
 
   private fun findInternalServiceBaseUrl(name: String): String {
-    val normalized = name.toLowerCase()
+    val normalized = name.lowercase()
     val paths = baseUrlPaths.map { it.replace(serviceNamePlaceholder, normalized) }
 
     for (path in paths) {

--- a/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/update/SpinnakerUpdateManager.kt
+++ b/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/update/SpinnakerUpdateManager.kt
@@ -99,7 +99,7 @@ class SpinnakerUpdateManager(
 
     log.debug("Downloading plugin '{}' with version '{}'", pluginId, props.version)
     val tmpPath = downloadPluginRelease(pluginId, props.version)
-    val downloadedPluginPath = pluginManager.pluginsRoot.write(pluginId, tmpPath)
+    val downloadedPluginPath = pluginManager.pluginsRoots.single().write(pluginId, tmpPath)
 
     log.debug("Downloaded plugin '{}'", pluginId)
     applicationEventPublisher.publishEvent(
@@ -160,7 +160,7 @@ class SpinnakerUpdateManager(
    * necessary.
    */
   private fun Path.write(pluginId: String, downloaded: Path): Path {
-    if (pluginManager.pluginsRoot == this) {
+    if (pluginManager.pluginsRoots.single() == this) {
       val file = this.resolve(pluginId + "-" + downloaded.fileName.toString())
       File(this.toString()).mkdirs()
       try {

--- a/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/update/downloader/FileDownloaderProvider.kt
+++ b/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/update/downloader/FileDownloaderProvider.kt
@@ -61,7 +61,7 @@ class FileDownloaderProvider(
         ?: throw IntegrationException("Could not find matching constructor on file downloader for injecting config")
       ctor.newInstance(config)
     } else {
-      downloaderClass.newInstance()
+      downloaderClass.getDeclaredConstructor().newInstance()
     } as FileDownloader
   }
 }

--- a/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/v2/PluginContainer.kt
+++ b/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/v2/PluginContainer.kt
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.kork.plugins.v2
 import com.netflix.spinnaker.kork.plugins.SpinnakerPluginDescriptor
 import com.netflix.spinnaker.kork.plugins.proxy.aspects.InvocationAspect
 import org.pf4j.Plugin
+import org.pf4j.PluginWrapper
 import org.springframework.beans.factory.config.AutowireCapableBeanFactory
 import org.springframework.beans.factory.config.BeanDefinition
 import org.springframework.beans.factory.support.BeanDefinitionBuilder
@@ -33,14 +34,16 @@ import org.springframework.context.support.GenericApplicationContext
  * `$plugin.actual::java.class` to get access to the actual plugin Java class.
  *
  * @param actual The actual plugin-provided [Plugin] class.
+ * @param pluginWrapper The [PluginWrapper] for the actual plugin.
  */
 class PluginContainer(
   val actual: Plugin,
   private val serviceApplicationContext: GenericApplicationContext,
-) : Plugin(actual.wrapper) {
+  val pluginWrapper: PluginWrapper,
+) : Plugin() {
 
   internal val pluginContext = GenericApplicationContext(serviceApplicationContext).also {
-    ApplicationContextGraph.pluginContexts[wrapper.pluginId] = it
+    ApplicationContextGraph.pluginContexts[pluginWrapper.pluginId] = it
   }
 
   /**
@@ -48,13 +51,13 @@ class PluginContainer(
    * initialized at the correct time in the service's startup process.
    */
   fun registerInitializer(registry: BeanDefinitionRegistry): String {
-    val initializerBeanName = "${wrapper.pluginId}Initializer"
+    val initializerBeanName = "${pluginWrapper.pluginId}Initializer"
 
     val initializerBeanDefinition = BeanDefinitionBuilder.genericBeanDefinition(SpringPluginInitializer::class.java)
       .setScope(BeanDefinition.SCOPE_SINGLETON)
       .setAutowireMode(AutowireCapableBeanFactory.AUTOWIRE_NO)
       .addConstructorArgValue(actual)
-      .addConstructorArgValue(actual.wrapper)
+      .addConstructorArgValue(pluginWrapper)
       .addConstructorArgValue(pluginContext)
       .beanDefinition
 

--- a/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/v2/SpinnakerPluginService.kt
+++ b/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/v2/SpinnakerPluginService.kt
@@ -51,7 +51,7 @@ class SpinnakerPluginService(
   private val updateManager: SpinnakerUpdateManager,
   private val pluginInfoReleaseProvider: PluginInfoReleaseProvider,
   private val springPluginStatusProvider: SpringPluginStatusProvider,
-  private val invocationAspects: List<InvocationAspect<*>>,
+  private val invocationAspects: List<InvocationAspect<InvocationState>>,
   private val applicationEventPublisher: ApplicationEventPublisher
 ) {
 
@@ -121,7 +121,7 @@ class SpinnakerPluginService(
       addIncludeFilter(AssignableTypeFilter(SpinnakerExtensionPoint::class.java))
       resourceLoader = DefaultResourceLoader(container.wrapper.pluginClassLoader)
     }.findCandidateComponents(container.actual.basePackageName).forEach { extensionBeanDefinition ->
-      val extensionBeanClass = container.wrapper.pluginClassLoader.loadClass(extensionBeanDefinition.beanClassName) as Class<out SpinnakerExtensionPoint>
+      val extensionBeanClass = container.wrapper.pluginClassLoader.loadClass(extensionBeanDefinition.beanClassName).asSubclass(SpinnakerExtensionPoint::class.java)
 
       // Find the name that the extension bean will (but hasn't yet) be given inside the plugin application context.
       // We'll use this to look up the extension inside the lazy loader.
@@ -141,7 +141,7 @@ class SpinnakerPluginService(
           return@lazy pluginContext.getBean(pluginContextBeanName) as SpinnakerExtensionPoint
         },
         extensionBeanClass,
-        invocationAspects as List<InvocationAspect<InvocationState>>,
+        invocationAspects,
         container.wrapper.descriptor as SpinnakerPluginDescriptor
       )
 

--- a/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/v2/SpinnakerPluginService.kt
+++ b/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/v2/SpinnakerPluginService.kt
@@ -150,7 +150,7 @@ class SpinnakerPluginService(
         beanClass = extensionBeanClass
       }
       registry.registerBeanDefinition(
-        "${pluginId}_${extensionBeanClass.simpleName.decapitalize()}",
+        "${pluginId}_${extensionBeanClass.simpleName.replaceFirstChar { it.lowercase() }}",
         proxyBeanDefinition
       )
 
@@ -165,7 +165,7 @@ class SpinnakerPluginService(
 
   private fun withTiming(task: String, callback: () -> Unit) {
     val start = System.currentTimeMillis()
-    log.debug(task.capitalize())
+    log.debug(task.replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() })
 
     callback.invoke()
 

--- a/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/v2/SpinnakerPluginService.kt
+++ b/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/v2/SpinnakerPluginService.kt
@@ -114,14 +114,14 @@ class SpinnakerPluginService(
    */
   private fun registerProxies(container: PluginContainer, registry: BeanDefinitionRegistry, initializerBeanName: String) {
     val pluginContext = container.pluginContext
-    val pluginId = container.wrapper.descriptor.pluginId
+    val pluginId = container.pluginWrapper.descriptor.pluginId
 
     // Find the plugin's SpinnakerExtensionPoints.
     ClassPathScanningCandidateComponentProvider(false).apply {
       addIncludeFilter(AssignableTypeFilter(SpinnakerExtensionPoint::class.java))
-      resourceLoader = DefaultResourceLoader(container.wrapper.pluginClassLoader)
+      resourceLoader = DefaultResourceLoader(container.pluginWrapper.pluginClassLoader)
     }.findCandidateComponents(container.actual.basePackageName).forEach { extensionBeanDefinition ->
-      val extensionBeanClass = container.wrapper.pluginClassLoader.loadClass(extensionBeanDefinition.beanClassName).asSubclass(SpinnakerExtensionPoint::class.java)
+      val extensionBeanClass = container.pluginWrapper.pluginClassLoader.loadClass(extensionBeanDefinition.beanClassName).asSubclass(SpinnakerExtensionPoint::class.java)
 
       // Find the name that the extension bean will (but hasn't yet) be given inside the plugin application context.
       // We'll use this to look up the extension inside the lazy loader.
@@ -142,7 +142,7 @@ class SpinnakerPluginService(
         },
         extensionBeanClass,
         invocationAspects,
-        container.wrapper.descriptor as SpinnakerPluginDescriptor
+        container.pluginWrapper.descriptor as SpinnakerPluginDescriptor
       )
 
       val proxyBeanDefinition = BeanDefinitionBuilder.genericBeanDefinition().beanDefinition.apply {

--- a/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/v2/SpringPluginFactory.kt
+++ b/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/v2/SpringPluginFactory.kt
@@ -59,7 +59,7 @@ class SpringPluginFactory(
     // PluginContainer attempts to offer some of the convenience that PrivilegedSpringPlugin does, but without using
     // Spring itself as an API contract.
     return if (actualPlugin !is PrivilegedSpringPlugin) {
-      PluginContainer(actualPlugin, serviceApplicationContext)
+      PluginContainer(actualPlugin, serviceApplicationContext, pluginWrapper)
     } else {
       actualPlugin
     }

--- a/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/v2/SpringPluginInitializer.kt
+++ b/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/v2/SpringPluginInitializer.kt
@@ -55,8 +55,8 @@ class SpringPluginInitializer(
       .addBeanPostProcessor(ApplicationEventListenerBeanPostProcessor())
 
     listOf(
-      PluginConfigurationRegisteringCustomizer(applicationContext.getBean(ConfigFactory::class.java)),
-      PluginSdksRegisteringCustomizer(applicationContext),
+      PluginConfigurationRegisteringCustomizer(applicationContext.getBean(ConfigFactory::class.java), pluginWrapper),
+      PluginSdksRegisteringCustomizer(applicationContext, pluginWrapper),
       ComponentScanningCustomizer()
     ).forEach {
       it.accept(plugin, pluginApplicationContext)

--- a/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/v2/context/PluginConfigurationRegisteringCustomizer.kt
+++ b/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/v2/context/PluginConfigurationRegisteringCustomizer.kt
@@ -21,6 +21,7 @@ import com.netflix.spinnaker.kork.plugins.api.PluginConfiguration
 import com.netflix.spinnaker.kork.plugins.config.ConfigFactory
 import com.netflix.spinnaker.kork.plugins.v2.basePackageName
 import org.pf4j.Plugin
+import org.pf4j.PluginWrapper
 import org.springframework.context.ConfigurableApplicationContext
 import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider
 import org.springframework.core.io.ResourceLoader
@@ -37,15 +38,16 @@ import org.springframework.util.ClassUtils
  */
 class PluginConfigurationRegisteringCustomizer(
   private val configFactory: ConfigFactory,
+  private val pluginWrapper: PluginWrapper,
   private var classResolver: ClassResolver? = null
 ) : PluginApplicationContextCustomizer {
 
   override fun accept(plugin: Plugin, context: ConfigurableApplicationContext) {
-    val resolver = classResolver ?: DefaultClassResolver(plugin.wrapper.pluginClassLoader)
+    val resolver = classResolver ?: DefaultClassResolver(pluginWrapper.pluginClassLoader)
 
     ClassPathScanningCandidateComponentProvider(false, context.environment)
       .apply {
-        resourceLoader = PathMatchingResourcePatternResolver(plugin.wrapper.pluginClassLoader)
+        resourceLoader = PathMatchingResourcePatternResolver(pluginWrapper.pluginClassLoader)
         addIncludeFilter(AnnotationTypeFilter(PluginConfiguration::class.java))
       }
       .findCandidateComponents(plugin.basePackageName)
@@ -54,7 +56,7 @@ class PluginConfigurationRegisteringCustomizer(
         val cls = resolver.resolveClassName(it)
         configFactory.createPluginConfig(
           cls,
-          plugin.wrapper.pluginId,
+          pluginWrapper.pluginId,
           cls.getAnnotation(PluginConfiguration::class.java).value
         )
       }

--- a/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/v2/context/PluginSdksRegisteringCustomizer.kt
+++ b/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/v2/context/PluginSdksRegisteringCustomizer.kt
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.kork.plugins.v2.context
 import com.netflix.spinnaker.kork.plugins.sdk.PluginSdksImpl
 import com.netflix.spinnaker.kork.plugins.sdk.SdkFactory
 import org.pf4j.Plugin
+import org.pf4j.PluginWrapper
 import org.springframework.context.ConfigurableApplicationContext
 
 /**
@@ -28,13 +29,14 @@ import org.springframework.context.ConfigurableApplicationContext
  * the SDKs we want to expose, rather than proxying them through [PluginSdksImpl].
  */
 class PluginSdksRegisteringCustomizer(
-  private val serviceApplicationContext: ConfigurableApplicationContext
+  private val serviceApplicationContext: ConfigurableApplicationContext,
+  private val pluginWrapper: PluginWrapper,
 ) : PluginApplicationContextCustomizer {
 
   override fun accept(plugin: Plugin, context: ConfigurableApplicationContext) {
     val sdk = PluginSdksImpl(
       serviceApplicationContext.getBeansOfType(SdkFactory::class.java).values
-        .map { it.create(plugin.javaClass, plugin.wrapper) }
+        .map { it.create(plugin.javaClass, pluginWrapper) }
     )
     context.beanFactory.registerSingleton("pluginSdks", sdk)
   }

--- a/kork/kork-plugins/src/test/java/com/netflix/spinnaker/kork/plugins/testplugin/unsafe/UnsafeTestPlugin.java
+++ b/kork/kork-plugins/src/test/java/com/netflix/spinnaker/kork/plugins/testplugin/unsafe/UnsafeTestPlugin.java
@@ -19,9 +19,13 @@ package com.netflix.spinnaker.kork.plugins.testplugin.unsafe;
 import org.pf4j.Plugin;
 import org.pf4j.PluginWrapper;
 
-/** An unsafe (in-codebase) Plugin for UnsafeTestExtension. */
+/**
+ * An unsafe (in-codebase) Plugin for UnsafeTestExtension.
+ *
+ * <p>The wrapper parameter is required for createWithConstructor DI type matching but intentionally
+ * unused since Plugin() no-arg replaces the deprecated Plugin(PluginWrapper) constructor.
+ */
+@SuppressWarnings("unused")
 public class UnsafeTestPlugin extends Plugin {
-  public UnsafeTestPlugin(PluginWrapper wrapper) {
-    super(wrapper);
-  }
+  public UnsafeTestPlugin(PluginWrapper wrapper) {}
 }

--- a/kork/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/DependencyInjectionTest.kt
+++ b/kork/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/DependencyInjectionTest.kt
@@ -230,7 +230,8 @@ class DependencyInjectionTest : JUnit5Minutests {
     private val config: TheConfig
   ) : TheExtensionPoint
 
-  class MyPlugin(wrapper: PluginWrapper) : Plugin(wrapper) {
+  @Suppress("UNUSED_PARAMETER") // wrapper is required for createWithConstructor DI type matching
+  class MyPlugin(wrapper: PluginWrapper) : Plugin() {
 
     class NoConfigExtension : TheExtensionPoint
 
@@ -250,7 +251,7 @@ class DependencyInjectionTest : JUnit5Minutests {
       private val validConfig: ValidConfig
     ) : TheExtensionPoint {
 
-      constructor(bad: String, validConfig: ValidConfig) : this(validConfig)
+      constructor(_bad: String, validConfig: ValidConfig) : this(validConfig)
 
       @PluginConfiguration("valid-config")
       class ValidConfig
@@ -262,10 +263,19 @@ class DependencyInjectionTest : JUnit5Minutests {
   }
 }
 
-internal class PluginWithoutInjection(wrapper: PluginWrapper) : Plugin(wrapper)
-internal class PluginWithSdks(wrapper: PluginWrapper, val sdks: PluginSdks) : Plugin(wrapper)
-internal class PluginWithConfig(wrapper: PluginWrapper, val config: DependencyInjectionTest.PluginConfig) : Plugin(wrapper)
-internal class PluginWithUnsupportedArg(wrapper: PluginWrapper, val bad: String) : Plugin(wrapper)
-internal class PluginWithMultipleConstructors(wrapper: PluginWrapper) : Plugin(wrapper) {
-  constructor(wrapper: PluginWrapper, sdks: PluginSdks) : this(wrapper)
+// These test fixture classes take a PluginWrapper constructor parameter because
+// createWithConstructor in dsl.kt matches on parameter types for DI injection.
+// The parameter is intentionally unused since Plugin() no-arg replaces the
+// deprecated Plugin(PluginWrapper) constructor.
+@Suppress("UNUSED_PARAMETER")
+internal class PluginWithoutInjection(wrapper: PluginWrapper) : Plugin()
+@Suppress("UNUSED_PARAMETER")
+internal class PluginWithSdks(wrapper: PluginWrapper, val sdks: PluginSdks) : Plugin()
+@Suppress("UNUSED_PARAMETER")
+internal class PluginWithConfig(wrapper: PluginWrapper, val config: DependencyInjectionTest.PluginConfig) : Plugin()
+@Suppress("UNUSED_PARAMETER")
+internal class PluginWithUnsupportedArg(wrapper: PluginWrapper, val bad: String) : Plugin()
+@Suppress("UNUSED_PARAMETER")
+internal class PluginWithMultipleConstructors(wrapper: PluginWrapper) : Plugin() {
+  constructor(wrapper: PluginWrapper, _sdks: PluginSdks) : this(wrapper)
 }

--- a/kork/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/DependencyInjectionTest.kt
+++ b/kork/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/DependencyInjectionTest.kt
@@ -16,7 +16,6 @@
 package com.netflix.spinnaker.kork.plugins
 
 import com.netflix.spinnaker.kork.exceptions.IntegrationException
-import com.netflix.spinnaker.kork.plugins.api.ExtensionConfiguration
 import com.netflix.spinnaker.kork.plugins.api.PluginConfiguration
 import com.netflix.spinnaker.kork.plugins.api.PluginSdks
 import com.netflix.spinnaker.kork.plugins.api.yaml.YamlResourceLoader
@@ -221,7 +220,7 @@ class DependencyInjectionTest : JUnit5Minutests {
 
   private class NoConfigSystemExtension : TheExtensionPoint
 
-  @ExtensionConfiguration("extension-point-configuration")
+  @PluginConfiguration("extension-point-configuration")
   class TheConfig
 
   @PluginConfiguration
@@ -239,7 +238,7 @@ class DependencyInjectionTest : JUnit5Minutests {
       private val config: TheConfig
     ) : TheExtensionPoint {
 
-      @ExtensionConfiguration("extension-point-configuration")
+      @PluginConfiguration("extension-point-configuration")
       class TheConfig
     }
 
@@ -253,7 +252,7 @@ class DependencyInjectionTest : JUnit5Minutests {
 
       constructor(bad: String, validConfig: ValidConfig) : this(validConfig)
 
-      @ExtensionConfiguration("valid-config")
+      @PluginConfiguration("valid-config")
       class ValidConfig
     }
 

--- a/kork/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/ExtensionBeanDefinitionRegistryPostProcessorTest.kt
+++ b/kork/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/ExtensionBeanDefinitionRegistryPostProcessorTest.kt
@@ -15,7 +15,7 @@
  */
 package com.netflix.spinnaker.kork.plugins
 
-import com.netflix.spinnaker.kork.plugins.api.ExtensionConfiguration
+import com.netflix.spinnaker.kork.plugins.api.PluginConfiguration
 import com.netflix.spinnaker.kork.plugins.api.spring.PrivilegedSpringPlugin
 import com.netflix.spinnaker.kork.plugins.events.ExtensionLoaded
 import com.netflix.spinnaker.kork.plugins.internal.TestPlugin
@@ -142,7 +142,7 @@ class ExtensionBeanDefinitionRegistryPostProcessorTest : JUnit5Minutests {
   private class FooExtension : ExampleExtensionPoint {
     lateinit var config: FooExtensionConfig
 
-    @ExtensionConfiguration("netflix.foo")
+    @PluginConfiguration("netflix.foo")
     class FooExtensionConfig
   }
 

--- a/kork/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/SpinnakerPluginManagerTest.kt
+++ b/kork/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/SpinnakerPluginManagerTest.kt
@@ -77,8 +77,8 @@ class FakePluginStatusProvider : PluginStatusProvider {
 }
 
 class FakeConfigResolver : ConfigResolver {
-  override fun <T> resolve(coordinates: ConfigCoordinates, expectedType: Class<T>) = expectedType.newInstance()
+  override fun <T> resolve(coordinates: ConfigCoordinates, expectedType: Class<T>): T = expectedType.getDeclaredConstructor().newInstance()
   override fun <T> resolve(coordinates: ConfigCoordinates, expectedType: TypeReference<T>): T =
     @Suppress("UNCHECKED_CAST")
-    ((expectedType.type as ParameterizedType).rawType as Class<T>).newInstance()
+    ((expectedType.type as ParameterizedType).rawType as Class<T>).getDeclaredConstructor().newInstance()
 }

--- a/kork/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/config/ConfigFactoryTest.kt
+++ b/kork/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/config/ConfigFactoryTest.kt
@@ -15,7 +15,7 @@
  */
 package com.netflix.spinnaker.kork.plugins.config
 
-import com.netflix.spinnaker.kork.plugins.api.ExtensionConfiguration
+import com.netflix.spinnaker.kork.plugins.api.PluginConfiguration
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
 import io.mockk.every
@@ -57,7 +57,7 @@ class ConfigFactoryTest : JUnit5Minutests {
     val subject = ConfigFactory(configResolver)
   }
 
-  @ExtensionConfiguration("my-sweet-extension")
+  @PluginConfiguration("my-sweet-extension")
   private data class MyExtensionConfig(val message: String)
 
   private data class MyPluginConfig(val message: String)

--- a/kork/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/internal/TestPlugin.kt
+++ b/kork/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/internal/TestPlugin.kt
@@ -18,4 +18,7 @@ package com.netflix.spinnaker.kork.plugins.internal
 import org.pf4j.Plugin
 import org.pf4j.PluginWrapper
 
-class TestPlugin(wrapper: PluginWrapper) : Plugin(wrapper)
+// wrapper is required for createWithConstructor DI type matching but intentionally
+// unused since Plugin() no-arg replaces the deprecated Plugin(PluginWrapper) constructor.
+@Suppress("UNUSED_PARAMETER")
+class TestPlugin(wrapper: PluginWrapper) : Plugin()

--- a/kork/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/loaders/SpinnakerPluginLoaderTests.kt
+++ b/kork/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/loaders/SpinnakerPluginLoaderTests.kt
@@ -65,7 +65,7 @@ abstract class SpinnakerPluginLoadersTCK : JUnit5Minutests {
       val extensionClass = classpath.loadClass(extensionClassName)
       val extensionConfigClassName = "${pluginClass.`package`.name}.${standardPluginName}PluginConfiguration"
       val extensionConfigClass = classpath.loadClass(extensionConfigClassName)
-      val extensionConfig = extensionConfigClass.newInstance()
+      val extensionConfig = extensionConfigClass.getDeclaredConstructor().newInstance()
       expectThat(TestExtension::class.java.isAssignableFrom(extensionClass)).isTrue()
       val extension = extensionClass.constructors.first().newInstance(extensionConfig) as TestExtension
       expectThat(extension.testValue).isEqualTo(extensionClass.simpleName)

--- a/kork/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/update/SpinnakerUpdateManagerTest.kt
+++ b/kork/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/update/SpinnakerUpdateManagerTest.kt
@@ -22,7 +22,7 @@ import com.netflix.spinnaker.kork.plugins.SpinnakerServiceVersionManager
 import com.netflix.spinnaker.kork.plugins.bundle.PluginBundleExtractor
 import com.netflix.spinnaker.kork.plugins.events.PluginDownloaded
 import com.netflix.spinnaker.kork.plugins.internal.PluginZip
-import com.netflix.spinnaker.kork.plugins.testplugin.TestPluginBuilderSupport
+import com.netflix.spinnaker.kork.plugins.testplugin.basicGeneratedPlugin
 import com.netflix.spinnaker.kork.plugins.update.internal.SpinnakerPluginInfo
 import com.netflix.spinnaker.kork.plugins.update.release.PluginInfoRelease
 import com.netflix.spinnaker.kork.version.ServiceVersion
@@ -221,30 +221,29 @@ class SpinnakerUpdateManagerTest : JUnit5Minutests {
       pluginVersion: String = "0.0.1",
       className: String = "Generated"
     ): SpinnakerPluginInfo {
-      val generatedPluginPath = Files.createTempDirectory("generated-plugin")
-      val pluginBuilder = TestPluginBuilderSupport(
-        pluginPath = generatedPluginPath,
-        name = className,
-        version = pluginVersion
-      )
-      pluginBuilder.build()
+      val plugin = basicGeneratedPlugin(className, pluginVersion).apply {
+        pluginId = "spinnaker.${className.lowercase()}testplugin"
+      }
+      val result = plugin.generate()
+      val generatedPluginPath = result.pluginPath
+      val canonicalExtensionClass = plugin.canonicalClass("${className}Extension")
 
-      val releasePath = File(repository.resolve("${pluginBuilder.pluginId}/$pluginVersion").toUri())
+      val releasePath = File(repository.resolve("${plugin.pluginId}/$pluginVersion").toUri())
         .also { it.mkdirs() }
         .let { pluginRepositoryPath ->
-          val pluginPath = pluginRepositoryPath.resolve("${pluginBuilder.pluginId}-$pluginVersion.zip").toPath()
+          val pluginPath = pluginRepositoryPath.resolve("${plugin.pluginId}-$pluginVersion.zip").toPath()
 
-          val zip = PluginZip.Builder(pluginPath, pluginBuilder.pluginId)
-            .pluginClass(pluginBuilder.canonicalPluginClass)
-            .pluginVersion(pluginBuilder.version)
+          val zip = PluginZip.Builder(pluginPath, plugin.pluginId)
+            .pluginClass(plugin.canonicalPluginClass())
+            .pluginVersion(plugin.version)
 
-          "classes/${pluginBuilder.canonicalPluginClass.replace(".", "/")}.class".let {
+          "classes/${plugin.canonicalPluginClass().replace(".", "/")}.class".let {
             zip.addFile(Paths.get(it), generatedPluginPath.resolve(it).toFile().readBytes())
           }
-          "classes/${pluginBuilder.canonicalExtensionClass.replace(".", "/")}.class".let {
+          "classes/${canonicalExtensionClass.replace(".", "/")}.class".let {
             zip.addFile(Paths.get(it), generatedPluginPath.resolve(it).toFile().readBytes())
           }
-          zip.addFile(Paths.get("META-INF/extensions.idx"), pluginBuilder.canonicalExtensionClass)
+          zip.addFile(Paths.get("META-INF/extensions.idx"), canonicalExtensionClass)
 
           zip.build()
 
@@ -252,14 +251,14 @@ class SpinnakerUpdateManagerTest : JUnit5Minutests {
         }
 
       return SpinnakerPluginInfo().apply {
-        id = pluginBuilder.pluginId
-        name = pluginBuilder.name
+        id = plugin.pluginId
+        name = plugin.name
         description = "A generated TestPlugin named $name"
         provider = "Spinnaker"
         releases = listOf(
           SpinnakerPluginInfo.SpinnakerPluginRelease(false).apply {
             requires = "orca>=0.0.0"
-            version = pluginBuilder.version
+            version = plugin.version
             date = Date.from(Instant.now())
             url = releasePath.toUri().toURL().toString()
           }

--- a/kork/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/v2/PluginContainerTest.kt
+++ b/kork/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/v2/PluginContainerTest.kt
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.plugins.v2
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.pf4j.Plugin
+import org.pf4j.PluginWrapper
+import org.springframework.beans.factory.support.DefaultListableBeanFactory
+import org.springframework.beans.factory.support.BeanDefinitionRegistry
+import org.springframework.context.support.GenericApplicationContext
+
+class PluginContainerTest {
+
+  private lateinit var actual: Plugin
+  private lateinit var pluginWrapper: PluginWrapper
+  private lateinit var serviceContext: GenericApplicationContext
+  private lateinit var container: PluginContainer
+
+  companion object {
+    private const val PLUGIN_ID = "test.plugin"
+  }
+
+  @BeforeEach
+  fun setUp() {
+    actual = mock(Plugin::class.java)
+    pluginWrapper = mock(PluginWrapper::class.java)
+    @Suppress("DEPRECATION")
+    `when`(actual.wrapper).thenReturn(pluginWrapper)
+    `when`(pluginWrapper.pluginId).thenReturn(PLUGIN_ID)
+
+    serviceContext = GenericApplicationContext()
+    container = PluginContainer(actual, serviceContext)
+  }
+
+  @AfterEach
+  fun tearDown() {
+    ApplicationContextGraph.pluginContexts.remove(PLUGIN_ID)
+    try { serviceContext.close() } catch (_: Exception) {}
+  }
+
+  @Test
+  fun `pluginContext is registered in ApplicationContextGraph`() {
+    assertThat(ApplicationContextGraph.pluginContext(PLUGIN_ID))
+      .isNotNull
+      .isSameAs(container.pluginContext)
+  }
+
+  @Test
+  fun `registerInitializer creates bean with correct name`() {
+    val registry = mock(BeanDefinitionRegistry::class.java)
+    val beanName = container.registerInitializer(registry)
+
+    assertThat(beanName).isEqualTo("${PLUGIN_ID}Initializer")
+    verify(registry).registerBeanDefinition(
+      org.mockito.ArgumentMatchers.eq("${PLUGIN_ID}Initializer"),
+      org.mockito.ArgumentMatchers.any()
+    )
+  }
+
+  @Test
+  fun `registerInitializer passes actual plugin and wrapper as constructor args`() {
+    val registry = DefaultListableBeanFactory()
+    container.registerInitializer(registry)
+
+    val beanDef = registry.getBeanDefinition("${PLUGIN_ID}Initializer")
+    val constructorArgs = beanDef.constructorArgumentValues
+    assertThat(constructorArgs.getArgumentValue(0, Plugin::class.java)?.value).isSameAs(actual)
+    @Suppress("DEPRECATION")
+    assertThat(constructorArgs.getArgumentValue(1, PluginWrapper::class.java)?.value).isSameAs(actual.wrapper)
+    assertThat(constructorArgs.getArgumentValue(2, GenericApplicationContext::class.java)?.value)
+      .isSameAs(container.pluginContext)
+  }
+
+  @Test
+  fun `start delegates to actual plugin`() {
+    container.start()
+    verify(actual).start()
+  }
+
+  @Test
+  fun `stop delegates to actual plugin`() {
+    container.stop()
+    verify(actual).stop()
+  }
+
+  @Test
+  fun `delete delegates to actual plugin`() {
+    container.delete()
+    verify(actual).delete()
+  }
+}

--- a/kork/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/v2/PluginContainerTest.kt
+++ b/kork/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/v2/PluginContainerTest.kt
@@ -43,12 +43,10 @@ class PluginContainerTest {
   fun setUp() {
     actual = mock(Plugin::class.java)
     pluginWrapper = mock(PluginWrapper::class.java)
-    @Suppress("DEPRECATION")
-    `when`(actual.wrapper).thenReturn(pluginWrapper)
     `when`(pluginWrapper.pluginId).thenReturn(PLUGIN_ID)
 
     serviceContext = GenericApplicationContext()
-    container = PluginContainer(actual, serviceContext)
+    container = PluginContainer(actual, serviceContext, pluginWrapper)
   }
 
   @AfterEach
@@ -84,8 +82,7 @@ class PluginContainerTest {
     val beanDef = registry.getBeanDefinition("${PLUGIN_ID}Initializer")
     val constructorArgs = beanDef.constructorArgumentValues
     assertThat(constructorArgs.getArgumentValue(0, Plugin::class.java)?.value).isSameAs(actual)
-    @Suppress("DEPRECATION")
-    assertThat(constructorArgs.getArgumentValue(1, PluginWrapper::class.java)?.value).isSameAs(actual.wrapper)
+    assertThat(constructorArgs.getArgumentValue(1, PluginWrapper::class.java)?.value).isSameAs(pluginWrapper)
     assertThat(constructorArgs.getArgumentValue(2, GenericApplicationContext::class.java)?.value)
       .isSameAs(container.pluginContext)
   }

--- a/kork/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/v2/PluginContainerTest.kt
+++ b/kork/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/v2/PluginContainerTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Netflix, Inc.
+ * Copyright 2026 Salesforce, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kork/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/v2/SpringPluginInitializerTest.kt
+++ b/kork/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/v2/SpringPluginInitializerTest.kt
@@ -24,11 +24,7 @@ import dev.minutest.rootContext
 import org.springframework.boot.autoconfigure.AutoConfigurations
 import org.springframework.boot.test.context.assertj.AssertableApplicationContext
 import org.springframework.boot.test.context.runner.ApplicationContextRunner
-import strikt.api.expectThat
-import strikt.assertions.isA
-import strikt.assertions.isEqualTo
-import strikt.assertions.isNotNull
-import strikt.assertions.isTrue
+import org.assertj.core.api.Assertions.assertThat
 
 class SpringPluginInitializerTest : JUnit5Minutests {
 
@@ -41,9 +37,9 @@ class SpringPluginInitializerTest : JUnit5Minutests {
       app.run { ctx: AssertableApplicationContext ->
         val pluginContext = ctx.pluginContext(generated.plugin.pluginId)
 
-        expectThat(pluginContext.containsBean("initializerExtension")).isTrue()
-        expectThat(pluginContext.containsBean("initializerPluginConfiguration")).isTrue()
-        expectThat(pluginContext.containsBean("initializerThing")).isTrue()
+        assertThat(pluginContext.containsBean("initializerExtension")).isTrue()
+        assertThat(pluginContext.containsBean("initializerPluginConfiguration")).isTrue()
+        assertThat(pluginContext.containsBean("initializerThing")).isTrue()
       }
     }
 
@@ -51,11 +47,9 @@ class SpringPluginInitializerTest : JUnit5Minutests {
       app.run { ctx: AssertableApplicationContext ->
         val pluginContext = ctx.pluginContext(generated.plugin.pluginId)
 
-        expectThat(pluginContext.getBean("initializerPluginConfiguration"))
-          .isNotNull()
-          .and {
-            get { javaClass.getDeclaredField("foo").get(this) }.isEqualTo("foo")
-          }
+        val configBean = pluginContext.getBean("initializerPluginConfiguration")
+        assertThat(configBean.javaClass.getDeclaredField("foo").get(configBean))
+          .isEqualTo("foo")
       }
     }
 
@@ -63,11 +57,9 @@ class SpringPluginInitializerTest : JUnit5Minutests {
       app.run { ctx: AssertableApplicationContext ->
         val pluginContext = ctx.pluginContext(generated.plugin.pluginId)
 
-        expectThat(pluginContext.getBean("initializerThing"))
-          .isNotNull()
-          .and {
-            get { javaClass.getDeclaredField("sdks").get(this) }.isA<PluginSdks>()
-          }
+        val thingBean = pluginContext.getBean("initializerThing")
+        assertThat(thingBean.javaClass.getDeclaredField("sdks").get(thingBean))
+          .isInstanceOf(PluginSdks::class.java)
       }
     }
 
@@ -76,16 +68,16 @@ class SpringPluginInitializerTest : JUnit5Minutests {
         val pluginId = generated.plugin.pluginId
 
         // PluginContainer registers the plugin context using wrapper.pluginId
-        expectThat(ApplicationContextGraph.pluginContext(pluginId)).isNotNull()
+        assertThat(ApplicationContextGraph.pluginContext(pluginId)).isNotNull()
 
         // PluginContainer.registerInitializer names the bean using wrapper.pluginId
-        expectThat(ctx.containsBean("${pluginId}Initializer")).isTrue()
+        assertThat(ctx.containsBean("${pluginId}Initializer")).isTrue()
 
         // SpinnakerPluginService.registerProxies names proxy beans using wrapper.descriptor.pluginId
         val proxyBeanNames = ctx.sourceApplicationContext.getBeanNamesForType(
           com.netflix.spinnaker.kork.plugins.testplugin.api.TestExtension::class.java
         )
-        expectThat(proxyBeanNames.any { name -> name.startsWith(pluginId) }).isTrue()
+        assertThat(proxyBeanNames.any { name -> name.startsWith(pluginId) }).isTrue()
       }
     }
   }

--- a/kork/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/v2/SpringPluginInitializerTest.kt
+++ b/kork/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/v2/SpringPluginInitializerTest.kt
@@ -70,6 +70,24 @@ class SpringPluginInitializerTest : JUnit5Minutests {
           }
       }
     }
+
+    test("wrapper-derived identifiers propagate correctly") {
+      app.run { ctx: AssertableApplicationContext ->
+        val pluginId = generated.plugin.pluginId
+
+        // PluginContainer registers the plugin context using wrapper.pluginId
+        expectThat(ApplicationContextGraph.pluginContext(pluginId)).isNotNull()
+
+        // PluginContainer.registerInitializer names the bean using wrapper.pluginId
+        expectThat(ctx.containsBean("${pluginId}Initializer")).isTrue()
+
+        // SpinnakerPluginService.registerProxies names proxy beans using wrapper.descriptor.pluginId
+        val proxyBeanNames = ctx.sourceApplicationContext.getBeanNamesForType(
+          com.netflix.spinnaker.kork.plugins.testplugin.api.TestExtension::class.java
+        )
+        expectThat(proxyBeanNames.any { name -> name.startsWith(pluginId) }).isTrue()
+      }
+    }
   }
 
   private inner class GeneratedPluginFixture {

--- a/kork/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/v2/context/PluginConfigurationRegisteringCustomizerTest.kt
+++ b/kork/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/v2/context/PluginConfigurationRegisteringCustomizerTest.kt
@@ -34,8 +34,8 @@ import org.springframework.core.env.StandardEnvironment
  * [Plugin.basePackageName][com.netflix.spinnaker.kork.plugins.v2.basePackageName]
  * returns this package name, allowing classpath scanning to find [SamplePluginConfig].
  */
-@Suppress("DEPRECATION")
-internal class ConfigTestPlugin(wrapper: PluginWrapper) : Plugin(wrapper)
+@Suppress("UNUSED_PARAMETER") // wrapper exists for classpath scanning package resolution
+internal class ConfigTestPlugin(wrapper: PluginWrapper) : Plugin()
 
 /** A sample configuration class that classpath scanning can discover. */
 @PluginConfiguration("test")

--- a/kork/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/v2/context/PluginConfigurationRegisteringCustomizerTest.kt
+++ b/kork/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/v2/context/PluginConfigurationRegisteringCustomizerTest.kt
@@ -71,7 +71,7 @@ class PluginConfigurationRegisteringCustomizerTest {
     stubConfigFactory(pluginId, config)
 
     val context = GenericApplicationContext().apply { environment = StandardEnvironment() }
-    val customizer = PluginConfigurationRegisteringCustomizer(configFactory)
+    val customizer = PluginConfigurationRegisteringCustomizer(configFactory, pluginWrapper)
     customizer.accept(plugin, context)
 
     assertThat(context.beanFactory.containsBean("samplePluginConfig")).isTrue()
@@ -86,7 +86,7 @@ class PluginConfigurationRegisteringCustomizerTest {
     stubConfigFactory(pluginId, config)
 
     val context = GenericApplicationContext().apply { environment = StandardEnvironment() }
-    val customizer = PluginConfigurationRegisteringCustomizer(configFactory)
+    val customizer = PluginConfigurationRegisteringCustomizer(configFactory, pluginWrapper)
     customizer.accept(plugin, context)
 
     verify(configFactory).createPluginConfig(SamplePluginConfig::class.java, pluginId, "test")
@@ -108,7 +108,7 @@ class PluginConfigurationRegisteringCustomizerTest {
     }
 
     val context = GenericApplicationContext().apply { environment = StandardEnvironment() }
-    val customizer = PluginConfigurationRegisteringCustomizer(configFactory, customResolver)
+    val customizer = PluginConfigurationRegisteringCustomizer(configFactory, pluginWrapper, customResolver)
     customizer.accept(plugin, context)
 
     assertThat(resolvedClass).isEqualTo(SamplePluginConfig::class.java.name)
@@ -125,7 +125,7 @@ class PluginConfigurationRegisteringCustomizerTest {
     // Pre-register a bean with the same name to trigger the duplicate path
     context.beanFactory.registerSingleton("samplePluginConfig", "existingBean")
 
-    val customizer = PluginConfigurationRegisteringCustomizer(configFactory)
+    val customizer = PluginConfigurationRegisteringCustomizer(configFactory, pluginWrapper)
     customizer.accept(plugin, context)
 
     // Original bean is still there

--- a/kork/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/v2/context/PluginConfigurationRegisteringCustomizerTest.kt
+++ b/kork/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/v2/context/PluginConfigurationRegisteringCustomizerTest.kt
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.plugins.v2.context
+
+import com.netflix.spinnaker.kork.plugins.api.PluginConfiguration
+import com.netflix.spinnaker.kork.plugins.config.ConfigFactory
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.junit.jupiter.MockitoExtension
+import org.pf4j.Plugin
+import org.pf4j.PluginWrapper
+import org.springframework.context.support.GenericApplicationContext
+import org.springframework.core.env.StandardEnvironment
+
+/**
+ * A concrete Plugin subclass in this test package so that
+ * [Plugin.basePackageName][com.netflix.spinnaker.kork.plugins.v2.basePackageName]
+ * returns this package name, allowing classpath scanning to find [SamplePluginConfig].
+ */
+@Suppress("DEPRECATION")
+internal class ConfigTestPlugin(wrapper: PluginWrapper) : Plugin(wrapper)
+
+/** A sample configuration class that classpath scanning can discover. */
+@PluginConfiguration("test")
+internal class SamplePluginConfig {
+  var value: String = ""
+}
+
+@ExtendWith(MockitoExtension::class)
+class PluginConfigurationRegisteringCustomizerTest {
+
+  @Mock
+  private lateinit var pluginWrapper: PluginWrapper
+
+  @Mock
+  private lateinit var configFactory: ConfigFactory
+
+  private fun createPlugin(pluginId: String): Plugin {
+    `when`(pluginWrapper.pluginClassLoader).thenReturn(javaClass.classLoader)
+    `when`(pluginWrapper.pluginId).thenReturn(pluginId)
+    return ConfigTestPlugin(pluginWrapper)
+  }
+
+  private fun stubConfigFactory(pluginId: String, config: Any) {
+    `when`(configFactory.createPluginConfig(SamplePluginConfig::class.java, pluginId, "test"))
+      .thenReturn(config)
+  }
+
+  @Test
+  fun `accept registers plugin configuration beans`() {
+    val pluginId = "test.plugin"
+    val plugin = createPlugin(pluginId)
+    val config = SamplePluginConfig().apply { value = "hello" }
+    stubConfigFactory(pluginId, config)
+
+    val context = GenericApplicationContext().apply { environment = StandardEnvironment() }
+    val customizer = PluginConfigurationRegisteringCustomizer(configFactory)
+    customizer.accept(plugin, context)
+
+    assertThat(context.beanFactory.containsBean("samplePluginConfig")).isTrue()
+    assertThat(context.beanFactory.getBean("samplePluginConfig")).isSameAs(config)
+  }
+
+  @Test
+  fun `accept passes pluginId to configFactory`() {
+    val pluginId = "my.custom.plugin"
+    val plugin = createPlugin(pluginId)
+    val config = SamplePluginConfig()
+    stubConfigFactory(pluginId, config)
+
+    val context = GenericApplicationContext().apply { environment = StandardEnvironment() }
+    val customizer = PluginConfigurationRegisteringCustomizer(configFactory)
+    customizer.accept(plugin, context)
+
+    verify(configFactory).createPluginConfig(SamplePluginConfig::class.java, pluginId, "test")
+  }
+
+  @Test
+  fun `accept uses custom classResolver when provided`() {
+    val pluginId = "test.plugin"
+    val plugin = createPlugin(pluginId)
+    val config = SamplePluginConfig()
+    stubConfigFactory(pluginId, config)
+
+    var resolvedClass: String? = null
+    val customResolver = object : PluginConfigurationRegisteringCustomizer.ClassResolver {
+      override fun resolveClassName(className: String): Class<*> {
+        resolvedClass = className
+        return Class.forName(className)
+      }
+    }
+
+    val context = GenericApplicationContext().apply { environment = StandardEnvironment() }
+    val customizer = PluginConfigurationRegisteringCustomizer(configFactory, customResolver)
+    customizer.accept(plugin, context)
+
+    assertThat(resolvedClass).isEqualTo(SamplePluginConfig::class.java.name)
+  }
+
+  @Test
+  fun `accept handles duplicate bean names`() {
+    val pluginId = "test.plugin"
+    val plugin = createPlugin(pluginId)
+    val config = SamplePluginConfig()
+    stubConfigFactory(pluginId, config)
+
+    val context = GenericApplicationContext().apply { environment = StandardEnvironment() }
+    // Pre-register a bean with the same name to trigger the duplicate path
+    context.beanFactory.registerSingleton("samplePluginConfig", "existingBean")
+
+    val customizer = PluginConfigurationRegisteringCustomizer(configFactory)
+    customizer.accept(plugin, context)
+
+    // Original bean is still there
+    assertThat(context.beanFactory.getBean("samplePluginConfig")).isEqualTo("existingBean")
+    // New bean was registered with a suffixed name (contains nanoTime)
+    val beanNames = context.beanFactory.singletonNames.toList()
+    val suffixedNames = beanNames.filter { it.startsWith("samplePluginConfig") && it != "samplePluginConfig" }
+    assertThat(suffixedNames).hasSize(1)
+  }
+}

--- a/kork/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/v2/context/PluginConfigurationRegisteringCustomizerTest.kt
+++ b/kork/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/v2/context/PluginConfigurationRegisteringCustomizerTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Netflix, Inc.
+ * Copyright 2026 Salesforce, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kork/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/v2/context/PluginSdksRegisteringCustomizerTest.kt
+++ b/kork/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/v2/context/PluginSdksRegisteringCustomizerTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Netflix, Inc.
+ * Copyright 2026 Salesforce, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kork/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/v2/context/PluginSdksRegisteringCustomizerTest.kt
+++ b/kork/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/v2/context/PluginSdksRegisteringCustomizerTest.kt
@@ -54,14 +54,12 @@ class PluginSdksRegisteringCustomizerTest {
 
   @Test
   fun `accept registers pluginSdks bean into context`() {
-    @Suppress("DEPRECATION")
-    `when`(plugin.wrapper).thenReturn(pluginWrapper)
     `when`(serviceApplicationContext.getBeansOfType(SdkFactory::class.java))
       .thenReturn(mapOf("sdkFactory" to sdkFactory))
     `when`(sdkFactory.create(plugin.javaClass, pluginWrapper)).thenReturn("sdk")
     `when`(pluginContext.beanFactory).thenReturn(pluginBeanFactory)
 
-    val customizer = PluginSdksRegisteringCustomizer(serviceApplicationContext)
+    val customizer = PluginSdksRegisteringCustomizer(serviceApplicationContext, pluginWrapper)
     customizer.accept(plugin, pluginContext)
 
     val beanCaptor = ArgumentCaptor.forClass(Any::class.java)
@@ -71,14 +69,12 @@ class PluginSdksRegisteringCustomizerTest {
 
   @Test
   fun `accept passes plugin class and wrapper to each SdkFactory`() {
-    @Suppress("DEPRECATION")
-    `when`(plugin.wrapper).thenReturn(pluginWrapper)
     `when`(serviceApplicationContext.getBeansOfType(SdkFactory::class.java))
       .thenReturn(mapOf("sdkFactory" to sdkFactory))
     `when`(sdkFactory.create(plugin.javaClass, pluginWrapper)).thenReturn("sdk")
     `when`(pluginContext.beanFactory).thenReturn(pluginBeanFactory)
 
-    val customizer = PluginSdksRegisteringCustomizer(serviceApplicationContext)
+    val customizer = PluginSdksRegisteringCustomizer(serviceApplicationContext, pluginWrapper)
     customizer.accept(plugin, pluginContext)
 
     verify(sdkFactory).create(plugin.javaClass, pluginWrapper)
@@ -90,7 +86,7 @@ class PluginSdksRegisteringCustomizerTest {
       .thenReturn(emptyMap())
     `when`(pluginContext.beanFactory).thenReturn(pluginBeanFactory)
 
-    val customizer = PluginSdksRegisteringCustomizer(serviceApplicationContext)
+    val customizer = PluginSdksRegisteringCustomizer(serviceApplicationContext, pluginWrapper)
     customizer.accept(plugin, pluginContext)
 
     val beanCaptor = ArgumentCaptor.forClass(Any::class.java)

--- a/kork/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/v2/context/PluginSdksRegisteringCustomizerTest.kt
+++ b/kork/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/v2/context/PluginSdksRegisteringCustomizerTest.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.plugins.v2.context
+
+import com.netflix.spinnaker.kork.plugins.sdk.PluginSdksImpl
+import com.netflix.spinnaker.kork.plugins.sdk.SdkFactory
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.ArgumentCaptor
+import org.mockito.Mock
+import org.mockito.Mockito.eq
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.junit.jupiter.MockitoExtension
+import org.pf4j.Plugin
+import org.pf4j.PluginWrapper
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory
+import org.springframework.context.ConfigurableApplicationContext
+
+@ExtendWith(MockitoExtension::class)
+class PluginSdksRegisteringCustomizerTest {
+
+  @Mock
+  private lateinit var plugin: Plugin
+
+  @Mock
+  private lateinit var pluginWrapper: PluginWrapper
+
+  @Mock
+  private lateinit var sdkFactory: SdkFactory
+
+  @Mock
+  private lateinit var serviceApplicationContext: ConfigurableApplicationContext
+
+  @Mock
+  private lateinit var pluginContext: ConfigurableApplicationContext
+
+  @Mock
+  private lateinit var pluginBeanFactory: ConfigurableListableBeanFactory
+
+  @Test
+  fun `accept registers pluginSdks bean into context`() {
+    @Suppress("DEPRECATION")
+    `when`(plugin.wrapper).thenReturn(pluginWrapper)
+    `when`(serviceApplicationContext.getBeansOfType(SdkFactory::class.java))
+      .thenReturn(mapOf("sdkFactory" to sdkFactory))
+    `when`(sdkFactory.create(plugin.javaClass, pluginWrapper)).thenReturn("sdk")
+    `when`(pluginContext.beanFactory).thenReturn(pluginBeanFactory)
+
+    val customizer = PluginSdksRegisteringCustomizer(serviceApplicationContext)
+    customizer.accept(plugin, pluginContext)
+
+    val beanCaptor = ArgumentCaptor.forClass(Any::class.java)
+    verify(pluginBeanFactory).registerSingleton(eq("pluginSdks"), beanCaptor.capture())
+    assertThat(beanCaptor.value).isInstanceOf(PluginSdksImpl::class.java)
+  }
+
+  @Test
+  fun `accept passes plugin class and wrapper to each SdkFactory`() {
+    @Suppress("DEPRECATION")
+    `when`(plugin.wrapper).thenReturn(pluginWrapper)
+    `when`(serviceApplicationContext.getBeansOfType(SdkFactory::class.java))
+      .thenReturn(mapOf("sdkFactory" to sdkFactory))
+    `when`(sdkFactory.create(plugin.javaClass, pluginWrapper)).thenReturn("sdk")
+    `when`(pluginContext.beanFactory).thenReturn(pluginBeanFactory)
+
+    val customizer = PluginSdksRegisteringCustomizer(serviceApplicationContext)
+    customizer.accept(plugin, pluginContext)
+
+    verify(sdkFactory).create(plugin.javaClass, pluginWrapper)
+  }
+
+  @Test
+  fun `accept works with no SdkFactory beans`() {
+    `when`(serviceApplicationContext.getBeansOfType(SdkFactory::class.java))
+      .thenReturn(emptyMap())
+    `when`(pluginContext.beanFactory).thenReturn(pluginBeanFactory)
+
+    val customizer = PluginSdksRegisteringCustomizer(serviceApplicationContext)
+    customizer.accept(plugin, pluginContext)
+
+    val beanCaptor = ArgumentCaptor.forClass(Any::class.java)
+    verify(pluginBeanFactory).registerSingleton(eq("pluginSdks"), beanCaptor.capture())
+    assertThat(beanCaptor.value).isInstanceOf(PluginSdksImpl::class.java)
+  }
+}


### PR DESCRIPTION
Along the way, add jacoco / code coverage support in kork so it's clear where we're missing coverage.  This is supposed to be a no-op, i.e. no change for existing plugins.

```
> Task :kork:kork-plugins-tck:compileKotlin
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-plugins-tck/src/main/kotlin/com/netflix/spinnaker/kork/plugins/tck/PluginsTck.kt:78:61 Type mismatch: inferred type is F but Any was expected
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-plugins-tck/src/main/kotlin/com/netflix/spinnaker/kork/plugins/testplugin/GeneratedTestPlugin.kt:36:21 'capitalize(): String' is deprecated. Use replaceFirstChar instead.
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-plugins-tck/src/main/kotlin/com/netflix/spinnaker/kork/plugins/testplugin/GeneratedTestPlugin.kt:52:44 'toLowerCase(): String' is deprecated. Use lowercase() instead.
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-plugins-tck/src/main/kotlin/com/netflix/spinnaker/kork/plugins/testplugin/TestPluginBuilderSupport.kt:63:36 'toLowerCase(): String' is deprecated. Use lowercase() instead.
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-plugins-tck/src/main/kotlin/com/netflix/spinnaker/kork/plugins/testplugin/TestPluginBuilderSupport.kt:194:47 'toLowerCase(): String' is deprecated. Use lowercase() instead.
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-plugins-tck/src/main/kotlin/com/netflix/spinnaker/kork/plugins/testplugin/builders.kt:32:25 'capitalize(): String' is deprecated. Use replaceFirstChar instead.
```
```
> Task :kork:kork-plugins:compileKotlin
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/ExtensionBeanDefinitionRegistryPostProcessor.kt:90:51 'decapitalize(): String' is deprecated. Use replaceFirstChar instead.
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/ExtensionBeanDefinitionRegistryPostProcessor.kt:118:31 Unchecked cast: List<InvocationAspect<*>> to List<InvocationAspect<InvocationState>>
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/ExtensionBeanDefinitionRegistryPostProcessor.kt:125:88 'capitalize(): String' is deprecated. Use replaceFirstChar instead.
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/SpinnakerPluginManager.kt:130:36 'getPluginsRoot(): Path!' is deprecated. Overrides deprecated member in 'org.pf4j.PluginManager'. Deprecated in Java
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/dsl.kt:19:47 'ExtensionConfiguration' is deprecated. Deprecated in Java
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/dsl.kt:57:54 'toLowerCase(): String' is deprecated. Use lowercase() instead.
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/dsl.kt:101:37 'ExtensionConfiguration' is deprecated. Deprecated in Java
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/dsl.kt:105:35 'ExtensionConfiguration' is deprecated. Deprecated in Java
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/dsl.kt:123:5 'newInstance(): T!' is deprecated. Deprecated in Java
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/pluginref/PluginRef.kt:79:68 'toLowerCase(): String' is deprecated. Use lowercase() instead.
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/proxy/aspects/MetricInvocationAspect.kt:178:46 'toLowerCase(): String' is deprecated. Use lowercase() instead.
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/sdk/PluginSdksImpl.kt:50:12 Unchecked cast: ServiceSdk to T
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/sdk/httpclient/Ok3HttpClientRegistry.kt:76:27 'toLowerCase(): String' is deprecated. Use lowercase() instead.
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/update/SpinnakerUpdateManager.kt:102:46 'getter for pluginsRoot: Path!' is deprecated. Deprecated in Java
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/update/SpinnakerUpdateManager.kt:163:23 'getter for pluginsRoot: Path!' is deprecated. Deprecated in Java
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/update/downloader/FileDownloaderProvider.kt:64:23 'newInstance(): T!' is deprecated. Deprecated in Java
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/v2/PluginContainer.kt:40:5 'constructor Plugin(PluginWrapper!)' is deprecated. Deprecated in Java
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/v2/PluginContainer.kt:40:19 'getter for wrapper: PluginWrapper!' is deprecated. Deprecated in Java
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/v2/PluginContainer.kt:43:44 'wrapper: PluginWrapper!' is deprecated. Deprecated in Java
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/v2/PluginContainer.kt:51:34 'wrapper: PluginWrapper!' is deprecated. Deprecated in Java
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/v2/PluginContainer.kt:57:38 'getter for wrapper: PluginWrapper!' is deprecated. Deprecated in Java
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/v2/SpinnakerPluginService.kt:117:30 'getter for wrapper: PluginWrapper!' is deprecated. Deprecated in Java
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/v2/SpinnakerPluginService.kt:122:56 'getter for wrapper: PluginWrapper!' is deprecated. Deprecated in Java
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/v2/SpinnakerPluginService.kt:124:42 'getter for wrapper: PluginWrapper!' is deprecated. Deprecated in Java
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/v2/SpinnakerPluginService.kt:124:117 Unchecked cast: Class<*>! to Class<out SpinnakerExtensionPoint>
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/v2/SpinnakerPluginService.kt:144:27 Unchecked cast: List<InvocationAspect<*>> to List<InvocationAspect<InvocationState>>
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/v2/SpinnakerPluginService.kt:145:19 'getter for wrapper: PluginWrapper!' is deprecated. Deprecated in Java
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/v2/SpinnakerPluginService.kt:153:54 'decapitalize(): String' is deprecated. Use replaceFirstChar instead.
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/v2/SpinnakerPluginService.kt:168:20 'capitalize(): String' is deprecated. Use replaceFirstChar instead.
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/v2/context/PluginConfigurationRegisteringCustomizer.kt:44:65 'getter for wrapper: PluginWrapper!' is deprecated. Deprecated in Java
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/v2/context/PluginConfigurationRegisteringCustomizer.kt:48:69 'getter for wrapper: PluginWrapper!' is deprecated. Deprecated in Java
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/v2/context/PluginConfigurationRegisteringCustomizer.kt:57:18 'getter for wrapper: PluginWrapper!' is deprecated. Deprecated in Java
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/v2/context/PluginSdksRegisteringCustomizer.kt:37:51 'getter for wrapper: PluginWrapper!' is deprecated. Deprecated in Java
```
```
> Task :kork:kork-plugins:compileTestKotlin
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/DependencyInjectionTest.kt:19:47 'ExtensionConfiguration' is deprecated. Deprecated in Java
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/DependencyInjectionTest.kt:224:4 'ExtensionConfiguration' is deprecated. Deprecated in Java
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/DependencyInjectionTest.kt:234:44 'constructor Plugin(PluginWrapper!)' is deprecated. Deprecated in Java
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/DependencyInjectionTest.kt:242:8 'ExtensionConfiguration' is deprecated. Deprecated in Java
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/DependencyInjectionTest.kt:254:19 Parameter 'bad' is never used
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/DependencyInjectionTest.kt:256:8 'ExtensionConfiguration' is deprecated. Deprecated in Java
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/DependencyInjectionTest.kt:266:65 'constructor Plugin(PluginWrapper!)' is deprecated. Deprecated in Java
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/DependencyInjectionTest.kt:267:79 'constructor Plugin(PluginWrapper!)' is deprecated. Deprecated in Java
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/DependencyInjectionTest.kt:268:109 'constructor Plugin(PluginWrapper!)' is deprecated. Deprecated in Java
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/DependencyInjectionTest.kt:269:84 'constructor Plugin(PluginWrapper!)' is deprecated. Deprecated in Java
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/DependencyInjectionTest.kt:270:73 'constructor Plugin(PluginWrapper!)' is deprecated. Deprecated in Java
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/DependencyInjectionTest.kt:271:39 Parameter 'sdks' is never used
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/ExtensionBeanDefinitionRegistryPostProcessorTest.kt:18:47 'ExtensionConfiguration' is deprecated. Deprecated in Java
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/ExtensionBeanDefinitionRegistryPostProcessorTest.kt:145:6 'ExtensionConfiguration' is deprecated. Deprecated in Java
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/SpinnakerPluginManagerTest.kt:80:99 'newInstance(): T!' is deprecated. Deprecated in Java
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/SpinnakerPluginManagerTest.kt:83:68 'newInstance(): T!' is deprecated. Deprecated in Java
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/config/ConfigFactoryTest.kt:18:47 'ExtensionConfiguration' is deprecated. Deprecated in Java
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/config/ConfigFactoryTest.kt:60:4 'ExtensionConfiguration' is deprecated. Deprecated in Java
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/internal/TestPlugin.kt:21:44 'constructor Plugin(PluginWrapper!)' is deprecated. Deprecated in Java
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/loaders/SpinnakerPluginLoaderTests.kt:68:50 'newInstance(): T!' is deprecated. Deprecated in Java
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/update/SpinnakerUpdateManagerTest.kt:25:54 'TestPluginBuilderSupport' is deprecated. use testPlugin builder instead
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/update/SpinnakerUpdateManagerTest.kt:225:27 'TestPluginBuilderSupport' is deprecated. use testPlugin builder instead
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/v2/SpringPluginInitializerTest.kt:54:9 Unsafe use of a nullable receiver of type DescribeableBuilder<Any>
w: file:///Users/dbyron/src/spinnaker/spinnaker/kork/kork-plugins/src/test/kotlin/com/netflix/spinnaker/kork/plugins/v2/SpringPluginInitializerTest.kt:66:9 Unsafe use of a nullable receiver of type DescribeableBuilder<Any>
```