### PR TITLE
fix(clouddriver/eureka):remove leading slashes from all the retrofit2 api interfaces

### DIFF
--- a/clouddriver/clouddriver-eureka/src/main/groovy/com/netflix/spinnaker/clouddriver/eureka/api/Eureka.groovy
+++ b/clouddriver/clouddriver-eureka/src/main/groovy/com/netflix/spinnaker/clouddriver/eureka/api/Eureka.groovy
@@ -28,18 +28,18 @@ import retrofit2.http.Query
 
 interface Eureka {
   @Headers('Accept: application/json')
-  @GET('/instances/{instanceId}')
+  @GET('instances/{instanceId}')
   Call<Map> getInstanceInfo(@Path('instanceId') String instanceId)
 
   @Headers('Accept: application/json')
-  @PUT('/apps/{application}/{instanceId}/status')
+  @PUT('apps/{application}/{instanceId}/status')
   Call<ResponseBody> updateInstanceStatus(@Path('application') String application, @Path('instanceId') String instanceId, @Query('value') String status)
 
   @Headers('Accept: application/json')
-  @DELETE('/apps/{application}/{instanceId}/status')
+  @DELETE('apps/{application}/{instanceId}/status')
   Call<ResponseBody> resetInstanceStatus(@Path('application') String application, @Path('instanceId') String instanceId, @Query('value') String status)
 
   @Headers('Accept: application/json')
-  @GET('/apps/{application}')
+  @GET('apps/{application}')
   Call<EurekaApplication> getApplication(@Path('application') String application)
 }

--- a/clouddriver/clouddriver-eureka/src/main/groovy/com/netflix/spinnaker/clouddriver/eureka/api/EurekaApi.groovy
+++ b/clouddriver/clouddriver-eureka/src/main/groovy/com/netflix/spinnaker/clouddriver/eureka/api/EurekaApi.groovy
@@ -23,7 +23,7 @@ import retrofit2.http.Headers
 
 interface EurekaApi {
 
-  @GET('/apps')
+  @GET('apps')
   @Headers(['Accept: application/json'])
   Call<EurekaApplications> loadEurekaApplications()
 }


### PR DESCRIPTION
As described in this [issue](https://github.com/spinnaker/spinnaker/issues/7463), clouddriver-eureka was unable to perform application discovery, if Eureka v2 is used as the health provider for the AWS account, for Spinnaker 1.37.0 and above.


This seems to be a miss from this [PR](https://github.com/spinnaker/spinnaker/pull/7159), where a number of  Spinnaker API interfaces were updated to support the retrofit2 client after Spinnaker 1.37.0.