### PR TITLE
feat(kork/artifact/artifactstore/s3): add context to artifact store exceptions

### DIFF
--- a/kork/kork-artifacts/kork-artifacts.gradle
+++ b/kork/kork-artifacts/kork-artifacts.gradle
@@ -26,5 +26,7 @@ dependencies {
   testImplementation "org.mockito:mockito-core"
   testImplementation "org.springframework.boot:spring-boot-starter-test"
   testImplementation project(":kork-core")
+  testImplementation project(":kork-web")
+  testImplementation project(":kork-retrofit")
   testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
 }

--- a/kork/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/artifactstore/ArtifactReferenceURI.java
+++ b/kork/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/artifactstore/ArtifactReferenceURI.java
@@ -51,6 +51,11 @@ public class ArtifactReferenceURI {
     return reference.startsWith(uriScheme);
   }
 
+  @Override
+  public String toString() {
+    return uri();
+  }
+
   public static ArtifactReferenceURI parse(String reference) {
     String noSchemeURI = StringUtils.removeStart(reference, uriScheme);
     String[] paths = StringUtils.split(noSchemeURI, '/');

--- a/kork/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/artifactstore/s3/S3ArtifactStoreGetter.java
+++ b/kork/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/artifactstore/s3/S3ArtifactStoreGetter.java
@@ -84,15 +84,14 @@ public class S3ArtifactStoreGetter implements ArtifactStoreGetter {
 
       return builder.build();
     } catch (SdkServiceException e) {
-      throw new ResponseStatusException(
-          e.statusCode(),
-          String.format(
-              "artifact storage failed to complete s3 request bucket=%s ref=%s", bucket, uri),
-          e);
+      throw new ResponseStatusException(e.statusCode(), getErrorMessage(uri), e);
     } catch (Exception e) {
-      throw new RuntimeException(
-          String.format("artifact failed to be retrieved %s/%s", this.bucket, uri), e);
+      throw new RuntimeException(getErrorMessage(uri), e);
     }
+  }
+
+  private String getErrorMessage(ArtifactReferenceURI uri) {
+    return String.format("artifact failed to be retrieved: bucket=%s ref=%s", this.bucket, uri);
   }
 
   /**

--- a/kork/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/artifactstore/s3/S3ArtifactStoreGetter.java
+++ b/kork/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/artifactstore/s3/S3ArtifactStoreGetter.java
@@ -28,7 +28,9 @@ import java.util.Base64;
 import java.util.NoSuchElementException;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.security.authentication.AuthenticationServiceException;
+import org.springframework.web.server.ResponseStatusException;
 import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.core.exception.SdkServiceException;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
@@ -65,21 +67,32 @@ public class S3ArtifactStoreGetter implements ArtifactStoreGetter {
     log.debug("Attempting to get artifact reference={} s3Key={}", uri.uri(), uri.paths());
     GetObjectRequest request = GetObjectRequest.builder().bucket(bucket).key(uri.paths()).build();
 
-    ResponseBytes<GetObjectResponse> resp = s3Client.getObjectAsBytes(request);
-    Artifact.ArtifactBuilder builder =
-        Artifact.builder()
-            .type(ArtifactTypes.REMOTE_BASE64.getMimeType())
-            .reference(Base64.getEncoder().encodeToString(resp.asByteArray()));
+    try {
+      ResponseBytes<GetObjectResponse> resp = s3Client.getObjectAsBytes(request);
+      Artifact.ArtifactBuilder builder =
+          Artifact.builder()
+              .type(ArtifactTypes.REMOTE_BASE64.getMimeType())
+              .reference(Base64.getEncoder().encodeToString(resp.asByteArray()));
 
-    if (decorators == null) {
+      if (decorators == null) {
+        return builder.build();
+      }
+
+      for (ArtifactDecorator decorator : decorators) {
+        builder = decorator.decorate(builder);
+      }
+
       return builder.build();
+    } catch (SdkServiceException e) {
+      throw new ResponseStatusException(
+          e.statusCode(),
+          String.format(
+              "artifact storage failed to complete s3 request bucket=%s ref=%s", bucket, uri),
+          e);
+    } catch (Exception e) {
+      throw new RuntimeException(
+          String.format("artifact failed to be retrieved %s/%s", this.bucket, uri), e);
     }
-
-    for (ArtifactDecorator decorator : decorators) {
-      builder = decorator.decorate(builder);
-    }
-
-    return builder.build();
   }
 
   /**

--- a/kork/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/artifactstore/s3/S3ArtifactStoreGetter.java
+++ b/kork/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/artifactstore/s3/S3ArtifactStoreGetter.java
@@ -84,14 +84,15 @@ public class S3ArtifactStoreGetter implements ArtifactStoreGetter {
 
       return builder.build();
     } catch (SdkServiceException e) {
-      throw new ResponseStatusException(e.statusCode(), getErrorMessage(uri), e);
+      throw new ResponseStatusException(e.statusCode(), getErrorMessage(uri, e), e);
     } catch (Exception e) {
-      throw new RuntimeException(getErrorMessage(uri), e);
+      throw new RuntimeException(getErrorMessage(uri, e), e);
     }
   }
 
-  private String getErrorMessage(ArtifactReferenceURI uri) {
-    return String.format("artifact failed to be retrieved: bucket=%s ref=%s", this.bucket, uri);
+  private String getErrorMessage(ArtifactReferenceURI uri, Exception e) {
+    return String.format(
+        "artifact failed to be retrieved: bucket=%s ref=%s: %s", this.bucket, uri, e.getMessage());
   }
 
   /**

--- a/kork/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/artifactstore/s3/S3ArtifactStoreStorer.java
+++ b/kork/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/artifactstore/s3/S3ArtifactStoreStorer.java
@@ -125,15 +125,16 @@ public class S3ArtifactStoreStorer implements ArtifactStoreStorer {
 
       s3Client.putObject(request, RequestBody.fromBytes(referenceBytes));
     } catch (SdkServiceException e) {
-      throw new ResponseStatusException(e.statusCode(), storeErrorMessage(ref.uri()), e);
+      throw new ResponseStatusException(e.statusCode(), storeErrorMessage(ref.uri(), e), e);
     } catch (Exception e) {
-      throw new RuntimeException(storeErrorMessage(ref.uri()), e);
+      throw new RuntimeException(storeErrorMessage(ref.uri(), e), e);
     }
     return remoteArtifact;
   }
 
-  private String storeErrorMessage(String uri) {
-    return String.format("artifact failed to be stored: bucket=%s ref=%s", this.bucket, uri);
+  private String storeErrorMessage(String uri, Exception e) {
+    return String.format(
+        "artifact failed to be stored: bucket=%s ref=%s: %s", this.bucket, uri, e.getMessage());
   }
 
   private byte[] getReferenceAsBytes(Artifact artifact) {

--- a/kork/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/artifactstore/s3/S3ArtifactStoreStorer.java
+++ b/kork/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/artifactstore/s3/S3ArtifactStoreStorer.java
@@ -125,16 +125,15 @@ public class S3ArtifactStoreStorer implements ArtifactStoreStorer {
 
       s3Client.putObject(request, RequestBody.fromBytes(referenceBytes));
     } catch (SdkServiceException e) {
-      throw new ResponseStatusException(
-          e.statusCode(),
-          String.format(
-              "artifact storage failed to complete s3 request bucket=%s ref=%s", bucket, ref.uri()),
-          e);
+      throw new ResponseStatusException(e.statusCode(), storeErrorMessage(ref.uri()), e);
     } catch (Exception e) {
-      throw new RuntimeException(
-          String.format("artifact failed to be stored %s/%s", this.bucket, ref.uri()), e);
+      throw new RuntimeException(storeErrorMessage(ref.uri()), e);
     }
     return remoteArtifact;
+  }
+
+  private String storeErrorMessage(String uri) {
+    return String.format("artifact failed to be stored: bucket=%s ref=%s", this.bucket, uri);
   }
 
   private byte[] getReferenceAsBytes(Artifact artifact) {

--- a/kork/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/artifactstore/s3/S3ArtifactStoreStorer.java
+++ b/kork/kork-artifacts/src/main/java/com/netflix/spinnaker/kork/artifacts/artifactstore/s3/S3ArtifactStoreStorer.java
@@ -27,6 +27,8 @@ import com.netflix.spinnaker.security.AuthenticatedRequest;
 import java.util.Base64;
 import java.util.regex.Pattern;
 import lombok.extern.log4j.Log4j2;
+import org.springframework.web.server.ResponseStatusException;
+import software.amazon.awssdk.core.exception.SdkServiceException;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
@@ -104,23 +106,34 @@ public class S3ArtifactStoreStorer implements ArtifactStoreStorer {
     }
 
     Artifact remoteArtifact = builder.build();
-    if (objectExists(ref)) {
-      log.debug("Artifact exists. No need to store. reference={}", ref.uri());
-      return remoteArtifact;
+    try {
+      if (objectExists(ref)) {
+        log.debug("Artifact exists. No need to store. reference={}", ref.uri());
+        return remoteArtifact;
+      }
+
+      // purpose of tagging is to ensure some sort of identity is persisted to
+      // enforce permissions when retrieving the artifact
+      Tag accountTag = Tag.builder().key(ENFORCE_PERMS_KEY).value(application).build();
+
+      PutObjectRequest request =
+          PutObjectRequest.builder()
+              .bucket(bucket)
+              .key(ref.paths())
+              .tagging(Tagging.builder().tagSet(accountTag).build())
+              .build();
+
+      s3Client.putObject(request, RequestBody.fromBytes(referenceBytes));
+    } catch (SdkServiceException e) {
+      throw new ResponseStatusException(
+          e.statusCode(),
+          String.format(
+              "artifact storage failed to complete s3 request bucket=%s ref=%s", bucket, ref.uri()),
+          e);
+    } catch (Exception e) {
+      throw new RuntimeException(
+          String.format("artifact failed to be stored %s/%s", this.bucket, ref.uri()), e);
     }
-
-    // purpose of tagging is to ensure some sort of identity is persisted to
-    // enforce permissions when retrieving the artifact
-    Tag accountTag = Tag.builder().key(ENFORCE_PERMS_KEY).value(application).build();
-
-    PutObjectRequest request =
-        PutObjectRequest.builder()
-            .bucket(bucket)
-            .key(ref.paths())
-            .tagging(Tagging.builder().tagSet(accountTag).build())
-            .build();
-
-    s3Client.putObject(request, RequestBody.fromBytes(referenceBytes));
     return remoteArtifact;
   }
 

--- a/kork/kork-artifacts/src/test/java/com/netflix/spinnaker/kork/artifacts/artifactstoretest/S3ArtifactStoreControllerTest.java
+++ b/kork/kork-artifacts/src/test/java/com/netflix/spinnaker/kork/artifacts/artifactstoretest/S3ArtifactStoreControllerTest.java
@@ -1,0 +1,353 @@
+/*
+ * Copyright 2026 Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.artifacts.artifactstoretest;
+
+import static com.netflix.spinnaker.kork.artifacts.artifactstore.s3.S3ArtifactStore.ENFORCE_PERMS_KEY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import com.google.common.hash.Hashing;
+import com.netflix.spinnaker.config.ErrorConfiguration;
+import com.netflix.spinnaker.config.RetrofitErrorConfiguration;
+import com.netflix.spinnaker.filters.AuthenticatedRequestFilter;
+import com.netflix.spinnaker.kork.artifacts.ArtifactTypes;
+import com.netflix.spinnaker.kork.artifacts.artifactstore.ArtifactReferenceURI;
+import com.netflix.spinnaker.kork.artifacts.artifactstore.ArtifactStoreConfigurationProperties;
+import com.netflix.spinnaker.kork.artifacts.artifactstore.ArtifactStoreGetter;
+import com.netflix.spinnaker.kork.artifacts.artifactstore.ArtifactStoreStorer;
+import com.netflix.spinnaker.kork.artifacts.artifactstore.ArtifactStoreURIBuilder;
+import com.netflix.spinnaker.kork.artifacts.artifactstore.ArtifactStoreURISHA256Builder;
+import com.netflix.spinnaker.kork.artifacts.artifactstore.filters.ApplicationStorageFilter;
+import com.netflix.spinnaker.kork.artifacts.artifactstore.s3.S3ArtifactStoreConfiguration;
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import com.netflix.spinnaker.kork.common.Header;
+import com.netflix.spinnaker.security.UserPermissionEvaluator;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.GetObjectTaggingRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectTaggingResponse;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.s3.model.Tag;
+
+/**
+ * Test how AWS SDK exceptions thrown by S3ArtifactStoreGetter and S3ArtifactStoreStorer are
+ * serialized. Test the success cases too.
+ */
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = {
+      "artifact-store.type=s3",
+      "artifact-store.s3.bucket=my-bucket",
+      "artifact-store.s3.enabled=true"
+    },
+    classes = {
+      ErrorConfiguration.class,
+      RetrofitErrorConfiguration.class,
+      S3ArtifactStoreConfiguration.class,
+      S3ArtifactStoreControllerTest.TestControllerConfiguration.class
+    })
+class S3ArtifactStoreControllerTest {
+
+  private static final String APPLICATION = "my-application";
+  private static final String USER = "my-user";
+  private static final String STORE_REFERENCE =
+      Base64.getEncoder().encodeToString("hello world".getBytes(StandardCharsets.UTF_8));
+  private static final String STORE_ARTIFACT_REFERENCE =
+      "ref://"
+          + APPLICATION
+          + "/"
+          + Hashing.sha256().hashBytes(STORE_REFERENCE.getBytes(StandardCharsets.UTF_8)).toString();
+
+  private static final ParameterizedTypeReference<Map<String, Object>> MAP_TYPE =
+      new ParameterizedTypeReference<>() {};
+
+  @Configuration
+  @EnableAutoConfiguration
+  @EnableWebSecurity
+  @EnableConfigurationProperties(ArtifactStoreConfigurationProperties.class)
+  static class TestControllerConfiguration implements WebMvcConfigurer {
+    @Bean
+    protected SecurityFilterChain configure(HttpSecurity http) throws Exception {
+      http.csrf(csrf -> csrf.disable()).headers(headers -> headers.disable());
+      http.authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
+      http.anonymous(anon -> anon.disable());
+      return http.build();
+    }
+
+    @Bean
+    FilterRegistrationBean<AuthenticatedRequestFilter> authenticatedRequestFilter() {
+      return new FilterRegistrationBean<>(
+          new AuthenticatedRequestFilter(/* extractSpinnakerHeaders= */ true));
+    }
+
+    @Bean
+    Map<String, List<ApplicationStorageFilter>> excludeFilters() {
+      return Map.of();
+    }
+
+    @Bean
+    ArtifactStoreURIBuilder artifactStoreURIBuilder() {
+      return new ArtifactStoreURISHA256Builder();
+    }
+
+    @Bean
+    ArtifactController artifactController(ArtifactStoreGetter getter, ArtifactStoreStorer storer) {
+      return new ArtifactController(getter, storer);
+    }
+  }
+
+  @RestController
+  @RequiredArgsConstructor
+  static class ArtifactController {
+    private final ArtifactStoreGetter getter;
+    private final ArtifactStoreStorer storer;
+
+    @GetMapping("/get-artifact")
+    Artifact get() {
+      return getter.get(ArtifactReferenceURI.parse("ref://some-artifact"));
+    }
+
+    @GetMapping("/store-artifact")
+    Artifact store() {
+      Artifact artifact =
+          Artifact.builder()
+              .type(ArtifactTypes.EMBEDDED_BASE64.getMimeType())
+              .reference(STORE_REFERENCE)
+              .build();
+      return storer.store(artifact);
+    }
+  }
+
+  @Autowired private TestRestTemplate restTemplate;
+
+  @MockBean private S3Client s3Client;
+  @MockBean private UserPermissionEvaluator userPermissionEvaluator;
+
+  private HttpEntity<Void> getRequestEntity;
+  private HttpEntity<Void> storeRequestEntity;
+
+  @BeforeEach
+  void setUp(TestInfo testInfo) {
+    System.out.println("--------------- Test " + testInfo.getDisplayName());
+
+    HttpHeaders getHeaders = new HttpHeaders();
+    getHeaders.set(Header.USER.getHeader(), USER);
+    getRequestEntity = new HttpEntity<>(getHeaders);
+
+    HttpHeaders storeHeaders = new HttpHeaders();
+    storeHeaders.set(Header.APPLICATION.getHeader(), APPLICATION);
+    storeRequestEntity = new HttpEntity<>(storeHeaders);
+
+    Tag tag = Tag.builder().key(ENFORCE_PERMS_KEY).value(APPLICATION).build();
+    GetObjectTaggingResponse taggingResponse =
+        GetObjectTaggingResponse.builder().tagSet(List.of(tag)).build();
+    when(s3Client.getObjectTagging(any(GetObjectTaggingRequest.class))).thenReturn(taggingResponse);
+
+    when(userPermissionEvaluator.hasPermission(
+            eq(USER), eq(APPLICATION), eq("application"), eq("READ")))
+        .thenReturn(true);
+  }
+
+  @Test
+  void testSuccessfulGetReturnsArtifact() throws Exception {
+    byte[] content = "hello world".getBytes(StandardCharsets.UTF_8);
+    GetObjectResponse getObjectResponse = GetObjectResponse.builder().build();
+    ResponseBytes<GetObjectResponse> responseBytes =
+        ResponseBytes.fromByteArray(getObjectResponse, content);
+    when(s3Client.getObjectAsBytes(any(GetObjectRequest.class))).thenReturn(responseBytes);
+
+    ResponseEntity<Map<String, Object>> response =
+        restTemplate.exchange("/get-artifact", HttpMethod.GET, getRequestEntity, MAP_TYPE);
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody())
+        .containsEntry("type", ArtifactTypes.REMOTE_BASE64.getMimeType())
+        .containsEntry("reference", Base64.getEncoder().encodeToString(content));
+  }
+
+  @Test
+  void testS3NoSuchKey() throws Exception {
+    when(s3Client.getObjectAsBytes(any(GetObjectRequest.class)))
+        .thenThrow(
+            NoSuchKeyException.builder()
+                .statusCode(404)
+                .message("The specified key does not exist.")
+                .build());
+
+    ResponseEntity<Map<String, Object>> response =
+        restTemplate.exchange("/get-artifact", HttpMethod.GET, getRequestEntity, MAP_TYPE);
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+    assertThat(response.getBody())
+        .containsKey("timestamp")
+        .containsEntry("status", 500)
+        .containsEntry("error", "Internal Server Error")
+        .containsEntry("exception", "software.amazon.awssdk.services.s3.model.NoSuchKeyException")
+        .containsEntry("message", "The specified key does not exist.");
+  }
+
+  @Test
+  void testS3AccessDenied() throws Exception {
+    when(s3Client.getObjectAsBytes(any(GetObjectRequest.class)))
+        .thenThrow(S3Exception.builder().statusCode(403).message("Access Denied").build());
+
+    ResponseEntity<Map<String, Object>> response =
+        restTemplate.exchange("/get-artifact", HttpMethod.GET, getRequestEntity, MAP_TYPE);
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+    assertThat(response.getBody())
+        .containsKey("timestamp")
+        .containsEntry("status", 500)
+        .containsEntry("error", "Internal Server Error")
+        .containsEntry("exception", "software.amazon.awssdk.services.s3.model.S3Exception")
+        .containsEntry("message", "Access Denied");
+  }
+
+  @Test
+  void testS3InternalError() throws Exception {
+    when(s3Client.getObjectAsBytes(any(GetObjectRequest.class)))
+        .thenThrow(S3Exception.builder().statusCode(500).message("Internal Error").build());
+
+    ResponseEntity<Map<String, Object>> response =
+        restTemplate.exchange("/get-artifact", HttpMethod.GET, getRequestEntity, MAP_TYPE);
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+    assertThat(response.getBody())
+        .containsKey("timestamp")
+        .containsEntry("status", 500)
+        .containsEntry("error", "Internal Server Error")
+        .containsEntry("exception", "software.amazon.awssdk.services.s3.model.S3Exception")
+        .containsEntry("message", "Internal Error");
+  }
+
+  @Test
+  void testGetRuntimeException() throws Exception {
+    when(s3Client.getObjectAsBytes(any(GetObjectRequest.class)))
+        .thenThrow(new RuntimeException("something unexpected"));
+
+    ResponseEntity<Map<String, Object>> response =
+        restTemplate.exchange("/get-artifact", HttpMethod.GET, getRequestEntity, MAP_TYPE);
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+    assertThat(response.getBody())
+        .containsKey("timestamp")
+        .containsEntry("status", 500)
+        .containsEntry("error", "Internal Server Error")
+        .containsEntry("exception", "java.lang.RuntimeException")
+        .containsEntry("message", "something unexpected");
+  }
+
+  // ---- S3ArtifactStoreStorer tests ----
+
+  @Test
+  void testSuccessfulStoreReturnsArtifact() throws Exception {
+    when(s3Client.listObjectsV2(any(ListObjectsV2Request.class)))
+        .thenReturn(ListObjectsV2Response.builder().build());
+
+    ResponseEntity<Map<String, Object>> response =
+        restTemplate.exchange("/store-artifact", HttpMethod.GET, storeRequestEntity, MAP_TYPE);
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody())
+        .containsEntry("type", ArtifactTypes.REMOTE_BASE64.getMimeType())
+        .containsEntry("reference", STORE_ARTIFACT_REFERENCE);
+  }
+
+  @Test
+  void testStoreS3PutObjectException() throws Exception {
+    when(s3Client.listObjectsV2(any(ListObjectsV2Request.class)))
+        .thenReturn(ListObjectsV2Response.builder().build());
+    when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
+        .thenThrow(S3Exception.builder().statusCode(403).message("Access Denied").build());
+
+    ResponseEntity<Map<String, Object>> response =
+        restTemplate.exchange("/store-artifact", HttpMethod.GET, storeRequestEntity, MAP_TYPE);
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+    assertThat(response.getBody())
+        .containsKey("timestamp")
+        .containsEntry("status", 500)
+        .containsEntry("error", "Internal Server Error")
+        .containsEntry("exception", "software.amazon.awssdk.services.s3.model.S3Exception")
+        .containsEntry("message", "Access Denied");
+  }
+
+  @Test
+  void testStoreS3ListObjectsException() throws Exception {
+    when(s3Client.listObjectsV2(any(ListObjectsV2Request.class)))
+        .thenThrow(S3Exception.builder().statusCode(500).message("Internal Error").build());
+
+    ResponseEntity<Map<String, Object>> response =
+        restTemplate.exchange("/store-artifact", HttpMethod.GET, storeRequestEntity, MAP_TYPE);
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+    assertThat(response.getBody())
+        .containsKey("timestamp")
+        .containsEntry("status", 500)
+        .containsEntry("error", "Internal Server Error")
+        .containsEntry("exception", "software.amazon.awssdk.services.s3.model.S3Exception")
+        .containsEntry("message", "Internal Error");
+  }
+
+  @Test
+  void testStoreRuntimeException() throws Exception {
+    when(s3Client.listObjectsV2(any(ListObjectsV2Request.class)))
+        .thenReturn(ListObjectsV2Response.builder().build());
+    when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
+        .thenThrow(new RuntimeException("something unexpected"));
+
+    ResponseEntity<Map<String, Object>> response =
+        restTemplate.exchange("/store-artifact", HttpMethod.GET, storeRequestEntity, MAP_TYPE);
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+    assertThat(response.getBody())
+        .containsKey("timestamp")
+        .containsEntry("status", 500)
+        .containsEntry("error", "Internal Server Error")
+        .containsEntry("exception", "java.lang.RuntimeException")
+        .containsEntry("message", "something unexpected");
+  }
+}

