### PR TITLE
fix(jooq): replaces all deprecated MySQLDSL.values() with cross-dialect DSL

### DIFF
--- a/clouddriver/cats/cats-sql/src/main/kotlin/com/netflix/spinnaker/cats/sql/cache/SqlCache.kt
+++ b/clouddriver/cats/cats-sql/src/main/kotlin/com/netflix/spinnaker/cats/sql/cache/SqlCache.kt
@@ -44,7 +44,7 @@ import org.jooq.impl.DSL.field
 import org.jooq.impl.DSL.noCondition
 import org.jooq.impl.DSL.sql
 import org.jooq.impl.DSL.table
-import org.jooq.util.mysql.MySQLDSL
+import org.jooq.impl.DSL
 import org.slf4j.LoggerFactory
 import org.springframework.jdbc.BadSqlGrammarException
 
@@ -623,10 +623,10 @@ class SqlCache(
                   .set(field("last_updated"), SqlUtil.excluded(field("last_updated")) as Any)
               else ->
                 onDuplicateKeyUpdate()
-                  .set(field("application"), MySQLDSL.values(field("application")) as Any)
-                  .set(field("body_hash"), MySQLDSL.values(field("body_hash")) as Any)
-                  .set(field("body"), MySQLDSL.values(field("body")) as Any)
-                  .set(field("last_updated"), MySQLDSL.values(field("last_updated")) as Any)
+                  .set(field("application"), DSL.excluded(field("application")) as Any)
+                  .set(field("body_hash"), DSL.excluded(field("body_hash")) as Any)
+                  .set(field("body"), DSL.excluded(field("body")) as Any)
+                  .set(field("last_updated"), DSL.excluded(field("last_updated")) as Any)
             }
           }
         }

--- a/clouddriver/cats/cats-sql/src/test/kotlin/com/netflix/spinnaker/cats/sql/cache/Jooq31936MySql8Experiment.kt
+++ b/clouddriver/cats/cats-sql/src/test/kotlin/com/netflix/spinnaker/cats/sql/cache/Jooq31936MySql8Experiment.kt
@@ -1,0 +1,75 @@
+package com.netflix.spinnaker.cats.sql.cache
+
+import org.assertj.core.api.Assertions.assertThat
+import org.jooq.SQLDialect
+import org.jooq.impl.DSL
+import org.jooq.impl.DSL.field
+import org.jooq.impl.DSL.table
+import org.junit.jupiter.api.Test
+
+/**
+ * Experiment: verify jOOQ 3.19.36 generates valid MySQL 8.0.19+ syntax
+ * using DSL.excluded() inside onDuplicateKeyUpdate().
+ */
+class Jooq31936MySql8Experiment {
+
+  private val ctx = DSL.using(SQLDialect.MYSQL)
+
+  @Test
+  fun `jOOQ 3_19_36 onDuplicateKeyUpdate with DSL_excluded generates MySQL 8 row alias syntax`() {
+    val insert = ctx.insertInto(table("t"), field("id"), field("body"))
+    insert.values("id-1", "body")
+    insert.onDuplicateKeyUpdate()
+      .set(field("body"), DSL.excluded(field("body")) as Any)
+
+    val sql = insert.getSQL()
+    println("SQL: $sql")
+
+    assertThat(sql.lowercase())
+      .`as`("jOOQ 3.19.36 should emit 'as excluded' for MySQL dialect")
+      .contains("as excluded")
+
+    assertThat(sql.lowercase())
+      .`as`("Update clause should use excluded.column for MySQL 8.0.19+")
+      .contains("excluded.body")
+
+    assertThat(sql.lowercase())
+      .`as`("Must NOT contain deprecated VALUES(col) which fails when mixed with row alias")
+      .doesNotContain("values(body)")
+  }
+
+  @Test
+  fun `jOOQ 3_19_36 multi-row onDuplicateKeyUpdate with DSL_excluded`() {
+    val insert = ctx.insertInto(table("t"), field("id"), field("body"))
+    insert.values("id-1", "body-1")
+    insert.values("id-2", "body-2")
+    insert.onDuplicateKeyUpdate()
+      .set(field("body"), DSL.excluded(field("body")) as Any)
+
+    val sql = insert.getSQL()
+    println("Multi-row SQL: $sql")
+
+    assertThat(sql.lowercase())
+      .contains("as excluded")
+
+    assertThat(sql.lowercase())
+      .contains("excluded.body")
+  }
+
+  @Test
+  fun `jOOQ 3_19_36 onDuplicateKeyUpdate with literal values still works`() {
+    // Orca pattern: .set(Map<Field, Any>) passes literal values
+    val insert = ctx.insertInto(table("t"), field("id"), field("status"))
+      .values("id-1", "RUNNING")
+      .onDuplicateKeyUpdate()
+      .set(field("status"), "RUNNING")
+
+    val sql = insert.getSQL()
+    println("Literal values SQL: $sql")
+
+    // MySQL 8.0.19+ accepts row alias even when update clause uses literals
+    assertThat(sql.lowercase())
+      .`as`("Literal values in update clause should be valid with row alias")
+      .contains("on duplicate key update status = ?")
+  }
+}

