### PR TITLE
fix(jooq): Downgrade jooq to 3.19.29 from 3.19.35

### DIFF
--- a/kork/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/kork/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -59,6 +59,10 @@ dependencies {
   api(platform("io.arrow-kt:arrow-stack:${versions.arrow}"))
 
   constraints {
+    // Pin jOOQ 3.19.29: Spring Boot 3.5.x pulls 3.19.35 which introduces a MySQL
+    // ON DUPLICATE KEY UPDATE regression (generates invalid 'as excluded' syntax).
+    // 3.19.29 is the last known good version for SQLDialect.MYSQL upserts.
+    api("org.jooq:jooq:3.19.29")
     api("cglib:cglib-nodep:3.3.0")
     api("com.amazonaws:aws-java-sdk:${versions.aws}")
     api("com.google.api-client:google-api-client:2.4.1")


### PR DESCRIPTION
### Problem
After upgrading to Spring Boot 3.5.x (which pulls in jOOQ 3.19.35), services using MySQL backend fail with `BadSqlGrammarException` on upsert operations:

BadSqlGrammarException: You have an error in your SQL syntax; ... near 'as excluded on duplicate key update application = values(application)'


### Root Cause
jOOQ 3.19.35 generates PostgreSQL-specific `AS excluded` syntax **even when the configured dialect is MySQL**, whenever `onDuplicateKeyUpdate()` is chained after `.values()`:

```sql
insert into t (id, body) values ('id-1', 'body') as excluded
on duplicate key update body = values(body)
```

MySQL rejects AS excluded as invalid syntax. This is a jOOQ regression introduced in 3.19.30.

### Fix
Pin jOOQ to the last known good version 3.19.29 in the spinnaker-dependencies BOM. The original jOOQ DSL in all four services works correctly with 3.19.29