### PR TITLE
fix(mvc): UrlHandlerFilter to trailing slash handle route matching

### DIFF
--- a/halyard/halyard-web/config/halyard.yml
+++ b/halyard/halyard-web/config/halyard.yml
@@ -32,3 +32,11 @@ management:
 backup:
   google:
     enabled: false
+
+# Spring Framework 6 (Spring Boot 3) removed lenient trailing-slash route matching. Halyard maps many
+# endpoints with an explicit trailing slash (e.g. .../haServices/, .../generate/, .../deploy/), and
+# the hal CLI calls them that way. Disable the kork-web UrlHandlerFilter, which would otherwise trim
+# the trailing slash before dispatch and make those routes return 404.
+url-handler:
+  trailing-slash:
+    enabled: false

--- a/kork/kork-web/src/main/java/com/netflix/spinnaker/kork/web/config/UrlHandlerFilterAutoConfiguration.java
+++ b/kork/kork-web/src/main/java/com/netflix/spinnaker/kork/web/config/UrlHandlerFilterAutoConfiguration.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 Harness, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.web.config;
+
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.Ordered;
+import org.springframework.web.filter.UrlHandlerFilter;
+
+/**
+ * Registers a {@link UrlHandlerFilter} that trims trailing slashes from incoming request paths so
+ * that requests like {@code PUT /artifacts/fetch/} are routed to controllers mapped to {@code
+ * /artifacts/fetch}.
+ *
+ * <p>This restores the lenient trailing slash matching that was the default before Spring Framework
+ * 6.0 / Spring Boot 3.0. Because it lives in kork-web, every Spinnaker service that depends on
+ * kork-web inherits the behavior without per-service configuration. It can be disabled with {@code
+ * url-handler.trailing-slash.enabled=false}.
+ */
+@AutoConfiguration
+@ConditionalOnClass(UrlHandlerFilter.class)
+@ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
+@ConditionalOnProperty(value = "url-handler.trailing-slash.enabled", matchIfMissing = true)
+@EnableConfigurationProperties(UrlHandlerFilterConfigurationProperties.class)
+public class UrlHandlerFilterAutoConfiguration {
+
+  @Bean
+  public FilterRegistrationBean<UrlHandlerFilter> trailingSlashUrlHandlerFilter(
+      UrlHandlerFilterConfigurationProperties properties) {
+    UrlHandlerFilter filter =
+        UrlHandlerFilter.trailingSlashHandler(properties.getPathPatterns().toArray(new String[0]))
+            .wrapRequest()
+            .build();
+
+    FilterRegistrationBean<UrlHandlerFilter> registration = new FilterRegistrationBean<>(filter);
+    // Run before other filters (e.g. security) so the trimmed path is used consistently.
+    registration.setOrder(Ordered.HIGHEST_PRECEDENCE);
+    return registration;
+  }
+}

--- a/kork/kork-web/src/main/java/com/netflix/spinnaker/kork/web/config/UrlHandlerFilterConfigurationProperties.java
+++ b/kork/kork-web/src/main/java/com/netflix/spinnaker/kork/web/config/UrlHandlerFilterConfigurationProperties.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 Harness, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.web.config;
+
+import java.util.List;
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration for the trailing slash {@link org.springframework.web.filter.UrlHandlerFilter}.
+ *
+ * <p>Spring Framework 6.0 (Spring Boot 3.0) removed lenient trailing slash matching, so a request
+ * to {@code /path/} no longer matches a controller mapped to {@code /path}. This regresses
+ * inter-service calls where the client (e.g. a Retrofit interface) emits a trailing slash. Enabling
+ * this filter restores the previous behavior across all Spinnaker services that depend on kork-web.
+ */
+@Data
+@ConfigurationProperties("url-handler.trailing-slash")
+public class UrlHandlerFilterConfigurationProperties {
+
+  /** Whether to register the trailing slash {@code UrlHandlerFilter}. Enabled by default. */
+  private boolean enabled = true;
+
+  /**
+   * Ant-style path patterns for which a trailing slash is trimmed before request handling. Defaults
+   * to all paths.
+   */
+  private List<String> pathPatterns = List.of("/**");
+}