--- a/clouddriver/cats/cats-sql/src/test/kotlin/com/netflix/spinnaker/cats/sql/cache/JooqExcludedDialectExperiment.kt
+++ b/clouddriver/cats/cats-sql/src/test/kotlin/com/netflix/spinnaker/cats/sql/cache/JooqExcludedDialectExperiment.kt
@@ -1,0 +1,57 @@
+package com.netflix.spinnaker.cats.sql.cache
+
+import org.assertj.core.api.Assertions.assertThat
+import org.jooq.SQLDialect
+import org.jooq.impl.DSL
+import org.jooq.impl.DSL.field
+import org.jooq.impl.DSL.table
+import org.junit.jupiter.api.Test
+
+class JooqExcludedDialectExperiment {
+
+  @Test
+  fun `DSL_excluded generates valid SQL for MySQL`() {
+    val ctx = DSL.using(SQLDialect.MYSQL)
+    val sql = ctx.insertInto(table("t"), field("id"), field("body"))
+      .values("1", "a")
+      .onDuplicateKeyUpdate()
+      .set(field("body"), DSL.excluded(field("body")) as Any)
+      .getSQL()
+
+    println("MySQL: $sql")
+    assertThat(sql.lowercase())
+      .contains("as excluded")
+      .contains("excluded.body")
+  }
+
+  @Test
+  fun `DSL_excluded generates valid SQL for MariaDB`() {
+    val ctx = DSL.using(SQLDialect.MARIADB)
+    val sql = ctx.insertInto(table("t"), field("id"), field("body"))
+      .values("1", "a")
+      .onDuplicateKeyUpdate()
+      .set(field("body"), DSL.excluded(field("body")) as Any)
+      .getSQL()
+
+    println("MariaDB: $sql")
+    assertThat(sql.lowercase())
+      .contains("on duplicate key update")
+      .contains("values(body)")
+  }
+
+  @Test
+  fun `DSL_excluded generates valid SQL for Postgres`() {
+    val ctx = DSL.using(SQLDialect.POSTGRES)
+    val sql = ctx.insertInto(table("t"), field("id"), field("body"))
+      .values("1", "a")
+      .onConflict(field("id"))
+      .doUpdate()
+      .set(field("body"), DSL.excluded(field("body")) as Any)
+      .getSQL()
+
+    println("Postgres: $sql")
+    assertThat(sql.lowercase())
+      .contains("on conflict")
+      .contains("excluded.body")
+  }
+}

--- a/fiat/fiat-sql/src/main/kotlin/com/netflix/spinnaker/fiat/permissions/SqlPermissionsRepository.kt
+++ b/fiat/fiat-sql/src/main/kotlin/com/netflix/spinnaker/fiat/permissions/SqlPermissionsRepository.kt
@@ -38,9 +38,9 @@ import kotlinx.coroutines.*
 import org.jooq.*
 import org.jooq.exception.DataAccessException
 import org.jooq.exception.SQLDialectNotSupportedException