--- a/kork/kork-artifacts/src/test/java/com/netflix/spinnaker/kork/artifacts/artifactstoretest/S3ArtifactStoreControllerTest.java
+++ b/kork/kork-artifacts/src/test/java/com/netflix/spinnaker/kork/artifacts/artifactstoretest/S3ArtifactStoreControllerTest.java
@@ -110,14 +110,11 @@ class S3ArtifactStoreControllerTest {
           + "/"
           + Hashing.sha256().hashBytes(STORE_REFERENCE.getBytes(StandardCharsets.UTF_8)).toString();
 
-  // Prefix only because ArtifactReferenceURI lacks a toString() override, so the full message is
-  // e.g. "artifact failed to be retrieved: bucket=my-bucket
-  // ref=com.netflix.spinnaker.kork.artifacts.artifactstore.ArtifactReferenceURI@21119757"
-  private static final String S3_GET_ERROR_MESSAGE_PREFIX =
-      "artifact failed to be retrieved: bucket=my-bucket ref=";
+  private static final String S3_GET_ERROR_MESSAGE =
+      "artifact failed to be retrieved: bucket=my-bucket ref=ref://some-artifact";
 
-  private static final String S3_STORE_ERROR_MESSAGE_PREFIX =
-      "artifact failed to be stored: bucket=my-bucket ref=";
+  private static final String S3_STORE_ERROR_MESSAGE =
+      "artifact failed to be stored: bucket=my-bucket ref=" + STORE_ARTIFACT_REFERENCE;
 
   private static final ParameterizedTypeReference<Map<String, Object>> MAP_TYPE =
       new ParameterizedTypeReference<>() {};
@@ -242,8 +239,7 @@ class S3ArtifactStoreControllerTest {
         .containsEntry("status", 404)
         .containsEntry("error", "Not Found")
         .containsEntry("exception", "org.springframework.web.server.ResponseStatusException")
-        .hasEntrySatisfying(
-            "message", msg -> assertThat((String) msg).startsWith(S3_GET_ERROR_MESSAGE_PREFIX));
+        .containsEntry("message", S3_GET_ERROR_MESSAGE);
   }
 
   @Test
@@ -259,8 +255,7 @@ class S3ArtifactStoreControllerTest {
         .containsEntry("status", 403)
         .containsEntry("error", "Forbidden")
         .containsEntry("exception", "org.springframework.web.server.ResponseStatusException")
-        .hasEntrySatisfying(
-            "message", msg -> assertThat((String) msg).startsWith(S3_GET_ERROR_MESSAGE_PREFIX));
+        .containsEntry("message", S3_GET_ERROR_MESSAGE);
   }
 
   @Test
@@ -276,8 +271,7 @@ class S3ArtifactStoreControllerTest {
         .containsEntry("status", 500)
         .containsEntry("error", "Internal Server Error")
         .containsEntry("exception", "org.springframework.web.server.ResponseStatusException")
-        .hasEntrySatisfying(
-            "message", msg -> assertThat((String) msg).startsWith(S3_GET_ERROR_MESSAGE_PREFIX));
+        .containsEntry("message", S3_GET_ERROR_MESSAGE);
   }
 
   @Test
@@ -293,8 +287,7 @@ class S3ArtifactStoreControllerTest {
         .containsEntry("status", 500)
         .containsEntry("error", "Internal Server Error")
         .containsEntry("exception", "java.lang.RuntimeException")
-        .hasEntrySatisfying(
-            "message", msg -> assertThat((String) msg).startsWith(S3_GET_ERROR_MESSAGE_PREFIX));
+        .containsEntry("message", S3_GET_ERROR_MESSAGE);
   }
 
   // ---- S3ArtifactStoreStorer tests ----
@@ -327,8 +320,7 @@ class S3ArtifactStoreControllerTest {
         .containsEntry("status", 403)
         .containsEntry("error", "Forbidden")
         .containsEntry("exception", "org.springframework.web.server.ResponseStatusException")
-        .hasEntrySatisfying(
-            "message", msg -> assertThat((String) msg).startsWith(S3_STORE_ERROR_MESSAGE_PREFIX));
+        .containsEntry("message", S3_STORE_ERROR_MESSAGE);
   }
 
   @Test
@@ -344,8 +336,7 @@ class S3ArtifactStoreControllerTest {
         .containsEntry("status", 500)
         .containsEntry("error", "Internal Server Error")
         .containsEntry("exception", "org.springframework.web.server.ResponseStatusException")
-        .hasEntrySatisfying(
-            "message", msg -> assertThat((String) msg).startsWith(S3_STORE_ERROR_MESSAGE_PREFIX));
+        .containsEntry("message", S3_STORE_ERROR_MESSAGE);
   }
 
   @Test
@@ -363,7 +354,6 @@ class S3ArtifactStoreControllerTest {
         .containsEntry("status", 500)
         .containsEntry("error", "Internal Server Error")
         .containsEntry("exception", "java.lang.RuntimeException")
-        .hasEntrySatisfying(
-            "message", msg -> assertThat((String) msg).startsWith(S3_STORE_ERROR_MESSAGE_PREFIX));
+        .containsEntry("message", S3_STORE_ERROR_MESSAGE);
   }
 }

