### PR TITLE
fix(echo): GitHub status conversion exception

### DIFF
--- a/echo/echo-notifications/src/main/java/com/netflix/spinnaker/echo/cdevents/CDEventsSenderClient.java
+++ b/echo/echo-notifications/src/main/java/com/netflix/spinnaker/echo/cdevents/CDEventsSenderClient.java
@@ -18,13 +18,12 @@ package com.netflix.spinnaker.echo.cdevents;
 
 import okhttp3.ResponseBody;
 import retrofit2.Call;
-import retrofit2.Response;
 import retrofit2.http.Body;
 import retrofit2.http.POST;
 import retrofit2.http.Path;
 
 public interface CDEventsSenderClient {
   @POST("{brokerUrl}")
-  Call<Response<ResponseBody>> sendCDEvent(
+  Call<ResponseBody> sendCDEvent(
       @Body String cdEvent, @Path(value = "brokerUrl", encoded = true) String brokerUrl);
 }

--- a/echo/echo-notifications/src/main/java/com/netflix/spinnaker/echo/cdevents/CDEventsSenderService.java
+++ b/echo/echo-notifications/src/main/java/com/netflix/spinnaker/echo/cdevents/CDEventsSenderService.java
@@ -59,7 +59,7 @@ public class CDEventsSenderService {
             .create(CDEventsSenderClient.class);
     String jsonEvent = converterFactory.convertCDEventToJson(cdEvent);
     log.info("Sending CDEvent Json {} ", jsonEvent);
-    return Retrofit2SyncCall.execute(
+    return Retrofit2SyncCall.executeCall(
         cdEventsSenderClient.sendCDEvent(jsonEvent, getRelativePath(eventsBrokerUrl)));
   }
 

--- a/echo/echo-notifications/src/main/java/com/netflix/spinnaker/echo/github/GithubService.java
+++ b/echo/echo-notifications/src/main/java/com/netflix/spinnaker/echo/github/GithubService.java
@@ -18,7 +18,6 @@ package com.netflix.spinnaker.echo.github;
 
 import okhttp3.ResponseBody;
 import retrofit2.Call;
-import retrofit2.Response;
 import retrofit2.http.Body;
 import retrofit2.http.GET;
 import retrofit2.http.Header;
@@ -27,7 +26,7 @@ import retrofit2.http.Path;
 
 public interface GithubService {
   @POST("repos/{repo}/statuses/{sha}")
-  Call<Response<ResponseBody>> updateCheck(
+  Call<ResponseBody> updateCheck(
       @Header("Authorization") String token,
       @Path(value = "repo", encoded = true) String repo,
       @Path("sha") String sha,


### PR DESCRIPTION
## Summary

Fix a Retrofit 2 migration bug in echo that causes `SpinnakerConversionException` when echo sends GitHub status checks, and the same issue for CDEvents responses.

After upgrading to Spinnaker 2026.1.0, echo can log errors like:

> Failed to send github status for application: '****' pipeline: '****', com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerConversionException: Failed to process response body: Cannot construct instance of `retrofit2.Response` ...

## Root cause

Two Retrofit service interfaces were migrated with the wrong return type:

- `GithubService.updateCheck(...)`
- `CDEventsSenderClient.sendCDEvent(...)`

Both were declared as `Call<Response<ResponseBody>>`, but in Retrofit 2 the generic parameter of `Call<T>` should be the actual response body type, not another `retrofit2.Response`.

This causes Jackson to try to deserialize the HTTP response into `retrofit2.Response<ResponseBody>`, which fails with `SpinnakerConversionException`.

## Changes

- Change `GithubService.updateCheck(...)` to return `Call<ResponseBody>`
- Change `CDEventsSenderClient.sendCDEvent(...)` to return `Call<ResponseBody>`
- Update `CDEventsSenderService` to use `Retrofit2SyncCall.executeCall(...)` so it still returns `Response<ResponseBody>` to callers

## Impact

- GitHub status updates no longer fail during response deserialization
- CDEvents response handling keeps the same caller contract
- The actual HTTP request behavior is unchanged

## Related

Fixes #7700.