### PR TITLE
Fixes #7282: honor `stageTimeoutMs` in `CreateWebhookTask`

### DIFF
--- a/orca/orca-queue/orca-queue.gradle
+++ b/orca/orca-queue/orca-queue.gradle
@@ -43,6 +43,7 @@ dependencies {
   testImplementation(project(":orca-queue-tck"))
   testImplementation(project(":orca-queue-redis"))
   testImplementation(project(":orca-echo"))
+  testImplementation(project(":orca-webhook"))
   testImplementation("org.apache.groovy:groovy")
   testImplementation("org.assertj:assertj-core")
   testImplementation("com.squareup.retrofit2:converter-jackson")

--- a/orca/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandlerTest.kt
+++ b/orca/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/RunTaskHandlerTest.kt
@@ -43,6 +43,7 @@ import com.netflix.spinnaker.orca.pipeline.tasks.WaitTask
 import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor
 import com.netflix.spinnaker.orca.pipeline.util.StageNavigator
 import com.netflix.spinnaker.orca.q.*
+import com.netflix.spinnaker.orca.webhook.tasks.CreateWebhookTask
 import com.netflix.spinnaker.q.Queue
 import com.netflix.spinnaker.spek.and
 import com.nhaarman.mockito_kotlin.*
@@ -79,10 +80,14 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
     on { extensionClass } doReturn DummyTimeoutOverrideTask::class.java
     on { aliases() } doReturn emptyList<String>()
   }
+  val createWebhookTask: CreateWebhookTask = mock {
+    on { extensionClass } doReturn CreateWebhookTask::class.java
+    on { aliases() } doReturn emptyList<String>()
+  }
   val logMessageTask = LogMessageTask()
 
   // tasks can only contain mocks
-  val tasks = mutableListOf(task, cloudProviderAwareTask, timeoutOverrideTask)
+  val tasks = mutableListOf(task, cloudProviderAwareTask, timeoutOverrideTask, createWebhookTask)
 
   val exceptionHandler: ExceptionHandler = mock()
   // Stages store times as ms-since-epoch, and we do a lot of tests to make sure things run at the
@@ -104,7 +109,7 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
       stageNavigator,
       DefaultStageDefinitionBuilderFactory(stageResolver),
       contextParameterProcessor,
-      TaskResolver(TasksProvider(mutableListOf(task, timeoutOverrideTask, cloudProviderAwareTask, logMessageTask) as Collection<Task>)),
+      TaskResolver(TasksProvider(mutableListOf(task, timeoutOverrideTask, cloudProviderAwareTask, createWebhookTask, logMessageTask) as Collection<Task>)),
       clock,
       listOf(exceptionHandler),
       taskExecutionInterceptors,
@@ -114,7 +119,7 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
     )
   }
 
-  fun resetMocks() = reset(queue, repository, task, timeoutOverrideTask, cloudProviderAwareTask, exceptionHandler, retriableLock)
+  fun resetMocks() = reset(queue, repository, task, timeoutOverrideTask, cloudProviderAwareTask, createWebhookTask, exceptionHandler, retriableLock)
 
   describe("running a task") {
 
@@ -1466,7 +1471,7 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
                 startTime = clock.instant().minusMillis(timeout.toMillis() + 1).toEpochMilli() // started 5.1 minutes ago
                 task {
                   id = "1"
-                  implementingClass = DummyTimeoutOverrideTask::class.jvmName
+                  implementingClass = CreateWebhookTask::class.jvmName
                   status = RUNNING
                   startTime = clock.instant().minusMillis(timeout.toMillis() + 1).toEpochMilli() // started 5.1 minutes ago
                 }
@@ -1474,14 +1479,14 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
             }
             val stage = pipeline.stages.first()
             val taskResult = TaskResult.RUNNING
-            val message = RunTask(pipeline.type, pipeline.id, "foo", stage.id, "1", DummyTimeoutOverrideTask::class.java)
+            val message = RunTask(pipeline.type, pipeline.id, "foo", stage.id, "1", CreateWebhookTask::class.java)
 
             beforeGroup {
               tasks.forEach { whenever(it.extensionClass) doReturn it::class.java }
-              taskExecutionInterceptors.forEach { whenever(it.beforeTaskExecution(timeoutOverrideTask, stage)) doReturn stage }
-              taskExecutionInterceptors.forEach { whenever(it.afterTaskExecution(timeoutOverrideTask, stage, taskResult)) doReturn taskResult }
+              taskExecutionInterceptors.forEach { whenever(it.beforeTaskExecution(createWebhookTask, stage)) doReturn stage }
+              taskExecutionInterceptors.forEach { whenever(it.afterTaskExecution(createWebhookTask, stage, taskResult)) doReturn taskResult }
               whenever(repository.retrieve(PIPELINE, message.executionId)) doReturn pipeline
-              whenever(timeoutOverrideTask.timeout) doReturn timeout.toMillis()
+              whenever(createWebhookTask.timeout) doReturn timeout.toMillis()
               setupRetriableLock(true, retriableLock)
             }
 
