### PR TITLE
Improve parallelization of redis fiat get and put

### DIFF
--- a/fiat/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/permissions/DefaultPermissionsResolver.java
+++ b/fiat/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/permissions/DefaultPermissionsResolver.java
@@ -206,10 +206,10 @@ public class DefaultPermissionsResolver implements PermissionsResolver {
   @Override
   public Map<String, UserPermission> resolveResources(
       @NonNull Map<String, Collection<Role>> userToRoles) {
-    return userToRoles.entrySet().stream()
+    return userToRoles.entrySet().parallelStream()
         .map(
             entry -> {
-              final String userId = entry.getKey();
+              final String userId = String.valueOf(entry.getKey());
               final Set<Role> userRoles = new HashSet<>(entry.getValue());
               final boolean isAdmin = hasAdminRole(userRoles);
 
@@ -220,7 +220,7 @@ public class DefaultPermissionsResolver implements PermissionsResolver {
                   .setAccountManager(hasAccountManagerRole(userRoles))
                   .addResources(getResources(userId, userRoles, isAdmin));
             })
-        .collect(Collectors.toMap(UserPermission::getId, Function.identity()));
+        .collect(Collectors.toConcurrentMap(UserPermission::getId, Function.identity()));
   }
 
   private Set<Resource> getResources(String userId, Set<Role> userRoles, boolean isAdmin) {

--- a/fiat/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/permissions/RedisPermissionsRepository.java
+++ b/fiat/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/permissions/RedisPermissionsRepository.java
@@ -34,6 +34,7 @@ import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.atomic.AtomicReference;
@@ -302,8 +303,15 @@ public class RedisPermissionsRepository implements PermissionsRepository {
       return;
     }
 
-    for (UserPermission permission : permissions.values()) {
-      put(permission);
+    try {
+      syncThreadPool.submit(() -> permissions.values().parallelStream().forEach(this::put)).get();
+    } catch (ExecutionException e) {
+      log.error("Failed to put permissions in parallel", e.getCause());
+      throw new IntegrationException("Failed to put permissions", e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      log.error("Interrupted while putting permissions", e);
+      throw new IntegrationException("Interrupted while putting permissions", e);
     }
   }
 
@@ -471,23 +479,44 @@ public class RedisPermissionsRepository implements PermissionsRepository {
       return new HashMap<>(0);
     }
 
-    Map<String, Set<Role>> usersToRoles = new HashMap<>(userIds.size());
+    Map<String, Set<Role>> usersToRoles = new ConcurrentHashMap<>(userIds.size());
 
-    for (String userId : userIds) {
-      try {
-        Set<Role> roles =
-            getUserResourceMapFromRedis(userId, ResourceType.ROLE).values().stream()
-                .map(it -> (Role) it)
-                .collect(Collectors.toSet());
-        usersToRoles.put(userId, roles);
-      } catch (Throwable t) {
-        String message = String.format("Storage exception reading %s entry.", userId);
-        log.error(message, t);
-        if (t instanceof SpinnakerException) {
-          throw (SpinnakerException) t;
-        }
-        throw new PermissionReadException(message, t);
+    try {
+      syncThreadPool
+          .submit(
+              () ->
+                  userIds.parallelStream()
+                      .forEach(
+                          userId -> {
+                            try {
+                              Set<Role> roles =
+                                  getUserResourceMapFromRedis(userId, ResourceType.ROLE)
+                                      .values()
+                                      .stream()
+                                      .map(it -> (Role) it)
+                                      .collect(Collectors.toSet());
+                              usersToRoles.put(userId, roles);
+                            } catch (Throwable t) {
+                              String message =
+                                  String.format("Storage exception reading %s entry.", userId);
+                              log.error(message, t);
+                              if (t instanceof SpinnakerException) {
+                                throw (SpinnakerException) t;
+                              }
+                              throw new PermissionReadException(message, t);
+                            }
+                          }))
+          .get();
+    } catch (ExecutionException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof RuntimeException) {
+        throw (RuntimeException) cause;
       }
+      throw new PermissionReadException(
+          "Failed to get roles from Redis", cause != null ? cause : e);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new PermissionReadException("Interrupted while getting roles from Redis", e);
     }
 
     return usersToRoles;

--- a/fiat/fiat-roles/src/test/java/com/netflix/spinnaker/fiat/permissions/DefaultPermissionsResolverTest.java
+++ b/fiat/fiat-roles/src/test/java/com/netflix/spinnaker/fiat/permissions/DefaultPermissionsResolverTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2026 DoorDash, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use it except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.fiat.permissions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.fiat.config.AccountManagerConfig;
+import com.netflix.spinnaker.fiat.config.FiatAdminConfig;
+import com.netflix.spinnaker.fiat.model.UserPermission;
+import com.netflix.spinnaker.fiat.model.resources.Application;
+import com.netflix.spinnaker.fiat.model.resources.Resource;
+import com.netflix.spinnaker.fiat.model.resources.Role;
+import com.netflix.spinnaker.fiat.model.resources.ServiceAccount;
+import com.netflix.spinnaker.fiat.providers.ResourceProvider;
+import com.netflix.spinnaker.fiat.roles.UserRolesProvider;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class DefaultPermissionsResolverTest {
+
+  @Test
+  void resolveResourcesShouldHandleManyUsersInParallel() {
+    Role role = new Role("test-role");
+    @SuppressWarnings("unchecked")
+    ResourceProvider<Application> applicationProvider = mock(ResourceProvider.class);
+
+    Map<String, Collection<Role>> userToRoles = new HashMap<>();
+    for (int i = 1; i <= 50; i++) {
+      userToRoles.put("user" + i, List.of(role));
+    }
+
+    when(applicationProvider.getAllRestricted(any(), anySet(), anyBoolean()))
+        .thenAnswer(
+            invocation -> {
+              String userId = invocation.getArgument(0);
+              return Set.of(new Application().setName("app-" + userId));
+            });
+
+    UserRolesProvider userRolesProvider = mock(UserRolesProvider.class);
+    ResourceProvider<ServiceAccount> serviceAccountProvider = mock(ResourceProvider.class);
+    List<ResourceProvider<? extends Resource>> resourceProviders = new ArrayList<>();
+    resourceProviders.add(applicationProvider);
+
+    DefaultPermissionsResolver resolver =
+        new DefaultPermissionsResolver(
+            userRolesProvider,
+            serviceAccountProvider,
+            resourceProviders,
+            new FiatAdminConfig(),
+            new AccountManagerConfig(),
+            new ObjectMapper());
+
+    Map<String, UserPermission> result = resolver.resolveResources(userToRoles);
+
+    assertEquals(50, result.size());
+    for (int i = 1; i <= 50; i++) {
+      String userId = "user" + i;
+      UserPermission perm = result.get(userId);
+      assertNotNull(perm, "User " + userId + " should be in result");
+      assertEquals(userId, perm.getId());
+      assertEquals(Set.of(role), perm.getRoles());
+      assertTrue(
+          perm.getApplications().stream().anyMatch(a -> a.getName().equals("app-" + userId)),
+          "User " + userId + " should have app-" + userId);
+    }
+  }
+}

--- a/fiat/fiat-roles/src/test/java/com/netflix/spinnaker/fiat/permissions/RedisPermissionsRepositoryTest.java
+++ b/fiat/fiat-roles/src/test/java/com/netflix/spinnaker/fiat/permissions/RedisPermissionsRepositoryTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2026 DoorDash, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use it except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.fiat.permissions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.fiat.model.UserPermission;
+import com.netflix.spinnaker.fiat.model.resources.Account;
+import com.netflix.spinnaker.fiat.model.resources.Application;
+import com.netflix.spinnaker.fiat.model.resources.BuildService;
+import com.netflix.spinnaker.fiat.model.resources.Role;
+import com.netflix.spinnaker.fiat.model.resources.ServiceAccount;
+import com.netflix.spinnaker.kork.jedis.JedisClientDelegate;
+import io.github.resilience4j.retry.RetryRegistry;
+import java.time.Clock;
+import java.util.HashMap;
+import java.util.Map;
+import net.jpountz.lz4.LZ4DecompressorWithLength;
+import net.jpountz.lz4.LZ4Factory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.util.SafeEncoder;
+
+class RedisPermissionsRepositoryTest {
+
+  private static final String PREFIX = "unittests";
+
+  private static GenericContainer<?> embeddedRedis;
+  private static Jedis jedis;
+  private static JedisPool jedisPool;
+  private static JedisClientDelegate redisClientDelegate;
+  private static LZ4DecompressorWithLength lz4Decompressor;
+
+  private static final ObjectMapper objectMapper =
+      new ObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL);
+
+  private RedisPermissionRepositoryConfigProps configProps;
+  private RedisPermissionsRepository repo;
+
+  @BeforeAll
+  static void setupRedis() {
+    assumeTrue(
+        DockerClientFactory.instance().isDockerAvailable(),
+        "Docker is required for RedisPermissionsRepositoryTest");
+    embeddedRedis =
+        new GenericContainer<>(DockerImageName.parse("library/redis:5-alpine"))
+            .withExposedPorts(6379);
+    embeddedRedis.start();
+
+    jedisPool = new JedisPool(embeddedRedis.getHost(), embeddedRedis.getMappedPort(6379));
+    jedis = jedisPool.getResource();
+    jedis.flushDB();
+
+    redisClientDelegate = new JedisClientDelegate(jedisPool);
+
+    LZ4Factory factory = LZ4Factory.fastestInstance();
+    lz4Decompressor = new LZ4DecompressorWithLength(factory.fastDecompressor());
+  }
+
+  @BeforeEach
+  void setup() {
+    configProps = new RedisPermissionRepositoryConfigProps();
+    configProps.setPrefix(PREFIX);
+
+    repo =
+        new RedisPermissionsRepository(
+            Clock.systemUTC(),
+            objectMapper,
+            redisClientDelegate,
+            java.util.List.of(
+                new Application(),
+                new Account(),
+                new ServiceAccount(),
+                new Role(),
+                new BuildService()),
+            configProps,
+            RetryRegistry.ofDefaults());
+  }
+
+  @AfterEach
+  void cleanup() {
+    jedis.flushDB();
+  }
+
+  private String getCompressed(String key) {
+    byte[] k = SafeEncoder.encode(key);
+    byte[] val = jedis.get(k);
+    if (val == null) {
+      return null;
+    }
+    return SafeEncoder.encode(lz4Decompressor.decompress(val));
+  }
+
+  @Test
+  void putAllByIdShouldPersistManyUsersInParallel() {
+    Map<String, UserPermission> permissions = new HashMap<>();
+    for (int i = 1; i <= 20; i++) {
+      UserPermission user =
+          new UserPermission()
+              .setId("parallelUser" + i)
+              .setAccounts(java.util.Set.of(new Account().setName("account" + i)));
+      permissions.put("paralleluser" + i, user);
+    }
+
+    repo.putAllById(permissions);
+
+    assertEquals(20, jedis.scard(PREFIX + ":users"));
+    for (int i = 1; i <= 20; i++) {
+      assertTrue(
+          jedis.sismember(PREFIX + ":users", "paralleluser" + i),
+          "User paralleluser" + i + " should be in users set");
+      assertNotNull(
+          getCompressed(PREFIX + ":permissions-v2:paralleluser" + i + ":accounts"),
+          "Accounts for paralleluser" + i + " should be persisted");
+    }
+  }
+
+  @Test
+  void getAllByIdShouldReadManyUsersInParallel() {
+    Map<String, UserPermission> permissions = new HashMap<>();
+    for (int i = 1; i <= 25; i++) {
+      Role role = new Role("role" + (i % 5));
+      UserPermission user =
+          new UserPermission()
+              .setId("getAllUser" + i)
+              .setRoles(java.util.Set.of(role))
+              .setAccounts(java.util.Set.of(new Account().setName("account" + i)));
+      permissions.put("getalluser" + i, user);
+    }
+
+    repo.putAllById(permissions);
+
+    Map<String, java.util.Set<Role>> result = repo.getAllById();
+
+    assertEquals(25, result.size());
+    for (int i = 1; i <= 25; i++) {
+      final int userIndex = i;
+      String userId = "getalluser" + i;
+      assertTrue(result.containsKey(userId), "User " + userId + " should be in result");
+      java.util.Set<Role> roles = result.get(userId);
+      assertNotNull(roles, "Roles for " + userId + " should not be null");
+      assertEquals(1, roles.size(), "User " + userId + " should have 1 role");
+      assertTrue(
+          roles.stream().anyMatch(r -> r.getName().equals("role" + (userIndex % 5))),
+          "User " + userId + " should have role" + (userIndex % 5));
+    }
+  }
+}


### PR DESCRIPTION
# Improve parallelization of Redis fiat `get` and `put`

## Summary

Parallelize Redis reads and writes in `RedisPermissionsRepository` and user permission resolution in `DefaultPermissionsResolver` to reduce the wall-clock time of fiat role syncs in environments with many users.

Ported from doordash/spinnaker PR #95 ("Improve parallelization of redis fiat get and put").

## Changes

### `RedisPermissionsRepository`

- **Bulk `put(Map<String, UserPermission>)`**: replace the sequential `for` loop over `permissions.values()` with `permissions.values().parallelStream().forEach(this::put)` submitted to the existing `syncThreadPool` (`ForkJoinPool` sized via `configProps.getRepository().getSyncThreads()`).
- **`getAllByRoles` (bulk role reads)**: replace the sequential per-user loop calling `getUserResourceMapFromRedis` with a parallel stream over `userIds` submitted to `syncThreadPool`, accumulating into a `ConcurrentHashMap<String, Set<Role>>` instead of a plain `HashMap`.
- Wrap both parallel submissions with proper exception translation:
  - `ExecutionException` → unwrap and rethrow the original `RuntimeException` / `SpinnakerException`, or wrap in `PermissionReadException` / `IntegrationException`.
  - `InterruptedException` → restore the interrupt flag and surface as a `PermissionReadException` / `IntegrationException`.

### `DefaultPermissionsResolver`

- `resolveResources` now uses `parallelStream()` over the `userToRoles` entry set so that per-user `getResources` lookups run concurrently.
- Collect into a `ConcurrentMap` via `Collectors.toConcurrentMap(...)` to make the terminal operation thread-safe.

### Tests

- New `DefaultPermissionsResolverTest` covering the parallelized `resolveResources` path.
- New `RedisPermissionsRepositoryTest` covering parallel `put(Map)` and `getAllByRoles`, including exception propagation for interrupt and underlying Redis failures.

## Motivation

Fiat role syncs for large user sets were dominated by sequential Redis round trips. Using the already-configured `syncThreadPool` lets us fan out both reads and writes to the same bounded pool that the rest of the syncer uses, without introducing a new concurrency knob.

## Tuning Thread Parallelism

There are two pools involved, and they are controlled independently.

### 1. Redis read/write pool (`RedisPermissionsRepository`)

The parallel `put(Map)` and `getAllByRoles` operations run on a dedicated `ForkJoinPool` owned by `RedisPermissionsRepository`. Its size is controlled by the existing property:

```yaml
fiat:
  redis:
    repository:
      sync-threads: 16   # default: Runtime.getRuntime().availableProcessors()
```

Guidance:

- Start with the default (number of CPU cores). This is a good baseline because the work is a mix of Redis I/O and JSON (de)serialization.
- If fiat is I/O-bound against Redis (CPU idle, role sync still slow), increase `sync-threads` (e.g. 2–4x cores) to get more concurrent Redis round trips in flight.
- If Redis itself starts showing elevated latency, CPU saturation, or connection pool exhaustion, decrease `sync-threads`. Make sure the Jedis / Redis client pool (`max-total`) is ≥ `sync-threads`, otherwise threads will just block waiting for a connection.
- Very high values (hundreds) are rarely useful and can make Redis the bottleneck; prefer scaling Redis or sharding before pushing this too high.

### 2. Permission resolution pool (`DefaultPermissionsResolver`)

`resolveResources` uses `parallelStream()`, which runs on the JVM common `ForkJoinPool`. Its parallelism is controlled by the standard JVM system property:

```
-Djava.util.concurrent.ForkJoinPool.common.parallelism=16
```

Default is `Runtime.getRuntime().availableProcessors() - 1`. Raise this if permission resolution (not Redis) is the bottleneck — for example, when upstream role/account providers (Google Groups, LDAP, etc.) dominate sync time and can tolerate more concurrent calls. Note that this pool is shared JVM-wide, so tune with awareness of other `parallelStream()` users in fiat.

### Recommended approach

1. Leave both at defaults initially.
2. Measure: look at `UserRolesSyncer` sync duration, Redis latency/CPU, and fiat pod CPU.
3. Adjust `fiat.redis.repository.sync-threads` first — it has the most direct impact on the bulk Redis operations introduced here.
4. Only tune the common pool parallelism if provider-side resolution is clearly the bottleneck.

