### PR TITLE
fix(build): Defer publishing configuration until -bom subproject evaluation

### DIFF
--- a/spinnaker-gradle-project/spinnaker-project-plugin/src/main/groovy/com/netflix/spinnaker/gradle/publishing/nexus/NexusPublishPlugin.groovy
+++ b/spinnaker-gradle-project/spinnaker-project-plugin/src/main/groovy/com/netflix/spinnaker/gradle/publishing/nexus/NexusPublishPlugin.groovy
@@ -72,7 +72,7 @@ class NexusPublishPlugin implements Plugin<Project> {
       }
     }
 
-    project.afterEvaluate {
+    project.gradle.projectsEvaluated {
       // For some reason, the nexus plugin seems to only create one of these named tasks ever
       // As soon as the top-level task in Clouddriver is made, it won't ever define any more on other root projects
       // However, it will happily define all the subproject versions of publishToNexus, which we can collect here


### PR DESCRIPTION
The `project.afterEvaluate` hook is too early to define subproject publishing hooks, since the `java-platform` plugin has not been applied to subprojects yet - root project evaluation happens before any subproject evaluation.  Instead, hook `projectsEvaluated`.

Note the presence of the tasks `*-bom:publishToNexus` and `*-api:publishToNexus`, which is not present when this is evaluated on `main`.

This change:
<img width="813" height="222" alt="image" src="https://github.com/user-attachments/assets/b176c695-b772-4901-af99-e06031aef3ba" />

Main:
<img width="819" height="176" alt="image" src="https://github.com/user-attachments/assets/9ca4af8c-879b-48d8-8fca-a1cc8694e693" />