--- a/kork/kork-artifacts/src/test/java/com/netflix/spinnaker/kork/artifacts/artifactstoretest/S3ArtifactStoreControllerTest.java
+++ b/kork/kork-artifacts/src/test/java/com/netflix/spinnaker/kork/artifacts/artifactstoretest/S3ArtifactStoreControllerTest.java
@@ -110,6 +110,15 @@ class S3ArtifactStoreControllerTest {
           + "/"
           + Hashing.sha256().hashBytes(STORE_REFERENCE.getBytes(StandardCharsets.UTF_8)).toString();
 
+  // Prefix only because ArtifactReferenceURI lacks a toString() override, so the full message is
+  // e.g. "artifact failed to be retrieved: bucket=my-bucket
+  // ref=com.netflix.spinnaker.kork.artifacts.artifactstore.ArtifactReferenceURI@21119757"
+  private static final String S3_GET_ERROR_MESSAGE_PREFIX =
+      "artifact failed to be retrieved: bucket=my-bucket ref=";
+
+  private static final String S3_STORE_ERROR_MESSAGE_PREFIX =
+      "artifact failed to be stored: bucket=my-bucket ref=";
+
   private static final ParameterizedTypeReference<Map<String, Object>> MAP_TYPE =
       new ParameterizedTypeReference<>() {};
 
@@ -227,13 +236,14 @@ class S3ArtifactStoreControllerTest {
 
     ResponseEntity<Map<String, Object>> response =
         restTemplate.exchange("/get-artifact", HttpMethod.GET, getRequestEntity, MAP_TYPE);
-    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
     assertThat(response.getBody())
         .containsKey("timestamp")
-        .containsEntry("status", 500)
-        .containsEntry("error", "Internal Server Error")
-        .containsEntry("exception", "software.amazon.awssdk.services.s3.model.NoSuchKeyException")
-        .containsEntry("message", "The specified key does not exist.");
+        .containsEntry("status", 404)
+        .containsEntry("error", "Not Found")
+        .containsEntry("exception", "org.springframework.web.server.ResponseStatusException")
+        .hasEntrySatisfying(
+            "message", msg -> assertThat((String) msg).startsWith(S3_GET_ERROR_MESSAGE_PREFIX));
   }
 
   @Test
@@ -243,13 +253,14 @@ class S3ArtifactStoreControllerTest {
 
     ResponseEntity<Map<String, Object>> response =
         restTemplate.exchange("/get-artifact", HttpMethod.GET, getRequestEntity, MAP_TYPE);
-    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
     assertThat(response.getBody())
         .containsKey("timestamp")
-        .containsEntry("status", 500)
-        .containsEntry("error", "Internal Server Error")
-        .containsEntry("exception", "software.amazon.awssdk.services.s3.model.S3Exception")
-        .containsEntry("message", "Access Denied");
+        .containsEntry("status", 403)
+        .containsEntry("error", "Forbidden")
+        .containsEntry("exception", "org.springframework.web.server.ResponseStatusException")
+        .hasEntrySatisfying(
+            "message", msg -> assertThat((String) msg).startsWith(S3_GET_ERROR_MESSAGE_PREFIX));
   }
 
   @Test
@@ -264,8 +275,9 @@ class S3ArtifactStoreControllerTest {
         .containsKey("timestamp")
         .containsEntry("status", 500)
         .containsEntry("error", "Internal Server Error")
-        .containsEntry("exception", "software.amazon.awssdk.services.s3.model.S3Exception")
-        .containsEntry("message", "Internal Error");
+        .containsEntry("exception", "org.springframework.web.server.ResponseStatusException")
+        .hasEntrySatisfying(
+            "message", msg -> assertThat((String) msg).startsWith(S3_GET_ERROR_MESSAGE_PREFIX));
   }
 
   @Test
@@ -281,7 +293,8 @@ class S3ArtifactStoreControllerTest {
         .containsEntry("status", 500)
         .containsEntry("error", "Internal Server Error")
         .containsEntry("exception", "java.lang.RuntimeException")
-        .containsEntry("message", "something unexpected");
+        .hasEntrySatisfying(
+            "message", msg -> assertThat((String) msg).startsWith(S3_GET_ERROR_MESSAGE_PREFIX));
   }
 
   // ---- S3ArtifactStoreStorer tests ----
@@ -308,13 +321,14 @@ class S3ArtifactStoreControllerTest {
 
     ResponseEntity<Map<String, Object>> response =
         restTemplate.exchange("/store-artifact", HttpMethod.GET, storeRequestEntity, MAP_TYPE);
-    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
     assertThat(response.getBody())
         .containsKey("timestamp")
-        .containsEntry("status", 500)
-        .containsEntry("error", "Internal Server Error")
-        .containsEntry("exception", "software.amazon.awssdk.services.s3.model.S3Exception")
-        .containsEntry("message", "Access Denied");
+        .containsEntry("status", 403)
+        .containsEntry("error", "Forbidden")
+        .containsEntry("exception", "org.springframework.web.server.ResponseStatusException")
+        .hasEntrySatisfying(
+            "message", msg -> assertThat((String) msg).startsWith(S3_STORE_ERROR_MESSAGE_PREFIX));
   }
 
   @Test
@@ -329,8 +343,9 @@ class S3ArtifactStoreControllerTest {
         .containsKey("timestamp")
         .containsEntry("status", 500)
         .containsEntry("error", "Internal Server Error")
-        .containsEntry("exception", "software.amazon.awssdk.services.s3.model.S3Exception")
-        .containsEntry("message", "Internal Error");
+        .containsEntry("exception", "org.springframework.web.server.ResponseStatusException")
+        .hasEntrySatisfying(
+            "message", msg -> assertThat((String) msg).startsWith(S3_STORE_ERROR_MESSAGE_PREFIX));
   }
 
   @Test
@@ -348,6 +363,7 @@ class S3ArtifactStoreControllerTest {
         .containsEntry("status", 500)
         .containsEntry("error", "Internal Server Error")
         .containsEntry("exception", "java.lang.RuntimeException")
-        .containsEntry("message", "something unexpected");
+        .hasEntrySatisfying(
+            "message", msg -> assertThat((String) msg).startsWith(S3_STORE_ERROR_MESSAGE_PREFIX));
   }
 }

