### PR TITLE
fix(build): Support find Nexus staging repository task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,12 @@ tasks.register('publishToNexus') { task ->
   }
 }
 
+tasks.register('findNexusStagingRepository') { task ->
+  mainProjects.each { build ->
+    task.dependsOn build.task(':findNexusStagingRepository')
+  }
+}
+
 tasks.register('closeAndReleaseNexusStagingRepository') { task ->
   mainProjects.each { build ->
     task.dependsOn build.task(':closeAndReleaseNexusStagingRepository')

--- a/spinnaker-gradle-project/spinnaker-project-plugin/src/main/groovy/com/netflix/spinnaker/gradle/publishing/nexus/NexusPublishPlugin.groovy
+++ b/spinnaker-gradle-project/spinnaker-project-plugin/src/main/groovy/com/netflix/spinnaker/gradle/publishing/nexus/NexusPublishPlugin.groovy
@@ -80,12 +80,20 @@ class NexusPublishPlugin implements Plugin<Project> {
         project.tasks.register("publishToNexus")
       }
 
+      if(project.tasks.findByName("findNexusStagingRepository") == null) {
+        project.tasks.register("findNexusStagingRepository")
+      }
+
       if(project.tasks.findByName("closeAndReleaseNexusStagingRepository") == null) {
         project.tasks.register("closeAndReleaseNexusStagingRepository")
       }
 
       project.tasks.named("publishToNexus") {
         it.dependsOn project.subprojects*.tasks*.findByName('publishToNexus').minus(null)
+      }
+
+      project.tasks.named("findNexusStagingRepository") {
+        it.dependsOn project.subprojects*.tasks*.findByName('findNexusStagingRepository').minus(null)
       }
 
       project.tasks.named("closeAndReleaseNexusStagingRepository") {


### PR DESCRIPTION
Missed a part of having `closeAndRelease` in a separate step - apparently it needs to be explicitly re-found in the new Gradle context.