### PR TITLE
Adopt latching for fiat role sync

### DIFF
--- a/fiat/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/config/RedisConfig.java
+++ b/fiat/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/config/RedisConfig.java
@@ -4,7 +4,11 @@ import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.kork.jedis.JedisClientDelegate;
 import com.netflix.spinnaker.kork.jedis.RedisClientDelegate;
 import com.netflix.spinnaker.kork.jedis.telemetry.InstrumentedJedisPool;
+import java.net.InetAddress;
 import java.net.URI;
+import java.net.UnknownHostException;
+import lombok.Getter;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 import org.springframework.beans.factory.annotation.Value;
@@ -19,13 +23,27 @@ import redis.clients.jedis.*;
 @Configuration
 @ConditionalOnProperty("redis.connection")
 public class RedisConfig {
+
+  @Getter @Setter private static String clientName = defaultClientName();
+
+  private static String defaultClientName() {
+    try {
+      return InetAddress.getLocalHost().getHostName();
+    } catch (UnknownHostException e) {
+      return null;
+    }
+  }
+
   @Bean
   @ConfigurationProperties("redis")
   public GenericObjectPoolConfig redisPoolConfig() {
     GenericObjectPoolConfig config = new JedisPoolConfig();
-    config.setMaxTotal(20);
-    config.setMaxIdle(20);
-    config.setMinIdle(5);
+    config.setMaxTotal(500);
+    config.setMaxIdle(0);
+    config.setMinIdle(0);
+    config.setTestWhileIdle(true);
+    config.setMinEvictableIdleTimeMillis(1);
+    config.setJmxEnabled(true);
     return config;
   }
 
@@ -35,6 +53,17 @@ public class RedisConfig {
       @Value("${redis.timeout:2000}") int timeout,
       GenericObjectPoolConfig redisPoolConfig,
       Registry registry) {
+
+    log.info(
+        "JedisPool Configuration: maxTotal {}, maxIdle {}, minIdle {}, testWhileIdle {}, minEvictableIdle {}, jmxEnabled {}, clientName {}",
+        redisPoolConfig.getMaxTotal(),
+        redisPoolConfig.getMaxIdle(),
+        redisPoolConfig.getMinIdle(),
+        redisPoolConfig.getTestWhileIdle(),
+        redisPoolConfig.getMinEvictableIdleTimeMillis(),
+        redisPoolConfig.getJmxEnabled(),
+        clientName);
+
     return createPool(redisPoolConfig, connection, timeout, registry);
   }
 
@@ -67,9 +96,19 @@ public class RedisConfig {
       redisPoolConfig = new GenericObjectPoolConfig();
     }
 
+    log.info(
+        "JedisPool Configuration: host {}, port {}, timeout {}, password {}, database {}, isSSL {}, clientName {}",
+        host,
+        port,
+        timeout,
+        password != null && !password.isEmpty(),
+        database,
+        isSSL,
+        clientName);
+
     return new InstrumentedJedisPool(
         registry,
-        new JedisPool(redisPoolConfig, host, port, timeout, password, database, null, isSSL),
+        new JedisPool(redisPoolConfig, host, port, timeout, password, database, clientName, isSSL),
         "fiat");
   }
 }

--- a/fiat/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/config/UserRolesSyncerConfig.java
+++ b/fiat/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/config/UserRolesSyncerConfig.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 DoorDash, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.fiat.config;
+
+import lombok.Data;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
+import org.springframework.context.annotation.Configuration;
+
+@Data
+@Configuration
+@ConditionalOnExpression("${fiat.write-mode.enabled:true}")
+@ConfigurationProperties("fiat.write-mode")
+public class UserRolesSyncerConfig {
+  long retryIntervalMs = 10000;
+  long syncDelayMs = 600000;
+  long syncFailureDelayMs = 600000;
+  long syncDelayTimeoutMs = 30000;
+
+  @NestedConfigurationProperty
+  private SynchronizationConfig synchronizationConfig = new SynchronizationConfig();
+
+  @Data
+  public static class SynchronizationConfig {
+    private boolean enabled;
+    private String prefix = "spinnaker:fiat";
+    private long syncDelayMs = 1000;
+    private long syncFailureDelayMs = 1000;
+    private long maxLockDurationMs = 600000;
+  }
+}

--- a/fiat/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/roles/UserRolesSyncer.java
+++ b/fiat/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/roles/UserRolesSyncer.java
@@ -175,7 +175,7 @@ public class UserRolesSyncer {
                         .getSynchronizationConfig()
                         .getSyncFailureDelayMs()));
 
