### PR TITLE
fix(yaml): A few classes were not using safe constructors. Fix these …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .gradle/
 .idea/
 build/
+.claude
 
 *.iml
 *.idea

--- a/keel/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/jackson/_yaml.kt
+++ b/keel/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/jackson/_yaml.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
 import com.fasterxml.jackson.module.kotlin.convertValue
 import com.netflix.spinnaker.keel.exceptions.YamlParsingException
+import com.netflix.spinnaker.kork.yaml.YamlHelper
 import org.yaml.snakeyaml.LoaderOptions
 import org.yaml.snakeyaml.Yaml
 import java.io.InputStream
@@ -28,4 +29,4 @@ inline fun <reified T> YAMLMapper.readValueInliningAliases(yaml: String): T {
  * Converts a YAML stream into JSON with any anchors and aliases resolved.
  */
 fun ObjectMapper.writeYamlAsJsonString(stream: InputStream): String =
-  writeValueAsString(Yaml().load<Map<String, Any?>>(stream))
+  writeValueAsString(YamlHelper.newYamlSafeConstructor().load<Map<String, Any?>>(stream))

--- a/kork/kork-core/src/main/java/com/netflix/spinnaker/kork/yaml/YamlHelper.java
+++ b/kork/kork-core/src/main/java/com/netflix/spinnaker/kork/yaml/YamlHelper.java
@@ -1,0 +1,170 @@
+package com.netflix.spinnaker.kork.yaml;
+
+import lombok.extern.log4j.Log4j2;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.LoaderOptions;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.Constructor;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
+import org.yaml.snakeyaml.representer.Representer;
+import org.yaml.snakeyaml.resolver.Resolver;
+
+/**
+ * Utility component for creating preconfigured {@link Yaml} instances with optional
+ * security-related parsing limits.
+ *
+ * <p>This helper centralizes the creation of {@link Yaml} objects used across the Spinnaker
+ * ecosystem, ensuring that YAML parsing behavior is consistent and secure. It applies limits
+ * defined in {@link YamlParserProperties}, such as:
+ *
+ * <ul>
+ *   <li>{@code maxAliasesForCollections} – to prevent Billion Laughs (entity expansion) attacks
+ *   <li>{@code codePointLimit} – to restrict the maximum size of YAML input
+ * </ul>
+ *
+ * <p>If no security-related properties are configured, the helper falls back to creating standard
+ * {@link Yaml} instances using SnakeYAML defaults.
+ *
+ * <p>This class also provides convenience factory methods for constructing {@link Yaml} objects
+ * with various configurations such as: {@link Constructor}, {@link SafeConstructor}, {@link
+ * DumperOptions}, {@link LoaderOptions}, and {@link Representer}.
+ *
+ * <p><strong>Usage Example:</strong>
+ *
+ * <pre>{@code
+ * Yaml yaml = YamlHelper.newYaml(); // creates a secure YAML parser if properties are set
+ * Map<String, Object> data = yaml.load(yamlContent);
+ * }</pre>
+ *
+ * <p>When {@link YamlParserProperties} is available in the Spring context, security properties are
+ * automatically applied to all created {@link Yaml} instances.
+ */
+@Component
+@Log4j2
+public class YamlHelper {
+
+  private static YamlParserProperties yamlParserProperties;
+
+  @Autowired
+  public YamlHelper(YamlParserProperties props) {
+    yamlParserProperties = props;
+  }
+
+  private static boolean hasYamlSecurityPropertiesConfigured() {
+    return yamlParserProperties != null
+        && (yamlParserProperties.getMaxAliasesForCollections() != null
+            || yamlParserProperties.getCodePointLimit() != null);
+  }
+
+  /**
+   * Creates a new {@link Yaml} instance using either default or secure {@link LoaderOptions},
+   * depending on whether {@link YamlParserProperties} are configured.
+   *
+   * @return a new {@link Yaml} instance
+   */
+  @Deprecated
+  public static Yaml newYaml() {
+    log.warn(
+        "WARNING:  Invoked newYaml!  THIS DOES NOT load yaml safely and should ONLY be used in initialization or by processes that are trusted!",
+        new Exception());
+    if (hasYamlSecurityPropertiesConfigured()) {
+      LoaderOptions opts = getLoaderOptions();
+
+      Constructor constructor = new Constructor(opts);
+      DumperOptions dumperOpts = new DumperOptions();
+      Representer representer = new Representer(dumperOpts);
+      Resolver resolver = new Resolver(); // default tag resolver
+
+      return new Yaml(constructor, representer, dumperOpts, opts, resolver);
+    }
+
+    return new Yaml();
+  }
+
+  /**
+   * Creates a new {@link Yaml} instance with a {@link SafeConstructor}, ensuring that only standard
+   * types are loaded (no arbitrary object instantiation). If security properties are set, they are
+   * applied via {@link LoaderOptions}.
+   *
+   * @return a new {@link Yaml} instance with safe construction
+   */
+  public static Yaml newYamlSafeConstructor() {
+    if (hasYamlSecurityPropertiesConfigured()) {
+      LoaderOptions opts = getLoaderOptions();
+
+      SafeConstructor constructor = new SafeConstructor(opts);
+      DumperOptions dumperOpts = new DumperOptions();
+      Representer representer = new Representer(dumperOpts);
+
+      return new Yaml(constructor, representer, dumperOpts, opts);
+    }
+
+    return new Yaml(new SafeConstructor(new LoaderOptions()));
+  }
+
+  /**
+   * Creates a new {@link Yaml} instance using the specified {@link DumperOptions}. Applies
+   * security-related {@link LoaderOptions} if available.
+   *
+   * @param dumperOptions configuration for YAML serialization
+   * @return a new {@link Yaml} instance
+   */
+  public static Yaml newYamlDumperOptions(DumperOptions dumperOptions) {
+    if (hasYamlSecurityPropertiesConfigured()) {
+      LoaderOptions opts = getLoaderOptions();
+
+      SafeConstructor constructor = new SafeConstructor(opts);
+      Representer representer = new Representer(dumperOptions);
+
+      return new Yaml(constructor, representer, dumperOptions, opts);
+    }
+
+    return new Yaml(
+        new SafeConstructor(new LoaderOptions()), new Representer(dumperOptions), dumperOptions);
+  }
+
+  /**
+   * Creates a new {@link Yaml} instance with the specified {@link LoaderOptions}. If security
+   * properties are configured, they override the provided options.
+   *
+   * @param loaderOptions custom loader options for YAML parsing
+   * @return a new {@link Yaml} instance
+   */
+  public static Yaml newYamlLoaderOptions(LoaderOptions loaderOptions) {
+    if (hasYamlSecurityPropertiesConfigured()) {
+      LoaderOptions opts = getLoaderOptions();
+      return new Yaml(opts);
+    }
+    return new Yaml(loaderOptions);
+  }
+
+  /**
+   * Creates a new {@link Yaml} instance using the given {@link Constructor} and {@link
+   * Representer}. Applies secure {@link LoaderOptions} if configured.
+   *
+   * @param constructor the YAML constructor
+   * @param representer the YAML representer
+   * @return a new {@link Yaml} instance
+   */
+  public static Yaml newYamlRepresenter(Constructor constructor, Representer representer) {
+    if (hasYamlSecurityPropertiesConfigured()) {
+      LoaderOptions opts = getLoaderOptions();
+      return new Yaml(constructor, representer, new DumperOptions(), opts);
+    }
+    return new Yaml(constructor, representer);
+  }
+
+  private static LoaderOptions getLoaderOptions() {
+    LoaderOptions opts = new LoaderOptions();
+    if (yamlParserProperties.getMaxAliasesForCollections() != null) {
+      opts.setMaxAliasesForCollections(yamlParserProperties.getMaxAliasesForCollections());
+    }
+
+    if (yamlParserProperties.getCodePointLimit() != null) {
+      opts.setCodePointLimit(yamlParserProperties.getCodePointLimit());
+    }
+    return opts;
+  }
+}

--- a/kork/kork-core/src/main/java/com/netflix/spinnaker/kork/yaml/YamlParserProperties.java
+++ b/kork/kork-core/src/main/java/com/netflix/spinnaker/kork/yaml/YamlParserProperties.java
@@ -1,0 +1,11 @@
+package com.netflix.spinnaker.kork.yaml;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "snakeyaml")
+@Data
+public class YamlParserProperties {
+  private Integer maxAliasesForCollections;
+  private Integer codePointLimit;
+}

