### PR TITLE
fix(build): Close Nexus staging repo in a later GHA step

### DIFF
--- a/.github/workflows/spinnaker-libraries.yml
+++ b/.github/workflows/spinnaker-libraries.yml
@@ -61,4 +61,15 @@ jobs:
           ORG_GRADLE_PROJECT_nexusPgpSigningKey: ${{ secrets.NEXUS_PGP_SIGNING_KEY }}
           ORG_GRADLE_PROJECT_nexusPgpSigningPassword: ${{ secrets.NEXUS_PGP_SIGNING_PASSWORD }}
         run: |
-          ./gradlew assemble publishToNexus closeAndReleaseNexusStagingRepository
+          ./gradlew assemble publishToNexus
+
+      - name: Close and release Nexus staging repository
+        env:
+          ORG_GRADLE_PROJECT_version: ${{ steps.version.outputs.version }}
+          ORG_GRADLE_PROJECT_nexusPublishEnabled: true
+          ORG_GRADLE_PROJECT_nexusUsername: ${{ secrets.NEXUS_USERNAME }}
+          ORG_GRADLE_PROJECT_nexusPassword: ${{ secrets.NEXUS_PASSWORD }}
+          ORG_GRADLE_PROJECT_nexusPgpSigningKey: ${{ secrets.NEXUS_PGP_SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_nexusPgpSigningPassword: ${{ secrets.NEXUS_PGP_SIGNING_PASSWORD }}
+        run: |
+          ./gradlew closeAndReleaseNexusStagingRepository


### PR DESCRIPTION
Try to dodge staging repository failures by allowing all publishes to complete before any staging repositories are closed.