--- a/kork/kork-artifacts/src/test/java/com/netflix/spinnaker/kork/artifacts/artifactstoretest/S3ArtifactStoreControllerTest.java
+++ b/kork/kork-artifacts/src/test/java/com/netflix/spinnaker/kork/artifacts/artifactstoretest/S3ArtifactStoreControllerTest.java
@@ -111,10 +111,10 @@ class S3ArtifactStoreControllerTest {
           + Hashing.sha256().hashBytes(STORE_REFERENCE.getBytes(StandardCharsets.UTF_8)).toString();
 
   private static final String S3_GET_ERROR_MESSAGE =
-      "artifact failed to be retrieved: bucket=my-bucket ref=ref://some-artifact";
+      "artifact failed to be retrieved: bucket=my-bucket ref=ref://some-artifact: ";
 
   private static final String S3_STORE_ERROR_MESSAGE =
-      "artifact failed to be stored: bucket=my-bucket ref=" + STORE_ARTIFACT_REFERENCE;
+      "artifact failed to be stored: bucket=my-bucket ref=" + STORE_ARTIFACT_REFERENCE + ": ";
 
   private static final ParameterizedTypeReference<Map<String, Object>> MAP_TYPE =
       new ParameterizedTypeReference<>() {};
@@ -239,7 +239,7 @@ class S3ArtifactStoreControllerTest {
         .containsEntry("status", 404)
         .containsEntry("error", "Not Found")
         .containsEntry("exception", "org.springframework.web.server.ResponseStatusException")
-        .containsEntry("message", S3_GET_ERROR_MESSAGE);
+        .containsEntry("message", S3_GET_ERROR_MESSAGE + "The specified key does not exist.");
   }
 
   @Test
@@ -255,7 +255,7 @@ class S3ArtifactStoreControllerTest {
         .containsEntry("status", 403)
         .containsEntry("error", "Forbidden")
         .containsEntry("exception", "org.springframework.web.server.ResponseStatusException")
-        .containsEntry("message", S3_GET_ERROR_MESSAGE);
+        .containsEntry("message", S3_GET_ERROR_MESSAGE + "Access Denied");
   }
 
   @Test
@@ -271,7 +271,7 @@ class S3ArtifactStoreControllerTest {
         .containsEntry("status", 500)
         .containsEntry("error", "Internal Server Error")
         .containsEntry("exception", "org.springframework.web.server.ResponseStatusException")
-        .containsEntry("message", S3_GET_ERROR_MESSAGE);
+        .containsEntry("message", S3_GET_ERROR_MESSAGE + "Internal Error");
   }
 
   @Test
@@ -287,7 +287,7 @@ class S3ArtifactStoreControllerTest {
         .containsEntry("status", 500)
         .containsEntry("error", "Internal Server Error")
         .containsEntry("exception", "java.lang.RuntimeException")
-        .containsEntry("message", S3_GET_ERROR_MESSAGE);
+        .containsEntry("message", S3_GET_ERROR_MESSAGE + "something unexpected");
   }
 
   // ---- S3ArtifactStoreStorer tests ----
@@ -320,7 +320,7 @@ class S3ArtifactStoreControllerTest {
         .containsEntry("status", 403)
         .containsEntry("error", "Forbidden")
         .containsEntry("exception", "org.springframework.web.server.ResponseStatusException")
-        .containsEntry("message", S3_STORE_ERROR_MESSAGE);
+        .containsEntry("message", S3_STORE_ERROR_MESSAGE + "Access Denied");
   }
 
   @Test
@@ -336,7 +336,7 @@ class S3ArtifactStoreControllerTest {
         .containsEntry("status", 500)
         .containsEntry("error", "Internal Server Error")
         .containsEntry("exception", "org.springframework.web.server.ResponseStatusException")
-        .containsEntry("message", S3_STORE_ERROR_MESSAGE);
+        .containsEntry("message", S3_STORE_ERROR_MESSAGE + "Internal Error");
   }
 
   @Test
@@ -354,6 +354,6 @@ class S3ArtifactStoreControllerTest {
         .containsEntry("status", 500)
         .containsEntry("error", "Internal Server Error")
         .containsEntry("exception", "java.lang.RuntimeException")
-        .containsEntry("message", S3_STORE_ERROR_MESSAGE);
+        .containsEntry("message", S3_STORE_ERROR_MESSAGE + "something unexpected");
   }
 }

