### PR TITLE
fix(retrofit2): remove leading slashes from eureka retrofit2 api interfaces

### DIFF
--- a/clouddriver/clouddriver-eureka/src/main/groovy/com/netflix/spinnaker/clouddriver/eureka/api/Eureka.groovy
+++ b/clouddriver/clouddriver-eureka/src/main/groovy/com/netflix/spinnaker/clouddriver/eureka/api/Eureka.groovy
@@ -28,18 +28,18 @@ import retrofit2.http.Query
 
 interface Eureka {
   @Headers('Accept: application/json')
-  @GET('/instances/{instanceId}')
+  @GET('instances/{instanceId}')
   Call<Map> getInstanceInfo(@Path('instanceId') String instanceId)
 
   @Headers('Accept: application/json')
-  @PUT('/apps/{application}/{instanceId}/status')
+  @PUT('apps/{application}/{instanceId}/status')
   Call<ResponseBody> updateInstanceStatus(@Path('application') String application, @Path('instanceId') String instanceId, @Query('value') String status)
 
   @Headers('Accept: application/json')
-  @DELETE('/apps/{application}/{instanceId}/status')
+  @DELETE('apps/{application}/{instanceId}/status')
   Call<ResponseBody> resetInstanceStatus(@Path('application') String application, @Path('instanceId') String instanceId, @Query('value') String status)
 
   @Headers('Accept: application/json')
-  @GET('/apps/{application}')
+  @GET('apps/{application}')
   Call<EurekaApplication> getApplication(@Path('application') String application)
 }

--- a/clouddriver/clouddriver-eureka/src/main/groovy/com/netflix/spinnaker/clouddriver/eureka/api/EurekaApi.groovy
+++ b/clouddriver/clouddriver-eureka/src/main/groovy/com/netflix/spinnaker/clouddriver/eureka/api/EurekaApi.groovy
@@ -23,7 +23,7 @@ import retrofit2.http.Headers
 
 interface EurekaApi {
 
-  @GET('/apps')
+  @GET('apps')
   @Headers(['Accept: application/json'])
   Call<EurekaApplications> loadEurekaApplications()
 }


### PR DESCRIPTION
This is the fix for this [issue](https://github.com/spinnaker/spinnaker/issues/7463)
Without this patch, Spinnaker 1.37.0 and above are not able to use Eureka for application discovery if the base URL has the suffix ```/eureka/v2```


It seems like this was missed in this PR https://github.com/spinnaker/spinnaker/pull/7159 when all the retrofit2 API interfaces were being updated to support retrofit2