+import org.jooq.impl.DSL
 import org.jooq.impl.DSL.field
 import org.jooq.impl.SQLDataType
-import org.jooq.util.mysql.MySQLDSL
 import org.slf4j.LoggerFactory
 import java.time.Clock
 import java.time.Duration
@@ -238,9 +238,9 @@ class SqlPermissionsRepository(
                         .set(USER.UPDATED_AT, SqlUtil.excluded(field("updated_at", SQLDataType.BIGINT)))
                 else ->
                     onDuplicateKeyUpdate()
-                        .set(USER.ADMIN, MySQLDSL.values(field("admin", SQLDataType.BOOLEAN)))
-                        .set(USER.ACCOUNT_MANAGER, MySQLDSL.values(field("account_manager", SQLDataType.BOOLEAN)))
-                        .set(USER.UPDATED_AT, MySQLDSL.values(field("updated_at", SQLDataType.BIGINT)))
+                        .set(USER.ADMIN, DSL.excluded(field("admin", SQLDataType.BOOLEAN)))
+                        .set(USER.ACCOUNT_MANAGER, DSL.excluded(field("account_manager", SQLDataType.BOOLEAN)))
+                        .set(USER.UPDATED_AT, DSL.excluded(field("updated_at", SQLDataType.BIGINT)))
             }
         }
 
@@ -401,9 +401,9 @@ class SqlPermissionsRepository(
                                     .set(RESOURCE.UPDATED_AT, SqlUtil.excluded(field("updated_at", SQLDataType.BIGINT)))
                             else ->
                                 onDuplicateKeyUpdate()
-                                    .set(RESOURCE.BODY, MySQLDSL.values(field("body", SQLDataType.LONGVARCHAR)))
-                                    .set(RESOURCE.BODY_HASH, MySQLDSL.values(field("body_hash", SQLDataType.VARCHAR)))
-                                    .set(RESOURCE.UPDATED_AT, MySQLDSL.values(field("updated_at", SQLDataType.BIGINT)))
+                                    .set(RESOURCE.BODY, DSL.excluded(field("body", SQLDataType.LONGVARCHAR)))
+                                    .set(RESOURCE.BODY_HASH, DSL.excluded(field("body_hash", SQLDataType.VARCHAR)))
+                                    .set(RESOURCE.UPDATED_AT, DSL.excluded(field("updated_at", SQLDataType.BIGINT)))
                         }
                     }
                 }

--- a/keel/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
+++ b/keel/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
@@ -62,7 +62,6 @@ import org.jooq.SelectJoinStep
 import org.jooq.impl.DSL
 import org.jooq.impl.DSL.select
 import org.jooq.impl.DSL.selectOne
-import org.jooq.util.mysql.MySQLDSL
 import org.slf4j.LoggerFactory
 import org.springframework.context.ApplicationEventPublisher
 import java.security.MessageDigest
@@ -1537,7 +1536,7 @@ class SqlArtifactRepository(
           .set(ENVIRONMENT_ARTIFACT_PIN.ARTIFACT_VERSION, version)
           .set(ENVIRONMENT_ARTIFACT_PIN.PINNED_AT, now)
           .set(ENVIRONMENT_ARTIFACT_PIN.PINNED_BY, pinnedBy ?: "anonymous")
-          .set(ENVIRONMENT_ARTIFACT_PIN.COMMENT, MySQLDSL.values(ENVIRONMENT_ARTIFACT_PIN.COMMENT))
+          .set(ENVIRONMENT_ARTIFACT_PIN.COMMENT, DSL.excluded(ENVIRONMENT_ARTIFACT_PIN.COMMENT))
           .execute()
       }
     }

--- a/keel/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepository.kt
+++ b/keel/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepository.kt
@@ -69,7 +69,6 @@ import org.jooq.impl.DSL.max
 import org.jooq.impl.DSL.select
 import org.jooq.impl.DSL.selectOne
 import org.jooq.impl.DSL.value
-import org.jooq.util.mysql.MySQLDSL.values
 import org.slf4j.LoggerFactory
 import org.springframework.context.ApplicationEventPublisher
 import java.net.InetAddress