--- a/kork/kork-web/src/main/java/com/netflix/spinnaker/kork/web/exceptions/BaseExceptionHandlers.java
+++ b/kork/kork-web/src/main/java/com/netflix/spinnaker/kork/web/exceptions/BaseExceptionHandlers.java
@@ -18,16 +18,49 @@ package com.netflix.spinnaker.kork.web.exceptions;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.web.servlet.error.DefaultErrorAttributes;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 public class BaseExceptionHandlers extends ResponseEntityExceptionHandler {
+  private static final Logger logger = LoggerFactory.getLogger(BaseExceptionHandlers.class);
+
   private final DefaultErrorAttributes defaultErrorAttributes = new DefaultErrorAttributes();
 
   protected final ExceptionMessageDecorator exceptionMessageDecorator;
 
   public BaseExceptionHandlers(ExceptionMessageDecorator exceptionMessageDecorator) {
     this.exceptionMessageDecorator = exceptionMessageDecorator;
+  }
+
+  /**
+   * Handle {@link ResponseStatusException} by routing it through {@code response.sendError()},
+   * producing the standard Spinnaker error format (timestamp, status, error, exception, message).
+   *
+   * <p>Without this handler, {@link ResponseStatusException} is handled by the inherited {@link
+   * ResponseEntityExceptionHandler#handleErrorResponseException}, which produces RFC 7807 Problem
+   * Details (type, title, status, detail, instance) instead.
+   */
+  @ExceptionHandler(ResponseStatusException.class)
+  public void handleResponseStatusException(
+      ResponseStatusException e, HttpServletResponse response, HttpServletRequest request)
+      throws IOException {
+    storeException(request, response, e);
+    HttpStatusCode statusCode = e.getStatusCode();
+    String reason = StringUtils.hasText(e.getReason()) ? e.getReason() : e.getMessage();
+    if (statusCode.is5xxServerError()) {
+      logger.error(reason, e);
+    } else if (statusCode != HttpStatus.NOT_FOUND) {
+      logger.error("{}: {}", reason, e.toString());
+    }
+    response.sendError(statusCode.value(), exceptionMessageDecorator.decorate(e, reason));
   }
 
   protected void storeException(

--- a/kork/kork-web/src/test/java/com/netflix/spinnaker/kork/web/exceptions/BaseExceptionHandlersTest.java
+++ b/kork/kork-web/src/test/java/com/netflix/spinnaker/kork/web/exceptions/BaseExceptionHandlersTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2026 Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.web.exceptions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ch.qos.logback.classic.Level;
+import com.netflix.spinnaker.config.ErrorConfiguration;
+import com.netflix.spinnaker.kork.test.log.MemoryAppender;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+/** Test the HTTP response format when controllers throw {@link ResponseStatusException}. */
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = {
+      ErrorConfiguration.class,
+      BaseExceptionHandlersTest.TestControllerConfiguration.class
+    })
+class BaseExceptionHandlersTest {
+
+  private static final String REASON = "something went wrong";
+
+  private static final ParameterizedTypeReference<Map<String, Object>> MAP_TYPE =
+      new ParameterizedTypeReference<>() {};
+
+  @Configuration
+  @EnableAutoConfiguration
+  static class TestControllerConfiguration {
+    @EnableWebSecurity
+    static class WebSecurityConfig implements WebMvcConfigurer {
+      @Bean
+      protected SecurityFilterChain configure(HttpSecurity http) throws Exception {
+        http.csrf(csrf -> csrf.disable()).headers(headers -> headers.disable());
+        http.authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
+        return http.build();
+      }
+    }
+
+    @Bean
+    TestController testController() {
+      return new TestController();
+    }
+  }
+
+  @RestController
+  static class TestController {
+    @GetMapping("/responseStatusException/{status}")
+    void responseStatusException(
+        @PathVariable int status, @RequestParam(required = false) String reason) {
+      throw new ResponseStatusException(status, reason, null);
+    }
+  }
+
+  @Autowired private TestRestTemplate restTemplate;
+
+  private MemoryAppender memoryAppender;
+
+  @BeforeEach
+  void setUp(TestInfo testInfo) {
+    System.out.println("--------------- Test " + testInfo.getDisplayName());
+    memoryAppender = new MemoryAppender(BaseExceptionHandlers.class);
+  }
+
+  @ParameterizedTest(name = "testResponseStatusException status = {0}")
+  @ValueSource(ints = {400, 403, 500})
+  void testResponseStatusException(int status) {
+    ResponseEntity<Map<String, Object>> response =
+        restTemplate.exchange(
+            "/responseStatusException/" + status + "?reason=" + REASON,
+            HttpMethod.GET,
+            null,
+            MAP_TYPE);
+    assertThat(response.getStatusCode().value()).isEqualTo(status);
+    assertThat(response.getBody())
+        .containsEntry("type", "about:blank")
+        .containsEntry("title", HttpStatus.valueOf(status).getReasonPhrase())
+        .containsEntry("status", status)
+        .containsEntry("detail", REASON)
+        .containsEntry("instance", "/responseStatusException/" + status);
+
+    assertThat(memoryAppender.countEventsForLevel(Level.ERROR)).isZero();
+  }
+
+  @Test
+  void testResponseStatusException404() {
+    ResponseEntity<Map<String, Object>> response =
+        restTemplate.exchange(
+            "/responseStatusException/404?reason=" + REASON, HttpMethod.GET, null, MAP_TYPE);
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    assertThat(response.getBody())
+        .containsEntry("type", "about:blank")
+        .containsEntry("title", "Not Found")
+        .containsEntry("status", 404)
+        .containsEntry("detail", REASON)
+        .containsEntry("instance", "/responseStatusException/404");
+
+    assertThat(memoryAppender.countEventsForLevel(Level.ERROR)).isZero();
+  }
+
+  @Test
+  void testResponseStatusExceptionNullReason() {
+    ResponseEntity<Map<String, Object>> response =
+        restTemplate.exchange("/responseStatusException/500", HttpMethod.GET, null, MAP_TYPE);
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+    assertThat(response.getBody())
+        .containsEntry("type", "about:blank")
+        .containsEntry("title", "Internal Server Error")
+        .containsEntry("status", 500)
+        .doesNotContainKey("detail")
+        .containsEntry("instance", "/responseStatusException/500");
+
+    assertThat(memoryAppender.countEventsForLevel(Level.ERROR)).isZero();
+  }
+}

--- a/kork/kork-web/src/test/java/com/netflix/spinnaker/kork/web/exceptions/BaseExceptionHandlersTest.java
+++ b/kork/kork-web/src/test/java/com/netflix/spinnaker/kork/web/exceptions/BaseExceptionHandlersTest.java
@@ -110,13 +110,13 @@ class BaseExceptionHandlersTest {
             MAP_TYPE);
     assertThat(response.getStatusCode().value()).isEqualTo(status);
     assertThat(response.getBody())
-        .containsEntry("type", "about:blank")
-        .containsEntry("title", HttpStatus.valueOf(status).getReasonPhrase())
+        .containsKey("timestamp")
         .containsEntry("status", status)
-        .containsEntry("detail", REASON)
-        .containsEntry("instance", "/responseStatusException/" + status);
+        .containsEntry("error", HttpStatus.valueOf(status).getReasonPhrase())
+        .containsEntry("exception", "org.springframework.web.server.ResponseStatusException")
+        .containsEntry("message", REASON);
 
-    assertThat(memoryAppender.countEventsForLevel(Level.ERROR)).isZero();
+    assertThat(memoryAppender.countEventsForLevel(Level.ERROR)).isEqualTo(1);
   }
 
   @Test