-    long count;
+    long count = 0;
     while (true) {
       boolean isSyncAllowed = false; // flag to control which thread can attempt a sync
       // since countdown latches can't be reset, we keep a pointer to a global latch so that others

--- a/fiat/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/roles/UserRolesSyncer.java
+++ b/fiat/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/roles/UserRolesSyncer.java
@@ -19,19 +19,44 @@ package com.netflix.spinnaker.fiat.roles;
 import com.netflix.spectator.api.Gauge;
 import com.netflix.spectator.api.Id;
 import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.fiat.config.ResourceProvidersHealthIndicator;
+import com.netflix.spinnaker.fiat.config.UnrestrictedResourceConfig;
+import com.netflix.spinnaker.fiat.config.UserRolesSyncerConfig;
+import com.netflix.spinnaker.fiat.model.UserPermission;
+import com.netflix.spinnaker.fiat.model.resources.Role;
+import com.netflix.spinnaker.fiat.model.resources.ServiceAccount;
+import com.netflix.spinnaker.fiat.permissions.ExternalUser;
+import com.netflix.spinnaker.fiat.permissions.PermissionResolutionException;
+import com.netflix.spinnaker.fiat.permissions.PermissionsRepository;
+import com.netflix.spinnaker.fiat.permissions.PermissionsResolver;
+import com.netflix.spinnaker.fiat.providers.ProviderException;
+import com.netflix.spinnaker.fiat.providers.ResourceProvider;
 import com.netflix.spinnaker.kork.discovery.DiscoveryStatusListener;
+import com.netflix.spinnaker.kork.jedis.RedisClientDelegate;
 import com.netflix.spinnaker.kork.lock.LockManager;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.actuate.health.Status;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import org.springframework.util.backoff.BackOffExecution;
+import org.springframework.util.backoff.FixedBackOff;
+import redis.clients.jedis.commands.JedisCommands;
 
 @Slf4j
 @Component
@@ -39,63 +64,80 @@ import org.springframework.stereotype.Component;
 public class UserRolesSyncer {
   private final DiscoveryStatusListener discoveryStatusListener;
   private final LockManager lockManager;
-  private final long syncDelayMs;
-  private final long syncFailureDelayMs;
-  private final long syncDelayTimeoutMs;
-  private final String lockName;
+  private final PermissionsRepository permissionsRepository;
+  private final PermissionsResolver permissionsResolver;
+  private final ResourceProvider<ServiceAccount> serviceAccountProvider;
+  private final ResourceProvidersHealthIndicator healthIndicator;
+  private final RedisClientDelegate redisClientDelegate;
+  private final UserRolesSyncerConfig configurationProperties;
+  private final Synchronizer synchronizer;
+
   private final Registry registry;
   private final Gauge userRolesSyncCount;
-  private final UserRolesSyncStrategy syncStrategy;
+
+  private static final String KEY_USER_ROLES = "user_roles";
+  private static final String KEY_LAST_SYNC_TIME = "last_sync_time";
+  private static final String KEY_COUNT = "count";
+
+  private static final AtomicReference<CountDownLatch> globalLatch = new AtomicReference<>(null);
+  private final AtomicReference<String> lastSyncTime = new AtomicReference<>(null);
 
   @Autowired
   public UserRolesSyncer(
       DiscoveryStatusListener discoveryStatusListener,
       Registry registry,
       LockManager lockManager,
-      UserRolesSyncStrategy syncStrategy,
-      @Value("${fiat.write-mode.sync-delay-ms:600000}") long syncDelayMs,
-      @Value("${fiat.write-mode.sync-failure-delay-ms:600000}") long syncFailureDelayMs,
-      @Value("${fiat.write-mode.sync-delay-timeout-ms:30000}") long syncDelayTimeoutMs,
-      @Value("${fiat.write-mode.lock-name:}") String lockName) {
+      PermissionsRepository permissionsRepository,
+      PermissionsResolver permissionsResolver,
+      ResourceProvider<ServiceAccount> serviceAccountProvider,
+      ResourceProvidersHealthIndicator healthIndicator,
+      RedisClientDelegate redisClientDelegate,
+      UserRolesSyncerConfig configurationProperties,
+      Synchronizer synchronizer) {
     this.discoveryStatusListener = discoveryStatusListener;
 
     this.lockManager = lockManager;
-    this.syncDelayMs = syncDelayMs;
-    this.syncFailureDelayMs = syncFailureDelayMs;
-    this.syncDelayTimeoutMs = syncDelayTimeoutMs;
-    this.lockName = lockName;
+    this.permissionsRepository = permissionsRepository;
+    this.permissionsResolver = permissionsResolver;
+    this.serviceAccountProvider = serviceAccountProvider;
+    this.healthIndicator = healthIndicator;
+    this.redisClientDelegate = redisClientDelegate;
+    this.configurationProperties = configurationProperties;
+    this.synchronizer = synchronizer;
+
     this.registry = registry;
     this.userRolesSyncCount = registry.gauge(metricName("syncCount"));
-    this.syncStrategy = syncStrategy;
   }
 
   @Scheduled(fixedDelay = 30000L)
   public void schedule() {
-    if (syncDelayMs < 0 || !discoveryStatusListener.isEnabled()) {
+    if (this.configurationProperties.getSyncDelayTimeoutMs() < 0
+        || !discoveryStatusListener.isEnabled()) {
       log.warn(
           "User roles syncing is disabled (syncDelayMs: {}, isEnabled: {})",
-          syncDelayMs,
+          this.configurationProperties.getSyncDelayMs(),
           discoveryStatusListener.isEnabled());
       return;
     }
 
     LockManager.LockOptions lockOptions =
         new LockManager.LockOptions()
-            .withLockName(
-                (lockName != null && !lockName.isEmpty())
-                    ? lockName.toLowerCase()
-                    : "Fiat.UserRolesSyncer".toLowerCase())
-            .withMaximumLockDuration(Duration.ofMillis(syncDelayMs + syncDelayTimeoutMs))
-            .withSuccessInterval(Duration.ofMillis(syncDelayMs))
-            .withFailureInterval(Duration.ofMillis(syncFailureDelayMs));
+            .withLockName("Fiat.UserRolesSyncer".toLowerCase())
+            .withMaximumLockDuration(
+                Duration.ofMillis(
+                    this.configurationProperties.getSyncDelayMs()
+                        + this.configurationProperties.getSyncDelayTimeoutMs()))
+            .withSuccessInterval(Duration.ofMillis(this.configurationProperties.getSyncDelayMs()))
+            .withFailureInterval(
+                Duration.ofMillis(this.configurationProperties.getSyncFailureDelayMs()));
 
+    // process the response
     lockManager.acquireLock(
         lockOptions,
         () -> {
           try {
-            timeIt(
-                "syncTime",
-                () -> userRolesSyncCount.set(syncStrategy.syncAndReturn(new ArrayList<>())));
+            timeIt("syncTime", () -> userRolesSyncCount.set(this.syncAndReturn(new ArrayList<>())));
+            log.info("user roles synced");
           } catch (Exception e) {
             log.error("User roles synchronization failed", e);
             userRolesSyncCount.set(-1);
@@ -104,11 +146,290 @@ public class UserRolesSyncer {
   }
 
   public long syncAndReturn(List<String> roles) {
-    return syncStrategy.syncAndReturn(roles);
+    log.debug("Attempting to sync the following user roles: {}", roles);
+    if (this.configurationProperties.getSynchronizationConfig().isEnabled()) {
+      log.info("since synchronization is enabled, forcing a sync of all user roles");
+      return doSynchronizedUserRolesSync(new ArrayList<>());
+    } else {
+      return syncUserRoles(roles);
+    }
+  }
+
+  private long doSynchronizedUserRolesSync(List<String> roles) {
+    // this is the timestamp at which a thread attempts to refresh
+    long syncAttemptTime = System.currentTimeMillis();
+    log.debug("Attempting to sync user roles at: {}", new Date(syncAttemptTime));
+
+    LockManager.LockOptions lockOptions =
+        new LockManager.LockOptions()
+            .withLockName("Fiat.UserRolesSyncer.Synchronize".toLowerCase())
+            .withMaximumLockDuration(
+                Duration.ofMillis(
+                    this.configurationProperties.getSynchronizationConfig().getMaxLockDurationMs()))
+            .withSuccessInterval(
+                Duration.ofMillis(
+                    this.configurationProperties.getSynchronizationConfig().getSyncDelayMs()))
+            .withFailureInterval(
+                Duration.ofMillis(
+                    this.configurationProperties
+                        .getSynchronizationConfig()
+                        .getSyncFailureDelayMs()));
+
+    long count;
+    while (true) {
+      boolean isSyncAllowed = false; // flag to control which thread can attempt a sync
+      // since countdown latches can't be reset, we keep a pointer to a global latch so that others
+      // can wait on it
+      CountDownLatch localLatch;
+      synchronized (this) {
+        if (globalLatch.get() == null) {
+          isSyncAllowed = true;
+          globalLatch.set(new CountDownLatch(1));
+        }
+        localLatch = globalLatch.get();
+      }
+
+      if (isSyncAllowed) {
+        try {
+          // acquire redis lock to sync across fiat pods
+          LockManager.AcquireLockResponse<Long> acquireLockResponse =
+              lockManager.acquireLock(
+                  lockOptions,
+                  () -> {
+                    //
+                    if (lastSyncTime.get() != null
+                        && Long.parseLong(lastSyncTime.get()) > syncAttemptTime) {
+                      log.info(
+                          "Not syncing since user roles lastSyncTime: {} is later than this thread's syncAttemptTime: {}",
+                          new Date(Long.parseLong(lastSyncTime.get())),
+                          new Date(syncAttemptTime));
+                      // get the most recent count value
+                      String lastKnownSyncCount =
+                          redisClientDelegate.withCommandsClient(
+                              (Function<JedisCommands, String>) c -> c.get(userRolesCountKey()));
+                      return Long.parseLong(lastKnownSyncCount);
+                    }
+                    return syncUserRoles(roles);
+                  });
+
+          // update in-mem last sync time by getting the most recent value
+          String redisSyncTime =
+              redisClientDelegate.withCommandsClient(
+                  (Function<JedisCommands, String>) c -> c.get(userRolesLastSyncTimeKey()));
+          log.debug("obtained the following lastSyncTime from redis: {}", redisSyncTime);
+          this.lastSyncTime.set(redisSyncTime);
+
+          if (acquireLockResponse != null && acquireLockResponse.isReleased()) {
+            count = acquireLockResponse.getOnLockAcquiredCallbackResult();
+            break;
+          }
+        } catch (Exception e) {
+          log.warn("syncing user roles failed", e);
+        } finally {
+          synchronized (this) {
+            localLatch.countDown(); // release all other threads waiting on this one
+            globalLatch.set(null);
+          }
+        }
+      } else {
+        try {
+          localLatch.await(); // all other threads will be waiting here
+
+        } catch (Exception e) {
+          log.warn("current thread was interrupted while waiting to obtain the latch", e);
+        }
+      }
+
+      if (lastSyncTime.get() != null && Long.parseLong(lastSyncTime.get()) > syncAttemptTime) {
+        log.info(
+            "Not syncing since user roles lastSyncTime: {} is later than this thread's syncAttemptTime: {}",
+            new Date(Long.parseLong(lastSyncTime.get())),
+            new Date(syncAttemptTime));
+        // get the most recent count value
+        String lastKnownSyncCount =
+            redisClientDelegate.withCommandsClient(
+                (Function<JedisCommands, String>) c -> c.get(userRolesCountKey()));
+        return Long.parseLong(lastKnownSyncCount);
+      }
+    }
+    return count;
+  }
+
+  private long syncUserRoles(List<String> roles) {
+    FixedBackOff backoff = new FixedBackOff();
+    backoff.setInterval(this.configurationProperties.getRetryIntervalMs());
+    backoff.setMaxAttempts(
+        Math.floorDiv(
+                this.configurationProperties.getSyncDelayTimeoutMs(),
+                this.configurationProperties.getRetryIntervalMs())
+            + 1);
+    BackOffExecution backOffExec = backoff.start();
+
+    // after this point the execution will get rescheduled
+    final long timeout =
+        System.currentTimeMillis() + this.configurationProperties.getSyncDelayTimeoutMs();
+
+    if (!isServerHealthy()) {
+      log.warn(
+          "Server is currently UNHEALTHY. User permission role synchronization and "
+              + "resolution may not complete until this server becomes healthy again.");
+    }
+
+    // Ensure we're going to reload app and service account definitions
+    permissionsResolver.clearCache();
+
+    while (true) {
+      try {
+        Map<String, UserPermission> combo = new HashMap<>();
+        // force a refresh of the unrestricted user in case the backing repository is empty:
+        combo.put(UnrestrictedResourceConfig.UNRESTRICTED_USERNAME, new UserPermission());
+        Map<String, UserPermission> temp;
+        if (!(temp = getUserPermissions(roles)).isEmpty()) {
+          combo.putAll(temp);
+        }
+        if (!(temp = getServiceAccountsAsMap(roles)).isEmpty()) {
+          combo.putAll(temp);
+        }
+
+        return updateUserPermissions(combo);
+      } catch (ProviderException | PermissionResolutionException ex) {
+        registry
+            .counter(metricName("syncFailure"), "cause", ex.getClass().getSimpleName())
+            .increment();
+        Status status = healthIndicator.health().getStatus();
+        long waitTime = backOffExec.nextBackOff();
+        if (waitTime == BackOffExecution.STOP || System.currentTimeMillis() > timeout) {
+          String cause = (waitTime == BackOffExecution.STOP) ? "backoff-exhausted" : "timeout";
+          registry.counter("syncAborted", "cause", cause).increment();
+          log.error("sync aborted as backoff is exhausted or the timeout is exceeded", ex);
+          return 0;
+        }
+        String message =
+            new StringBuilder("User permission sync failed. ")
+                .append("Server status is ")
+                .append(status)
+                .append(". Trying again in ")
+                .append(waitTime)
+                .append(" ms. Cause:")
+                .append(ex.getMessage())
+                .toString();
+        if (log.isDebugEnabled()) {
+          log.debug(message, ex);
+        } else {
+          log.warn(message);
+        }
+
+        try {
+          Thread.sleep(waitTime);
+        } catch (InterruptedException ignored) {
+        }
+      } finally {
+        isServerHealthy();
+      }
+    }
+  }
+
+  private boolean isServerHealthy() {
+    return healthIndicator.health().getStatus() == Status.UP;
+  }
+
+  private Map<String, UserPermission> getServiceAccountsAsMap(List<String> roles) {
+    List<UserPermission> allServiceAccounts =
+        serviceAccountProvider.getAll().stream()
+            .map(ServiceAccount::toUserPermission)
+            .collect(Collectors.toList());
+    if (roles == null || roles.isEmpty()) {
+      return allServiceAccounts.stream()
+          .collect(Collectors.toMap(UserPermission::getId, Function.identity()));
+    } else {
+      Map<String, UserPermission> filteredServiceAccounts =
+          allServiceAccounts.stream()
+              .filter(p -> p.getRoles().stream().map(Role::getName).anyMatch(roles::contains))
+              .collect(Collectors.toMap(UserPermission::getId, Function.identity()));
+
+      log.debug(
+          "found {} service accounts that match roles: {}", filteredServiceAccounts.size(), roles);
+      return filteredServiceAccounts;
+    }
+  }
+
+  private Map<String, UserPermission> getUserPermissions(List<String> roles) {
+    Map<String, Set<Role>> rolesById;
+    if (roles == null || roles.isEmpty()) {
+      rolesById = permissionsRepository.getAllById();
+    } else {
+      rolesById = permissionsRepository.getAllByRoles(roles);
+    }
+    return rolesById.entrySet().stream()
+        .collect(
+            Collectors.toMap(
+                Map.Entry::getKey,
+                e ->
+                    new UserPermission()
+                        .setId(e.getKey())
+                        .setRoles(new HashSet<>(e.getValue()))));
   }
 
   public long syncServiceAccount(String serviceAccountId, List<String> roles) {
-    return syncStrategy.syncServiceAccount(serviceAccountId, roles);
+    return synchronizer.syncServiceAccount(serviceAccountId, roles);
+  }
+
+  public long updateUserPermissions(Map<String, UserPermission> permissionsById) {
+    log.debug("updating permissions for {} users", permissionsById.size());
+    if (permissionsById.remove(UnrestrictedResourceConfig.UNRESTRICTED_USERNAME) != null) {
+      timeIt(
+          "syncAnonymous",
+          () -> {
+            permissionsRepository.put(permissionsResolver.resolveUnrestrictedUser());
+            log.info("Synced anonymous user role.");
+          });
+    }
+
+    List<ExternalUser> extUsers =
+        permissionsById.values().stream()
+            .map(
+                permission ->
+                    new ExternalUser()
+                        .setId(permission.getId())
+                        .setExternalRoles(
+                            permission.getRoles().stream()
+                                .filter(role -> role.getSource() == Role.Source.EXTERNAL)
+                                .collect(Collectors.toList())))
+            .collect(Collectors.toList());
+
+    long syncTime = System.currentTimeMillis();
+
+    long count = 0;
+    if (extUsers.isEmpty()) {
+      log.info("Found no non-anonymous user roles to sync.");
+    } else {
+      count =
+          timeIt(
+              "syncUsers",
+              () -> {
+                Map<String, UserPermission> resolved =
+                    permissionsResolver.resolve(extUsers);
+                permissionsRepository.putAllById(resolved);
+                return resolved.size();
+              });
+    }
+
+    redisClientDelegate.withCommandsClient(
+        c -> {
+          log.debug("setting last sync time for user roles to {}", syncTime);
+          c.set(userRolesLastSyncTimeKey(), String.valueOf(syncTime));
+        });
+    this.lastSyncTime.set(String.valueOf(syncTime));
+
+    long finalCount = count;
+    redisClientDelegate.withCommandsClient(
+        c -> {
+          log.debug("setting count for user roles to {}", finalCount);
+          c.set(userRolesCountKey(), String.valueOf(finalCount));
+        });
+
+    log.info("Synced {} non-anonymous user roles.", finalCount);
+    return finalCount;
   }
 
   private static String metricName(String name) {
@@ -142,5 +463,21 @@ public class UserRolesSyncer {
           .timer(success ? timer : timer.withTag("cause", cause))
           .record(System.nanoTime() - startTime, TimeUnit.NANOSECONDS);
     }
+  }
+
+  private String userRolesLastSyncTimeKey() {
+    return String.format(
+        "%s:%s:%s",
+        this.configurationProperties.getSynchronizationConfig().getPrefix(),
+        KEY_USER_ROLES,
+        KEY_LAST_SYNC_TIME);
+  }
+
+  private String userRolesCountKey() {
+    return String.format(
+        "%s:%s:%s",
+        this.configurationProperties.getSynchronizationConfig().getPrefix(),
+        KEY_USER_ROLES,
+        KEY_COUNT);
   }
 }

--- a/fiat/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/roles/UserRolesSyncer.java
+++ b/fiat/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/roles/UserRolesSyncer.java
@@ -364,10 +364,7 @@ public class UserRolesSyncer {
         .collect(
             Collectors.toMap(
                 Map.Entry::getKey,
-                e ->
-                    new UserPermission()
-                        .setId(e.getKey())
-                        .setRoles(new HashSet<>(e.getValue()))));
+                e -> new UserPermission().setId(e.getKey()).setRoles(new HashSet<>(e.getValue()))));
   }
 
   public long syncServiceAccount(String serviceAccountId, List<String> roles) {
@@ -407,8 +404,7 @@ public class UserRolesSyncer {
           timeIt(
               "syncUsers",
               () -> {
-                Map<String, UserPermission> resolved =
-                    permissionsResolver.resolve(extUsers);
+                Map<String, UserPermission> resolved = permissionsResolver.resolve(extUsers);
                 permissionsRepository.putAllById(resolved);
                 return resolved.size();
               });

--- a/fiat/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/roles/UserRolesSyncer.java
+++ b/fiat/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/roles/UserRolesSyncer.java
@@ -189,6 +189,7 @@ public class UserRolesSyncer {
         localLatch = globalLatch.get();
       }
 
+      boolean lockAcquired = false;
       if (isSyncAllowed) {
         try {
           // acquire redis lock to sync across fiat pods
@@ -219,17 +220,50 @@ public class UserRolesSyncer {
           log.debug("obtained the following lastSyncTime from redis: {}", redisSyncTime);
           this.lastSyncTime.set(redisSyncTime);
 
-          if (acquireLockResponse != null && acquireLockResponse.isReleased()) {
+          if (acquireLockResponse != null
+              && acquireLockResponse.getLockStatus() == LockManager.LockStatus.ACQUIRED
+              && acquireLockResponse.isReleased()) {
             count = acquireLockResponse.getOnLockAcquiredCallbackResult();
-            break;
+            lockAcquired = true;
           }
         } catch (Exception e) {
           log.warn("syncing user roles failed", e);
         } finally {
+          // If the lock was not acquired (held by another pod or transient error) and the
+          // authoritative lastSyncTime has not advanced past our syncAttemptTime, back off
+          // before releasing the in-process latch. Keeping the latch held during the sleep
+          // parks all other threads in this pod on localLatch.await() so they can't fire
+          // off their own Redis lock attempts in parallel. Waiter threads that subsequently
+          // wake up will re-check lastSyncTime and either return early or take a turn as
+          // the next syncer (and pay their own backoff).
+          if (!lockAcquired) {
+            String currentLastSyncTime = lastSyncTime.get();
+            boolean lastSyncAdvanced =
+                currentLastSyncTime != null
+                    && Long.parseLong(currentLastSyncTime) > syncAttemptTime;
+            if (!lastSyncAdvanced) {
+              long failureDelayMs =
+                  this.configurationProperties.getSynchronizationConfig().getSyncFailureDelayMs();
+              if (failureDelayMs > 0) {
+                try {
+                  Thread.sleep(failureDelayMs);
+                } catch (InterruptedException ignored) {
+                  Thread.currentThread().interrupt();
+                }
+              }
+            }
+          }
           synchronized (this) {
             localLatch.countDown(); // release all other threads waiting on this one
             globalLatch.set(null);
           }
+        }
+
+        if (lockAcquired) {
+          break;
+        }
+        if (Thread.currentThread().isInterrupted()) {
+          break;
         }
       } else {
         try {

--- a/fiat/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/permissions/RedisPermissionsRepositorySpec.groovy
+++ b/fiat/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/permissions/RedisPermissionsRepositorySpec.groovy
@@ -212,9 +212,8 @@ class RedisPermissionsRepositorySpec extends Specification {
 
     when:
     redisClientDelegate.pause(latch)
-    def resultValue
     def result = exec.submit {
-      resultValue = repo.get("foo")
+      repo.get("foo")
     }
 
     latch.await()
@@ -229,7 +228,9 @@ class RedisPermissionsRepositorySpec extends Specification {
     result.get()
 
     then:
-    resultValue.isEmpty() == true
+    def ex = thrown(ExecutionException)
+    ex.cause instanceof PermissionReadException
+    ex.cause.message.contains("timeout")
   }
 
   def "should set last modified for unrestricted user on save"() {

--- a/fiat/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/permissions/RedisPermissionsRepositorySpec.groovy
+++ b/fiat/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/permissions/RedisPermissionsRepositorySpec.groovy
@@ -212,8 +212,9 @@ class RedisPermissionsRepositorySpec extends Specification {
 
     when:
     redisClientDelegate.pause(latch)
+    def resultValue
     def result = exec.submit {
-      repo.get("foo")
+      resultValue = repo.get("foo")
     }
 
     latch.await()
@@ -228,9 +229,7 @@ class RedisPermissionsRepositorySpec extends Specification {
     result.get()
 
     then:
-    def ex = thrown(ExecutionException)
-    ex.cause instanceof PermissionReadException
-    ex.cause.message.contains("timeout")
+    resultValue.isEmpty() == true
   }
 
   def "should set last modified for unrestricted user on save"() {

--- a/fiat/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/providers/DefaultApplicationProviderSpec.groovy
+++ b/fiat/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/providers/DefaultApplicationProviderSpec.groovy
@@ -58,7 +58,7 @@ class DefaultApplicationProviderSpec extends Specification {
       getAllApplications() >> [
           new Application().setName("onlyKnownToFront50"),
           new Application().setName("app1")
-                           .setPermissions(new Permissions.Builder().add(Authorization.READ, "role").build()),
+                       .setPermissions(new Permissions.Builder().add(Authorization.READ, "role").build()),
       ]
     }
     ClouddriverService clouddriverService = Mock(ClouddriverService) {

--- a/fiat/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/roles/UserRolesSyncerSpec.groovy
+++ b/fiat/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/roles/UserRolesSyncerSpec.groovy
@@ -53,6 +53,7 @@ import spock.lang.Unroll
 
 import java.time.Clock
 import java.util.concurrent.Callable
+import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.Executors
 
 class UserRolesSyncerSpec extends Specification {
@@ -489,6 +490,70 @@ class UserRolesSyncerSpec extends Specification {
     syncRoles    | synchronizeUserRolesSync
     ["extrolec"] | true
     ["extrolec"] | false
+  }
+
+  def "should back off between retries when the sync lock is held by another pod"() {
+    setup:
+    UserRolesSyncerConfig config = new UserRolesSyncerConfig()
+    config.getSynchronizationConfig().setEnabled(true)
+    config.getSynchronizationConfig().setSyncFailureDelayMs(150)
+    config.setSyncDelayTimeoutMs(10000)
+
+    def unrestrictedUser = new UserPermission()
+            .setId(UnrestrictedResourceConfig.UNRESTRICTED_USERNAME)
+            .setAccounts([new Account().setName("unrestrictedAccount")] as Set)
+    repo.put(unrestrictedUser)
+
+    def serviceAccountProvider = Mock(ResourceProvider) {
+      getAll() >> []
+    }
+    def permissionsResolver = Mock(PermissionsResolver) {
+      resolve(_ as List) >> [:]
+      resolveUnrestrictedUser() >> unrestrictedUser
+    }
+
+    // Simulate another pod holding the Redis lock for the first two attempts,
+    // then release it so the third attempt can proceed.
+    def attemptTimes = new CopyOnWriteArrayList<Long>()
+    def mockLockManager = Mock(LockManager)
+
+    @Subject
+    def syncer = new UserRolesSyncer(
+            new DiscoveryStatusListener(true),
+            registry,
+            mockLockManager,
+            repo,
+            permissionsResolver,
+            serviceAccountProvider,
+            new AlwaysUpHealthIndicator(),
+            new JedisClientDelegate(embeddedRedis.pool as JedisPool),
+            config
+    )
+
+    when:
+    def result = syncer.syncAndReturn([])
+
+    then:
+    3 * mockLockManager.acquireLock(_ as LockManager.LockOptions, _ as Callable) >> {
+      LockManager.LockOptions opts, Callable cb ->
+        attemptTimes.add(System.currentTimeMillis())
+        if (attemptTimes.size() < 3) {
+          // Lock is held by someone else: the callback is NOT invoked and
+          // the response reports TAKEN + not released.
+          return new LockManager.AcquireLockResponse(null, null, LockManager.LockStatus.TAKEN, null, false)
+        }
+        // Third attempt succeeds: invoke the callback and report ACQUIRED + released.
+        def cbResult = cb.call()
+        return new LockManager.AcquireLockResponse(null, cbResult, LockManager.LockStatus.ACQUIRED, null, true)
+    }
+
+    and: "we waited at least one syncFailureDelayMs between each retry"
+    attemptTimes.size() == 3
+    (attemptTimes[1] - attemptTimes[0]) >= (config.getSynchronizationConfig().getSyncFailureDelayMs() - 20)
+    (attemptTimes[2] - attemptTimes[1]) >= (config.getSynchronizationConfig().getSyncFailureDelayMs() - 20)
+
+    and: "the sync ultimately completed successfully"
+    result != null
   }
 
   @Unroll

--- a/fiat/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/roles/UserRolesSyncerSpec.groovy
+++ b/fiat/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/roles/UserRolesSyncerSpec.groovy
@@ -22,6 +22,7 @@ import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.fiat.config.ResourceProvidersHealthIndicator
 import com.netflix.spinnaker.fiat.config.UnrestrictedResourceConfig
+import com.netflix.spinnaker.fiat.config.UserRolesSyncerConfig
 import com.netflix.spinnaker.fiat.model.UserPermission
 import com.netflix.spinnaker.fiat.model.resources.Account
 import com.netflix.spinnaker.fiat.model.resources.Application
@@ -29,12 +30,14 @@ import com.netflix.spinnaker.fiat.model.resources.BuildService
 import com.netflix.spinnaker.fiat.model.resources.Role
 import com.netflix.spinnaker.fiat.model.resources.ServiceAccount
 import com.netflix.spinnaker.fiat.permissions.ExternalUser
+import com.netflix.spinnaker.fiat.permissions.PermissionResolutionException
 import com.netflix.spinnaker.fiat.permissions.PermissionsResolver
 import com.netflix.spinnaker.fiat.permissions.RedisPermissionRepositoryConfigProps
 import com.netflix.spinnaker.fiat.permissions.RedisPermissionsRepository
 import com.netflix.spinnaker.fiat.providers.ResourceProvider
 import com.netflix.spinnaker.kork.discovery.DiscoveryStatusListener
 import com.netflix.spinnaker.kork.jedis.JedisClientDelegate
+import com.netflix.spinnaker.kork.jedis.lock.RedisLockManager
 import com.netflix.spinnaker.kork.lock.LockManager
 import io.github.resilience4j.retry.RetryRegistry
 import org.springframework.boot.actuate.health.Health
@@ -48,7 +51,9 @@ import spock.lang.Specification
 import spock.lang.Subject
 import spock.lang.Unroll
 
+import java.time.Clock
 import java.util.concurrent.Callable
+import java.util.concurrent.Executors
 
 class UserRolesSyncerSpec extends Specification {
 
@@ -56,6 +61,8 @@ class UserRolesSyncerSpec extends Specification {
 
   @Shared
   Registry registry = new NoopRegistry()
+
+  LockManager lockManager
 
   @Shared
   @AutoCleanup("stop")
@@ -89,6 +96,16 @@ class UserRolesSyncerSpec extends Specification {
         new RedisPermissionRepositoryConfigProps(prefix: "unittests"),
         RetryRegistry.ofDefaults()
     )
+
+    lockManager = new RedisLockManager(
+            null, // will fall back to running node name
+            Clock.systemDefaultZone(),
+            registry,
+            objectMapper,
+            new JedisClientDelegate(embeddedRedis.pool as JedisPool),
+            Optional.empty(),
+            Optional.empty())
+
   }
 
   def cleanup() {
@@ -141,22 +158,19 @@ class UserRolesSyncerSpec extends Specification {
 
     def permissionsResolver = Mock(PermissionsResolver)
 
-    def lockManager = Mock(LockManager) {
-      _ * acquireLock() >> { LockManager.LockOptions lockOptions, Callable onLockAcquiredCallback ->
-        onLockAcquiredCallback.call()
-      }
-    }
-
+    UserRolesSyncerConfig config =  new UserRolesSyncerConfig()
+    config.getSynchronizationConfig().setEnabled(synchronizeUserRoleSync)
     @Subject
     def syncer = new UserRolesSyncer(
         new DiscoveryStatusListener(true),
         registry,
         lockManager,
-        new UserRolesSyncStrategy.DefaultSynchronizationStrategy(new Synchronizer(new AlwaysUpHealthIndicator(), permissionsResolver, repo, serviceAccountProvider, registry, 1, 1)),
-        1,
-        1,
-        1,
-        ""
+        repo,
+        permissionsResolver,
+        serviceAccountProvider,
+        new AlwaysUpHealthIndicator(),
+        new JedisClientDelegate(embeddedRedis.pool as JedisPool),
+        config
     )
 
     expect:
@@ -208,9 +222,272 @@ class UserRolesSyncerSpec extends Specification {
     repo.getAllById() == expectedResult
 
     where:
-    syncRoles    | fullsync
+    syncRoles    | fullsync  | synchronizeUserRoleSync
+    null         | true      | false
+    []           | true      | false
+    ["extrolec"] | false     | false
+    null         | true      | true
+    []           | true      | true
+    ["extrolec"] | true      | true
+  }
+
+  @Unroll
+  def "should update user roles & add service accounts when invoked by concurrent requests"() {
+    setup:
+    def extRoleA = new Role("extRoleA").setSource(Role.Source.EXTERNAL)
+    def extRoleB = new Role("extRoleB").setSource(Role.Source.EXTERNAL)
+    def extRoleC = new Role("extRoleC").setSource(Role.Source.EXTERNAL)
+    def user1 = new UserPermission()
+            .setId("user1")
+            .setAccounts([new Account().setName("account1")] as Set)
+            .setRoles([extRoleA] as Set)
+    def user2 = new UserPermission()
+            .setId("user2")
+            .setAccounts([new Account().setName("account2")] as Set)
+            .setRoles([extRoleB] as Set)
+    def user3 = new UserPermission()
+            .setId("user3")
+            .setAccounts([new Account().setName("account3")] as Set)
+            .setRoles([extRoleC] as Set)
+    def unrestrictedUser = new UserPermission()
+            .setId(UnrestrictedResourceConfig.UNRESTRICTED_USERNAME)
+            .setAccounts([new Account().setName("unrestrictedAccount")] as Set)
+
+    def abcServiceAcct = new UserPermission().setId("abc").setRoles([extRoleC] as Set)
+    def xyzServiceAcct = new UserPermission().setId("xyz@domain.com")
+
+    repo.put(user1)
+    repo.put(user2)
+    repo.put(user3)
+    repo.put(unrestrictedUser)
+
+    def newUser2 = new UserPermission()
+            .setId("user2")
+            .setAccounts([new Account().setName("accountX")] as Set)
+            .setRoles([extRoleB] as Set)
+    def newUser3 = new UserPermission()
+            .setId("user3")
+            .setAccounts([new Account().setName("accountX")] as Set)
+            .setRoles([extRoleC] as Set)
+
+    def serviceAccountProvider = Mock(ResourceProvider) {
+      getAll() >> [new ServiceAccount().setName("abc").setMemberOf(["extRoleC"]),
+                   new ServiceAccount().setName("xyz@domain.com")]
+    }
+
+    def permissionsResolver = Mock(PermissionsResolver)
+
+    def extUsers
+    def expectedResolveOutput
+    def expectedResult
+    if (synchronizeUserRolesSync || (syncRoles == null || syncRoles.isEmpty())) {
+      extUsers = [
+              new ExternalUser()
+                      .setId(user1.id)
+                      .setExternalRoles([new Role("extrolea").setSource(Role.Source.EXTERNAL)] as List<Role>),
+              new ExternalUser()
+                      .setId(user2.id)
+                      .setExternalRoles([new Role("extroleb").setSource(Role.Source.EXTERNAL)] as List<Role>),
+              new ExternalUser()
+                      .setId(abcServiceAcct.id)
+                      .setExternalRoles([new Role("extrolec").setSource(Role.Source.EXTERNAL)] as List<Role>),
+              new ExternalUser()
+                      .setId(xyzServiceAcct.id)
+                      .setExternalRoles([]),
+              new ExternalUser()
+                      .setId(user3.id)
+                      .setExternalRoles([new Role("extrolec").setSource(Role.Source.EXTERNAL)] as List<Role>)
+      ]
+
+      expectedResolveOutput = [
+              "user1"         : user1,
+              "user2"         : newUser2,
+              "user3"         : newUser3,
+              "abc"           : abcServiceAcct,
+              "xyz@domain.com": xyzServiceAcct
+      ]
+
+      expectedResult = [
+              "user1"         : user1.merge(unrestrictedUser),
+              "user2"         : newUser2.merge(unrestrictedUser),
+              "user3"         : newUser3.merge(unrestrictedUser),
+              "abc"           : abcServiceAcct.merge(unrestrictedUser),
+              "xyz@domain.com": xyzServiceAcct.merge(unrestrictedUser),
+              (UNRESTRICTED)  : unrestrictedUser
+      ]
+    } else {
+      extUsers =  [
+              new ExternalUser()
+                      .setId(abcServiceAcct.id)
+                      .setExternalRoles([new Role("extrolec").setSource(Role.Source.EXTERNAL)] as List<Role>),
+              new ExternalUser()
+                      .setId(user3.id)
+                      .setExternalRoles([new Role("extrolec").setSource(Role.Source.EXTERNAL)] as List<Role>)
+      ]
+      expectedResolveOutput = [
+              "user3"         : newUser3,
+              "abc"           : abcServiceAcct
+      ]
+
+      expectedResult = [
+              "user1"         : user1.merge(unrestrictedUser),
+              "user2"         : user2.merge(unrestrictedUser),
+              "user3"         : newUser3.merge(unrestrictedUser),
+              "abc"           : abcServiceAcct.merge(unrestrictedUser),
+              (UNRESTRICTED)  : unrestrictedUser
+      ]
+    }
+
+    UserRolesSyncerConfig config =  new UserRolesSyncerConfig()
+    config.getSynchronizationConfig().setEnabled(synchronizeUserRolesSync)
+
+    @Subject
+    def syncer = new UserRolesSyncer(
+            new DiscoveryStatusListener(true),
+            registry,
+            lockManager,
+            repo,
+            permissionsResolver,
+            serviceAccountProvider,
+            new AlwaysUpHealthIndicator(),
+            new JedisClientDelegate(embeddedRedis.pool as JedisPool),
+            config
+    )
+
+    expect:
+    repo.getAllById() == [
+            "user1"       : user1.merge(unrestrictedUser),
+            "user2"       : user2.merge(unrestrictedUser),
+            "user3"       : user3.merge(unrestrictedUser),
+            (UNRESTRICTED): unrestrictedUser
+    ]
+
+    when:
+    def results = new ArrayList(10)
+    def futures = new ArrayList(10)
+
+    def threadPool = Executors.newFixedThreadPool(10)
+    try {
+      10.times {
+        futures.add(threadPool.submit({ ->
+          syncer.syncAndReturn(syncRoles)
+        } as Callable))
+      }
+      futures.each {results.add(it.get())}
+    } finally {
+      threadPool.shutdown()
+    }
+
+    then:
+    permissionsResolver.resolve(extUsers) >> expectedResolveOutput
+    permissionsResolver.resolveUnrestrictedUser() >> unrestrictedUser
+
+    expect:
+    repo.getAllById() == expectedResult
+
+    results.each {
+      assert it == extUsers.size()
+    }
+
+    where:
+    syncRoles    | synchronizeUserRolesSync
     null         | true
     []           | true
+    ["extrolec"] | true
+    null         | false
+    []           | false
+    ["extrolec"] | false
+  }
+
+  @Unroll
+  def "should handle exceptions when handling concurrent requests"() {
+    setup:
+    def extRoleA = new Role("extRoleA").setSource(Role.Source.EXTERNAL)
+    def extRoleB = new Role("extRoleB").setSource(Role.Source.EXTERNAL)
+    def extRoleC = new Role("extRoleC").setSource(Role.Source.EXTERNAL)
+    def user1 = new UserPermission()
+            .setId("user1")
+            .setAccounts([new Account().setName("account1")] as Set)
+            .setRoles([extRoleA] as Set)
+    def user2 = new UserPermission()
+            .setId("user2")
+            .setAccounts([new Account().setName("account2")] as Set)
+            .setRoles([extRoleB] as Set)
+    def user3 = new UserPermission()
+            .setId("user3")
+            .setAccounts([new Account().setName("account3")] as Set)
+            .setRoles([extRoleC] as Set)
+    def unrestrictedUser = new UserPermission()
+            .setId(UnrestrictedResourceConfig.UNRESTRICTED_USERNAME)
+            .setAccounts([new Account().setName("unrestrictedAccount")] as Set)
+
+    repo.put(user1)
+    repo.put(user2)
+    repo.put(user3)
+    repo.put(unrestrictedUser)
+
+    def serviceAccountProvider = Mock(ResourceProvider) {
+      getAll() >> [new ServiceAccount().setName("abc").setMemberOf(["extRoleC"]),
+                   new ServiceAccount().setName("xyz@domain.com")]
+    }
+
+    def permissionsResolver = Mock(PermissionsResolver)
+
+    UserRolesSyncerConfig config =  new UserRolesSyncerConfig()
+    config.getSynchronizationConfig().setEnabled(synchronizeUserRolesSync)
+    config.setSyncDelayTimeoutMs(50)
+
+    @Subject
+    def syncer = new UserRolesSyncer(
+            new DiscoveryStatusListener(true),
+            registry,
+            lockManager,
+            repo,
+            permissionsResolver,
+            serviceAccountProvider,
+            new AlwaysUpHealthIndicator(),
+            new JedisClientDelegate(embeddedRedis.pool as JedisPool),
+            config
+    )
+
+    expect:
+    repo.getAllById() == [
+            "user1"       : user1.merge(unrestrictedUser),
+            "user2"       : user2.merge(unrestrictedUser),
+            "user3"       : user3.merge(unrestrictedUser),
+            (UNRESTRICTED): unrestrictedUser
+    ]
+
+    when:
+    def results = new ArrayList(2)
+    def futures = new ArrayList(2)
+
+    def threadPool = Executors.newFixedThreadPool(2)
+    try {
+      2.times {
+        futures.add(threadPool.submit({ ->
+          syncer.syncAndReturn(syncRoles)
+        } as Callable))
+      }
+      futures.each {results.add(it.get())}
+    } finally {
+      threadPool.shutdown()
+    }
+
+    then:
+    permissionsResolver.resolve(_ as List) >> {
+      throw new PermissionResolutionException("permission resolution failed from provider")
+    }
+    permissionsResolver.resolveUnrestrictedUser() >> unrestrictedUser
+
+    expect:
+    results.each {
+      assert it == 0
+    }
+
+    where:
+    syncRoles    | synchronizeUserRolesSync
+    ["extrolec"] | true
     ["extrolec"] | false
   }
 
@@ -222,11 +499,12 @@ class UserRolesSyncerSpec extends Specification {
         new DiscoveryStatusListener(discoveryStatusEnabled),
         registry,
         lockManager,
-        new UserRolesSyncStrategy.DefaultSynchronizationStrategy(new Synchronizer(new AlwaysUpHealthIndicator(), null, null, null, registry, 1, 1)),
-        1,
-        1,
-        1,
-        ""
+        null,
+        null,
+        null,
+        new AlwaysUpHealthIndicator(),
+        new JedisClientDelegate(embeddedRedis.pool as JedisPool),
+        new UserRolesSyncerConfig()
     )
 
     when:

--- a/fiat/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/roles/UserRolesSyncerSpec.groovy
+++ b/fiat/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/roles/UserRolesSyncerSpec.groovy
@@ -35,6 +35,7 @@ import com.netflix.spinnaker.fiat.permissions.PermissionsResolver
 import com.netflix.spinnaker.fiat.permissions.RedisPermissionRepositoryConfigProps
 import com.netflix.spinnaker.fiat.permissions.RedisPermissionsRepository
 import com.netflix.spinnaker.fiat.providers.ResourceProvider
+import com.netflix.spinnaker.fiat.roles.Synchronizer
 import com.netflix.spinnaker.kork.discovery.DiscoveryStatusListener
 import com.netflix.spinnaker.kork.jedis.JedisClientDelegate
 import com.netflix.spinnaker.kork.jedis.lock.RedisLockManager
@@ -103,7 +104,7 @@ class UserRolesSyncerSpec extends Specification {
             Clock.systemDefaultZone(),
             registry,
             objectMapper,
-            new JedisClientDelegate(embeddedRedis.pool as JedisPool),
+            new JedisClientDelegate(jedisPool),
             Optional.empty(),
             Optional.empty())
 
@@ -161,6 +162,15 @@ class UserRolesSyncerSpec extends Specification {
 
     UserRolesSyncerConfig config =  new UserRolesSyncerConfig()
     config.getSynchronizationConfig().setEnabled(synchronizeUserRoleSync)
+    def synchronizer = new Synchronizer(
+        new AlwaysUpHealthIndicator(),
+        permissionsResolver,
+        repo,
+        serviceAccountProvider,
+        registry,
+        10000L,
+        30000L
+    )
     @Subject
     def syncer = new UserRolesSyncer(
         new DiscoveryStatusListener(true),
@@ -170,8 +180,9 @@ class UserRolesSyncerSpec extends Specification {
         permissionsResolver,
         serviceAccountProvider,
         new AlwaysUpHealthIndicator(),
-        new JedisClientDelegate(embeddedRedis.pool as JedisPool),
-        config
+        new JedisClientDelegate(jedisPool),
+        config,
+        synchronizer
     )
 
     expect:
@@ -309,12 +320,12 @@ class UserRolesSyncerSpec extends Specification {
       ]
 
       expectedResult = [
-              "user1"         : user1.merge(unrestrictedUser),
-              "user2"         : newUser2.merge(unrestrictedUser),
-              "user3"         : newUser3.merge(unrestrictedUser),
-              "abc"           : abcServiceAcct.merge(unrestrictedUser),
-              "xyz@domain.com": xyzServiceAcct.merge(unrestrictedUser),
-              (UNRESTRICTED)  : unrestrictedUser
+              "user1"         : user1.getRoles() + unrestrictedUser.getRoles(),
+              "user2"         : newUser2.getRoles() + unrestrictedUser.getRoles(),
+              "user3"         : newUser3.getRoles() + unrestrictedUser.getRoles(),
+              "abc"           : abcServiceAcct.getRoles() + unrestrictedUser.getRoles(),
+              "xyz@domain.com": xyzServiceAcct.getRoles() + unrestrictedUser.getRoles(),
+              (UNRESTRICTED)  : unrestrictedUser.getRoles()
       ]
     } else {
       extUsers =  [
@@ -331,16 +342,26 @@ class UserRolesSyncerSpec extends Specification {
       ]
 
       expectedResult = [
-              "user1"         : user1.merge(unrestrictedUser),
-              "user2"         : user2.merge(unrestrictedUser),
-              "user3"         : newUser3.merge(unrestrictedUser),
-              "abc"           : abcServiceAcct.merge(unrestrictedUser),
-              (UNRESTRICTED)  : unrestrictedUser
+              "user1"         : user1.getRoles() + unrestrictedUser.getRoles(),
+              "user2"         : user2.getRoles() + unrestrictedUser.getRoles(),
+              "user3"         : newUser3.getRoles() + unrestrictedUser.getRoles(),
+              "abc"           : abcServiceAcct.getRoles() + unrestrictedUser.getRoles(),
+              (UNRESTRICTED)  : unrestrictedUser.getRoles()
       ]
     }
 
     UserRolesSyncerConfig config =  new UserRolesSyncerConfig()
     config.getSynchronizationConfig().setEnabled(synchronizeUserRolesSync)
+
+    def synchronizer = new Synchronizer(
+            new AlwaysUpHealthIndicator(),
+            permissionsResolver,
+            repo,
+            serviceAccountProvider,
+            registry,
+            10000L,
+            30000L
+    )
 
     @Subject
     def syncer = new UserRolesSyncer(
@@ -351,16 +372,17 @@ class UserRolesSyncerSpec extends Specification {
             permissionsResolver,
             serviceAccountProvider,
             new AlwaysUpHealthIndicator(),
-            new JedisClientDelegate(embeddedRedis.pool as JedisPool),
-            config
+            new JedisClientDelegate(jedisPool),
+            config,
+            synchronizer
     )
 
     expect:
     repo.getAllById() == [
-            "user1"       : user1.merge(unrestrictedUser),
-            "user2"       : user2.merge(unrestrictedUser),
-            "user3"       : user3.merge(unrestrictedUser),
-            (UNRESTRICTED): unrestrictedUser
+            "user1"       : user1.getRoles() + unrestrictedUser.getRoles(),
+            "user2"       : user2.getRoles() + unrestrictedUser.getRoles(),
+            "user3"       : user3.getRoles() + unrestrictedUser.getRoles(),
+            (UNRESTRICTED): unrestrictedUser.getRoles()
     ]
 
     when:
@@ -438,6 +460,16 @@ class UserRolesSyncerSpec extends Specification {
     config.getSynchronizationConfig().setEnabled(synchronizeUserRolesSync)
     config.setSyncDelayTimeoutMs(50)
 
+    def synchronizer = new Synchronizer(
+            new AlwaysUpHealthIndicator(),
+            permissionsResolver,
+            repo,
+            serviceAccountProvider,
+            registry,
+            10000L,
+            50L
+    )
+
     @Subject
     def syncer = new UserRolesSyncer(
             new DiscoveryStatusListener(true),
@@ -447,16 +479,17 @@ class UserRolesSyncerSpec extends Specification {
             permissionsResolver,
             serviceAccountProvider,
             new AlwaysUpHealthIndicator(),
-            new JedisClientDelegate(embeddedRedis.pool as JedisPool),
-            config
+            new JedisClientDelegate(jedisPool),
+            config,
+            synchronizer
     )
 
     expect:
     repo.getAllById() == [
-            "user1"       : user1.merge(unrestrictedUser),
-            "user2"       : user2.merge(unrestrictedUser),
-            "user3"       : user3.merge(unrestrictedUser),
-            (UNRESTRICTED): unrestrictedUser
+            "user1"       : user1.getRoles() + unrestrictedUser.getRoles(),
+            "user2"       : user2.getRoles() + unrestrictedUser.getRoles(),
+            "user3"       : user3.getRoles() + unrestrictedUser.getRoles(),
+            (UNRESTRICTED): unrestrictedUser.getRoles()
     ]
 
     when:
@@ -517,6 +550,16 @@ class UserRolesSyncerSpec extends Specification {
     def attemptTimes = new CopyOnWriteArrayList<Long>()
     def mockLockManager = Mock(LockManager)
 
+    def synchronizer = new Synchronizer(
+            new AlwaysUpHealthIndicator(),
+            permissionsResolver,
+            repo,
+            serviceAccountProvider,
+            registry,
+            10000L,
+            10000L
+    )
+
     @Subject
     def syncer = new UserRolesSyncer(
             new DiscoveryStatusListener(true),
@@ -526,8 +569,9 @@ class UserRolesSyncerSpec extends Specification {
             permissionsResolver,
             serviceAccountProvider,
             new AlwaysUpHealthIndicator(),
-            new JedisClientDelegate(embeddedRedis.pool as JedisPool),
-            config
+            new JedisClientDelegate(jedisPool),
+            config,
+            synchronizer
     )
 
     when:
@@ -568,8 +612,9 @@ class UserRolesSyncerSpec extends Specification {
         null,
         null,
         new AlwaysUpHealthIndicator(),
-        new JedisClientDelegate(embeddedRedis.pool as JedisPool),
-        new UserRolesSyncerConfig()
+        new JedisClientDelegate(jedisPool),
+        new UserRolesSyncerConfig(),
+        null
     )
 
     when:
@@ -636,24 +681,28 @@ class UserRolesSyncerSpec extends Specification {
       }
     }
 
+    def synchronizer = new Synchronizer(
+            new AlwaysUpHealthIndicator(),
+            permissionsResolver,
+            repo,
+            serviceAccountProvider,
+            registry,
+            1L,
+            1L
+    )
+
     @Subject
     def syncer = new UserRolesSyncer(
             new DiscoveryStatusListener(false),
             registry,
             lockManager,
-            new UserRolesSyncStrategy.DefaultSynchronizationStrategy(
-                    new Synchronizer(
-                            new AlwaysUpHealthIndicator(),
-                            permissionsResolver,
-                            repo,
-                            serviceAccountProvider,
-                            registry,
-                            1,
-                            1)),
-            1,
-            1,
-            1,
-            ""
+            repo,
+            permissionsResolver,
+            serviceAccountProvider,
+            new AlwaysUpHealthIndicator(),
+            new JedisClientDelegate(jedisPool),
+            new UserRolesSyncerConfig(),
+            synchronizer
     )
 
     expect:


### PR DESCRIPTION
taken from: https://github.com/spinnaker/fiat/compare/master...dbyron-sf:fiat:pr-4-synchronize-user-role-syncs

# Fiat User Roles Sync – Synchronization and Configuration

## Summary

This PR refactors Fiat's user-roles sync to use configuration properties, adds an optional cross-pod synchronization path (in-process latch + Redis lock), and preserves parallel Redis writes via `putAllById`. It also documents the Front50 option to avoid full sync locks when saving service accounts.

## What This PR Does

1. **Config-driven user roles syncer**
   - Sync is driven by `UserRolesSyncerConfig` (`fiat.write-mode.*`) instead of `@Value` and the previous `UserRolesSyncStrategy` abstraction.
   - The syncer now depends directly on `PermissionsRepository`, `PermissionsResolver`, `Synchronizer`, etc.
   - Uses `putAllById` for parallel Redis writes (preserves `syncThreads` behavior).

2. **Optional synchronization path (latch + Redis lock)**
   - When enabled:
     - **In-process CountDownLatch**: Only one thread per Fiat instance runs sync; others wait for that result.
     - **Redis lock** (`Fiat.UserRolesSyncer.Synchronize`): Only one Fiat pod runs a full sync at a time.
     - **Redis keys** for last sync time and sync count (`{prefix}:user_roles:last_sync_time`, `{prefix}:user_roles:count`) so pods that didn't run the sync can skip work and reuse the latest count.

3. **Backoff and health**
   - Sync uses `FixedBackOff` and respects `ResourceProvidersHealthIndicator`; failed syncs are retried until timeout/backoff exhaustion.

4. **Other changes**
   - Redis pool/config: client name, pool sizing, and logging (e.g. in `RedisConfig`).
   - `DefaultApplicationResourceProvider`: constructor parameter order fix and duplicate field cleanup.
   - Test updates for the new syncer constructor and behavior (`UserRolesSyncerSpec`, `RedisPermissionsRepositorySpec`).

---

## How to Enable the Synchronization (Latching) Path

The latch + Redis lock path is **off** by default. Enable it so only one pod runs a full sync and others wait or reuse the result.

### YAML (Fiat or shared config)

```yaml
fiat:
  write-mode:
    synchronization-config:
      enabled: true
    # optional overrides:
    # sync-delay-ms: 600000
    # sync-failure-delay-ms: 600000
    # sync-delay-timeout-ms: 30000
    # retry-interval-ms: 10000
```

### Properties

```properties
fiat.write-mode.synchronization-config.enabled=true
```

### Logs when enabled

- `since synchronization is enabled, forcing a sync of all user roles`
- `Not syncing since user roles lastSyncTime: ... is later than this thread's syncAttemptTime: ...` (when another pod/thread already synced)
- `user roles synced` after a successful run

---

## Avoiding Extra Locks When Saving Service Accounts (Front50)

When Front50 creates/updates a **service account**, it can either:

- Call Fiat's **full sync** for the affected roles (`sync(rolesToSync)`), which goes through the latch + Redis lock when synchronization is enabled, or
- Call Fiat's **service-account-only** sync (`syncServiceAccount(id, roles)`), which only updates that one service account and does **not** trigger the full sync path or those locks.

To avoid extra locks and full syncs on every service account save, use the service-account-only path by setting the following in **Front50** config:

### YAML

```yaml
fiat:
  disableRoleSyncWhenSavingServiceAccounts: true
```

### Properties

```properties
fiat.disableRoleSyncWhenSavingServiceAccounts=true
```

When `true`, Front50 uses `syncServiceAccount(serviceAccount.getId(), serviceAccount.getMemberOf())` on create/update instead of `sync(rolesToSync)`, so you get correct permissions without taking the full sync lock.

---

## Suggested Production Config (Multi-Pod Fiat + Front50)

```yaml
# Fiat – enable cross-pod sync coordination
fiat:
  write-mode:
    enabled: true
    synchronization-config:
      enabled: true
      prefix: "spinnaker:fiat"
    sync-delay-ms: 600000
    sync-failure-delay-ms: 600000
    sync-delay-timeout-ms: 30000
    retry-interval-ms: 10000

# Front50 – avoid full sync (and locks) when saving service accounts
fiat:
  disableRoleSyncWhenSavingServiceAccounts: true
```

This gives you the full PR behavior (latching + Redis lock + parallel writes), with synchronization enabled, and avoids extra locks when saving service accounts by using the dedicated `syncServiceAccount` path.
