### PR TITLE
fix(pubsub/aws): rename enableQueueCreationFallback -> skipQueueBootstrap and skip all bootstrap ops for cross-account queues

### DIFF
--- a/echo/echo-pubsub-aws/src/main/java/com/netflix/spinnaker/echo/config/AmazonPubsubProperties.java
+++ b/echo/echo-pubsub-aws/src/main/java/com/netflix/spinnaker/echo/config/AmazonPubsubProperties.java
@@ -58,7 +58,7 @@ public class AmazonPubsubProperties {
     int sqsMessageRetentionPeriodSeconds = 120;
     int waitTimeSeconds = 5;
 
-    boolean enableQueueCreationFallback = true;
+    boolean skipQueueBootstrap = false;
 
     // 1 hour default
     private Integer dedupeRetentionSeconds = 3600;

--- a/echo/echo-pubsub-aws/src/main/java/com/netflix/spinnaker/echo/pubsub/aws/SQSSubscriber.java
+++ b/echo/echo-pubsub-aws/src/main/java/com/netflix/spinnaker/echo/pubsub/aws/SQSSubscriber.java
@@ -132,15 +132,19 @@ public class SQSSubscriber implements Runnable, PubsubSubscriber {
     }
   }
 
-  private void initializeQueue() {
-    this.queueId =
-        PubSubUtils.ensureQueueExists(
-            sqsClient,
-            queueARN,
-            topicARN,
-            subscription.getSqsMessageRetentionPeriodSeconds(),
-            subscription.isEnableQueueCreationFallback());
-    PubSubUtils.subscribeToTopic(snsClient, topicARN, queueARN);
+  @VisibleForTesting
+  void initializeQueue() {
+    if (subscription.isSkipQueueBootstrap()) {
+      this.queueId = PubSubUtils.getQueueUrl(sqsClient, queueARN);
+      log.info(
+          "skipQueueBootstrap=true for {}; resolving queue URL only, not calling setQueueAttributes/subscribe",
+          queueARN);
+    } else {
+      this.queueId =
+          PubSubUtils.ensureQueueExists(
+              sqsClient, queueARN, topicARN, subscription.getSqsMessageRetentionPeriodSeconds());
+      PubSubUtils.subscribeToTopic(snsClient, topicARN, queueARN);
+    }
   }
 
   private void listenForMessages() {

--- a/echo/echo-pubsub-aws/src/test/java/com/netflix/spinnaker/echo/pubsub/aws/AmazonSQSSubscriberTest.java
+++ b/echo/echo-pubsub-aws/src/test/java/com/netflix/spinnaker/echo/pubsub/aws/AmazonSQSSubscriberTest.java
@@ -18,6 +18,11 @@ package com.netflix.spinnaker.echo.pubsub.aws;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import ch.qos.logback.classic.Level;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -36,7 +41,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.services.sns.SnsClient;
+import software.amazon.awssdk.services.sns.model.SubscribeRequest;
+import software.amazon.awssdk.services.sns.model.SubscribeResponse;
 import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.model.GetQueueUrlResponse;
+import software.amazon.awssdk.services.sqs.model.SetQueueAttributesRequest;
+import software.amazon.awssdk.services.sqs.model.SetQueueAttributesResponse;
 
 @ExtendWith(MockitoExtension.class)
 public class AmazonSQSSubscriberTest {
@@ -125,5 +135,60 @@ public class AmazonSQSSubscriberTest {
             "Unable unmarshal NotificationMessageWrapper. Unknown message type", Level.ERROR);
     assertThat(logMsgs).hasSize(0);
     assertEquals(payload, result);
+  }
+
+  @Test
+  void initializeQueueResolvesUrlOnlyWhenSkipQueueBootstrapTrue() {
+    // given
+    subscription.setSkipQueueBootstrap(true);
+    when(sqsClient.getQueueUrl(any(java.util.function.Consumer.class)))
+        .thenReturn(GetQueueUrlResponse.builder().queueUrl("https://queue").build());
+
+    SQSSubscriber localSubject =
+        new SQSSubscriber(
+            objectMapper,
+            subscription,
+            pubsubMessageHandler,
+            snsClient,
+            sqsClient,
+            () -> true,
+            registry);
+
+    // when
+    localSubject.initializeQueue();
+
+    // then
+    verify(sqsClient, times(1)).getQueueUrl(any(java.util.function.Consumer.class));
+    verify(sqsClient, never()).setQueueAttributes(any(SetQueueAttributesRequest.class));
+    verify(snsClient, never()).subscribe(any(SubscribeRequest.class));
+  }
+
+  @Test
+  void initializeQueueBootstrapsWhenSkipQueueBootstrapFalse() {
+    // given — default subscription has skipQueueBootstrap=false
+    when(sqsClient.getQueueUrl(any(java.util.function.Consumer.class)))
+        .thenReturn(GetQueueUrlResponse.builder().queueUrl("https://queue").build());
+    when(sqsClient.setQueueAttributes(any(SetQueueAttributesRequest.class)))
+        .thenReturn(SetQueueAttributesResponse.builder().build());
+    when(snsClient.subscribe(any(SubscribeRequest.class)))
+        .thenReturn(SubscribeResponse.builder().subscriptionArn("arn:sub").build());
+
+    SQSSubscriber localSubject =
+        new SQSSubscriber(
+            objectMapper,
+            subscription,
+            pubsubMessageHandler,
+            snsClient,
+            sqsClient,
+            () -> true,
+            registry);
+
+    // when
+    localSubject.initializeQueue();
+
+    // then
+    verify(sqsClient, times(1)).getQueueUrl(any(java.util.function.Consumer.class));
+    verify(sqsClient, times(1)).setQueueAttributes(any(SetQueueAttributesRequest.class));
+    verify(snsClient, times(1)).subscribe(any(SubscribeRequest.class));
   }
 }

--- a/kork/kork-pubsub-aws/src/main/java/com/netflix/spinnaker/kork/pubsub/aws/PubSubUtils.java
+++ b/kork/kork-pubsub-aws/src/main/java/com/netflix/spinnaker/kork/pubsub/aws/PubSubUtils.java
@@ -62,70 +62,49 @@ public class PubSubUtils {
   private static final Duration RETRY_BACKOFF = Duration.ofSeconds(1);
   private static final boolean EXPONENTIAL = true;
 
-  private static String getQueueUrl(
-      AmazonSQS amazonSQS, ARN queueARN, boolean enableQueueCreationFallback) {
-    String queueUrl;
-
-    try {
-      GetQueueUrlRequest getQueueUrlRequest =
-          new GetQueueUrlRequest()
-              .withQueueName(queueARN.getName())
-              .withQueueOwnerAWSAccountId(queueARN.getAccount());
-      queueUrl = amazonSQS.getQueueUrl(getQueueUrlRequest).getQueueUrl();
-      log.debug("Reusing existing queue {}", queueUrl);
-    } catch (QueueDoesNotExistException e) {
-      if (!enableQueueCreationFallback) {
-        throw e;
-      }
-      queueUrl = amazonSQS.createQueue(queueARN.getName()).getQueueUrl();
-      log.debug("Created queue {}", queueUrl);
-    }
-
-    return queueUrl;
+  public static String getQueueUrl(AmazonSQS amazonSQS, ARN queueARN) {
+    return retrySupport.retry(
+        () -> {
+          GetQueueUrlRequest request =
+              new GetQueueUrlRequest()
+                  .withQueueName(queueARN.getName())
+                  .withQueueOwnerAWSAccountId(queueARN.getAccount());
+          String queueUrl = amazonSQS.getQueueUrl(request).getQueueUrl();
+          log.debug("Reusing existing queue {}", queueUrl);
+          return queueUrl;
+        },
+        MAX_RETRIES,
+        RETRY_BACKOFF,
+        EXPONENTIAL);
   }
 
-  private static String getQueueUrl(
-      SqsClient sqsClient, ARN queueARN, boolean enableQueueCreationFallback) {
-    String queueUrl;
-
-    try {
-      queueUrl =
-          sqsClient
-              .getQueueUrl(
-                  r ->
-                      r.queueName(queueARN.getName()).queueOwnerAWSAccountId(queueARN.getAccount()))
-              .queueUrl();
-      log.debug("Reusing existing queue {}", queueUrl);
-    } catch (software.amazon.awssdk.services.sqs.model.QueueDoesNotExistException e) {
-      if (!enableQueueCreationFallback) {
-        throw e;
-      }
-      CreateQueueRequest createQueueRequest =
-          CreateQueueRequest.builder().queueName(queueARN.getName()).build();
-      queueUrl = sqsClient.createQueue(createQueueRequest).queueUrl();
-      log.debug("Created queue {}", queueUrl);
-    }
-
-    return queueUrl;
+  public static String getQueueUrl(SqsClient sqsClient, ARN queueARN) {
+    return retrySupport.retry(
+        () -> {
+          String queueUrl =
+              sqsClient
+                  .getQueueUrl(
+                      r ->
+                          r.queueName(queueARN.getName())
+                              .queueOwnerAWSAccountId(queueARN.getAccount()))
+                  .queueUrl();
+          log.debug("Reusing existing queue {}", queueUrl);
+          return queueUrl;
+        },
+        MAX_RETRIES,
+        RETRY_BACKOFF,
+        EXPONENTIAL);
   }
 
   public static String ensureQueueExists(
       AmazonSQS amazonSQS, ARN queueARN, ARN topicARN, int sqsMessageRetentionPeriodSeconds) {
-    return ensureQueueExists(amazonSQS, queueARN, topicARN, sqsMessageRetentionPeriodSeconds, true);
-  }
-
-  public static String ensureQueueExists(
-      AmazonSQS amazonSQS,
-      ARN queueARN,
-      ARN topicARN,
-      int sqsMessageRetentionPeriodSeconds,
-      boolean enableQueueCreationFallback) {
-    String queueUrl =
-        retrySupport.retry(
-            () -> getQueueUrl(amazonSQS, queueARN, enableQueueCreationFallback),
-            MAX_RETRIES,
-            RETRY_BACKOFF,
-            EXPONENTIAL);
+    String queueUrl;
+    try {
+      queueUrl = getQueueUrl(amazonSQS, queueARN);
+    } catch (QueueDoesNotExistException e) {
+      queueUrl = amazonSQS.createQueue(queueARN.getName()).getQueueUrl();
+      log.debug("Created queue {}", queueUrl);
+    }
 
     HashMap<String, String> attributes = new HashMap<>();
     attributes.put("Policy", buildSQSPolicy(queueARN, topicARN).toJson());
@@ -137,21 +116,15 @@ public class PubSubUtils {
 
   public static String ensureQueueExists(
       SqsClient sqsClient, ARN queueARN, ARN topicARN, int sqsMessageRetentionPeriodSeconds) {
-    return ensureQueueExists(sqsClient, queueARN, topicARN, sqsMessageRetentionPeriodSeconds, true);
-  }
-
-  public static String ensureQueueExists(
-      SqsClient sqsClient,
-      ARN queueARN,
-      ARN topicARN,
-      int sqsMessageRetentionPeriodSeconds,
-      boolean enableQueueCreationFallback) {
-    String queueUrl =
-        retrySupport.retry(
-            () -> getQueueUrl(sqsClient, queueARN, enableQueueCreationFallback),
-            MAX_RETRIES,
-            RETRY_BACKOFF,
-            EXPONENTIAL);
+    String queueUrl;
+    try {
+      queueUrl = getQueueUrl(sqsClient, queueARN);
+    } catch (software.amazon.awssdk.services.sqs.model.QueueDoesNotExistException e) {
+      CreateQueueRequest createQueueRequest =
+          CreateQueueRequest.builder().queueName(queueARN.getName()).build();
+      queueUrl = sqsClient.createQueue(createQueueRequest).queueUrl();
+      log.debug("Created queue {}", queueUrl);
+    }
 
     Map<QueueAttributeName, String> attributes = new HashMap<>();
     attributes.put(QueueAttributeName.POLICY, buildSQSPolicy(queueARN, topicARN).toJson());

--- a/kork/kork-pubsub-aws/src/main/java/com/netflix/spinnaker/kork/pubsub/aws/SQSSubscriber.java
+++ b/kork/kork-pubsub-aws/src/main/java/com/netflix/spinnaker/kork/pubsub/aws/SQSSubscriber.java
@@ -122,14 +122,18 @@ public class SQSSubscriber implements Runnable, PubsubSubscriber {
 
   @VisibleForTesting
   void initializeQueue() {
-    String queueUrl =
-        PubSubUtils.ensureQueueExists(
-            amazonSQS,
-            queueARN,
-            topicARN,
-            subscription.getSqsMessageRetentionPeriodSeconds(),
-            subscription.isEnableQueueCreationFallback());
-    PubSubUtils.subscribeToTopic(amazonSNS, topicARN, queueARN);
+    String queueUrl;
+    if (subscription.isSkipQueueBootstrap()) {
+      queueUrl = PubSubUtils.getQueueUrl(amazonSQS, queueARN);
+      log.info(
+          "skipQueueBootstrap=true for {}; resolving queue URL only, not calling setQueueAttributes/subscribe",
+          queueARN);
+    } else {
+      queueUrl =
+          PubSubUtils.ensureQueueExists(
+              amazonSQS, queueARN, topicARN, subscription.getSqsMessageRetentionPeriodSeconds());
+      PubSubUtils.subscribeToTopic(amazonSNS, topicARN, queueARN);
+    }
 
     this.subscriptionInfo =
         AmazonSubscriptionInformation.builder()

--- a/kork/kork-pubsub-aws/src/main/java/com/netflix/spinnaker/kork/pubsub/aws/config/AmazonPubsubProperties.java
+++ b/kork/kork-pubsub-aws/src/main/java/com/netflix/spinnaker/kork/pubsub/aws/config/AmazonPubsubProperties.java
@@ -42,6 +42,6 @@ public class AmazonPubsubProperties {
     int sqsMessageRetentionPeriodSeconds = 120;
     int waitTimeSeconds = 5;
     int maxNumberOfMessages = 1;
-    boolean enableQueueCreationFallback = true;
+    boolean skipQueueBootstrap = false;
   }
 }

--- a/kork/kork-pubsub-aws/src/test/groovy/com/netflix/spinnaker/kork/pubsub/aws/PubSubUtilsSpec.groovy
+++ b/kork/kork-pubsub-aws/src/test/groovy/com/netflix/spinnaker/kork/pubsub/aws/PubSubUtilsSpec.groovy
@@ -32,7 +32,30 @@ class PubSubUtilsSpec extends Specification {
   ARN queueARN = new ARN("arn:aws:sqs:us-west-2:100:queueName")
   ARN topicARN = new ARN("arn:aws:sns:us-west-2:100:topicName")
 
-  def "should not create queue if it exists"() {
+  def "getQueueUrl returns URL and passes QueueOwnerAWSAccountId"() {
+    when:
+    def url = PubSubUtils.getQueueUrl(amazonSQS, queueARN)
+
+    then:
+    url == "my-queue-url"
+    1 * amazonSQS.getQueueUrl({ GetQueueUrlRequest req ->
+      req.queueName == queueARN.name && req.queueOwnerAWSAccountId == queueARN.account
+    }) >> { new GetQueueUrlResult().withQueueUrl("my-queue-url") }
+    0 * _
+  }
+
+  def "getQueueUrl propagates QueueDoesNotExistException (no createQueue fallback)"() {
+    when:
+    PubSubUtils.getQueueUrl(amazonSQS, queueARN)
+
+    then:
+    // retrySupport retries MAX_RETRIES (=5) times before giving up
+    (1.._) * amazonSQS.getQueueUrl(_ as GetQueueUrlRequest) >> { throw new QueueDoesNotExistException("nope") }
+    0 * amazonSQS.createQueue(_)
+    thrown(QueueDoesNotExistException)
+  }
+
+  def "ensureQueueExists does not create queue if it exists"() {
     when:
     def queueId = PubSubUtils.ensureQueueExists(amazonSQS, queueARN, topicARN, 1)
 
@@ -49,34 +72,19 @@ class PubSubUtilsSpec extends Specification {
     0 * _
   }
 
-  def "should create queue if it does not exist and fallback enabled"() {
+  def "ensureQueueExists falls back to createQueue when queue is missing"() {
     when:
     def queueId = PubSubUtils.ensureQueueExists(amazonSQS, queueARN, topicARN, 1)
 
     then:
     queueId == "my-queue-url"
-    1 * amazonSQS.getQueueUrl({ GetQueueUrlRequest req ->
-      req.queueName == queueARN.name && req.queueOwnerAWSAccountId == queueARN.account
-    }) >> { throw new QueueDoesNotExistException() }
+    // retry may re-invoke getQueueUrl before giving up and returning to ensureQueueExists
+    (1.._) * amazonSQS.getQueueUrl(_ as GetQueueUrlRequest) >> { throw new QueueDoesNotExistException("nope") }
     1 * amazonSQS.createQueue(queueARN.name) >> { new CreateQueueResult().withQueueUrl("my-queue-url") }
     1 * amazonSQS.setQueueAttributes("my-queue-url", [
       "Policy": PubSubUtils.buildSQSPolicy(queueARN, topicARN).toJson(),
       "MessageRetentionPeriod": "1"
     ])
     0 * _
-  }
-
-  def "should throw when queue does not exist and fallback disabled"() {
-    given:
-    amazonSQS.getQueueUrl({ GetQueueUrlRequest req ->
-      req.queueName == queueARN.name && req.queueOwnerAWSAccountId == queueARN.account
-    }) >> { throw new QueueDoesNotExistException() }
-
-    when:
-    PubSubUtils.ensureQueueExists(amazonSQS, queueARN, topicARN, 1, false)
-
-    then:
-    thrown(QueueDoesNotExistException)
-    0 * amazonSQS.createQueue(_)
   }
 }

--- a/kork/kork-pubsub-aws/src/test/java/com/netflix/spinnaker/kork/pubsub/aws/SQSSubscriberTest.java
+++ b/kork/kork-pubsub-aws/src/test/java/com/netflix/spinnaker/kork/pubsub/aws/SQSSubscriberTest.java
@@ -16,8 +16,8 @@
 
 package com.netflix.spinnaker.kork.pubsub.aws;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -39,6 +39,7 @@ import com.netflix.spinnaker.kork.pubsub.aws.api.AmazonMessageAcknowledger;
 import com.netflix.spinnaker.kork.pubsub.aws.api.AmazonPubsubMessageHandler;
 import com.netflix.spinnaker.kork.pubsub.aws.config.AmazonPubsubProperties;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Supplier;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -120,6 +121,60 @@ public class SQSSubscriberTest {
 
     // then
     verify(amazonSQS, never()).receiveMessage(any(ReceiveMessageRequest.class));
+  }
+
+  @Test
+  @DisplayName("initializeQueue resolves URL only when skipQueueBootstrap=true")
+  void testInitializeQueueSkipsBootstrapWhenFlagTrue() {
+    // given
+    AmazonPubsubProperties.AmazonPubsubSubscription sub = subscription();
+    sub.setSkipQueueBootstrap(true);
+
+    AmazonSQS sqs = amazonSQS();
+    AmazonSNS sns = amazonSNS();
+    subscriber =
+        new SQSSubscriber(
+            sub,
+            mock(AmazonPubsubMessageHandler.class),
+            mock(AmazonMessageAcknowledger.class),
+            sns,
+            sqs,
+            enableOnce(),
+            new DefaultRegistry());
+
+    // when
+    subscriber.initializeQueue();
+
+    // then
+    verify(sqs, times(1)).getQueueUrl(any(GetQueueUrlRequest.class));
+    verify(sqs, never()).createQueue(anyString());
+    verify(sqs, never()).setQueueAttributes(anyString(), any(Map.class));
+    verify(sns, never()).subscribe(anyString(), anyString(), anyString());
+  }
+
+  @Test
+  @DisplayName("initializeQueue bootstraps queue when skipQueueBootstrap=false (default)")
+  void testInitializeQueueBootstrapsWhenFlagFalse() {
+    // given — default subscription has skipQueueBootstrap=false
+    AmazonSQS sqs = amazonSQS();
+    AmazonSNS sns = amazonSNS();
+    subscriber =
+        new SQSSubscriber(
+            subscription(),
+            mock(AmazonPubsubMessageHandler.class),
+            mock(AmazonMessageAcknowledger.class),
+            sns,
+            sqs,
+            enableOnce(),
+            new DefaultRegistry());
+
+    // when
+    subscriber.initializeQueue();
+
+    // then
+    verify(sqs, times(1)).getQueueUrl(any(GetQueueUrlRequest.class));
+    verify(sqs, times(1)).setQueueAttributes(anyString(), any(Map.class));
+    verify(sns, times(1)).subscribe(anyString(), anyString(), anyString());
   }
 
   AmazonPubsubProperties.AmazonPubsubSubscription subscription() {


### PR DESCRIPTION
Follow-up to #7633. The `enableQueueCreationFallback` flag only suppressed `createQueue`; `setQueueAttributes` and `SNS.Subscribe` still run and still fail cross-account. Replace with a single `skipQueueBootstrap` flag (default `false`) that disables all three bootstrap operations, so cross-account / IaC-managed subscribers only resolve the queue URL.

As `enableQueueCreationFallback` has not yet shipped in any release, this is a pre-release rename with no deprecation need.

Changes:
- kork + echo: replace enableQueueCreationFallback field with skipQueueBootstrap
- PubSubUtils: make getQueueUrl public and pure (lookup + retry, throws on missing), keep QueueOwnerAWSAccountId fix; collapse 5-param ensureQueueExists overloads back to 4-param with createQueue fallback handled inside
- Both SQSSubscribers: branch `initializeQueue` on `skipQueueBootstrap`
- Tests updated and expanded for both paths

Minor behavior change: `createQueue` is no longer retried (it now lives outside the retry loop, inside `ensureQueueExists`). `setQueueAttributes` was never retried.

---

We prefer small, well tested pull requests.

Please refer to [Contributing to Spinnaker](https://spinnaker.io/community/contributing/).

When filling out a pull request, please consider the following:

* Follow the commit message conventions [found here](https://spinnaker.io/community/contributing/submitting/).
* Provide a descriptive summary for your changes.
* If it fixes a bug or resolves a feature request, be sure to link to that issue.
* Add inline code comments to changes that might not be obvious.
* Squash your commits as you keep adding changes.
* Add a comment to @spinnaker/reviewers for review if your issue has been outstanding for more than 3 days.

Note that we are unlikely to accept pull requests that add features without prior discussion. The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.