@@ -126,11 +126,11 @@ class BaseExceptionHandlersTest {
             "/responseStatusException/404?reason=" + REASON, HttpMethod.GET, null, MAP_TYPE);
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
     assertThat(response.getBody())
-        .containsEntry("type", "about:blank")
-        .containsEntry("title", "Not Found")
+        .containsKey("timestamp")
         .containsEntry("status", 404)
-        .containsEntry("detail", REASON)
-        .containsEntry("instance", "/responseStatusException/404");
+        .containsEntry("error", "Not Found")
+        .containsEntry("exception", "org.springframework.web.server.ResponseStatusException")
+        .containsEntry("message", REASON);
 
     assertThat(memoryAppender.countEventsForLevel(Level.ERROR)).isZero();
   }
@@ -141,12 +141,12 @@ class BaseExceptionHandlersTest {
         restTemplate.exchange("/responseStatusException/500", HttpMethod.GET, null, MAP_TYPE);
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
     assertThat(response.getBody())
-        .containsEntry("type", "about:blank")
-        .containsEntry("title", "Internal Server Error")
+        .containsKey("timestamp")
         .containsEntry("status", 500)
-        .doesNotContainKey("detail")
-        .containsEntry("instance", "/responseStatusException/500");
+        .containsEntry("error", "Internal Server Error")
+        .containsEntry("exception", "org.springframework.web.server.ResponseStatusException")
+        .containsEntry("message", "500 INTERNAL_SERVER_ERROR");
 
-    assertThat(memoryAppender.countEventsForLevel(Level.ERROR)).isZero();
+    assertThat(memoryAppender.countEventsForLevel(Level.ERROR)).isEqualTo(1);
   }
 }


### PR DESCRIPTION
with a global change to how Spinnaker serializes ResponseStatusException along the way, to make it consistent with other exception serialization.  This is the first use of ResponseStatusException in the codebase.  This includes the change from https://github.com/spinnaker/spinnaker/pull/7529, with additional test coverage to show the behavior changes, and some tweaks to the actual exception messages.