### PR TITLE
fix(ecs): Fix ecs on demand perf loading issue

### DIFF
--- a/clouddriver/clouddriver-api/src/main/java/com/netflix/spinnaker/cats/cache/Cache.java
+++ b/clouddriver/clouddriver-api/src/main/java/com/netflix/spinnaker/cats/cache/Cache.java
@@ -89,11 +89,14 @@ public interface Cache {
   Collection<String> filterIdentifiers(String type, String glob);
 
   /**
-   * Retrieves all the items for the specified type
+   * Retrieves all the items for the specified type.
+   *
+   * <p>"DO NOT USE THIS. It does really really really bad things to the cache"
    *
    * @param type the type for which to retrieve items
    * @return all the items for the type
    */
+  @Deprecated()
   Collection<CacheData> getAll(String type);
 
   Collection<CacheData> getAll(String type, CacheFilter cacheFilter);

--- a/clouddriver/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/Keys.java
+++ b/clouddriver/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/Keys.java
@@ -21,6 +21,8 @@ import static com.netflix.spinnaker.clouddriver.ecs.EcsCloudProvider.ID;
 
 import com.google.common.base.CaseFormat;
 import com.netflix.spinnaker.clouddriver.cache.KeyParser;
+import org.apache.commons.lang3.StringUtils;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -175,6 +177,7 @@ public class Keys implements KeyParser {
     return buildKey(Namespace.ECS_CLUSTERS.ns, account, region, clusterName);
   }
 
+
   public static String getApplicationKey(String name) {
     return ID + SEPARATOR + Namespace.ECS_APPLICATIONS + SEPARATOR + name.toLowerCase();
   }
@@ -233,5 +236,13 @@ public class Keys implements KeyParser {
         + region
         + SEPARATOR
         + identifier;
+  }
+
+  public static String buildGlob(String namespace, String account, String region, String identifier) {
+    return buildKey(
+      StringUtils.defaultIfBlank(namespace, "*"),
+      StringUtils.defaultIfBlank(account, "*"),
+      StringUtils.defaultIfBlank(region, "*"),
+      StringUtils.defaultIfBlank(identifier, "*"));
   }
 }

--- a/clouddriver/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/Keys.java
+++ b/clouddriver/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/Keys.java
@@ -21,10 +21,9 @@ import static com.netflix.spinnaker.clouddriver.ecs.EcsCloudProvider.ID;
 
 import com.google.common.base.CaseFormat;
 import com.netflix.spinnaker.clouddriver.cache.KeyParser;
-import org.apache.commons.lang3.StringUtils;
-
 import java.util.HashMap;
 import java.util.Map;
