### PR TITLE
fix(gate): guard PermissionService.isAdmin(String) with fiatStatus.isEnabled()

### DIFF
--- a/gate/gate-core/src/main/java/com/netflix/spinnaker/gate/services/PermissionService.java
+++ b/gate/gate-core/src/main/java/com/netflix/spinnaker/gate/services/PermissionService.java
@@ -244,6 +244,9 @@ public class PermissionService {
   }
 
   public boolean isAdmin(String userId) {
+    if (!fiatStatus.isEnabled()) {
+      return false;
+    }
     var permission = permissionEvaluator.getPermission(userId);
     return permission != null && permission.isAdmin();
   }

--- a/gate/gate-core/src/test/java/com/netflix/spinnaker/gate/services/PermissionServiceTest.java
+++ b/gate/gate-core/src/test/java/com/netflix/spinnaker/gate/services/PermissionServiceTest.java
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.gate.services;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -285,6 +286,36 @@ public class PermissionServiceTest {
     }
 
     verifyNoMoreInteractions(extendedFiatService, permissionEvaluator);
+  }
+
+  @Test
+  public void testIsAdminReturnsFalseWithoutCallingFiatWhenDisabled() {
+    FiatStatus fiatStatus = mock(FiatStatus.class);
+    FiatPermissionEvaluator permissionEvaluator = mock(FiatPermissionEvaluator.class);
+    when(fiatStatus.isEnabled()).thenReturn(false);
+
+    PermissionService permissionService =
+        new PermissionService(null, null, null, permissionEvaluator, fiatStatus);
+
+    assertFalse(permissionService.isAdmin("foo@bar.com"));
+    verify(permissionEvaluator, times(0)).getPermission("foo@bar.com");
+  }
+
+  @Test
+  public void testIsAdminDelegatesToFiatWhenEnabled() {
+    FiatStatus fiatStatus = mock(FiatStatus.class);
+    FiatPermissionEvaluator permissionEvaluator = mock(FiatPermissionEvaluator.class);
+    when(fiatStatus.isEnabled()).thenReturn(true);
+
+    UserPermission.View permission = new UserPermission.View();
+    permission.setAdmin(true);
+    when(permissionEvaluator.getPermission("foo@bar.com")).thenReturn(permission);
+
+    PermissionService permissionService =
+        new PermissionService(null, null, null, permissionEvaluator, fiatStatus);
+
+    assertTrue(permissionService.isAdmin("foo@bar.com"));
+    verify(permissionEvaluator, times(1)).getPermission("foo@bar.com");
   }
 
   private UserPermission.View sa(String name, String application, Collection<Authorization> auths) {


### PR DESCRIPTION
## Summary

`gate/gate-core/.../PermissionService.isAdmin(String)` is the only method in this class that calls out to Fiat without first checking `fiatStatus.isEnabled()`. Every sibling method (`login`, `logout`, `sync`, `getRoles`, `getServiceAccounts`, `getServiceAccountsForApplication`, `getRolesForTokenAuth`) does the check and short-circuits with a safe default; this one has called `FiatPermissionEvaluator.getPermission()` unconditionally since it was introduced in [spinnaker/gate#772](https://github.com/spinnaker/gate/commit/995a3f8dcbc5f3e82df5705c869c98742e6c7db9) (back when `gate` was its own repo, before consolidation into this monorepo), which added it without the guard even though `FiatStatus`/`fiatStatus.isEnabled()` already existed at the time.

## Impact

`isAdmin(String)` is reachable via `@PreAuthorize("@authController.isAdmin()")` on `POST /auth/roles/sync` and `POST /auth/deleteSessionCache`. On any deployment running with Fiat disabled or unreachable, every request to those endpoints still unconditionally calls `getPermission()`, which retries with exponential backoff (default `maxBackoffMillis: 10000`) before giving up - several seconds of added latency per request, purely from a code path that config alone can't gate. We hit this in production: `services.fiat.enabled`/`fiat.enabled` were both correctly set to `false`, yet these two endpoints kept blocking on failed Fiat calls. A full stack trace confirmed the call originated from this exact method.

## Fix

Add the same `if (!fiatStatus.isEnabled()) { return ...; }` guard used everywhere else in the class. `false` is the fail-closed default here (not admin), consistent with what happens today when `getPermission()` legitimately returns `null`.

## Test plan

- [x] Added `testIsAdminReturnsFalseWithoutCallingFiatWhenDisabled` - verifies `isAdmin` returns `false` and never calls `FiatPermissionEvaluator.getPermission()` when Fiat is disabled.
- [x] Added `testIsAdminDelegatesToFiatWhenEnabled` - verifies existing behavior is preserved when Fiat is enabled.