### PR TITLE
fix(sql): use inlined literal for compression_type to fix Postgres enum cast failure

### DIFF
--- a/orca/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/pipeline/persistence/SqlExecutionRepository.kt
+++ b/orca/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/pipeline/persistence/SqlExecutionRepository.kt
@@ -1223,7 +1223,12 @@ class SqlExecutionRepository(
         compressedExecTablePairs = mapOf(
           field("id") to id,
           field("compressed_body") to compressedBody,
-          field("compression_type") to compressionProperties.compressionType.type
+          // Bind as an inlined string literal rather than a typed bind parameter. Postgres can
+          // implicitly cast a string literal to the native compression_type_enum column type,
+          // but rejects an untyped ("unknown") bind parameter with a BadSqlGrammarException
+          // (column "compression_type" is of type compression_type_enum but expression is of
+          // type character varying). MySQL/MariaDB accept the inlined literal identically.
+          field("compression_type") to DSL.inline(compressionProperties.compressionType.type)
         )
         isBodyCompressed = true
       }

--- a/orca/orca-sql/src/test/kotlin/com/netflix/spinnaker/orca/sql/pipeline/persistence/SqlExecutionRepositoryPostgresCompressionTest.kt
+++ b/orca/orca-sql/src/test/kotlin/com/netflix/spinnaker/orca/sql/pipeline/persistence/SqlExecutionRepositoryPostgresCompressionTest.kt
@@ -21,12 +21,15 @@ import com.netflix.spinnaker.kork.sql.config.RetryProperties
 import com.netflix.spinnaker.kork.sql.test.SqlTestUtil
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionType
 import com.netflix.spinnaker.orca.jackson.OrcaObjectMapper
-import dev.minutest.junit.JUnit5Minutests
-import dev.minutest.rootContext
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatCode
 import org.jooq.impl.DSL.field
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
 import org.mockito.kotlin.mock
 import org.testcontainers.DockerClientFactory
 import java.lang.System.currentTimeMillis
@@ -50,116 +53,117 @@ import javax.sql.DataSource
  * exhibited this bug (no native enum type strictness), which is why the existing, MySQL-only
  * SqlExecutionRepositoryTest suite never caught it.
  */