@@ -622,23 +621,23 @@ class SqlDeliveryConfigRepository(
               .onDuplicateKeyUpdate()
               .set(
                 ENVIRONMENT_ARTIFACT_CONSTRAINT.STATUS,
-                values(ENVIRONMENT_ARTIFACT_CONSTRAINT.STATUS)
+                DSL.excluded(ENVIRONMENT_ARTIFACT_CONSTRAINT.STATUS)
               )
               .set(
                 ENVIRONMENT_ARTIFACT_CONSTRAINT.JUDGED_BY,
-                values(ENVIRONMENT_ARTIFACT_CONSTRAINT.JUDGED_BY)
+                DSL.excluded(ENVIRONMENT_ARTIFACT_CONSTRAINT.JUDGED_BY)
               )
               .set(
                 ENVIRONMENT_ARTIFACT_CONSTRAINT.JUDGED_AT,
-                values(ENVIRONMENT_ARTIFACT_CONSTRAINT.JUDGED_AT)
+                DSL.excluded(ENVIRONMENT_ARTIFACT_CONSTRAINT.JUDGED_AT)
               )
               .set(
                 ENVIRONMENT_ARTIFACT_CONSTRAINT.COMMENT,
-                values(ENVIRONMENT_ARTIFACT_CONSTRAINT.COMMENT)
+                DSL.excluded(ENVIRONMENT_ARTIFACT_CONSTRAINT.COMMENT)
               )
               .set(
                 ENVIRONMENT_ARTIFACT_CONSTRAINT.ATTRIBUTES,
-                values(ENVIRONMENT_ARTIFACT_CONSTRAINT.ATTRIBUTES)
+                DSL.excluded(ENVIRONMENT_ARTIFACT_CONSTRAINT.ATTRIBUTES)
               )
               .set(ENVIRONMENT_ARTIFACT_CONSTRAINT.ARTIFACT_REFERENCE, state.artifactReference)
               .execute()
@@ -652,7 +651,7 @@ class SqlDeliveryConfigRepository(
               .onDuplicateKeyUpdate()
               .set(
                 CURRENT_CONSTRAINT.CONSTRAINT_UID,
-                values(CURRENT_CONSTRAINT.CONSTRAINT_UID)
+                DSL.excluded(CURRENT_CONSTRAINT.CONSTRAINT_UID)
               )
               .execute()
 

--- a/kork/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/kork/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -59,6 +59,8 @@ dependencies {
   api(platform("io.arrow-kt:arrow-stack:${versions.arrow}"))
 
   constraints {
+    // Pin jOOQ 3.19.36 to use new MySQL 8.0.19+ row alias syntax
+    api("org.jooq:jooq:3.19.36")
     api("cglib:cglib-nodep:3.3.0")
     api("com.amazonaws:aws-java-sdk:${versions.aws}")
     api("com.google.api-client:google-api-client:2.4.1")

--- a/orca/keiko-sql/src/main/kotlin/com/netflix/spinnaker/q/sql/SqlDeadMessageHandler.kt
+++ b/orca/keiko-sql/src/main/kotlin/com/netflix/spinnaker/q/sql/SqlDeadMessageHandler.kt
@@ -21,7 +21,6 @@ import org.jooq.DSLContext
 import org.jooq.SQLDialect
 import org.jooq.exception.SQLDialectNotSupportedException
 import org.jooq.impl.DSL
-import org.jooq.util.mysql.MySQLDSL
 import org.slf4j.LoggerFactory
 
 class SqlDeadMessageHandler(
@@ -84,8 +83,8 @@ class SqlDeadMessageHandler(
                   .execute()
               else ->
                 onDuplicateKeyUpdate()
-                  .set(updatedAtField, MySQLDSL.values(updatedAtField) as Any)
-                  .set(bodyField, MySQLDSL.values(bodyField) as Any)
+                  .set(updatedAtField, DSL.excluded(updatedAtField) as Any)
+                  .set(bodyField, DSL.excluded(bodyField) as Any)
                   .execute()
             }
           }

--- a/orca/keiko-sql/src/main/kotlin/com/netflix/spinnaker/q/sql/SqlQueue.kt
+++ b/orca/keiko-sql/src/main/kotlin/com/netflix/spinnaker/q/sql/SqlQueue.kt
@@ -59,7 +59,6 @@ import org.jooq.impl.DSL.field
 import org.jooq.impl.DSL.select
 import org.jooq.impl.DSL.sql
 import org.jooq.impl.DSL.table
-import org.jooq.util.mysql.MySQLDSL
 import org.slf4j.LoggerFactory
 import org.springframework.scheduling.annotation.Scheduled
 
@@ -483,8 +482,8 @@ class SqlQueue(
                   .execute()
               else ->
                 onDuplicateKeyUpdate()
-                  .set(idField, MySQLDSL.values(idField) as Any)
-                  .set(bodyField, MySQLDSL.values(bodyField) as Any)
+                  .set(idField, DSL.excluded(idField) as Any)
+                  .set(bodyField, DSL.excluded(bodyField) as Any)
                   .execute()
             }
           }
@@ -503,7 +502,7 @@ class SqlQueue(
                   .execute()
               else ->
                 onDuplicateKeyUpdate()
-                  .set(deliveryField, MySQLDSL.values(deliveryField) as Any)
+                  .set(deliveryField, DSL.excluded(deliveryField) as Any)
                   .execute()
             }
           }
@@ -740,7 +739,7 @@ class SqlQueue(
                       .execute()
                   else ->
                     onDuplicateKeyUpdate()
-                      .set(deliveryField, MySQLDSL.values(deliveryField) as Any)
+                      .set(deliveryField, DSL.excluded(deliveryField) as Any)
                       .execute()
                 }
               }


### PR DESCRIPTION
This PR bumps jOOQ to 3.19.36 and replaces all deprecated `MySQLDSL.values()` usages with the cross-dialect `DSL.excluded()` API. This fixes the `BadSqlGrammarException` that occurs on MySQL 8.0.19+ when jOOQ generates invalid `AS excluded ... VALUES(col)` syntax.

### Problem

Starting with jOOQ 3.19.35, the MySQL dialect changed how `onDuplicateKeyUpdate()` is rendered. When the update clause references inserted values, jOOQ now **automatically emits `AS excluded`** (MySQL 8.0.19+ row alias syntax) in the insert clause:

```sql
-- jOOQ 3.19.35+ generates this insert clause
INSERT INTO t (id, body) VALUES (?, ?) AS excluded
```

However, the old production code still used `MySQLDSL.values(field("body"))` in the update clause, which generates:

```sql
-- Old update clause (still using VALUES(col))
ON DUPLICATE KEY UPDATE body = VALUES(body)
```

MySQL 8.0.19+ **rejects mixing `AS excluded` with `VALUES(col)`** — these are mutually exclusive syntax paths. Once a row alias is declared (`AS excluded`), all value references in the update clause must go through that alias (`excluded.col`). This produced:

```
BadSqlGrammarException: You have an error in your SQL syntax... near 'excluded'
```

### Why `DSL.excluded()` fixes it

`DSL.excluded(field)` tells jOOQ to use the row alias consistently:

```sql
-- Valid MySQL 8.0.19+ syntax
INSERT INTO t (id, body) VALUES (?, ?) AS excluded
ON DUPLICATE KEY UPDATE body = excluded.body
```

jOOQ handles dialect differences internally:

| Dialect | Generated SQL |
|---------|--------------|
| **MySQL 8+** | `insert ... values (?, ?) as excluded on duplicate key update body = excluded.body` |
| **MariaDB** | `insert ... values (?, ?) on duplicate key update body = values(body)` |
| **PostgreSQL** | `insert ... on conflict (id) do update set body = excluded.body` |

### Why the version bump to 3.19.36

jOOQ 3.19.35 introduced the auto-`AS excluded` behavior but still had `MySQLDSL.values()` deprecated (generating warnings). jOOQ 3.19.36 finalizes this transition by making `DSL.excluded()` the canonical cross-dialect API and ensures `DSL.excluded()` is fully supported for MySQL row alias syntax.