+import org.apache.commons.lang3.StringUtils;
 
 public class Keys implements KeyParser {
   public enum Namespace {
@@ -177,7 +176,6 @@ public class Keys implements KeyParser {
     return buildKey(Namespace.ECS_CLUSTERS.ns, account, region, clusterName);
   }
 
-
   public static String getApplicationKey(String name) {
     return ID + SEPARATOR + Namespace.ECS_APPLICATIONS + SEPARATOR + name.toLowerCase();
   }
@@ -238,11 +236,12 @@ public class Keys implements KeyParser {
         + identifier;
   }
 
-  public static String buildGlob(String namespace, String account, String region, String identifier) {
+  public static String buildGlob(
+      String namespace, String account, String region, String identifier) {
     return buildKey(
-      StringUtils.defaultIfBlank(namespace, "*"),
-      StringUtils.defaultIfBlank(account, "*"),
-      StringUtils.defaultIfBlank(region, "*"),
-      StringUtils.defaultIfBlank(identifier, "*"));
+        StringUtils.defaultIfBlank(namespace, "*"),
+        StringUtils.defaultIfBlank(account, "*"),
+        StringUtils.defaultIfBlank(region, "*"),
+        StringUtils.defaultIfBlank(identifier, "*"));
   }
 }

--- a/clouddriver/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskCachingAgent.java
+++ b/clouddriver/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskCachingAgent.java
@@ -37,6 +37,7 @@ import com.netflix.spinnaker.cats.provider.ProviderCache;
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider;
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
 import com.netflix.spinnaker.clouddriver.ecs.cache.Keys;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -106,39 +107,43 @@ public class TaskCachingAgent extends AbstractEcsOnDemandAgent<Task> {
 
   @Override
   public Collection<Map<String, Object>> pendingOnDemandRequests(ProviderCache providerCache) {
-    Collection<CacheData> allOnDemand = providerCache.getAll(ON_DEMAND.toString());
+
     List<Map<String, Object>> returnResults = new LinkedList<>();
-    for (CacheData onDemand : allOnDemand) {
+
+    Collection<String> serviceIds =
+        providerCache.filterIdentifiers(
+            ON_DEMAND.getNs(), Keys.buildGlob(SERVICES.toString(), accountName, region, null));
+    Collection<String> taskIds =
+        providerCache.filterIdentifiers(
+            ON_DEMAND.getNs(), Keys.buildGlob(TASKS.toString(), accountName, region, null));
+    List<String> combined = new ArrayList<>(serviceIds.size() + taskIds.size());
+    combined.addAll(serviceIds);
+    combined.addAll(taskIds);
+
+    Collection<CacheData> matchingTheCache = providerCache.getAll(ON_DEMAND.toString(), combined);
+    for (CacheData onDemand : matchingTheCache) {
       Map<String, String> parsedKey = Keys.parse(onDemand.getId());
-      if (parsedKey != null
-          && parsedKey.get("type") != null
-          && (parsedKey.get("type").equals(SERVICES.toString())
-            || parsedKey.get("type").equals(TASKS.toString()))
-                  && parsedKey.get("account").equals(accountName)
-                  && parsedKey.get("region").equals(region)) {
+      parsedKey.put("type", "serverGroup");
+      parsedKey.put("serverGroup", parsedKey.get("serviceName"));
 
-        parsedKey.put("type", "serverGroup");
-        parsedKey.put("serverGroup", parsedKey.get("serviceName"));
+      HashMap<String, Object> result = new HashMap<>();
+      result.put("id", onDemand.getId());
+      result.put("details", parsedKey);
 
-        HashMap<String, Object> result = new HashMap<>();
-        result.put("id", onDemand.getId());
-        result.put("details", parsedKey);
+      result.put("cacheTime", onDemand.getAttributes().get("cacheTime"));
+      result.put("cacheExpiry", onDemand.getAttributes().get("cacheExpiry"));
+      result.put(
+          "processedCount",
+          (onDemand.getAttributes().get("processedCount") != null
+              ? onDemand.getAttributes().get("processedCount")
+              : 1));
+      result.put(
+          "processedTime",
+          onDemand.getAttributes().get("processedTime") != null
+              ? onDemand.getAttributes().get("processedTime")
+              : new Date());
 
-        result.put("cacheTime", onDemand.getAttributes().get("cacheTime"));
-        result.put("cacheExpiry", onDemand.getAttributes().get("cacheExpiry"));
-        result.put(
-            "processedCount",
-            (onDemand.getAttributes().get("processedCount") != null
-                ? onDemand.getAttributes().get("processedCount")
-                : 1));
-        result.put(
-            "processedTime",
-            onDemand.getAttributes().get("processedTime") != null
-                ? onDemand.getAttributes().get("processedTime")
-                : new Date());
-
-        returnResults.add(result);
-      }
+      returnResults.add(result);
     }
     return returnResults;
   }

--- a/clouddriver/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskCachingAgent.java
+++ b/clouddriver/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskCachingAgent.java
@@ -113,9 +113,9 @@ public class TaskCachingAgent extends AbstractEcsOnDemandAgent<Task> {
       if (parsedKey != null
           && parsedKey.get("type") != null
           && (parsedKey.get("type").equals(SERVICES.toString())
-              || parsedKey.get("type").equals(TASKS.toString())
+            || parsedKey.get("type").equals(TASKS.toString()))
                   && parsedKey.get("account").equals(accountName)
-                  && parsedKey.get("region").equals(region))) {
+                  && parsedKey.get("region").equals(region)) {
 
         parsedKey.put("type", "serverGroup");
         parsedKey.put("serverGroup", parsedKey.get("serviceName"));

--- a/clouddriver/clouddriver-ecs/src/test/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskCachingAgentTest.java
+++ b/clouddriver/clouddriver-ecs/src/test/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskCachingAgentTest.java
@@ -16,7 +16,9 @@
 
 package com.netflix.spinnaker.clouddriver.ecs.provider.agent;
 
+import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.ON_DEMAND;
 import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.ECS_CLUSTERS;
+import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.SERVICES;
 import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.TASKS;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -30,17 +32,30 @@ import com.amazonaws.services.ecs.model.ListTasksRequest;
 import com.amazonaws.services.ecs.model.ListTasksResult;
 import com.amazonaws.services.ecs.model.Task;
 import com.netflix.spinnaker.cats.cache.CacheData;
+import com.netflix.spinnaker.cats.cache.DefaultCacheData;
+import com.netflix.spinnaker.cats.mem.InMemoryCache;
+import com.netflix.spinnaker.cats.provider.DefaultProviderCache;
+import com.netflix.spinnaker.cats.provider.ProviderCache;
 import com.netflix.spinnaker.clouddriver.ecs.cache.Keys;
+
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.DisplayName;
 import spock.lang.Subject;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TaskCachingAgentTest extends CommonCachingAgent {
   @Subject
@@ -154,4 +169,84 @@ public class TaskCachingAgentTest extends CommonCachingAgent {
               + ".");
     }
   }
+
+  /**
+   * This demonstrates an issue with the current (soon to be previous) implementation.  It loads ALL
+   * the cache data for ALL accounts THEN filters it.  What's WORSE... is it has a mis-placed paranethesis on the check
+   * loading services for ALL REGIONS for ALL ACCOUNTS and only tasks for the specific region/account.  This leads
+   * to a nasty situation of memroy usage which is much bigger than loading all the data even.
+   *
+   * What's worse this ALSO puts load on the ServerGroupCacheForceRefreshTask class which does a "model match"
+   * on this account/region match.  SO it's loading massive data, that's then later filtered by orca, for every account
+   * on every load.
+   */
+  @Test
+  @DisplayName("pendingOnDemandRequests should demonstrate performance issues when loading all ON_DEMAND cache entries")
+  void shouldDemonstratePerformanceIssueWithUnfilteredLoad() {
+    // Given: A cache with many unrelated on-demand entries
+    DefaultProviderCache testProviderCache = new DefaultProviderCache(new InMemoryCache());
+
+    // Add 10,000 unrelated on-demand entries from other accounts/regions
+    for (int i = 0; i < 10000; i++) {
+      String otherAccount = "other-account-" + (i % 10);
+      String otherRegion = "other-region-" + (i % 5);
+      String randomId = RandomStringUtils.randomAlphanumeric(10);
+
+      String key = Keys.getServiceKey(otherAccount, otherRegion, "service-" + randomId);
+      Map<String, Object> attrs = new HashMap<>();
+      attrs.put("cacheTime", new Date());
+      testProviderCache.putCacheData(ON_DEMAND.toString(), new DefaultCacheData(key, attrs, Collections.emptyMap()));
+    }
+
+    // Add only 10 relevant entries for our account/region
+    for (int i = 0; i < 10; i++) {
+      String key = Keys.getServiceKey(ACCOUNT, REGION, "service-" + i);
+      Map<String, Object> attrs = new HashMap<>();
+      attrs.put("cacheTime", new Date());
+      testProviderCache.putCacheData(ON_DEMAND.toString(), new DefaultCacheData(key, attrs, Collections.emptyMap()));
+    }
+
+    // When: Call pendingOnDemandRequests (current implementation loads ALL entries via getAll())
+    long startTime = System.currentTimeMillis();
+    Collection<Map<String, Object>> results = agent.pendingOnDemandRequests(testProviderCache);
+    long duration = System.currentTimeMillis() - startTime;
+
+    // Then: Performance issue demonstrated - we loaded all 10,010 entries and parsed them all
+    Collection<CacheData> allLoaded = testProviderCache.getAll(ON_DEMAND.toString());
+    assertThat(allLoaded)
+      .withFailMessage( "Performance issue: getAll() loaded all " + allLoaded.size() + " entries when only " + results.size() + " were relevant")
+      .hasSize(10010);
+    assertThat(results)
+      .withFailMessage( "Results should have been 10 but were " + results.size())
+      .hasSize(10);
+
+
+    System.out.println("Performance test: results loaded " + results.size() + " entries in " + duration + "ms");
+    System.out.println("  - Wasted effort: parsed and filtered " + (allLoaded.size() - results.size()) + " irrelevant entries");
+  }
+
+  @Test
+  @DisplayName("glob filtering should correctly filter by namespace, account, and region")
+  void shouldCorrectlyFilterByGlobPattern() {
+    // Given: A cache with entries in different namespaces, accounts, and regions
+    DefaultProviderCache testProviderCache = new DefaultProviderCache(new InMemoryCache());
+
+    Map<String, Object> exampleAttrs = Map.of("cacheTime", new Date());
+    testProviderCache.putCacheData(ON_DEMAND.toString(), new DefaultCacheData(Keys.getServiceKey(ACCOUNT, REGION, "service-1"), exampleAttrs, Collections.emptyMap()));
+    testProviderCache.putCacheData(ON_DEMAND.toString(), new DefaultCacheData(Keys.getServiceKey(ACCOUNT, "eu-west-1", "service-2"), exampleAttrs, Collections.emptyMap()));
+    testProviderCache.putCacheData(ON_DEMAND.toString(), new DefaultCacheData(Keys.getServiceKey("other-account", REGION, "service-3"), exampleAttrs, Collections.emptyMap()));
+    testProviderCache.putCacheData(ON_DEMAND.toString(), new DefaultCacheData(Keys.getTaskKey(ACCOUNT, REGION, "task-1"),exampleAttrs, Collections.emptyMap()));
+    testProviderCache.putCacheData(ON_DEMAND.toString(), new DefaultCacheData(Keys.getTaskKey(ACCOUNT, "eu-west-1", "task-2"), exampleAttrs, Collections.emptyMap()));
+    testProviderCache.putCacheData(ON_DEMAND.toString(), new DefaultCacheData(Keys.getTaskKey("other-account", REGION, "task-3"), exampleAttrs, Collections.emptyMap()));
+    testProviderCache.putCacheData(ON_DEMAND.toString(), new DefaultCacheData(Keys.getClusterKey(ACCOUNT, REGION, "cluster-1"), exampleAttrs, Collections.emptyMap()));
+
+    // When: We want the pending on demand requests for this particular account/region...
+    Collection<Map<String, Object>> results = agent.pendingOnDemandRequests(testProviderCache);
+
+    // Then: Should only match the selected on demand entires for this account/region
+    assertThat(results)
+      .withFailMessage("Incorrect number of results of " + results.size() + " returned fo the account/region of the provider.  ")
+      .hasSize(2);
+  }
+
 }

--- a/clouddriver/clouddriver-ecs/src/test/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskCachingAgentTest.java
+++ b/clouddriver/clouddriver-ecs/src/test/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskCachingAgentTest.java
@@ -18,8 +18,8 @@ package com.netflix.spinnaker.clouddriver.ecs.provider.agent;
 
 import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.ON_DEMAND;
 import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.ECS_CLUSTERS;
-import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.SERVICES;
 import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.TASKS;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -35,10 +35,7 @@ import com.netflix.spinnaker.cats.cache.CacheData;
 import com.netflix.spinnaker.cats.cache.DefaultCacheData;
 import com.netflix.spinnaker.cats.mem.InMemoryCache;
 import com.netflix.spinnaker.cats.provider.DefaultProviderCache;
-import com.netflix.spinnaker.cats.provider.ProviderCache;
 import com.netflix.spinnaker.clouddriver.ecs.cache.Keys;
-
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
@@ -48,14 +45,11 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-
 import org.apache.commons.lang3.RandomStringUtils;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import spock.lang.Subject;
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class TaskCachingAgentTest extends CommonCachingAgent {
   @Subject
@@ -171,17 +165,24 @@ public class TaskCachingAgentTest extends CommonCachingAgent {
   }
 
   /**
-   * This demonstrates an issue with the current (soon to be previous) implementation.  It loads ALL
-   * the cache data for ALL accounts THEN filters it.  What's WORSE... is it has a mis-placed paranethesis on the check
-   * loading services for ALL REGIONS for ALL ACCOUNTS and only tasks for the specific region/account.  This leads
-   * to a nasty situation of memroy usage which is much bigger than loading all the data even.
+   * This demonstrates an issue with the current (soon to be previous) implementation. It loads ALL
+   * the cache data for ALL accounts THEN filters it. What's WORSE... is it has a mis-placed
+   * paranethesis on the check loading services for ALL REGIONS for ALL ACCOUNTS and only tasks for
+   * the specific region/account. This leads to a nasty situation of memroy usage which is much
+   * bigger than loading all the data even.
    *
-   * What's worse this ALSO puts load on the ServerGroupCacheForceRefreshTask class which does a "model match"
-   * on this account/region match.  SO it's loading massive data, that's then later filtered by orca, for every account
-   * on every load.
+   * <p>What's worse this ALSO puts load on the ServerGroupCacheForceRefreshTask class which does a
+   * "model match" on this account/region match. SO it's loading massive data, that's then later
+   * filtered by orca, for every account on every load.
+   *
+   * <p>NOTE: Memory is worse than even performance. We'd see cases of multilple GB of data load due
+   * to this incorrectly bursting and processing in bad situations.
    */
   @Test
-  @DisplayName("pendingOnDemandRequests should demonstrate performance issues when loading all ON_DEMAND cache entries")
+  @DisplayName(
+      "pendingOnDemandRequests should demonstrate performance issues when loading all ON_DEMAND cache entries")
+  @Disabled(
+      "Used to show some of the performance issues with large data in the account, but not needed now")
   void shouldDemonstratePerformanceIssueWithUnfilteredLoad() {
     // Given: A cache with many unrelated on-demand entries
     DefaultProviderCache testProviderCache = new DefaultProviderCache(new InMemoryCache());
@@ -195,7 +196,8 @@ public class TaskCachingAgentTest extends CommonCachingAgent {
       String key = Keys.getServiceKey(otherAccount, otherRegion, "service-" + randomId);
       Map<String, Object> attrs = new HashMap<>();
       attrs.put("cacheTime", new Date());
-      testProviderCache.putCacheData(ON_DEMAND.toString(), new DefaultCacheData(key, attrs, Collections.emptyMap()));
+      testProviderCache.putCacheData(
+          ON_DEMAND.toString(), new DefaultCacheData(key, attrs, Collections.emptyMap()));
     }
 
     // Add only 10 relevant entries for our account/region
@@ -203,7 +205,8 @@ public class TaskCachingAgentTest extends CommonCachingAgent {
       String key = Keys.getServiceKey(ACCOUNT, REGION, "service-" + i);
       Map<String, Object> attrs = new HashMap<>();
       attrs.put("cacheTime", new Date());
-      testProviderCache.putCacheData(ON_DEMAND.toString(), new DefaultCacheData(key, attrs, Collections.emptyMap()));
+      testProviderCache.putCacheData(
+          ON_DEMAND.toString(), new DefaultCacheData(key, attrs, Collections.emptyMap()));
     }
 
     // When: Call pendingOnDemandRequests (current implementation loads ALL entries via getAll())
@@ -214,15 +217,23 @@ public class TaskCachingAgentTest extends CommonCachingAgent {
     // Then: Performance issue demonstrated - we loaded all 10,010 entries and parsed them all
     Collection<CacheData> allLoaded = testProviderCache.getAll(ON_DEMAND.toString());
     assertThat(allLoaded)
-      .withFailMessage( "Performance issue: getAll() loaded all " + allLoaded.size() + " entries when only " + results.size() + " were relevant")
-      .hasSize(10010);
+        .withFailMessage(
+            "Performance issue: getAll() loaded all "
+                + allLoaded.size()
+                + " entries when only "
+                + results.size()
+                + " were relevant")
+        .hasSize(10010);
     assertThat(results)
-      .withFailMessage( "Results should have been 10 but were " + results.size())
-      .hasSize(10);
+        .withFailMessage("Results should have been 10 but were " + results.size())
+        .hasSize(10);
 
-
-    System.out.println("Performance test: results loaded " + results.size() + " entries in " + duration + "ms");
-    System.out.println("  - Wasted effort: parsed and filtered " + (allLoaded.size() - results.size()) + " irrelevant entries");
+    System.out.println(
+        "Performance test: results loaded " + results.size() + " entries in " + duration + "ms");
+    System.out.println(
+        "  - Wasted effort: parsed and filtered "
+            + (allLoaded.size() - results.size())
+            + " irrelevant entries");
   }
 
   @Test
@@ -232,21 +243,54 @@ public class TaskCachingAgentTest extends CommonCachingAgent {
     DefaultProviderCache testProviderCache = new DefaultProviderCache(new InMemoryCache());
 
     Map<String, Object> exampleAttrs = Map.of("cacheTime", new Date());
-    testProviderCache.putCacheData(ON_DEMAND.toString(), new DefaultCacheData(Keys.getServiceKey(ACCOUNT, REGION, "service-1"), exampleAttrs, Collections.emptyMap()));
-    testProviderCache.putCacheData(ON_DEMAND.toString(), new DefaultCacheData(Keys.getServiceKey(ACCOUNT, "eu-west-1", "service-2"), exampleAttrs, Collections.emptyMap()));
-    testProviderCache.putCacheData(ON_DEMAND.toString(), new DefaultCacheData(Keys.getServiceKey("other-account", REGION, "service-3"), exampleAttrs, Collections.emptyMap()));
-    testProviderCache.putCacheData(ON_DEMAND.toString(), new DefaultCacheData(Keys.getTaskKey(ACCOUNT, REGION, "task-1"),exampleAttrs, Collections.emptyMap()));
-    testProviderCache.putCacheData(ON_DEMAND.toString(), new DefaultCacheData(Keys.getTaskKey(ACCOUNT, "eu-west-1", "task-2"), exampleAttrs, Collections.emptyMap()));
-    testProviderCache.putCacheData(ON_DEMAND.toString(), new DefaultCacheData(Keys.getTaskKey("other-account", REGION, "task-3"), exampleAttrs, Collections.emptyMap()));
-    testProviderCache.putCacheData(ON_DEMAND.toString(), new DefaultCacheData(Keys.getClusterKey(ACCOUNT, REGION, "cluster-1"), exampleAttrs, Collections.emptyMap()));
+    testProviderCache.putCacheData(
+        ON_DEMAND.toString(),
+        new DefaultCacheData(
+            Keys.getServiceKey(ACCOUNT, REGION, "service-1"),
+            exampleAttrs,
+            Collections.emptyMap()));
+    testProviderCache.putCacheData(
+        ON_DEMAND.toString(),
+        new DefaultCacheData(
+            Keys.getServiceKey(ACCOUNT, "eu-west-1", "service-2"),
+            exampleAttrs,
+            Collections.emptyMap()));
+    testProviderCache.putCacheData(
+        ON_DEMAND.toString(),
+        new DefaultCacheData(
+            Keys.getServiceKey("other-account", REGION, "service-3"),
+            exampleAttrs,
+            Collections.emptyMap()));
+    testProviderCache.putCacheData(
+        ON_DEMAND.toString(),
+        new DefaultCacheData(
+            Keys.getTaskKey(ACCOUNT, REGION, "task-1"), exampleAttrs, Collections.emptyMap()));
+    testProviderCache.putCacheData(
+        ON_DEMAND.toString(),
+        new DefaultCacheData(
+            Keys.getTaskKey(ACCOUNT, "eu-west-1", "task-2"), exampleAttrs, Collections.emptyMap()));
+    testProviderCache.putCacheData(
+        ON_DEMAND.toString(),
+        new DefaultCacheData(
+            Keys.getTaskKey("other-account", REGION, "task-3"),
+            exampleAttrs,
+            Collections.emptyMap()));
+    testProviderCache.putCacheData(
+        ON_DEMAND.toString(),
+        new DefaultCacheData(
+            Keys.getClusterKey(ACCOUNT, REGION, "cluster-1"),
+            exampleAttrs,
+            Collections.emptyMap()));
 
     // When: We want the pending on demand requests for this particular account/region...
     Collection<Map<String, Object>> results = agent.pendingOnDemandRequests(testProviderCache);
 
     // Then: Should only match the selected on demand entires for this account/region
     assertThat(results)
-      .withFailMessage("Incorrect number of results of " + results.size() + " returned fo the account/region of the provider.  ")
-      .hasSize(2);
+        .withFailMessage(
+            "Incorrect number of results of "
+                + results.size()
+                + " returned fo the account/region of the provider.  ")
+        .hasSize(2);
   }
-
 }


### PR DESCRIPTION
Two issues with the pendingOnDemand cache handling for ECS:
* first an incorrect filter logic which returned ALL services... for ALL ACCOUNTS/REGIONS in the data return, but only the TASKS for the give account/region.  Mis-placed paranthesis.  Tests showing the filtering. NOTE Orca would then filter the payload on the remote side to the selected region in `ServerGroupCacheForceRefreshTask` code. E.g. all signs are this was an OLD bug on this method.
* The next problem... and this is as bad.  it loads ALL KNOWN on demand data into memory THEN filters.  This is a really bad implementation.  Instead, what this PR changes is to load the identifiers via the glob pattern on the onDemand tables.  This is the primary key, so does a wildcard.  This isn't "ideal" but MASSIVELY performs better than loading the entire table into memory THEN filtering
What's worse on the above, and I call it out in a comment, was... this was multiplicative.  IF You had 10000 ECS accounts, each account would load ALL data then ALL regions, so if you say have 1000 onDemand operations across various systems (including NON ecs on demands), you end up with 1000 * 10000 data returned AND processed.  