--- a/kork/kork-core/src/main/java/com/netflix/spinnaker/kork/yaml/YamlParserPropertiesCondition.java
+++ b/kork/kork-core/src/main/java/com/netflix/spinnaker/kork/yaml/YamlParserPropertiesCondition.java
@@ -1,0 +1,51 @@
+package com.netflix.spinnaker.kork.yaml;
+
+import org.springframework.boot.autoconfigure.condition.ConditionOutcome;
+import org.springframework.boot.autoconfigure.condition.SpringBootCondition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+/**
+ * A custom {@link org.springframework.context.annotation.Condition} that determines whether the
+ * {@link org.yaml.snakeyaml.Yaml} bean should be created based on the values of {@link
+ * YamlParserProperties}.
+ *
+ * <p>This condition returns {@code true} only if at least one of the following properties is
+ * greater than zero:
+ *
+ * <ul>
+ *   <li>{@code maxAliasesForCollections}
+ *   <li>{@code codePointLimit}
+ * </ul>
+ *
+ * <p>This allows conditional creation of the SnakeYAML {@code Yaml} bean only when it is configured
+ * with meaningful parsing limits.
+ *
+ * <p>Used in combination with {@link org.springframework.context.annotation.Conditional} on a
+ * {@code @Bean} method.
+ *
+ * @see YamlParserProperties
+ */
+public class YamlParserPropertiesCondition extends SpringBootCondition {
+
+  @Override
+  public ConditionOutcome getMatchOutcome(
+      ConditionContext context, AnnotatedTypeMetadata metadata) {
+    String prefix = "spinnaker.yaml.";
+
+    Integer maxAliases =
+        context
+            .getEnvironment()
+            .getProperty(prefix + "max-aliases-for-collections", Integer.class, 0);
+    Integer codePointLimit =
+        context.getEnvironment().getProperty(prefix + "code-point-limit", Integer.class, 0);
+
+    boolean valid = (maxAliases > 0 || codePointLimit > 0);
+
+    if (valid) {
+      return ConditionOutcome.match("Valid values found in YamlParserProperties");
+    } else {
+      return ConditionOutcome.noMatch("YamlParserProperties values are not > 0");
+    }
+  }
+}