--- a/kork/kork-web/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/kork/kork-web/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.netflix.spinnaker.kork.web.config.UrlHandlerFilterAutoConfiguration

--- a/kork/kork-web/src/test/java/com/netflix/spinnaker/kork/web/trailingslash/FetchController.java
+++ b/kork/kork-web/src/test/java/com/netflix/spinnaker/kork/web/trailingslash/FetchController.java
@@ -15,6 +15,7 @@
  */
 package com.netflix.spinnaker.kork.web.trailingslash;
 
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -32,5 +33,26 @@ public class FetchController {
   @PutMapping("/fetch")
   String fetch(@RequestBody String body) {
     return "fetched:" + body;
+  }
+
+  /**
+   * Endpoint intentionally mapped WITH a trailing slash. When {@code UrlHandlerFilter} is enabled
+   * it trims the trailing slash before dispatch, so requests to {@code /fetchWithSlash/} are
+   * dispatched as {@code /fetchWithSlash} and never match this mapping (they 404). The distinct
+   * return value lets tests confirm whether this method is ever reached.
+   */
+  @PutMapping("/fetchWithSlash/")
+  String fetchWithSlash(@RequestBody String body) {
+    return "fetchedWithSlash:" + body;
+  }
+
+  /**
+   * Root mapping, mirroring controllers such as echo's {@code HistoryController} and gate's {@code
+   * RootController} that map {@code "/"}. Used to verify the filter does not trim the root path to
+   * an empty string and break it.
+   */
+  @PostMapping("/")
+  String root(@RequestBody String body) {
+    return "root:" + body;
   }
 }

--- a/kork/kork-web/src/test/java/com/netflix/spinnaker/kork/web/trailingslash/FetchController.java
+++ b/kork/kork-web/src/test/java/com/netflix/spinnaker/kork/web/trailingslash/FetchController.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 Harness, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.web.trailingslash;
+
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Test controller mapped to {@code /fetch} (no trailing slash), mirroring the real {@code
+ * ArtifactController.fetch} mapping that Orca calls with a trailing slash.
+ *
+ * <p>Lives in an isolated package so it is not picked up by other tests' component scans. It is
+ * registered explicitly via {@code @SpringBootTest(classes = ...)} rather than component scanning.
+ */
+@RestController
+public class FetchController {
+
+  @PutMapping("/fetch")
+  String fetch(@RequestBody String body) {
+    return "fetched:" + body;
+  }
+}

--- a/kork/kork-web/src/test/java/com/netflix/spinnaker/kork/web/trailingslash/TrailingSlashScopedPatternsTest.java
+++ b/kork/kork-web/src/test/java/com/netflix/spinnaker/kork/web/trailingslash/TrailingSlashScopedPatternsTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026 Harness, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.web.trailingslash;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+
+/**
+ * Shows how to cover endpoints that are intentionally mapped WITH a trailing slash. By scoping
+ * {@code url-handler.trailing-slash.path-patterns} so it does not match those routes, the filter
+ * leaves them untouched (so they keep working), while still normalizing the routes that are listed.
+ *
+ * <p>Here the filter is scoped to {@code /fetch/} only, so:
+ *
+ * <ul>
+ *   <li>{@code /fetch/} is trimmed and served by the {@code /fetch} handler.
+ *   <li>{@code /fetchWithSlash/} is NOT trimmed, so its explicit trailing-slash mapping is
+ *       reachable.
+ * </ul>
+ */
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = {TrailingSlashTestConfig.class, FetchController.class},
+    properties = "url-handler.trailing-slash.path-patterns=/fetch/")
+class TrailingSlashScopedPatternsTest {
+
+  @Autowired private TestRestTemplate restTemplate;
+
+  private HttpEntity<String> request() {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.TEXT_PLAIN);
+    return new HttpEntity<>("payload", headers);
+  }
+
+  @Test
+  void scopedRouteIsStillNormalized() {
+    ResponseEntity<String> response =
+        restTemplate.exchange("/fetch/", HttpMethod.PUT, request(), String.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody()).isEqualTo("fetched:payload");
+  }
+
+  @Test
+  void explicitTrailingSlashRouteOutsideScopeRemainsReachable() {
+    ResponseEntity<String> response =
+        restTemplate.exchange("/fetchWithSlash/", HttpMethod.PUT, request(), String.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody()).isEqualTo("fetchedWithSlash:payload");
+  }
+}

