### PR TITLE
fix(build): Temporary fix to ignore closing a staging repo

### DIFF
--- a/.github/workflows/spinnaker-libraries.yml
+++ b/.github/workflows/spinnaker-libraries.yml
@@ -64,6 +64,7 @@ jobs:
           ./gradlew assemble publishToNexus
 
       - name: Close and release Nexus staging repository
+        continue-on-error: true
         env:
           ORG_GRADLE_PROJECT_version: ${{ steps.version.outputs.version }}
           ORG_GRADLE_PROJECT_nexusPublishEnabled: true


### PR DESCRIPTION
Looking at options to more "completely" redo our nexus integration