### PR TITLE
fix(build): Use default resolution for javaPlatform

### DIFF
--- a/spinnaker-gradle-project/spinnaker-project-plugin/src/main/groovy/com/netflix/spinnaker/gradle/publishing/PublishingPlugin.groovy
+++ b/spinnaker-gradle-project/spinnaker-project-plugin/src/main/groovy/com/netflix/spinnaker/gradle/publishing/PublishingPlugin.groovy
@@ -57,7 +57,7 @@ class PublishingPlugin implements Plugin<Project> {
           // Use enforcedPlatform versions
           pub.versionMapping {
             it.usage("java-api") {
-              it.fromResolutionOf("runtimeClasspath")
+              it.fromResolutionResult()
             }
             it.usage("java-runtime") {
               it.fromResolutionResult()


### PR DESCRIPTION
Sample POM file generated for `orca-bom` with a supplied version of `1.2.3`:

```
<?xml version="1.0" encoding="UTF-8"?>
<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <modelVersion>4.0.0</modelVersion>
  <groupId>io.spinnaker.orca</groupId>
  <artifactId>orca-bom</artifactId>
  <version>1.2.3</version>
  <packaging>pom</packaging>
  <licenses>
    <license>
      <name>Apache License, Version 2.0</name>
      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
      <distribution>repo</distribution>
    </license>
  </licenses>
  <dependencyManagement>
    <dependencies>
      <dependency>
        <groupId>io.spinnaker.orca</groupId>
        <artifactId>keiko-core</artifactId>
        <version>1.2.3</version>
      </dependency>
      <dependency>
        <groupId>io.spinnaker.orca</groupId>
        <artifactId>keiko-mem</artifactId>
        <version>1.2.3</version>
      </dependency>
      <dependency>
        <groupId>io.spinnaker.orca</groupId>
        <artifactId>keiko-mem-spring</artifactId>
        <version>1.2.3</version>
      </dependency>
      <dependency>
        <groupId>io.spinnaker.orca</groupId>
        <artifactId>keiko-redis</artifactId>
        <version>1.2.3</version>
      </dependency>
      <dependency>
        <groupId>io.spinnaker.orca</groupId>
        <artifactId>keiko-redis-spring</artifactId>
        <version>1.2.3</version>
      </dependency>
      <dependency>
        <groupId>io.spinnaker.orca</groupId>
        <artifactId>keiko-spring</artifactId>
        <version>1.2.3</version>
      </dependency>
      <dependency>
        <groupId>io.spinnaker.orca</groupId>
        <artifactId>keiko-sql</artifactId>
        <version>1.2.3</version>
      </dependency>
      <dependency>
        <groupId>io.spinnaker.orca</groupId>
        <artifactId>keiko-tck</artifactId>
        <version>1.2.3</version>
      </dependency>
      <dependency>
        <groupId>io.spinnaker.orca</groupId>
        <artifactId>keiko-test-common</artifactId>
        <version>1.2.3</version>
      </dependency>
      <dependency>
        <groupId>io.spinnaker.orca</groupId>
        <artifactId>orca-api</artifactId>
        <version>1.2.3</version>
      </dependency>
      <dependency>
        <groupId>io.spinnaker.orca</groupId>
        <artifactId>orca-api-tck</artifactId>
        <version>1.2.3</version>
      </dependency>
      <dependency>
        <groupId>io.spinnaker.orca</groupId>
        <artifactId>orca-applications</artifactId>
        <version>1.2.3</version>
      </dependency>
      <dependency>
        <groupId>io.spinnaker.orca</groupId>
        <artifactId>orca-bakery</artifactId>
        <version>1.2.3</version>
      </dependency>
      <dependency>
        <groupId>io.spinnaker.orca</groupId>
        <artifactId>orca-clouddriver</artifactId>
        <version>1.2.3</version>
      </dependency>
      <dependency>
        <groupId>io.spinnaker.orca</groupId>
        <artifactId>orca-clouddriver-provider-titus</artifactId>
        <version>1.2.3</version>
      </dependency>
      <dependency>
        <groupId>io.spinnaker.orca</groupId>
        <artifactId>orca-core</artifactId>
        <version>1.2.3</version>
      </dependency>
      <dependency>
        <groupId>io.spinnaker.orca</groupId>
        <artifactId>orca-core-tck</artifactId>
        <version>1.2.3</version>
      </dependency>
      <dependency>
        <groupId>io.spinnaker.orca</groupId>
        <artifactId>orca-deploymentmonitor</artifactId>
        <version>1.2.3</version>
      </dependency>
      <dependency>
        <groupId>io.spinnaker.orca</groupId>
        <artifactId>orca-dry-run</artifactId>
        <version>1.2.3</version>
      </dependency>
      <dependency>
        <groupId>io.spinnaker.orca</groupId>
        <artifactId>orca-echo</artifactId>
        <version>1.2.3</version>
      </dependency>
      <dependency>
        <groupId>io.spinnaker.orca</groupId>
        <artifactId>orca-flex</artifactId>
        <version>1.2.3</version>
      </dependency>
      <dependency>
        <groupId>io.spinnaker.orca</groupId>
        <artifactId>orca-front50</artifactId>
        <version>1.2.3</version>
      </dependency>
      <dependency>
        <groupId>io.spinnaker.orca</groupId>
        <artifactId>orca-igor</artifactId>
        <version>1.2.3</version>
      </dependency>
      <dependency>
        <groupId>io.spinnaker.orca</groupId>
        <artifactId>orca-integration</artifactId>
        <version>1.2.3</version>
      </dependency>
      <dependency>
        <groupId>io.spinnaker.orca</groupId>
        <artifactId>orca-integrations-cloudfoundry</artifactId>
        <version>1.2.3</version>
      </dependency>
      <dependency>
        <groupId>io.spinnaker.orca</groupId>
        <artifactId>orca-integrations-gremlin</artifactId>
        <version>1.2.3</version>
      </dependency>
      <dependency>
        <groupId>io.spinnaker.orca</groupId>
        <artifactId>orca-interlink</artifactId>
        <version>1.2.3</version>
      </dependency>
      <dependency>
        <groupId>io.spinnaker.orca</groupId>
        <artifactId>orca-kayenta</artifactId>
        <version>1.2.3</version>
      </dependency>
      <dependency>
        <groupId>io.spinnaker.orca</groupId>
        <artifactId>orca-keel</artifactId>
        <version>1.2.3</version>
      </dependency>
      <dependency>
        <groupId>io.spinnaker.orca</groupId>
        <artifactId>orca-kotlin</artifactId>
        <version>1.2.3</version>
      </dependency>
      <dependency>
        <groupId>io.spinnaker.orca</groupId>
        <artifactId>orca-migration</artifactId>
        <version>1.2.3</version>
      </dependency>
      <dependency>
        <groupId>io.spinnaker.orca</groupId>
        <artifactId>orca-mine</artifactId>
        <version>1.2.3</version>
      </dependency>
      <dependency>
        <groupId>io.spinnaker.orca</groupId>
        <artifactId>orca-peering</artifactId>
        <version>1.2.3</version>
      </dependency>
      <dependency>
        <groupId>io.spinnaker.orca</groupId>
        <artifactId>orca-pipelinetemplate</artifactId>
        <version>1.2.3</version>
      </dependency>
      <dependency>
        <groupId>io.spinnaker.orca</groupId>
        <artifactId>orca-plugins-test</artifactId>
        <version>1.2.3</version>
      </dependency>
      <dependency>
        <groupId>io.spinnaker.orca</groupId>
        <artifactId>orca-qos</artifactId>
        <version>1.2.3</version>
      </dependency>
      <dependency>
        <groupId>io.spinnaker.orca</groupId>
        <artifactId>orca-queue</artifactId>
        <version>1.2.3</version>
      </dependency>
      <dependency>
        <groupId>io.spinnaker.orca</groupId>
        <artifactId>orca-queue-redis</artifactId>
        <version>1.2.3</version>
      </dependency>
      <dependency>
        <groupId>io.spinnaker.orca</groupId>
        <artifactId>orca-queue-sql</artifactId>
        <version>1.2.3</version>
      </dependency>
      <dependency>
        <groupId>io.spinnaker.orca</groupId>
        <artifactId>orca-queue-tck</artifactId>
        <version>1.2.3</version>
      </dependency>
      <dependency>
        <groupId>io.spinnaker.orca</groupId>
        <artifactId>orca-redis</artifactId>
        <version>1.2.3</version>
      </dependency>
      <dependency>
        <groupId>io.spinnaker.orca</groupId>
        <artifactId>orca-remote-stage</artifactId>
        <version>1.2.3</version>
      </dependency>
      <dependency>
        <groupId>io.spinnaker.orca</groupId>
        <artifactId>orca-retrofit</artifactId>
        <version>1.2.3</version>
      </dependency>
      <dependency>
        <groupId>io.spinnaker.orca</groupId>
        <artifactId>orca-sql</artifactId>
        <version>1.2.3</version>
      </dependency>
      <dependency>
        <groupId>io.spinnaker.orca</groupId>
        <artifactId>orca-sql-mysql</artifactId>
        <version>1.2.3</version>
      </dependency>
      <dependency>
        <groupId>io.spinnaker.orca</groupId>
        <artifactId>orca-sql-postgres</artifactId>
        <version>1.2.3</version>
      </dependency>
      <dependency>
        <groupId>io.spinnaker.orca</groupId>
        <artifactId>orca-test</artifactId>
        <version>1.2.3</version>
      </dependency>
      <dependency>
        <groupId>io.spinnaker.orca</groupId>
        <artifactId>orca-test-groovy</artifactId>
        <version>1.2.3</version>
      </dependency>
      <dependency>
        <groupId>io.spinnaker.orca</groupId>
        <artifactId>orca-test-kotlin</artifactId>
        <version>1.2.3</version>
      </dependency>
      <dependency>
        <groupId>io.spinnaker.orca</groupId>
        <artifactId>orca-test-redis</artifactId>
        <version>1.2.3</version>
      </dependency>
      <dependency>
        <groupId>io.spinnaker.orca</groupId>
        <artifactId>orca-validation</artifactId>
        <version>1.2.3</version>
      </dependency>
      <dependency>
        <groupId>io.spinnaker.orca</groupId>
        <artifactId>orca-web</artifactId>
        <version>1.2.3</version>
      </dependency>
      <dependency>
        <groupId>io.spinnaker.orca</groupId>
        <artifactId>orca-webhook</artifactId>
        <version>1.2.3</version>
      </dependency>
      <dependency>
        <groupId>io.spinnaker.kork</groupId>
        <artifactId>kork-bom</artifactId>
        <version>1.2.3</version>
        <type>pom</type>
        <scope>import</scope>
      </dependency>
    </dependencies>
  </dependencyManagement>
</project>
```