--- a/kork/kork-core/src/test/java/com/netflix/spinnaker/kork/yaml/YamlHelperInjectionTest.java
+++ b/kork/kork-core/src/test/java/com/netflix/spinnaker/kork/yaml/YamlHelperInjectionTest.java
@@ -1,0 +1,283 @@
+package com.netflix.spinnaker.kork.yaml;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.net.URL;
+import java.util.Map;
+import javax.script.ScriptEngineManager;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.TestPropertySource;
+import org.yaml.snakeyaml.constructor.ConstructorException;
+import org.yaml.snakeyaml.error.YAMLException;
+
+/**
+ * Security tests demonstrating YAML injection vulnerabilities.
+ *
+ * <p>These tests demonstrate potential injection attacks against YamlHelper, specifically showing
+ * how the regular Constructor allows arbitrary object instantiation which can lead to Remote Code
+ * Execution (RCE) vulnerabilities.
+ *
+ * <p>The tests compare the behavior of:
+ *
+ * <ul>
+ *   <li>{@code newYaml()} - Uses Constructor, vulnerable to arbitrary object instantiation
+ *   <li>{@code newYamlSafeConstructor()} - Uses SafeConstructor, blocks arbitrary object
+ *       instantiation
+ * </ul>
+ */
+@SpringBootTest(classes = YamlHelperInjectionTest.TestConfig.class)
+@TestPropertySource(
+    properties = {"snakeyaml.max-aliases-for-collections=50", "snakeyaml.code-point-limit=10000"})
+class YamlHelperInjectionTest {
+
+  /**
+   * Demonstrates arbitrary object instantiation attack using YAML tags.
+   *
+   * <p>This test shows that newYaml() allows instantiation of arbitrary Java classes using YAML
+   * tags (!!java.net.URL syntax). An attacker could use this to:
+   *
+   * <ul>
+   *   <li>Instantiate dangerous classes like ScriptEngineManager, URLClassLoader
+   *   <li>Trigger SSRF attacks by instantiating URL with attacker-controlled endpoints
+   *   <li>Execute arbitrary code through deserialization gadgets
+   * </ul>
+   *
+   * <p>This is a critical security vulnerability (CVE-2022-1471 class).
+   */
+  @Test
+  public void demonstratesArbitraryObjectInstantiationWithNewYaml() {
+    // YAML that instantiates a java.net.URL object
+    String maliciousYaml =
+        """
+            !!java.net.URL ["http://malicious.example.com/"]
+            """;
+
+    // newYaml() allows arbitrary object instantiation - VULNERABLE
+    Object result = YamlHelper.newYaml().load(maliciousYaml);
+
+    // Attacker successfully instantiated a URL object
+    assertThat(result).isInstanceOf(URL.class);
+    assertThat(result.toString()).isEqualTo("http://malicious.example.com/");
+  }
+
+  /**
+   * Demonstrates that SafeConstructor blocks arbitrary object instantiation.
+   *
+   * <p>This test shows that newYamlSafeConstructor() correctly prevents the same attack by
+   * rejecting YAML tags that attempt to instantiate arbitrary classes.
+   */
+  @Test
+  public void safeConstructorBlocksArbitraryObjectInstantiation() {
+    String maliciousYaml =
+        """
+            !!java.net.URL ["http://malicious.example.com/"]
+            """;
+
+    // newYamlSafeConstructor() blocks arbitrary object instantiation - SECURE
+    assertThatThrownBy(() -> YamlHelper.newYamlSafeConstructor().load(maliciousYaml))
+        .isInstanceOf(ConstructorException.class)
+        .hasMessageContaining(
+            "could not determine a constructor for the tag tag:yaml.org,2002:java.net.URL");
+  }
+
+  /**
+   * Demonstrates ScriptEngineManager instantiation attack.
+   *
+   * <p>ScriptEngineManager is a particularly dangerous class to instantiate from untrusted YAML
+   * because:
+   *
+   * <ul>
+   *   <li>Its constructor triggers service discovery via ServiceLoader
+   *   <li>This can lead to arbitrary code execution if attacker controls the classpath
+   *   <li>Part of common RCE gadget chains in Java deserialization attacks
+   * </ul>
+   */
+  @Test
+  public void demonstratesScriptEngineManagerInstantiation() {
+    String maliciousYaml = """
+            !!javax.script.ScriptEngineManager []
+            """;
+
+    // newYaml() allows instantiation of ScriptEngineManager - VULNERABLE
+    Object result = YamlHelper.newYaml().load(maliciousYaml);
+
+    assertThat(result).isInstanceOf(ScriptEngineManager.class);
+  }
+
+  /** Demonstrates that SafeConstructor blocks ScriptEngineManager instantiation. */
+  @Test
+  public void safeConstructorBlocksScriptEngineManagerInstantiation() {
+    String maliciousYaml = """
+            !!javax.script.ScriptEngineManager []
+            """;
+
+    // newYamlSafeConstructor() blocks ScriptEngineManager instantiation - SECURE
+    assertThatThrownBy(() -> YamlHelper.newYamlSafeConstructor().load(maliciousYaml))
+        .isInstanceOf(ConstructorException.class)
+        .hasMessageContaining(
+            "could not determine a constructor for the tag tag:yaml.org,2002:javax.script.ScriptEngineManager");
+  }
+
+  /**
+   * Demonstrates nested object instantiation attack.
+   *
+   * <p>Attackers can nest malicious object instantiation within seemingly innocent YAML structures
+   * to bypass simple pattern matching or WAF rules.
+   */
+  @Test
+  public void demonstratesNestedObjectInstantiationAttack() {
+    String maliciousYaml =
+        """
+            application:
+              name: myapp
+              config:
+                url: !!java.net.URL ["http://attacker.com/exfiltrate"]
+            """;
+
+    // newYaml() allows nested arbitrary objects - VULNERABLE
+    Object result = YamlHelper.newYaml().load(maliciousYaml);
+
+    assertThat(result).isInstanceOf(Map.class);
+    Map<?, ?> map = (Map<?, ?>) result;
+
+    // Extract nested malicious object
+    @SuppressWarnings("unchecked")
+    Map<String, Object> application = (Map<String, Object>) map.get("application");
+    @SuppressWarnings("unchecked")
+    Map<String, Object> config = (Map<String, Object>) application.get("config");
+    Object url = config.get("url");
+
+    // Attacker successfully instantiated URL deep in the structure
+    assertThat(url).isInstanceOf(URL.class);
+    assertThat(url.toString()).isEqualTo("http://attacker.com/exfiltrate");
+  }
+
+  /** Demonstrates that SafeConstructor blocks nested object instantiation. */
+  @Test
+  public void safeConstructorBlocksNestedObjectInstantiationAttack() {
+    String maliciousYaml =
+        """
+            application:
+              name: myapp
+              config:
+                url: !!java.net.URL ["http://attacker.com/exfiltrate"]
+            """;
+
+    // newYamlSafeConstructor() blocks nested arbitrary objects - SECURE
+    assertThatThrownBy(() -> YamlHelper.newYamlSafeConstructor().load(maliciousYaml))
+        .isInstanceOf(ConstructorException.class)
+        .hasMessageContaining(
+            "could not determine a constructor for the tag tag:yaml.org,2002:java.net.URL");
+  }
+
+  /**
+   * Demonstrates that newYamlDumperOptions also uses SafeConstructor and is secure.
+   *
+   * <p>Verifies that the security-enhanced methods consistently use SafeConstructor.
+   */
+  @Test
+  public void newYamlDumperOptionsBlocksArbitraryObjectInstantiation() {
+    String maliciousYaml =
+        """
+            !!java.net.URL ["http://malicious.example.com/"]
+            """;
+
+    // newYamlDumperOptions() uses SafeConstructor - SECURE
+    assertThatThrownBy(
+            () ->
+                YamlHelper.newYamlDumperOptions(new org.yaml.snakeyaml.DumperOptions())
+                    .load(maliciousYaml))
+        .isInstanceOf(ConstructorException.class)
+        .hasMessageContaining(
+            "could not determine a constructor for the tag tag:yaml.org,2002:java.net.URL");
+  }
+
+  /**
+   * Demonstrates YAML bomb (Billion Laughs) attack vector.
+   *
+   * <p>While YamlHelper does have alias limits, this test shows the attack pattern. A YAML bomb
+   * uses entity expansion to cause exponential memory consumption:
+   *
+   * <pre>
+   * a: &a ["lol","lol","lol","lol","lol","lol","lol","lol","lol"]
+   * b: &b [*a,*a,*a,*a,*a,*a,*a,*a,*a]
+   * c: &c [*b,*b,*b,*b,*b,*b,*b,*b,*b]
+   * </pre>
+   *
+   * <p>This creates 9^3 = 729 copies of the string "lol". With more levels, memory usage grows
+   * exponentially.
+   */
+  @Test
+  public void demonstratesYamlBombAttackIsBlocked() {
+    // Create a YAML bomb that exceeds the 50 alias limit configured in test properties
+    StringBuilder yamlBomb = new StringBuilder();
+    yamlBomb.append("a: &a [1,2,3,4,5]\n");
+
+    // Create 51 references to exceed the limit of 50
+    for (int i = 0; i < 51; i++) {
+      yamlBomb.append("b").append(i).append(": *a\n");
+    }
+
+    String bomb = yamlBomb.toString();
+
+    // Both methods should block this due to alias limits
+    assertThatThrownBy(() -> YamlHelper.newYaml().load(bomb))
+        .isInstanceOf(YAMLException.class)
+        .hasMessageContaining("Number of aliases for non-scalar nodes exceeds the specified max");
+
+    assertThatThrownBy(() -> YamlHelper.newYamlSafeConstructor().load(bomb))
+        .isInstanceOf(YAMLException.class)
+        .hasMessageContaining("Number of aliases for non-scalar nodes exceeds the specified max");
+  }
+
+  /**
+   * Demonstrates tag injection in map keys.
+   *
+   * <p>Attackers can use YAML tags in unexpected places like map keys to trigger object
+   * instantiation.
+   */
+  @Test
+  public void demonstratesTagInjectionInMapKeys() {
+    String maliciousYaml =
+        """
+            ? !!java.net.URL ["http://evil.com/"]
+            : value
+            """;
+
+    // newYaml() allows object instantiation in map keys - VULNERABLE
+    Object result = YamlHelper.newYaml().load(maliciousYaml);
+
+    assertThat(result).isInstanceOf(Map.class);
+    Map<?, ?> map = (Map<?, ?>) result;
+
+    // First key should be a URL object
+    Object firstKey = map.keySet().iterator().next();
+    assertThat(firstKey).isInstanceOf(URL.class);
+  }
+
+  /** Demonstrates that SafeConstructor blocks tag injection in map keys. */
+  @Test
+  public void safeConstructorBlocksTagInjectionInMapKeys() {
+    String maliciousYaml =
+        """
+            ? !!java.net.URL ["http://evil.com/"]
+            : value
+            """;
+
+    // newYamlSafeConstructor() blocks object instantiation in keys - SECURE
+    assertThatThrownBy(() -> YamlHelper.newYamlSafeConstructor().load(maliciousYaml))
+        .isInstanceOf(ConstructorException.class)
+        .hasMessageContaining(
+            "could not determine a constructor for the tag tag:yaml.org,2002:java.net.URL");
+  }
+
+  @Configuration
+  @EnableConfigurationProperties(YamlParserProperties.class)
+  @ComponentScan(basePackageClasses = YamlHelper.class)
+  static class TestConfig {}
+}