-class SqlExecutionRepositoryPostgresCompressionTest : JUnit5Minutests {
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class SqlExecutionRepositoryPostgresCompressionTest {
 
-  fun tests() = rootContext<Fixture> {
-    fixture { Fixture() }
+  private val testRetryProperties = RetryProperties()
+  private val orcaObjectMapper = OrcaObjectMapper.newInstance()
+  private val mockDataSource = mock<DataSource>()
 
-    beforeAll {
-      assumeTrue(DockerClientFactory.instance().isDockerAvailable)
-    }
-
-    after {
-      SqlTestUtil.cleanupDb(database.context)
-    }
-
-    context("execution body compression against PostgreSQL") {
-
-      val testType = ExecutionType.PIPELINE
-      val testTable = testType.tableName
-      val testId = "test_id"
-      val testApplication = "test-application"
-      val testCompressibleBody = "test_body_long_enough_to_compress"
-      val testCompressiblePairs = mutableMapOf(
-        field("id") to testId,
-        field("application") to testApplication,
-        field("body") to testCompressibleBody,
-        field("build_time") to currentTimeMillis(),
-        field("status") to "RUNNING"
-      )
-
-      test("upsert (INSERT) of a compressed execution body succeeds against PostgreSQL") {
-        assertThatCode {
-          sqlExecutionRepository.upsert(
-            database.context,
-            table = testTable,
-            insertPairs = testCompressiblePairs,
-            updatePairs = testCompressiblePairs,
-            id = testId,
-            enableCompression = true
-          )
-        }.doesNotThrowAnyException()
-
-        val compressedExecutions = database.context
-          .select(listOf(field("id"), field("compression_type")))
-          .from(testTable.compressedExecTable)
-          .fetch()
-        assertThat(compressedExecutions).hasSize(1)
-        assertThat(compressedExecutions.getValue(0, field("compression_type"))).isEqualTo("ZLIB")
-      }
-
-      test("upsert (ON CONFLICT DO UPDATE) of a compressed execution body succeeds against PostgreSQL") {
-        // Initial insert.
-        sqlExecutionRepository.upsert(
-          database.context,
-          table = testTable,
-          insertPairs = testCompressiblePairs,
-          updatePairs = testCompressiblePairs,
-          id = testId,
-          enableCompression = true
-        )
-
-        // Re-upserting the same id exercises the ON CONFLICT DO UPDATE SET path, which is
-        // where the original bug manifested.
-        assertThatCode {
-          sqlExecutionRepository.upsert(
-            database.context,
-            table = testTable,
-            insertPairs = testCompressiblePairs,
-            updatePairs = testCompressiblePairs,
-            id = testId,
-            enableCompression = true
-          )
-        }.doesNotThrowAnyException()
-
-        val compressedExecutions = database.context
-          .select(listOf(field("id"), field("compression_type")))
-          .from(testTable.compressedExecTable)
-          .fetch()
-        assertThat(compressedExecutions).hasSize(1)
-        assertThat(compressedExecutions.getValue(0, field("compression_type"))).isEqualTo("ZLIB")
-      }
-    }
+  private val executionCompressionPropertiesEnabled = ExecutionCompressionProperties().apply {
+    enabled = true
+    bodyCompressionThreshold = 9
+    compressionType = CompressionType.ZLIB
   }
 
-  private inner class Fixture {
-    val database = SqlTestUtil.initTcPostgresDatabase()!!
+  private val testType = ExecutionType.PIPELINE
+  private val testTable = testType.tableName
+  private val testId = "test_id"
+  private val testApplication = "test-application"
+  private val testCompressibleBody = "test_body_long_enough_to_compress"
 
-    val testRetryProprties = RetryProperties()
-    val orcaObjectMapper = OrcaObjectMapper.newInstance()
-    val mockDataSource = mock<DataSource>()
+  private val testCompressiblePairs = mutableMapOf(
+    field("id") to testId,
+    field("application") to testApplication,
+    field("body") to testCompressibleBody,
+    field("build_time") to currentTimeMillis(),
+    field("status") to "RUNNING"
+  )
 
-    val executionCompressionPropertiesEnabled = ExecutionCompressionProperties().apply {
-      enabled = true
-      bodyCompressionThreshold = 9
-      compressionType = CompressionType.ZLIB
-    }
+  private lateinit var database: SqlTestUtil.TestDatabase
+  private lateinit var sqlExecutionRepository: SqlExecutionRepository
 
-    val sqlExecutionRepository =
-      SqlExecutionRepository(
-        "test",
+  @BeforeAll
+  fun beforeAll() {
+    assumeTrue(DockerClientFactory.instance().isDockerAvailable)
+  }
+
+  @BeforeEach
+  fun setup() {
+    database = SqlTestUtil.initTcPostgresDatabase()!!
+    sqlExecutionRepository = SqlExecutionRepository(
+      "test",
+      database.context,
+      orcaObjectMapper,
+      testRetryProperties,
+      10,
+      100,
+      "poolName",
+      "myReadPoolName",
+      null,
+      emptyList(),
+      executionCompressionPropertiesEnabled,
+      false,
+      mockDataSource
+    )
+  }
+
+  @AfterEach
+  fun cleanup() {
+    SqlTestUtil.cleanupDb(database.context)
+  }
+
+  @Test
+  fun `upsert INSERT of a compressed execution body succeeds against PostgreSQL`() {
+    assertThatCode {
+      sqlExecutionRepository.upsert(
         database.context,
-        orcaObjectMapper,
-        testRetryProprties,
-        10,
-        100,
-        "poolName",
-        "myReadPoolName",
-        null,
-        emptyList(),
-        executionCompressionPropertiesEnabled,
-        false,
-        mockDataSource
+        table = testTable,
+        insertPairs = testCompressiblePairs,
+        updatePairs = testCompressiblePairs,
+        id = testId,
+        enableCompression = true
       )
+    }.doesNotThrowAnyException()
+
+    val compressedExecutions = database.context
+      .select(listOf(field("id"), field("compression_type")))
+      .from(testTable.compressedExecTable)
+      .fetch()
+    assertThat(compressedExecutions).hasSize(1)
+    assertThat(compressedExecutions.getValue(0, field("compression_type"))).isEqualTo("ZLIB")
+  }
+
+  @Test
+  fun `upsert ON CONFLICT DO UPDATE of a compressed execution body succeeds against PostgreSQL`() {
+    // Initial insert.
+    sqlExecutionRepository.upsert(
+      database.context,
+      table = testTable,
+      insertPairs = testCompressiblePairs,
+      updatePairs = testCompressiblePairs,
+      id = testId,
+      enableCompression = true
+    )
+
+    // Re-upserting the same id exercises the ON CONFLICT DO UPDATE SET path, which is
+    // where the original bug manifested.
+    assertThatCode {
+      sqlExecutionRepository.upsert(
+        database.context,
+        table = testTable,
+        insertPairs = testCompressiblePairs,
+        updatePairs = testCompressiblePairs,
+        id = testId,
+        enableCompression = true
+      )
+    }.doesNotThrowAnyException()
+
+    val compressedExecutions = database.context
+      .select(listOf(field("id"), field("compression_type")))
+      .from(testTable.compressedExecTable)
+      .fetch()
+    assertThat(compressedExecutions).hasSize(1)
+    assertThat(compressedExecutions.getValue(0, field("compression_type"))).isEqualTo("ZLIB")
   }
 }

--- a/orca/orca-sql/src/test/kotlin/com/netflix/spinnaker/orca/sql/pipeline/persistence/SqlExecutionRepositoryPostgresCompressionTest.kt
+++ b/orca/orca-sql/src/test/kotlin/com/netflix/spinnaker/orca/sql/pipeline/persistence/SqlExecutionRepositoryPostgresCompressionTest.kt
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2026 Harness, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.orca.sql.pipeline.persistence
+
+import com.netflix.spinnaker.config.CompressionType
+import com.netflix.spinnaker.config.ExecutionCompressionProperties
+import com.netflix.spinnaker.kork.sql.config.RetryProperties
+import com.netflix.spinnaker.kork.sql.test.SqlTestUtil
+import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionType
+import com.netflix.spinnaker.orca.jackson.OrcaObjectMapper
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatCode
+import org.jooq.impl.DSL.field
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.mockito.kotlin.mock
+import org.testcontainers.DockerClientFactory
+import java.lang.System.currentTimeMillis
+import javax.sql.DataSource
+
+/**
+ * Regression test for https://github.com/spinnaker/spinnaker/issues/7017.
+ *
+ * Prior to the fix, upserting a compressed execution body against a real PostgreSQL database
+ * failed with:
+ *
+ *   org.springframework.jdbc.BadSqlGrammarException: jOOQ; bad SQL grammar [insert into
+ *   pipelines_compressed_executions (id, compressed_body, compression_type) values (?, ?, ?)
+ *   on conflict (id) do update set id = ?, compressed_body = ?, compression_type = ?];
+ *   nested exception is org.postgresql.util.PSQLException: ERROR: column "compression_type"
+ *   is of type compression_type_enum but expression is of type character varying
+ *
+ * Root cause: `compression_type` was bound as an untyped jOOQ bind parameter (a plain Kotlin
+ * String). PostgreSQL refuses to implicitly cast an untyped bind parameter to a native enum
+ * column type, though it will implicitly cast an inlined string literal. MySQL/MariaDB never
+ * exhibited this bug (no native enum type strictness), which is why the existing, MySQL-only
+ * SqlExecutionRepositoryTest suite never caught it.
+ */
+class SqlExecutionRepositoryPostgresCompressionTest : JUnit5Minutests {
+
+  fun tests() = rootContext<Fixture> {
+    fixture { Fixture() }
+
+    beforeAll {
+      assumeTrue(DockerClientFactory.instance().isDockerAvailable)
+    }
+
+    after {
+      SqlTestUtil.cleanupDb(database.context)
+    }
+
+    context("execution body compression against PostgreSQL") {
+
+      val testType = ExecutionType.PIPELINE
+      val testTable = testType.tableName
+      val testId = "test_id"
+      val testApplication = "test-application"
+      val testCompressibleBody = "test_body_long_enough_to_compress"
+      val testCompressiblePairs = mutableMapOf(
+        field("id") to testId,
+        field("application") to testApplication,
+        field("body") to testCompressibleBody,
+        field("build_time") to currentTimeMillis(),
+        field("status") to "RUNNING"
+      )
+
+      test("upsert (INSERT) of a compressed execution body succeeds against PostgreSQL") {
+        assertThatCode {
+          sqlExecutionRepository.upsert(
+            database.context,
+            table = testTable,
+            insertPairs = testCompressiblePairs,
+            updatePairs = testCompressiblePairs,
+            id = testId,
+            enableCompression = true
+          )
+        }.doesNotThrowAnyException()
+
+        val compressedExecutions = database.context
+          .select(listOf(field("id"), field("compression_type")))
+          .from(testTable.compressedExecTable)
+          .fetch()
+        assertThat(compressedExecutions).hasSize(1)
+        assertThat(compressedExecutions.getValue(0, field("compression_type"))).isEqualTo("ZLIB")
+      }
+
+      test("upsert (ON CONFLICT DO UPDATE) of a compressed execution body succeeds against PostgreSQL") {
+        // Initial insert.
+        sqlExecutionRepository.upsert(
+          database.context,
+          table = testTable,
+          insertPairs = testCompressiblePairs,
+          updatePairs = testCompressiblePairs,
+          id = testId,
+          enableCompression = true
+        )
+
+        // Re-upserting the same id exercises the ON CONFLICT DO UPDATE SET path, which is
+        // where the original bug manifested.
+        assertThatCode {
+          sqlExecutionRepository.upsert(
+            database.context,
+            table = testTable,
+            insertPairs = testCompressiblePairs,
+            updatePairs = testCompressiblePairs,
+            id = testId,
+            enableCompression = true
+          )
+        }.doesNotThrowAnyException()
+
+        val compressedExecutions = database.context
+          .select(listOf(field("id"), field("compression_type")))
+          .from(testTable.compressedExecTable)
+          .fetch()
+        assertThat(compressedExecutions).hasSize(1)
+        assertThat(compressedExecutions.getValue(0, field("compression_type"))).isEqualTo("ZLIB")
+      }
+    }
+  }
+
+  private inner class Fixture {
+    val database = SqlTestUtil.initTcPostgresDatabase()!!
+
+    val testRetryProprties = RetryProperties()
+    val orcaObjectMapper = OrcaObjectMapper.newInstance()
+    val mockDataSource = mock<DataSource>()
+
+    val executionCompressionPropertiesEnabled = ExecutionCompressionProperties().apply {
+      enabled = true
+      bodyCompressionThreshold = 9
+      compressionType = CompressionType.ZLIB
+    }
+
+    val sqlExecutionRepository =
+      SqlExecutionRepository(
+        "test",
+        database.context,
+        orcaObjectMapper,
+        testRetryProprties,
+        10,
+        100,
+        "poolName",
+        "myReadPoolName",
+        null,
+        emptyList(),
+        executionCompressionPropertiesEnabled,
+        false,
+        mockDataSource
+      )
+  }
+}


### PR DESCRIPTION
**Bug**
SqlExecutionRepository fails to persist compressed pipeline executions against PostgreSQL, throwing BadSqlGrammarException on the pipelines_compressed_executions (and equivalent orchestration_stages_compressed_executions) INSERT/ON CONFLICT statement. MySQL/MariaDB are unaffected. Matches [spinnaker/spinnaker#7017](https://github.com/spinnaker/spinnaker/issues/7017).

**Root Cause**
compression_type was bound as an untyped jOOQ bind parameter. PostgreSQL allows an implicit cast from a string literal to a native enum column (compression_type_enum), but rejects an implicit cast from an untyped bind parameter of type character varying.

**Fix**
orca-sql/.../SqlExecutionRepository.kt:1223 — wrap the value with DSL.inline(...) so jOOQ renders it as an inlined SQL literal rather than a ? bind placeholder. Since it's a single combined INSERT ... ON CONFLICT (id) DO UPDATE SET ... statement, Postgres type-checks the entire statement (including the DO UPDATE SET clause) up front — so this one change fixes both the INSERT and the ON CONFLICT UPDATE paths in the same statement.

**Test Environment**
Local Kubernetes (Rancher Desktop/k3s), Spinnaker OSS deployed via Armory Operator + kustomize
PostgreSQL 16 (postgres:16-alpine), fresh database, Orca's execution repository fully switched to SQL (execution-repository.sql.enabled: true, execution-repository.redis.enabled: false), dialect: POSTGRES
Compression forced via bodyCompressionThreshold: 1 to guarantee every execution triggers the compressed-write path
**Verification Steps**
Before fix (armory/orca:2.38.0-rc1, unpatched): triggered pipeline execution → reproduced exact error:
org.postgresql.util.PSQLException: ERROR: column "compression_type" is of type compression_type_enum 
but expression is of type character varying
**Hint**: You will need to rewrite or cast the expression.
After fix (armory/spinnaker-orca:2026.07.10.16.28.53.fix-postgres-compression-type-enum-cast, built from this branch): confirmed bytecode contains the DSL.inline call in SqlExecutionRepository.class
Triggered pipeline execution twice independently → both succeeded with no exception:
sql
SELECT id, compression_type, LENGTH(compressed_body) FROM pipelines_compressed_executions;
-- 01KX6X4KVT7FCRDWTC3N9K5WWQ | ZLIB | 449
-- 01KX6X7DHWJFQ63XFZ59ZCHRMY | ZLIB | 450