--- a/kork/kork-web/src/test/java/com/netflix/spinnaker/kork/web/trailingslash/TrailingSlashTestConfig.java
+++ b/kork/kork-web/src/test/java/com/netflix/spinnaker/kork/web/trailingslash/TrailingSlashTestConfig.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 Harness, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.web.trailingslash;
+
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+/**
+ * Shared test configuration for trailing slash handling tests. Enables auto-configuration (so the
+ * production {@code UrlHandlerFilterAutoConfiguration} is applied) and permits all requests so the
+ * tests exercise routing rather than security.
+ */
+@Configuration
+@EnableAutoConfiguration
+@EnableWebSecurity
+class TrailingSlashTestConfig {
+
+  @Bean
+  SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    http.csrf(csrf -> csrf.disable()).headers(headers -> headers.disable());
+    http.authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
+    http.anonymous(anon -> anon.disable());
+    return http.build();
+  }
+}

--- a/kork/kork-web/src/test/java/com/netflix/spinnaker/kork/web/trailingslash/TrailingSlashWithoutFilterTest.java
+++ b/kork/kork-web/src/test/java/com/netflix/spinnaker/kork/web/trailingslash/TrailingSlashWithoutFilterTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026 Harness, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.web.trailingslash;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+
+/**
+ * Reproduces the bug: with the trailing slash filter disabled (Spring Boot 3.x default behavior), a
+ * PUT to {@code /fetch/} returns 404 because it no longer matches the controller mapped to {@code
+ * /fetch}. This is exactly the failure Orca hit calling {@code /artifacts/fetch/}.
+ */
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = {TrailingSlashTestConfig.class, FetchController.class},
+    properties = "url-handler.trailing-slash.enabled=false")
+class TrailingSlashWithoutFilterTest {
+
+  @Autowired private TestRestTemplate restTemplate;
+
+  private HttpEntity<String> request() {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.TEXT_PLAIN);
+    return new HttpEntity<>("payload", headers);
+  }
+
+  @Test
+  void trailingSlashReturns404WhenFilterDisabled() {
+    ResponseEntity<String> response =
+        restTemplate.exchange("/fetch/", HttpMethod.PUT, request(), String.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+  }
+
+  @Test
+  void noTrailingSlashStillWorksWhenFilterDisabled() {
+    ResponseEntity<String> response =
+        restTemplate.exchange("/fetch", HttpMethod.PUT, request(), String.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody()).isEqualTo("fetched:payload");
+  }
+}

--- a/kork/kork-web/src/test/java/com/netflix/spinnaker/kork/web/trailingslash/UrlHandlerFilterAutoConfigurationTest.java
+++ b/kork/kork-web/src/test/java/com/netflix/spinnaker/kork/web/trailingslash/UrlHandlerFilterAutoConfigurationTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026 Harness, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.web.trailingslash;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+
+/**
+ * Proves the fix: with the trailing slash {@link org.springframework.web.filter.UrlHandlerFilter}
+ * registered (the default), a PUT to {@code /fetch/} is routed to the controller mapped to {@code
+ * /fetch}.
+ */
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = {TrailingSlashTestConfig.class, FetchController.class})
+class UrlHandlerFilterAutoConfigurationTest {
+
+  @Autowired private TestRestTemplate restTemplate;
+
+  private HttpEntity<String> request() {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.TEXT_PLAIN);
+    return new HttpEntity<>("payload", headers);
+  }
+
+  @Test
+  void trailingSlashIsRoutedToControllerWhenFilterEnabled() {
+    ResponseEntity<String> response =
+        restTemplate.exchange("/fetch/", HttpMethod.PUT, request(), String.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody()).isEqualTo("fetched:payload");
+  }
+
+  @Test
+  void noTrailingSlashStillWorks() {
+    ResponseEntity<String> response =
+        restTemplate.exchange("/fetch", HttpMethod.PUT, request(), String.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody()).isEqualTo("fetched:payload");
+  }
+}