--- a/kork/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/engines/AbstractStorageSecretEngine.java
+++ b/kork/kork-secrets/src/main/java/com/netflix/spinnaker/kork/secrets/engines/AbstractStorageSecretEngine.java
@@ -21,6 +21,7 @@ import com.netflix.spinnaker.kork.secrets.EncryptedSecret;
 import com.netflix.spinnaker.kork.secrets.InvalidSecretFormatException;
 import com.netflix.spinnaker.kork.secrets.SecretDecryptionException;
 import com.netflix.spinnaker.kork.secrets.SecretEngine;
+import com.netflix.spinnaker.kork.yaml.YamlHelper;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -108,7 +109,7 @@ public abstract class AbstractStorageSecretEngine implements SecretEngine {
   }
 
   protected void parseAsYaml(String fileURI, InputStream inputStream) {
-    Map<String, Object> parsed = new Yaml().load(inputStream);
+    Map<String, Object> parsed = YamlHelper.newYamlSafeConstructor().load(inputStream);
     cache.put(fileURI, parsed);
   }
 

--- a/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/cloudformation/DeployCloudFormationTask.java
+++ b/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/cloudformation/DeployCloudFormationTask.java
@@ -39,6 +39,7 @@ import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.ResponseBody;
+import com.netflix.spinnaker.kork.yaml.YamlHelper;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -115,12 +116,14 @@ public class DeployCloudFormationTask implements CloudProviderAware, Task {
     Object templateBody = task.get("templateBody");
 
     if (templateBody instanceof Map && !((Map) templateBody).isEmpty()) {
-      templateBody = new Yaml().dump(templateBody);
+      templateBody = YamlHelper.newYamlSafeConstructor().dump(templateBody);
       task.put("templateBody", templateBody);
     } else if (templateBody instanceof List && !((List) templateBody).isEmpty()) {
       templateBody =
           ((List<?>) templateBody)
-              .stream().map(part -> new Yaml().dump(part)).collect(Collectors.joining("\n---\n"));
+              .stream()
+                  .map(part -> YamlHelper.newYamlSafeConstructor().dump(part))
+                  .collect(Collectors.joining("\n---\n"));
       task.put("templateBody", templateBody);
     }
 

--- a/rosco/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/cloudfoundry/CloudFoundryBakeManifestService.java
+++ b/rosco/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/cloudfoundry/CloudFoundryBakeManifestService.java
@@ -39,6 +39,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.lang.Nullable;
+import com.netflix.spinnaker.kork.yaml.YamlHelper;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.yaml.snakeyaml.Yaml;
@@ -67,7 +68,7 @@ public class CloudFoundryBakeManifestService
   public Artifact bake(CloudFoundryBakeManifestRequest bakeManifestRequest) throws IOException {
     String pattern = "\\(\\((!?[-/\\.\\w\\pL\\]\\[]+)\\)\\)";
 
-    Yaml yaml = new Yaml();
+    Yaml yaml = YamlHelper.newYamlSafeConstructor();
 
     String manifestTemplate =
         CharStreams.toString(


### PR DESCRIPTION
…(#7669) (backport to 2025.3.x)

This backport also includes YamlHelper, YamlParserProperties, and YamlParserPropertiesCondition which were not present in 2025.3.x.