@@ -1492,7 +1497,7 @@ object RunTaskHandlerTest : SubjectSpek<RunTaskHandler>({
             }
 
             it("executes the task") {
-              verify(timeoutOverrideTask).execute(any())
+              verify(createWebhookTask).execute(any())
             }
           }
         }

--- a/orca/orca-webhook/src/main/java/com/netflix/spinnaker/orca/webhook/tasks/CreateWebhookTask.java
+++ b/orca/orca-webhook/src/main/java/com/netflix/spinnaker/orca/webhook/tasks/CreateWebhookTask.java
@@ -1,7 +1,7 @@
 package com.netflix.spinnaker.orca.webhook.tasks;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.netflix.spinnaker.orca.api.pipeline.RetryableTask;
+import com.netflix.spinnaker.orca.api.pipeline.OverridableTimeoutRetryableTask;
 import com.netflix.spinnaker.orca.api.pipeline.TaskResult;
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
 import com.netflix.spinnaker.orca.webhook.config.WebhookProperties;
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
-public class CreateWebhookTask implements RetryableTask {
+public class CreateWebhookTask implements OverridableTimeoutRetryableTask {
   private final WebhookService webhookService;
   private final WebhookProperties webhookProperties;
   private final ObjectMapper objectMapper;


### PR DESCRIPTION
- Solution proposed [here](https://spinnakerteam.slack.com/archives/C091CCWRJ/p1761167488687779?thread_ts=1761153251.111699&cid=C091CCWRJ)
- Modified old test to use specific `CreateWebhookTask` instead of a dummy

<details>
<summary>Ensured the test fails on main, without this PR, like this:</summary>

```sh
/gradlew :orca:orca-queue:test              

> Task :orca:orca-queue:test

com.netflix.spinnaker.orca.q.handler.RunTaskHandlerTest > describe running a task > given there is a timeout override > and the override is a Integer > and the task is an overridabletimeout task that shouldn't time out > com.netflix.spinnaker.orca.q.handler.RunTaskHandlerTest.it executes the task FAILED
    Wanted but not invoked:
    createWebhookTask.execute(
        <any com.netflix.spinnaker.orca.api.pipeline.models.StageExecution>
    );
    -> at com.netflix.spinnaker.orca.webhook.tasks.CreateWebhookTask.execute(CreateWebhookTask.java:34)

    However, there were exactly 4 interactions with this mock:
    createWebhookTask.getExtensionClass();
    -> at com.netflix.spinnaker.orca.TaskResolver.<init>(TaskResolver.java:56)

    createWebhookTask.aliases();
    -> at com.netflix.spinnaker.orca.TaskResolver.addAliases(TaskResolver.java:167)

    createWebhookTask.getDynamicTimeout(
        Stage {id='01KSJD8R9MPN9ZNBE6SBES1YQS', executionId='01KSJD8R9MBDKE3VQTZGMPBEPF'}
    );
    -> at com.netflix.spinnaker.orca.q.handler.RunTaskHandler.checkForTaskTimeout(RunTaskHandler.kt:392)

    createWebhookTask.onTimeout(
        Stage {id='01KSJD8R9MPN9ZNBE6SBES1YQS', executionId='01KSJD8R9MBDKE3VQTZGMPBEPF'}
    );
    -> at com.netflix.spinnaker.orca.q.handler.RunTaskHandler$handle$1$1$1$1.invoke(RunTaskHandler.kt:152)
        at app//com.netflix.spinnaker.orca.webhook.tasks.CreateWebhookTask.execute(CreateWebhookTask.java:34)
        at app//com.netflix.spinnaker.orca.q.handler.RunTaskHandlerTest$1$2$11$2$1$3$4.invoke(RunTaskHandlerTest.kt:1500)
        at app//com.netflix.spinnaker.orca.q.handler.RunTaskHandlerTest$1$2$11$2$1$3$4.invoke(RunTaskHandlerTest.kt:1499)

com.netflix.spinnaker.orca.q.handler.RunTaskHandlerTest > describe running a task > given there is a timeout override > and the override is a Long > and the task is an overridabletimeout task that shouldn't time out > com.netflix.spinnaker.orca.q.handler.RunTaskHandlerTest.it executes the task FAILED
    Wanted but not invoked:
    createWebhookTask.execute(
        <any com.netflix.spinnaker.orca.api.pipeline.models.StageExecution>
    );
    -> at com.netflix.spinnaker.orca.webhook.tasks.CreateWebhookTask.execute(CreateWebhookTask.java:34)

    However, there were exactly 4 interactions with this mock:
    createWebhookTask.getExtensionClass();
    -> at com.netflix.spinnaker.orca.TaskResolver.<init>(TaskResolver.java:56)

    createWebhookTask.aliases();
    -> at com.netflix.spinnaker.orca.TaskResolver.addAliases(TaskResolver.java:167)

    createWebhookTask.getDynamicTimeout(
        Stage {id='01KSJD8R9P660AFNVE03CQ38AT', executionId='01KSJD8R9P6SA9JXXQV8VMDSKY'}
    );
    -> at com.netflix.spinnaker.orca.q.handler.RunTaskHandler.checkForTaskTimeout(RunTaskHandler.kt:392)

    createWebhookTask.onTimeout(
        Stage {id='01KSJD8R9P660AFNVE03CQ38AT', executionId='01KSJD8R9P6SA9JXXQV8VMDSKY'}
    );
    -> at com.netflix.spinnaker.orca.q.handler.RunTaskHandler$handle$1$1$1$1.invoke(RunTaskHandler.kt:152)
        at app//com.netflix.spinnaker.orca.webhook.tasks.CreateWebhookTask.execute(CreateWebhookTask.java:34)
        at app//com.netflix.spinnaker.orca.q.handler.RunTaskHandlerTest$1$2$11$2$1$3$4.invoke(RunTaskHandlerTest.kt:1500)
        at app//com.netflix.spinnaker.orca.q.handler.RunTaskHandlerTest$1$2$11$2$1$3$4.invoke(RunTaskHandlerTest.kt:1499)

com.netflix.spinnaker.orca.q.handler.RunTaskHandlerTest > describe running a task > given there is a timeout override > and the override is a Double > and the task is an overridabletimeout task that shouldn't time out > com.netflix.spinnaker.orca.q.handler.RunTaskHandlerTest.it executes the task FAILED
    Wanted but not invoked:
    createWebhookTask.execute(
        <any com.netflix.spinnaker.orca.api.pipeline.models.StageExecution>
    );
    -> at com.netflix.spinnaker.orca.webhook.tasks.CreateWebhookTask.execute(CreateWebhookTask.java:34)

    However, there were exactly 4 interactions with this mock:
    createWebhookTask.getExtensionClass();
    -> at com.netflix.spinnaker.orca.TaskResolver.<init>(TaskResolver.java:56)

    createWebhookTask.aliases();
    -> at com.netflix.spinnaker.orca.TaskResolver.addAliases(TaskResolver.java:167)

    createWebhookTask.getDynamicTimeout(
        Stage {id='01KSJD8R9PCGWTVG5E5EZAV1W3', executionId='01KSJD8R9P43ED8TAX5SDXA9QV'}
    );
    -> at com.netflix.spinnaker.orca.q.handler.RunTaskHandler.checkForTaskTimeout(RunTaskHandler.kt:392)

    createWebhookTask.onTimeout(
        Stage {id='01KSJD8R9PCGWTVG5E5EZAV1W3', executionId='01KSJD8R9P43ED8TAX5SDXA9QV'}
    );
    -> at com.netflix.spinnaker.orca.q.handler.RunTaskHandler$handle$1$1$1$1.invoke(RunTaskHandler.kt:152)
        at app//com.netflix.spinnaker.orca.webhook.tasks.CreateWebhookTask.execute(CreateWebhookTask.java:34)
        at app//com.netflix.spinnaker.orca.q.handler.RunTaskHandlerTest$1$2$11$2$1$3$4.invoke(RunTaskHandlerTest.kt:1500)
        at app//com.netflix.spinnaker.orca.q.handler.RunTaskHandlerTest$1$2$11$2$1$3$4.invoke(RunTaskHandlerTest.kt:1499)

530 tests completed, 3 failed
```
</details>