### PR TITLE
fix(build): Minor but on a new branch, the publish-debs was passed to deck-kayenta which doesn't support this as input.

### DIFF
--- a/.github/workflows/rebuild-all.yml
+++ b/.github/workflows/rebuild-all.yml
@@ -58,7 +58,7 @@ jobs:
               workflow_id: 'deck-kayenta.yml',
               ref: '${{ github.ref_name }}',
               inputs: {
-                'publish-debs': true,
+                'publish-npm': true,
                 'version-override': '${{ needs.version.outputs.version }}'
               }
             });


### PR DESCRIPTION
ONLY impacts the rebuild-all workflows.