### PR TITLE
fix(orca): Pipeline bulk save breaks with managed service accounts

### DIFF
--- a/gate/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PipelineController.groovy
+++ b/gate/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PipelineController.groovy
@@ -144,6 +144,9 @@ class PipelineController {
     @Parameter(description = "Application in which to run the bulk save task",
       example = "bulk_save_placeholder_app",
       required = false) String application,
+    @io.swagger.v3.oas.annotations.parameters.RequestBody( // qualified due to name collision
+      required = true,
+      description = "JSON array of pipeline definitions to upsert")
     @RequestBody List<Map> pipelines) {
     def operation = [
       description: "Bulk save pipelines",

--- a/orca/orca-front50/src/main/java/com/netflix/spinnaker/orca/front50/tasks/SavePipelineTask.java
+++ b/orca/orca-front50/src/main/java/com/netflix/spinnaker/orca/front50/tasks/SavePipelineTask.java
@@ -176,7 +176,7 @@ public class SavePipelineTask implements RetryableTask {
     return TimeUnit.SECONDS.toMillis(30);
   }
 
-  private void updateServiceAccount(Map<String, Object> pipeline, String serviceAccount) {
+  static void updateServiceAccount(Map<String, Object> pipeline, String serviceAccount) {
     if (StringUtils.isEmpty(serviceAccount) || !pipeline.containsKey("triggers")) {
       return;
     }
@@ -210,7 +210,7 @@ public class SavePipelineTask implements RetryableTask {
     return null;
   }
 
-  private boolean runAsUserIsNullOrManagedServiceAccount(String runAsUser) {
+  private static boolean runAsUserIsNullOrManagedServiceAccount(String runAsUser) {
     return runAsUser == null
         || runAsUser.endsWith(SavePipelineStage.SERVICE_ACCOUNT_SUFFIX)
         || runAsUser.endsWith(SavePipelineStage.SHARED_SERVICE_ACCOUNT_SUFFIX);

--- a/orca/orca-front50/src/main/java/com/netflix/spinnaker/orca/front50/tasks/SaveServiceAccountTask.java
+++ b/orca/orca-front50/src/main/java/com/netflix/spinnaker/orca/front50/tasks/SaveServiceAccountTask.java
@@ -18,6 +18,8 @@ package com.netflix.spinnaker.orca.front50.tasks;
 
 import static java.lang.String.format;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.hash.Hashing;
 import com.netflix.spinnaker.fiat.model.UserPermission;
@@ -34,6 +36,7 @@ import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
 import com.netflix.spinnaker.orca.front50.Front50Service;
 import com.netflix.spinnaker.orca.front50.pipeline.SavePipelineStage;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -63,6 +66,7 @@ public class SaveServiceAccountTask implements RetryableTask {
   private final FiatStatus fiatStatus;
   private final Front50Service front50Service;
   private final FiatPermissionEvaluator fiatPermissionEvaluator;
+  private final ObjectMapper objectMapper;
   private final boolean useSharedManagedServiceAccounts;
 
   @Autowired
@@ -70,11 +74,13 @@ public class SaveServiceAccountTask implements RetryableTask {
       Optional<FiatStatus> fiatStatus,
       Optional<Front50Service> front50Service,
       Optional<FiatPermissionEvaluator> fiatPermissionEvaluator,
+      ObjectMapper objectMapper,
       @Value("${tasks.use-shared-managed-service-accounts:false}")
           boolean useSharedManagedServiceAccounts) {
     this.fiatStatus = fiatStatus.get();
     this.front50Service = front50Service.get();
     this.fiatPermissionEvaluator = fiatPermissionEvaluator.get();
+    this.objectMapper = objectMapper;
     this.useSharedManagedServiceAccounts = useSharedManagedServiceAccounts;
   }
 
@@ -99,6 +105,12 @@ public class SaveServiceAccountTask implements RetryableTask {
     if (front50Service == null) {
       throw new UnsupportedOperationException(
           "Front50 is not enabled, no way to save pipeline. Fix this by setting front50.enabled: true");
+    }
+
+    boolean isBulkSavingPipelines =
+        (boolean) stage.getContext().getOrDefault("isBulkSavingPipelines", false);
+    if (isBulkSavingPipelines) {
+      return executeBulk(stage);
     }
 
     if (!stage.getContext().containsKey("pipeline")) {
@@ -144,6 +156,79 @@ public class SaveServiceAccountTask implements RetryableTask {
           .build();
     }
 
+    if (!validateAndSaveServiceAccount(user, serviceAccountName, roles)) {
+      return TaskResult.ofStatus(ExecutionStatus.TERMINAL);
+    }
+
+    outputs.put("pipeline.serviceAccount", serviceAccountName);
+
+    return TaskResult.builder(ExecutionStatus.SUCCEEDED).context(outputs).build();
+  }
+
+  /**
+   * Bulk variant: iterates over the {@code pipelines} list, applying per-pipeline service-account
+   * provisioning (id assignment, SA save, trigger {@code runAsUser} rewrite). The mutated list is
+   * re-encoded back into the stage context so {@link SavePipelineTask} sees the updated triggers.
+   */
+  @SuppressWarnings("unchecked")
+  private TaskResult executeBulk(StageExecution stage) {
+    if (!stage.getContext().containsKey("pipelines")) {
+      throw new IllegalArgumentException(
+          "pipelines context must be provided when bulk saving pipelines");
+    }
+
+    List<Map<String, Object>> pipelines;
+    try {
+      pipelines = (List<Map<String, Object>>) stage.decodeBase64("/pipelines", List.class);
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException("pipelines must be encoded as base64", e);
+    }
+
+    String user = stage.getExecution().getTrigger().getUser();
+
+    for (Map<String, Object> pipeline : pipelines) {
+      if (pipeline.get("id") == null) {
+        pipeline.put("id", UUID.randomUUID().toString());
+        pipeline.put("regenerateCronTriggerIds", true); // used by front50
+      }
+
+      if (!pipeline.containsKey("roles")) {
+        continue;
+      }
+      List<String> roles = (List<String>) pipeline.get("roles");
+
+      String serviceAccountName = generateSvcAcctName(pipeline, roles);
+      if (pipelineRolesChanged(serviceAccountName, roles)
+          && !validateAndSaveServiceAccount(user, serviceAccountName, roles)) {
+        return TaskResult.ofStatus(ExecutionStatus.TERMINAL);
+      }
+      SavePipelineTask.updateServiceAccount(pipeline, serviceAccountName);
+    }
+
+    String reEncoded;
+    try {
+      reEncoded =
+          Base64.getEncoder()
+              .encodeToString(
+                  objectMapper.writeValueAsString(pipelines).getBytes(StandardCharsets.UTF_8));
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(
+          "Failed to re-encode pipelines after applying service accounts", e);
+    }
+
+    return TaskResult.builder(ExecutionStatus.SUCCEEDED)
+        .context(ImmutableMap.of("pipelines", reEncoded))
+        .build();
+  }
+
+  /**
+   * Checks the user is authorized for the given roles, then saves (or updates) a service account
+   * with those roles in Front50. Throws {@link UserException} if the user is not authorized;
+   * returns {@code false} when Front50 returns a non-OK status (caller translates to {@link
+   * ExecutionStatus#TERMINAL}).
+   */
+  private boolean validateAndSaveServiceAccount(
+      String user, String serviceAccountName, List<String> roles) {
     if (!isUserAuthorized(user, roles)) {
       log.warn("User {} is not authorized with all roles for pipeline", user);
       throw new UserException(
@@ -160,12 +245,10 @@ public class SaveServiceAccountTask implements RetryableTask {
         Retrofit2SyncCall.executeCall(front50Service.saveServiceAccount(svcAcct));
 
     if (response.code() != HttpStatus.OK.value()) {
-      return TaskResult.ofStatus(ExecutionStatus.TERMINAL);
+      log.warn("Failed to save service account, got response code {}", response.code());
+      return false;
     }
-
-    outputs.put("pipeline.serviceAccount", svcAcct.getName());
-
-    return TaskResult.builder(ExecutionStatus.SUCCEEDED).context(outputs).build();
+    return true;
   }
 
   private String generateSvcAcctName(Map<String, Object> pipeline, List<String> roles) {

--- a/orca/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/tasks/SaveServiceAccountTaskSpec.groovy
+++ b/orca/orca-front50/src/test/groovy/com/netflix/spinnaker/orca/front50/tasks/SaveServiceAccountTaskSpec.groovy
@@ -46,7 +46,7 @@ class SaveServiceAccountTaskSpec extends Specification {
 
   @Subject
   SaveServiceAccountTask task = new SaveServiceAccountTask(Optional.of(fiatStatus), Optional.of(front50Service),
-  Optional.of(fiatPermissionEvaluator), useSharedManagedServiceAccounts)
+  Optional.of(fiatPermissionEvaluator), objectMapper, useSharedManagedServiceAccounts)
 
   def "should do nothing if no pipeline roles present"() {
     given:
@@ -261,7 +261,7 @@ class SaveServiceAccountTaskSpec extends Specification {
     def expectedServiceAccount = new ServiceAccount(name: expectedServiceAccountName, memberOf: ['foo'])
 
     task = new SaveServiceAccountTask(Optional.of(fiatStatus), Optional.of(front50Service),
-        Optional.of(fiatPermissionEvaluator), useSharedManagedServiceAccountsEnabled)
+        Optional.of(fiatPermissionEvaluator), objectMapper, useSharedManagedServiceAccountsEnabled)
 
     when:
     stage.getExecution().setTrigger(new DefaultTrigger('manual', null, 'abc@somedomain.io'))
@@ -293,5 +293,103 @@ class SaveServiceAccountTaskSpec extends Specification {
 
   private String generateSha256StringFromRolesString(String rolesString) {
     Hashing.sha256().hashBytes(rolesString.getBytes()).toString() + "@shared-managed-service-account"
+  }
+
+  private bulkStage(List pipelines, String user = 'abc@somedomain.io') {
+    def s = stage {
+      context = [
+          isBulkSavingPipelines: true,
+          pipelines            : Base64.encoder.encodeToString(
+              objectMapper.writeValueAsString(pipelines).bytes)
+      ]
+    }
+    s.getExecution().setTrigger(new DefaultTrigger('manual', null, user))
+    s
+  }
+
+  private List decodePipelines(result) {
+    objectMapper.readValue(Base64.decoder.decode(result.context.pipelines as String), List)
+  }
+
+  def "bulk save: provisions a service account per pipeline and rewrites runAsUser triggers"() {
+    given:
+    def pipelineWithRoles = [
+        application: 'app1',
+        id         : 'pipeline-1',
+        name       : 'p1',
+        roles      : ['foo'],
+        triggers   : [[type: 'cron', runAsUser: null]]
+    ]
+    def pipelineWithoutRoles = [
+        application: 'app2',
+        name       : 'p2',
+        triggers   : [[type: 'manual']]
+    ]
+
+    when:
+    def result = task.execute(bulkStage([pipelineWithRoles, pipelineWithoutRoles]))
+    def reDecoded = decodePipelines(result)
+
+    then:
+    1 * fiatPermissionEvaluator.getPermission('abc@somedomain.io') >> {
+      new UserPermission().addResources([new Role('foo')]).view
+    }
+    1 * front50Service.saveServiceAccount(
+        new ServiceAccount(name: 'pipeline-1@managed-service-account', memberOf: ['foo'])) >> {
+      Calls.response(ResponseBody.create(MediaType.parse("application/json"), "[]"))
+    }
+    0 * front50Service.saveServiceAccount({ it.name != 'pipeline-1@managed-service-account' })
+
+    result.status == ExecutionStatus.SUCCEEDED
+    reDecoded[0].triggers[0].runAsUser == 'pipeline-1@managed-service-account'
+    reDecoded[1].triggers[0].runAsUser == null
+    reDecoded[1].id != null
+    reDecoded[1].regenerateCronTriggerIds == true
+  }
+
+  def "bulk save: assigns id and regenerateCronTriggerIds when pipeline has no id"() {
+    given:
+    def pipeline = [
+        application: 'app1',
+        name       : 'p1',
+        roles      : ['foo'],
+        triggers   : []
+    ]
+
+    when:
+    def result = task.execute(bulkStage([pipeline]))
+    def reDecoded = decodePipelines(result)
+
+    then:
+    1 * fiatPermissionEvaluator.getPermission('abc@somedomain.io') >> {
+      new UserPermission().addResources([new Role('foo')]).view
+    }
+    1 * front50Service.saveServiceAccount(_) >> {
+      Calls.response(ResponseBody.create(MediaType.parse("application/json"), "[]"))
+    }
+
+    result.status == ExecutionStatus.SUCCEEDED
+    reDecoded[0].id != null
+    reDecoded[0].regenerateCronTriggerIds == true
+  }
+
+  def "bulk save: rejects when user lacks roles for any pipeline"() {
+    given:
+    def pipeline = [
+        application: 'app1',
+        id         : 'pipeline-1',
+        name       : 'p1',
+        roles      : ['restricted-role']
+    ]
+
+    when:
+    task.execute(bulkStage([pipeline]))
+
+    then:
+    1 * fiatPermissionEvaluator.getPermission('abc@somedomain.io') >> {
+      new UserPermission().addResources([new Role('foo')]).view
+    }
+    0 * front50Service.saveServiceAccount(_)
+    thrown(com.netflix.spinnaker.kork.exceptions.UserException)
   }
 }


### PR DESCRIPTION
* Support managed service accounts in pipeline bulk saves
* Update the tests, add a few more
* Document the expected format of the request body in Swagger

---

##  Issue

`POST /pipelines/bulksave` has been broken on our instance ever since we enabled managed service accounts. When enabled, `SavePipelineStage` runs `SaveServiceAccountTask` before `SavePipelineTask`. In a bulk save, the stage `context` provides the pipelines in a `pipelines` key (**plural**, base64) along with `isBulkSavingPipelines: true` ([here](https://github.com/spinnaker/spinnaker/blob/c69d00e4a43803757d4563b71551d042affa8328/gate/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PipelineController.groovy#L148-L160)). There is no `pipeline` key (singular).

This first task `SaveServiceAccountTask` only ever supported the single-pipeline path, its very first input check is: https://github.com/spinnaker/spinnaker/blob/c69d00e4a43803757d4563b71551d042affa8328/orca/orca-front50/src/main/java/com/netflix/spinnaker/orca/front50/tasks/SaveServiceAccountTask.java#L104-L106

→ the stage fails before `SavePipelineTask` ever runs.

## Fix

`SaveServiceAccountTask`: new `executeBulk` branch when `isBulkSavingPipelines` is set. Decodes `pipelines` (encoded by Gate), and for each entry:
- assigns `id` (+ `regenerateCronTriggerIds: true`) when missing; this is used by Front50
- handles service accounts if a `roles` list is present, just like in the single-pipeline path

`SavePipelineTask`: made two methods static to reuse them, both related to service accounts.

`SaveServiceAccountTaskSpec`: 3 new test cases for bulk saves (per-pipeline service account, cron trigger IDs with and without roles, and rejection when user lacks roles)

`PipelineController` in Gate: added a `RequestBody` Swagger annotation to describe what the body should contain on the Swagger page.