### PR TITLE
fix(jooq): jOOQ 3.19.35 (Spring Boot 3.5.x) generates invalid MySQL syntax

### DIFF
--- a/clouddriver/cats/cats-sql/src/main/kotlin/com/netflix/spinnaker/cats/sql/cache/SqlCache.kt
+++ b/clouddriver/cats/cats-sql/src/main/kotlin/com/netflix/spinnaker/cats/sql/cache/SqlCache.kt
@@ -44,7 +44,6 @@ import org.jooq.impl.DSL.field
 import org.jooq.impl.DSL.noCondition
 import org.jooq.impl.DSL.sql
 import org.jooq.impl.DSL.table
-import org.jooq.util.mysql.MySQLDSL
 import org.slf4j.LoggerFactory
 import org.springframework.jdbc.BadSqlGrammarException
 
@@ -610,29 +609,49 @@ class SqlCache(
           field("last_updated")
         )
 
-        insert.apply {
-          chunk.forEach {
-            values(it, sqlNames.checkAgentName(agent), apps[it], hashes[it], bodies[it], now)
-            when (jooq.dialect()) {
-              SQLDialect.POSTGRES ->
-                onConflict(field("id"), field("agent"))
-                  .doUpdate()
-                  .set(field("application"), SqlUtil.excluded(field("application")) as Any)
-                  .set(field("body_hash"), SqlUtil.excluded(field("body_hash")) as Any)
-                  .set(field("body"), SqlUtil.excluded(field("body")) as Any)
-                  .set(field("last_updated"), SqlUtil.excluded(field("last_updated")) as Any)
-              else ->
-                onDuplicateKeyUpdate()
-                  .set(field("application"), MySQLDSL.values(field("application")) as Any)
-                  .set(field("body_hash"), MySQLDSL.values(field("body_hash")) as Any)
-                  .set(field("body"), MySQLDSL.values(field("body")) as Any)
-                  .set(field("last_updated"), MySQLDSL.values(field("last_updated")) as Any)
+        when (jooq.dialect()) {
+          SQLDialect.POSTGRES -> {
+            insert.apply {
+              chunk.forEach {
+                values(it, sqlNames.checkAgentName(agent), apps[it], hashes[it], bodies[it], now)
+              }
+              onConflict(field("id"), field("agent"))
+                .doUpdate()
+                .set(field("application"), SqlUtil.excluded(field("application")) as Any)
+                .set(field("body_hash"), SqlUtil.excluded(field("body_hash")) as Any)
+                .set(field("body"), SqlUtil.excluded(field("body")) as Any)
+                .set(field("last_updated"), SqlUtil.excluded(field("last_updated")) as Any)
+            }
+            withRetry(RetryCategory.WRITE) {
+              insert.execute()
             }
           }
-        }
-
-        withRetry(RetryCategory.WRITE) {
-          insert.execute()
+          else -> {
+            // jOOQ 3.19.x renders invalid MySQL syntax for SQLDialect.MYSQL when
+            // onDuplicateKeyUpdate() is chained after values(). It emits the
+            // PostgreSQL-style "as excluded" row alias together with the deprecated
+            // values(col) function, which MySQL rejects, e.g.:
+            //   insert into t (...) values (...) as excluded
+            //   on duplicate key update col = values(col)
+            // Use raw SQL for the MySQL path instead.
+            val tableName = sqlNames.resourceTableName(type)
+            val valuesPlaceholders = chunk.joinToString(", ") { "(?, ?, ?, ?, ?, ?)" }
+            val params = chunk.flatMap {
+              listOf(it, sqlNames.checkAgentName(agent), apps[it], hashes[it], bodies[it], now)
+            }.toTypedArray()
+            val sql = """
+              |INSERT INTO $tableName (id, agent, application, body_hash, body, last_updated)
+              |VALUES $valuesPlaceholders
+              |ON DUPLICATE KEY UPDATE
+              |application = VALUES(application),
+              |body_hash = VALUES(body_hash),
+              |body = VALUES(body),
+              |last_updated = VALUES(last_updated)
+            """.trimMargin()
+            withRetry(RetryCategory.WRITE) {
+              jooq.execute(sql, *params)
+            }
+          }
         }
         result.itemsStored.addAndGet(chunk.size)
         result.writeQueries.incrementAndGet()

--- a/clouddriver/cats/cats-sql/src/test/kotlin/com/netflix/spinnaker/cats/sql/cache/SqlCacheBatchInsertTest.kt
+++ b/clouddriver/cats/cats-sql/src/test/kotlin/com/netflix/spinnaker/cats/sql/cache/SqlCacheBatchInsertTest.kt
@@ -1,0 +1,90 @@
+package com.netflix.spinnaker.cats.sql.cache
+
+import org.assertj.core.api.Assertions.assertThat
+import org.jooq.SQLDialect
+import org.jooq.conf.ParamType
+import org.jooq.impl.DSL
+import org.jooq.util.mysql.MySQLDSL
+import org.junit.jupiter.api.Test
+
+/**
+ * Regression test for jOOQ 3.19+ MySQL `ON DUPLICATE KEY UPDATE` rendering bug.
+ *
+ * jOOQ 3.19 (via Spring Boot 3.5.x) generates invalid MySQL syntax when using
+ * [InsertValuesStep.onDuplicateKeyUpdate] — it emits PostgreSQL-specific
+ * `AS excluded` even when the configured dialect is MySQL:
+ *
+ * ```sql
+ * insert into t (...) values (...) as excluded
+ * on duplicate key update ...
+ * ```
+ *
+ * MySQL rejects this syntax with `BadSqlGrammarException`.
+ *
+ * The production fix (in SqlCache.putCacheResult) bypasses jOOQ's DSL for the
+ * MySQL path and uses raw SQL instead, while keeping the PostgreSQL
+ * `onConflict()` DSL path unchanged.
+ */
+class SqlCacheBatchInsertTest {
+
+  @Test
+  fun `jOOQ 3_19 onDuplicateKeyUpdate generates invalid as excluded for MySQL dialect`() {
+    val ctx = DSL.using(SQLDialect.MYSQL)
+    val insert = ctx.insertInto(
+      DSL.table("cats_v1_test"),
+      DSL.field("id"),
+      DSL.field("agent"),
+      DSL.field("application"),
+      DSL.field("body_hash"),
+      DSL.field("body"),
+      DSL.field("last_updated")
+    )
+
+    insert.values("id-1", "agent", "app", "hash", "body", 1L)
+    insert.onDuplicateKeyUpdate()
+      .set(DSL.field("application"), MySQLDSL.values(DSL.field("application")) as Any)
+      .set(DSL.field("body_hash"), MySQLDSL.values(DSL.field("body_hash")) as Any)
+      .set(DSL.field("body"), MySQLDSL.values(DSL.field("body")) as Any)
+      .set(DSL.field("last_updated"), MySQLDSL.values(DSL.field("last_updated")) as Any)
+
+    val sql = insert.getSQL(ParamType.INLINED)
+
+    // This assertion documents the jOOQ bug that the production code works around.
+    assertThat(sql.lowercase())
+      .`as`("jOOQ 3.19 generates 'as excluded' even for MySQL dialect")
+      .contains("as excluded")
+  }
+
+  @Test
+  fun `raw SQL upsert does not contain invalid as excluded syntax`() {
+    val tableName = "cats_v1_test"
+    val chunk = listOf("id-1", "id-2")
+    val valuesPlaceholders = chunk.joinToString(", ") { "(?, ?, ?, ?, ?, ?)" }
+    val params = chunk.flatMap {
+      listOf(it, "agent", "app", "hash", "body", 1L)
+    }.toTypedArray()
+
+    val sql = """
+      |INSERT INTO $tableName (id, agent, application, body_hash, body, last_updated)
+      |VALUES $valuesPlaceholders
+      |ON DUPLICATE KEY UPDATE
+      |application = VALUES(application),
+      |body_hash = VALUES(body_hash),
+      |body = VALUES(body),
+      |last_updated = VALUES(last_updated)
+    """.trimMargin()
+
+    assertThat(sql.lowercase())
+      .`as`("Raw SQL must not contain PostgreSQL 'as excluded' syntax")
+      .doesNotContain("as excluded")
+
+    assertThat(sql.lowercase())
+      .`as`("Raw SQL must contain ON DUPLICATE KEY UPDATE")
+      .contains("on duplicate key update")
+
+    // Verify params match the number of placeholders
+    assertThat(params.size)
+      .`as`("Params count matches placeholders")
+      .isEqualTo(chunk.size * 6)
+  }
+}

--- a/fiat/fiat-sql/src/main/kotlin/com/netflix/spinnaker/fiat/permissions/SqlPermissionsRepository.kt
+++ b/fiat/fiat-sql/src/main/kotlin/com/netflix/spinnaker/fiat/permissions/SqlPermissionsRepository.kt
@@ -40,7 +40,6 @@ import org.jooq.exception.DataAccessException
 import org.jooq.exception.SQLDialectNotSupportedException
 import org.jooq.impl.DSL.field
 import org.jooq.impl.SQLDataType
-import org.jooq.util.mysql.MySQLDSL
 import org.slf4j.LoggerFactory
 import java.time.Clock
 import java.time.Duration
@@ -224,28 +223,38 @@ class SqlPermissionsRepository(
     }
 
     private fun putUserPermission(permission: UserPermission) {
-        val insert = jooq.insertInto(USER, USER.ID, USER.ADMIN, USER.ACCOUNT_MANAGER, USER.UPDATED_AT)
-
-        insert.apply {
-            values(permission.id, permission.isAdmin, permission.isAccountManager, clock.millis())
-            // https://github.com/jOOQ/jOOQ/issues/5975 means we have to duplicate field names here
-            when (jooq.dialect()) {
-                SQLDialect.POSTGRES ->
-                    onConflict(USER.ID)
-                        .doUpdate()
-                        .set(USER.ADMIN, SqlUtil.excluded(field("admin", SQLDataType.BOOLEAN)))
-                        .set(USER.ACCOUNT_MANAGER, SqlUtil.excluded(field("account_manager", SQLDataType.BOOLEAN)))
-                        .set(USER.UPDATED_AT, SqlUtil.excluded(field("updated_at", SQLDataType.BIGINT)))
-                else ->
-                    onDuplicateKeyUpdate()
-                        .set(USER.ADMIN, MySQLDSL.values(field("admin", SQLDataType.BOOLEAN)))
-                        .set(USER.ACCOUNT_MANAGER, MySQLDSL.values(field("account_manager", SQLDataType.BOOLEAN)))
-                        .set(USER.UPDATED_AT, MySQLDSL.values(field("updated_at", SQLDataType.BIGINT)))
+        when (jooq.dialect()) {
+            SQLDialect.POSTGRES -> {
+                val insert = jooq.insertInto(USER, USER.ID, USER.ADMIN, USER.ACCOUNT_MANAGER, USER.UPDATED_AT)
+                insert.values(permission.id, permission.isAdmin, permission.isAccountManager, clock.millis())
+                insert.onConflict(USER.ID)
+                    .doUpdate()
+                    .set(USER.ADMIN, SqlUtil.excluded(field("admin", SQLDataType.BOOLEAN)))
+                    .set(USER.ACCOUNT_MANAGER, SqlUtil.excluded(field("account_manager", SQLDataType.BOOLEAN)))
+                    .set(USER.UPDATED_AT, SqlUtil.excluded(field("updated_at", SQLDataType.BIGINT)))
+                withRetry(RetryCategory.WRITE) {
+                    insert.execute()
+                }
             }
-        }
-
-        withRetry(RetryCategory.WRITE) {
-            insert.execute()
+            else -> {
+                // jOOQ 3.19.x renders invalid MySQL syntax for SQLDialect.MYSQL when
+                // onDuplicateKeyUpdate() is chained after values(): it emits the
+                // PostgreSQL-style "as excluded" row alias together with the deprecated
+                // values(col) function, which MySQL rejects. Use raw SQL instead.
+                jooq.execute(
+                    """INSERT INTO ${jooq.render(USER)} (${jooq.render(USER.ID)}, ${jooq.render(USER.ADMIN)}, ${jooq.render(USER.ACCOUNT_MANAGER)}, ${jooq.render(USER.UPDATED_AT)})
+                        |VALUES (?, ?, ?, ?)
+                        |ON DUPLICATE KEY UPDATE
+                        |${jooq.render(USER.ADMIN)} = VALUES(${jooq.render(USER.ADMIN)}),
+                        |${jooq.render(USER.ACCOUNT_MANAGER)} = VALUES(${jooq.render(USER.ACCOUNT_MANAGER)}),
+                        |${jooq.render(USER.UPDATED_AT)} = VALUES(${jooq.render(USER.UPDATED_AT)})
+                    """.trimMargin(),
+                    permission.id,
+                    permission.isAdmin,
+                    permission.isAccountManager,
+                    clock.millis()
+                )
+            }
         }
 
         putUserPermissions(permission.id, permission.allResources)
@@ -379,37 +388,50 @@ class SqlPermissionsRepository(
             )
         ) { chunk ->
             try {
-                val insert = jooq.insertInto(
-                    RESOURCE,
-                    RESOURCE.RESOURCE_TYPE,
-                    RESOURCE.RESOURCE_NAME,
-                    RESOURCE.BODY,
-                    RESOURCE.BODY_HASH,
-                    RESOURCE.UPDATED_AT
-                )
-
-                insert.apply {
-                    chunk.forEach {
-                        values(it.type, it.name.toLowerCase(), bodies[it], hashes[it], now)
-                        when (jooq.dialect()) {
-                            // https://github.com/jOOQ/jOOQ/issues/5975 means we have to duplicate field names here
-                            SQLDialect.POSTGRES ->
-                                onConflict(RESOURCE.RESOURCE_TYPE, RESOURCE.RESOURCE_NAME)
-                                    .doUpdate()
-                                    .set(RESOURCE.BODY, SqlUtil.excluded(field("body", SQLDataType.LONGVARCHAR)))
-                                    .set(RESOURCE.BODY_HASH, SqlUtil.excluded(field("body_hash", SQLDataType.VARCHAR)))
-                                    .set(RESOURCE.UPDATED_AT, SqlUtil.excluded(field("updated_at", SQLDataType.BIGINT)))
-                            else ->
-                                onDuplicateKeyUpdate()
-                                    .set(RESOURCE.BODY, MySQLDSL.values(field("body", SQLDataType.LONGVARCHAR)))
-                                    .set(RESOURCE.BODY_HASH, MySQLDSL.values(field("body_hash", SQLDataType.VARCHAR)))
-                                    .set(RESOURCE.UPDATED_AT, MySQLDSL.values(field("updated_at", SQLDataType.BIGINT)))
+                when (jooq.dialect()) {
+                    SQLDialect.POSTGRES -> {
+                        val insert = jooq.insertInto(
+                            RESOURCE,
+                            RESOURCE.RESOURCE_TYPE,
+                            RESOURCE.RESOURCE_NAME,
+                            RESOURCE.BODY,
+                            RESOURCE.BODY_HASH,
+                            RESOURCE.UPDATED_AT
+                        )
+                        insert.apply {
+                            chunk.forEach {
+                                values(it.type, it.name.toLowerCase(), bodies[it], hashes[it], now)
+                            }
+                            onConflict(RESOURCE.RESOURCE_TYPE, RESOURCE.RESOURCE_NAME)
+                                .doUpdate()
+                                .set(RESOURCE.BODY, SqlUtil.excluded(field("body", SQLDataType.LONGVARCHAR)))
+                                .set(RESOURCE.BODY_HASH, SqlUtil.excluded(field("body_hash", SQLDataType.VARCHAR)))
+                                .set(RESOURCE.UPDATED_AT, SqlUtil.excluded(field("updated_at", SQLDataType.BIGINT)))
+                        }
+                        withRetry(RetryCategory.WRITE) {
+                            insert.execute()
                         }
                     }
-                }
-
-                withRetry(RetryCategory.WRITE) {
-                    insert.execute()
+                    else -> {
+                        // jOOQ 3.19.x renders invalid MySQL syntax for SQLDialect.MYSQL when
+                        // onDuplicateKeyUpdate() is chained after values(): it emits the
+                        // PostgreSQL-style "as excluded" row alias together with the deprecated
+                        // values(col) function, which MySQL rejects. Use raw SQL instead.
+                        val placeholders = chunk.joinToString(", ") { "(?, ?, ?, ?, ?)" }
+                        val params = chunk.flatMap {
+                            listOf(it.type, it.name.toLowerCase(), bodies[it], hashes[it], now)
+                        }.toTypedArray()
+                        jooq.execute(
+                            """INSERT INTO ${jooq.render(RESOURCE)} (${jooq.render(RESOURCE.RESOURCE_TYPE)}, ${jooq.render(RESOURCE.RESOURCE_NAME)}, ${jooq.render(RESOURCE.BODY)}, ${jooq.render(RESOURCE.BODY_HASH)}, ${jooq.render(RESOURCE.UPDATED_AT)})
+                                |VALUES $placeholders
+                                |ON DUPLICATE KEY UPDATE
+                                |${jooq.render(RESOURCE.BODY)} = VALUES(${jooq.render(RESOURCE.BODY)}),
+                                |${jooq.render(RESOURCE.BODY_HASH)} = VALUES(${jooq.render(RESOURCE.BODY_HASH)}),
+                                |${jooq.render(RESOURCE.UPDATED_AT)} = VALUES(${jooq.render(RESOURCE.UPDATED_AT)})
+                            """.trimMargin(),
+                            *params
+                        )
+                    }
                 }
             } catch (e: DataAccessException) {
                 log.error("Error inserting ids: $chunk", e)

--- a/fiat/fiat-sql/src/test/kotlin/com/netflix/spinnaker/fiat/permissions/SqlPermissionsRepositoryMySqlTest.kt
+++ b/fiat/fiat-sql/src/test/kotlin/com/netflix/spinnaker/fiat/permissions/SqlPermissionsRepositoryMySqlTest.kt
@@ -1,0 +1,83 @@
+package com.netflix.spinnaker.fiat.permissions
+
+import org.assertj.core.api.Assertions.assertThat
+import org.jooq.SQLDialect
+import org.jooq.conf.ParamType
+import org.jooq.impl.DSL
+import org.junit.jupiter.api.Test
+
+/**
+ * Regression tests for jOOQ 3.19+ MySQL `ON DUPLICATE KEY UPDATE` rendering bug.
+ *
+ * jOOQ 3.19 (via Spring Boot 3.5.x) generates invalid MySQL syntax when using
+ * [InsertValuesStep.onDuplicateKeyUpdate] — it emits PostgreSQL-specific
+ * `AS excluded` even when the configured dialect is MySQL.
+ */
+class SqlPermissionsRepositoryMySqlTest {
+
+  @Test
+  fun `jOOQ 3_19 onDuplicateKeyUpdate generates invalid as excluded for MySQL dialect`() {
+    val ctx = DSL.using(SQLDialect.MYSQL)
+    val insert = ctx.insertInto(
+      DSL.table("user"),
+      DSL.field("id"),
+      DSL.field("admin"),
+      DSL.field("account_manager"),
+      DSL.field("updated_at")
+    )
+
+    insert.values("test", true, false, 1L)
+    insert.onDuplicateKeyUpdate()
+      .set(DSL.field("admin"), DSL.field("admin") as Any)
+      .set(DSL.field("account_manager"), DSL.field("account_manager") as Any)
+      .set(DSL.field("updated_at"), DSL.field("updated_at") as Any)
+
+    val sql = insert.getSQL(ParamType.INLINED)
+
+    assertThat(sql.lowercase())
+      .`as`("jOOQ 3.19 generates 'as excluded' even for MySQL dialect")
+      .contains("as excluded")
+  }
+
+  @Test
+  fun `raw SQL upsert for user does not contain as excluded`() {
+    val sql = """
+      |INSERT INTO user (id, admin, account_manager, updated_at)
+      |VALUES (?, ?, ?, ?)
+      |ON DUPLICATE KEY UPDATE
+      |admin = VALUES(admin),
+      |account_manager = VALUES(account_manager),
+      |updated_at = VALUES(updated_at)
+    """.trimMargin()
+
+    assertThat(sql.lowercase())
+      .`as`("Raw SQL must not contain PostgreSQL 'as excluded' syntax")
+      .doesNotContain("as excluded")
+
+    assertThat(sql.lowercase())
+      .`as`("Raw SQL must contain ON DUPLICATE KEY UPDATE")
+      .contains("on duplicate key update")
+  }
+
+  @Test
+  fun `raw SQL upsert for resource batch does not contain as excluded`() {
+    val chunk = listOf("res1", "res2")
+    val placeholders = chunk.joinToString(", ") { "(?, ?, ?, ?, ?)" }
+    val sql = """
+      |INSERT INTO resource (resource_type, resource_name, body, body_hash, updated_at)
+      |VALUES $placeholders
+      |ON DUPLICATE KEY UPDATE
+      |body = VALUES(body),
+      |body_hash = VALUES(body_hash),
+      |updated_at = VALUES(updated_at)
+    """.trimMargin()
+
+    assertThat(sql.lowercase())
+      .`as`("Raw SQL must not contain PostgreSQL 'as excluded' syntax")
+      .doesNotContain("as excluded")
+
+    assertThat(sql.lowercase())
+      .`as`("Raw SQL must contain ON DUPLICATE KEY UPDATE")
+      .contains("on duplicate key update")
+  }
+}

--- a/orca/orca-peering/src/main/kotlin/com/netflix/spinnaker/orca/peering/MySqlRawAccess.kt
+++ b/orca/orca-peering/src/main/kotlin/com/netflix/spinnaker/orca/peering/MySqlRawAccess.kt
@@ -161,20 +161,17 @@ open class MySqlRawAccess(
     }
 
     val allFields = records[0].fields().toList()
+    val columns = allFields.joinToString(", ") { jooq.render(it) }
+    val rowPlaceholder = "(${allFields.joinToString(", ") { "?" }})"
+    val updateClause = allFields.joinToString(", ") { "${jooq.render(it)} = VALUES(${jooq.render(it)})" }
     var persisted = 0
 
     withPool(poolName) {
-      val updateSet = allFields.map {
-        it to field("VALUES({0})", it.dataType, it)
-      }.toMap()
-
       var cumulativeSize = 0
-      var batchQuery = jooq
-        .insertInto(table(tableName))
-        .columns(allFields)
+      val currentBatch = mutableListOf<List<Any?>>()
 
-      records.forEach { it ->
-        val values = it.intoList()
+      records.forEach { record ->
+        val values = record.intoList()
         val totalRecordSize = (3 * values.size) + values.sumBy { value -> (value?.toString()?.length ?: 4) }
 
         if (cumulativeSize + totalRecordSize > maxPacketSize) {
@@ -182,31 +179,36 @@ open class MySqlRawAccess(
             throw SystemException("Can't persist a single row for table $tableName due to maxPacketSize restriction. Row size = $totalRecordSize")
           }
 
-          // Dump it to the DB
-          persisted += batchQuery
-            .onDuplicateKeyUpdate()
-            .set(updateSet)
-            .execute()
+          // Dump current batch
+          val placeholders = currentBatch.joinToString(", ") { rowPlaceholder }
+          val sql = """
+            |INSERT INTO $tableName ($columns)
+            |VALUES $placeholders
+            |ON DUPLICATE KEY UPDATE
+            |$updateClause
+          """.trimMargin()
+          val params = currentBatch.flatten().toTypedArray()
+          persisted += jooq.execute(sql, *params)
 
-          batchQuery = jooq
-            .insertInto(table(tableName))
-            .columns(allFields)
-            .values(values)
+          currentBatch.clear()
           cumulativeSize = 0
-        } else {
-          batchQuery = batchQuery
-            .values(values)
         }
 
+        currentBatch.add(values)
         cumulativeSize += totalRecordSize
       }
 
-      if (cumulativeSize > 0) {
+      if (currentBatch.isNotEmpty()) {
         // Dump the last bit to the DB
-        persisted += batchQuery
-          .onDuplicateKeyUpdate()
-          .set(updateSet)
-          .execute()
+        val placeholders = currentBatch.joinToString(", ") { rowPlaceholder }
+        val sql = """
+          |INSERT INTO $tableName ($columns)
+          |VALUES $placeholders
+          |ON DUPLICATE KEY UPDATE
+          |$updateClause
+        """.trimMargin()
+        val params = currentBatch.flatten().toTypedArray()
+        persisted += jooq.execute(sql, *params)
       }
     }
 

--- a/orca/orca-peering/src/test/kotlin/com/netflix/spinnaker/orca/peering/MySqlRawAccessTest.kt
+++ b/orca/orca-peering/src/test/kotlin/com/netflix/spinnaker/orca/peering/MySqlRawAccessTest.kt
@@ -1,0 +1,46 @@
+package com.netflix.spinnaker.orca.peering
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Regression tests for jOOQ 3.19+ MySQL `ON DUPLICATE KEY UPDATE` rendering bug.
+ *
+ * jOOQ 3.19 (via Spring Boot 3.5.x) generates invalid MySQL syntax when using
+ * [InsertValuesStep.onDuplicateKeyUpdate] — it emits PostgreSQL-specific
+ * `AS excluded` even when the configured dialect is MySQL.
+ */
+class MySqlRawAccessTest {
+
+  @Test
+  fun `raw SQL batch upsert does not contain as excluded`() {
+    val tableName = "pipelines"
+    val allFields = listOf("id", "body", "status")
+    val columns = allFields.joinToString(", ")
+    val batch = listOf(
+      listOf("id1", "body1", "status1"),
+      listOf("id2", "body2", "status2")
+    )
+    val placeholders = batch.joinToString(", ") {
+      "(${allFields.joinToString(", ") { "?" }})"
+    }
+    val updateClause = allFields.joinToString(", ") {
+      "$it = VALUES($it)"
+    }
+
+    val sql = """
+      |INSERT INTO $tableName ($columns)
+      |VALUES $placeholders
+      |ON DUPLICATE KEY UPDATE
+      |$updateClause
+    """.trimMargin()
+
+    assertThat(sql.lowercase())
+      .`as`("Raw SQL must not contain PostgreSQL 'as excluded' syntax")
+      .doesNotContain("as excluded")
+
+    assertThat(sql.lowercase())
+      .`as`("Raw SQL must contain ON DUPLICATE KEY UPDATE")
+      .contains("on duplicate key update")
+  }
+}

--- a/orca/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/pipeline/persistence/SqlExecutionRepository.kt
+++ b/orca/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/pipeline/persistence/SqlExecutionRepository.kt
@@ -1263,23 +1263,35 @@ class SqlExecutionRepository(
     // to fallback to the simpler behavior.
     withPool(poolName) {
       try {
-        ctx.insertInto(table, *insertPairs.keys.toTypedArray())
-          .values(insertPairs.values)
-          .run {
-            when (jooq.dialect()) {
-              SQLDialect.POSTGRES -> {
-                onConflict(DSL.field("id"))
-                  .doUpdate()
-                  .set(updatePairs)
-                  .execute()
-              }
-              else -> {
-                onDuplicateKeyUpdate()
-                  .set(updatePairs)
-                  .execute()
-              }
-            }
+        when (jooq.dialect()) {
+          SQLDialect.POSTGRES -> {
+            ctx.insertInto(table, *insertPairs.keys.toTypedArray())
+              .values(insertPairs.values)
+              .onConflict(DSL.field("id"))
+              .doUpdate()
+              .set(updatePairs)
+              .execute()
           }
+          else -> {
+            // jOOQ 3.19.x renders invalid MySQL syntax for SQLDialect.MYSQL when
+            // onDuplicateKeyUpdate() is chained after values(): it emits the
+            // PostgreSQL-style "as excluded" row alias together with the deprecated
+            // values(col) function, which MySQL rejects. Use raw SQL instead.
+            val tableName = ctx.render(table)
+            val columns = insertPairs.keys.joinToString(", ") { ctx.render(it) }
+            val placeholders = "(${insertPairs.keys.joinToString(", ") { "?" }})"
+            val updateClause = updatePairs.keys.joinToString(", ") {
+              "${ctx.render(it)} = VALUES(${ctx.render(it)})"
+            }
+            val sql = """
+              |INSERT INTO $tableName ($columns)
+              |VALUES $placeholders
+              |ON DUPLICATE KEY UPDATE
+              |$updateClause
+            """.trimMargin()
+            ctx.execute(sql, *insertPairs.values.toTypedArray())
+          }
+        }
       } catch (e: SQLDialectNotSupportedException) {
         log.debug("Falling back to primitive upsert logic: ${e.message}")
         val exists = ctx.fetchExists(ctx.select().from(table).where(field("id").eq(updateId)).forUpdate())

--- a/orca/orca-sql/src/test/kotlin/com/netflix/spinnaker/orca/sql/pipeline/persistence/SqlExecutionRepositoryMySqlTest.kt
+++ b/orca/orca-sql/src/test/kotlin/com/netflix/spinnaker/orca/sql/pipeline/persistence/SqlExecutionRepositoryMySqlTest.kt
@@ -1,0 +1,60 @@
+package com.netflix.spinnaker.orca.sql.pipeline.persistence
+
+import org.assertj.core.api.Assertions.assertThat
+import org.jooq.impl.DSL
+import org.junit.jupiter.api.Test
+
+/**
+ * Regression tests for jOOQ 3.19+ MySQL `ON DUPLICATE KEY UPDATE` rendering bug.
+ *
+ * jOOQ 3.19 (via Spring Boot 3.5.x) generates invalid MySQL syntax when using
+ * [InsertValuesStep.onDuplicateKeyUpdate] — it emits PostgreSQL-specific
+ * `AS excluded` even when the configured dialect is MySQL.
+ */
+class SqlExecutionRepositoryMySqlTest {
+
+  @Test
+  fun `jOOQ 3_19 onDuplicateKeyUpdate generates invalid as excluded for MySQL dialect`() {
+    val ctx = DSL.using(org.jooq.SQLDialect.MYSQL)
+    val insert = ctx.insertInto(
+      DSL.table("pipelines"),
+      DSL.field("id"),
+      DSL.field("body"),
+      DSL.field("status")
+    )
+
+    insert.values("id-1", "body", "status")
+    insert.onDuplicateKeyUpdate()
+      .set(DSL.field("body"), DSL.field("body") as Any)
+      .set(DSL.field("status"), DSL.field("status") as Any)
+
+    val sql = insert.getSQL()
+
+    assertThat(sql.lowercase())
+      .`as`("jOOQ 3.19 generates 'as excluded' even for MySQL dialect")
+      .contains("as excluded")
+  }
+
+  @Test
+  fun `raw SQL upsert does not contain as excluded`() {
+    val tableName = "pipelines"
+    val columns = "id, body, status"
+    val placeholders = "(?, ?, ?)"
+    val updateClause = "body = VALUES(body), status = VALUES(status)"
+
+    val sql = """
+      |INSERT INTO $tableName ($columns)
+      |VALUES $placeholders
+      |ON DUPLICATE KEY UPDATE
+      |$updateClause
+    """.trimMargin()
+
+    assertThat(sql.lowercase())
+      .`as`("Raw SQL must not contain PostgreSQL 'as excluded' syntax")
+      .doesNotContain("as excluded")
+
+    assertThat(sql.lowercase())
+      .`as`("Raw SQL must contain ON DUPLICATE KEY UPDATE")
+      .contains("on duplicate key update")
+  }
+}


### PR DESCRIPTION
After upgrading to Spring Boot 3.5.x (which pulls in jOOQ 3.19.35), services using MySQL backend fail with BadSqlGrammarException on any upsert operation that uses InsertValuesStep.values() followed by onDuplicateKeyUpdate().

Example stack trace from clouddriver:
```
BadSqlGrammarException: You have an error in your SQL syntax;
... near 'as excluded on duplicate key update application = values(application)'
```
Root Cause

jOOQ 3.19.35 generates PostgreSQL-specific AS excluded syntax even when the configured dialect is MySQL, whenever onDuplicateKeyUpdate() is chained after .values():
```
insert into t (...) values (...) as excluded
on duplicate key update ...
```
MySQL rejects AS excluded as invalid syntax. 