### PR TITLE
fix(halyard-core): correct 'occured' -> 'occurred' in Problem javadoc

### DIFF
--- a/halyard/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/problem/v1/Problem.java
+++ b/halyard/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/problem/v1/Problem.java
@@ -64,7 +64,7 @@ public class Problem {
   /** Indicates if this will cause the deployment to fail or not. */
   @Getter private final Severity severity;
 
-  /** Where this problem occured. */
+  /** Where this problem occurred. */
   @Getter private final String location;
 
   @JsonCreator


### PR DESCRIPTION
The location-of-problem javadoc on `Problem` in `halyard/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/problem/v1/Problem.java:67` read `Where this problem occured`. Doc-only change inside a `/** */` block.