### PR TITLE
fix(jenkins): cancel Jenkins job when Spinnaker pipeline is cancelled

### DIFF
--- a/orca/orca-igor/src/main/java/com/netflix/spinnaker/orca/igor/BuildService.java
+++ b/orca/orca-igor/src/main/java/com/netflix/spinnaker/orca/igor/BuildService.java
@@ -51,7 +51,7 @@ public class BuildService {
     return this.igorFeatureFlagProperties.isJobNameAsQueryParameter()
         ? Retrofit2SyncCall.execute(
             igorService.stopWithJobNameAsQueryParameter(
-                master, jobName, queuedBuild, buildNumber, ""))
+                master, queuedBuild, buildNumber, jobName, ""))
         : Retrofit2SyncCall.execute(
             igorService.stop(master, jobName, queuedBuild, buildNumber, ""));
   }

--- a/orca/orca-igor/src/main/java/com/netflix/spinnaker/orca/igor/IgorService.java
+++ b/orca/orca-igor/src/main/java/com/netflix/spinnaker/orca/igor/IgorService.java
@@ -53,9 +53,9 @@ public interface IgorService {
   @PUT("masters/{name}/jobs/stop/{queuedBuild}/{buildNumber}")
   Call<String> stopWithJobNameAsQueryParameter(
       @Path("name") String master,
-      @Query(value = "jobName") String jobName,
       @Path(encoded = true, value = "queuedBuild") String queuedBuild,
       @Path(encoded = true, value = "buildNumber") Long buildNumber,
+      @Query(value = "jobName") String jobName,
       @Body String ignored);
 
   @PATCH("masters/{name}/jobs/{jobName}/update/{buildNumber}")

--- a/orca/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/BuildServiceSpec.groovy
+++ b/orca/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/BuildServiceSpec.groovy
@@ -104,6 +104,6 @@ class BuildServiceSpec extends Specification {
     buildService.stop(MASTER, JOB_NAME, QUEUED_BUILD, BUILD_NUMBER )
 
     then:
-    1 * igorService.stopWithJobNameAsQueryParameter(MASTER, JOB_NAME, QUEUED_BUILD, BUILD_NUMBER, '') >> Calls.response(null)
+    1 * igorService.stopWithJobNameAsQueryParameter(MASTER, QUEUED_BUILD, BUILD_NUMBER, JOB_NAME, '') >> Calls.response(null)
   }
 }


### PR DESCRIPTION
- Spinnaker pipeline cancellation does not cancel the underlying Jenkins job.
- Cancelling a Spinnaker pipeline leaves the associated Jenkins build running.
- Jenkins jobs continue running after the parent Spinnaker pipeline is cancelled.

The issue is that Retrofit requires @Path parameters to come before @Query parameters in the method signature. Currently, @Query comes before the @Path parameters, which violates Retrofit's parsing rules.

Fix: Reorder the parameters so @Path parameters come first:

```
@PUT("masters/{name}/jobs/stop/{queuedBuild}/{buildNumber}")
Call<String> stopWithJobNameAsQueryParameter(
    @Path("name") String master,
    @Path(encoded = true, value = "queuedBuild") String queuedBuild,
    @Path(encoded = true, value = "buildNumber") Long buildNumber,
    @Query(value = "jobName") String jobName,
    @Body String ignored);
```

The changes:
1. Move queuedBuild and buildNumber @Path parameters before jobName
2. Move jobName @Query parameter after all @Path parameters

This respects Retrofit's parameter order requirement: @Path → @Query → @Body/@Header/etc.

References: https://github.com/spinnaker/spinnaker/issues/7750