--- a/kork/kork-web/src/test/java/com/netflix/spinnaker/kork/web/trailingslash/UrlHandlerFilterAutoConfigurationTest.java
+++ b/kork/kork-web/src/test/java/com/netflix/spinnaker/kork/web/trailingslash/UrlHandlerFilterAutoConfigurationTest.java
@@ -63,4 +63,40 @@ class UrlHandlerFilterAutoConfigurationTest {
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
     assertThat(response.getBody()).isEqualTo("fetched:payload");
   }
+
+  @Test
+  void trailingSlashIsNormalizedToNonSlashHandlerWhenEnabled() {
+    // The filter trims the trailing slash before dispatch, so /fetch/ is served by the
+    // @PutMapping("/fetch") handler. This proves normalization happens at the filter layer.
+    ResponseEntity<String> response =
+        restTemplate.exchange("/fetch/", HttpMethod.PUT, request(), String.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody()).isEqualTo("fetched:payload");
+  }
+
+  @Test
+  void explicitTrailingSlashOnlyMappingBecomesUnreachableWhenEnabled() {
+    // Caveat: the filter trims the trailing slash before dispatch, so a request to
+    // /fetchWithSlash/ is dispatched as /fetchWithSlash. Because the controller only maps
+    // /fetchWithSlash/ (with the slash) and nothing maps /fetchWithSlash, the request 404s.
+    // In other words, endpoints that are intentionally mapped WITH a trailing slash become
+    // unreachable while the filter is enabled.
+    ResponseEntity<String> response =
+        restTemplate.exchange("/fetchWithSlash/", HttpMethod.PUT, request(), String.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+  }
+
+  @Test
+  void rootMappingIsNotBrokenWhenEnabled() {
+    // Controllers like echo's HistoryController and gate's RootController map "/". Verify the
+    // filter
+    // does not trim the root path to an empty string and break it.
+    ResponseEntity<String> response =
+        restTemplate.exchange("/", HttpMethod.POST, request(), String.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody()).isEqualTo("root:payload");
+  }
 }


### PR DESCRIPTION
Spring Boot 3.x (Spring Framework 6.0+) removed lenient trailing-slash route matching, so for example PUT /artifacts/fetch/ no longer matches a controller mapped to /artifacts/fetch and returns 404. This broke inter-service calls such as Orca → Clouddriver fetchArtifact, where the Retrofit client emits a trailing slash. Because this is a cross-cutting regression affecting every service, the fix is implemented once in kork-web so all services inherit it with no per-service changes.

- New auto-configuration UrlHandlerFilterAutoConfiguration (kork-web) registers a UrlHandlerFilter as a FilterRegistrationBean at highest precedence, using wrapRequest() so the trailing slash is trimmed transparently (no redirect round-trip for internal calls). The setUseTrailingSlashMatch(true) — deprecated since Spring 6.0 so using the UrlHandlerFilterAutoConfiguration follows the recommended remediation. 
- Enabled by default; can be disabled with url-handler.trailing-slash.enabled=false or scoped via url-handler.trailing-slash.path-patterns.
```
url-handler:
  trailing-slash:
    enabled: true          # default; set false to opt out
    path-patterns:
      - "/**"              # default; narrow if desired
```


## Codebase Audit (trailing-slash controller mappings)
- **Core data-plane services are safe**: `clouddriver`, `orca`, `front50`, `igor`, `fiat`, `rosco`, `kayenta`, `keel` have **zero** trailing-slash mappings.
- `gate` (`RootController`) and `echo` (`HistoryController`) only map the **root `/`**, which the filter does **not** break (verified by `rootMappingIsNotBrokenWhenEnabled`).
- **`halyard` is the exception**: it depends on `kork-web` and maps many endpoints with explicit trailing slashes (`.../haServices/`, `/generate/`, `/clean/`, `/connect/`, `/deploy/`, `/version/`, etc.), which the `hal` CLI calls with the trailing slash. Halyard therefore opts out via `url-handler.trailing-slash.enabled: false`.
