### PR TITLE
Add kork-secrets-k8s dependency to Halyard

### DIFF
--- a/halyard/halyard-config/halyard-config.gradle
+++ b/halyard/halyard-config/halyard-config.gradle
@@ -18,6 +18,7 @@ dependencies {
   implementation 'io.spinnaker.kork:kork-secrets'
   implementation 'io.spinnaker.kork:kork-secrets-aws'
   implementation 'io.spinnaker.kork:kork-secrets-gcp'
+  implementation 'io.spinnaker.kork:kork-secrets-k8s'
   implementation 'io.spinnaker.kork:kork-retrofit'
   implementation 'io.spinnaker.kork:kork-retrofit2'
   implementation "io.spinnaker.kork:kork-docker"

--- a/halyard/halyard-core/halyard-core.gradle
+++ b/halyard/halyard-core/halyard-core.gradle
@@ -9,6 +9,7 @@ dependencies {
   implementation 'io.spinnaker.kork:kork-secrets'
   implementation 'io.spinnaker.kork:kork-secrets-aws'
   implementation 'io.spinnaker.kork:kork-secrets-gcp'
+  implementation 'io.spinnaker.kork:kork-secrets-k8s'
   implementation 'com.google.apis:google-api-services-storage'
   implementation 'com.google.api.grpc:grpc-google-common-protos:1.0.5'
   implementation 'com.google.auth:google-auth-library-oauth2-http'

--- a/halyard/halyard-web/config/halyard.yml
+++ b/halyard/halyard-web/config/halyard.yml
@@ -18,6 +18,15 @@ spinnaker:
         enabled: true
       writerEnabled: false
       bucket: halconfig
+  secrets:
+    kubernetes:
+      # Enables kork's KubernetesSecretEngine (identifier "k8s") inside Halyard's own Spring
+      # context so that `hal config generate` can resolve `encrypted:k8s!...`/`encryptedFile:k8s!...`
+      # secrets embedded in a halconfig. This is separate from (and does not affect) the
+      # `spinnaker.secrets.kubernetes.enabled` property inside the *deployed* microservices'
+      # own spinnaker-local.yml, which must still be set there independently if those services
+      # also need to resolve k8s secrets themselves.
+      enabled: true
 
 management:
   endpoint:


### PR DESCRIPTION
## Summary

- Adds `kork-secrets-k8s` as a dependency of `halyard-core` and `halyard-config`, enabling Halyard's `hal config generate` to resolve `encrypted:k8s!...`/`encryptedFile:k8s!...` secrets the same way it already resolves `encrypted:s3!...`/`encrypted:gcs!...` via the already-present `kork-secrets-aws`/`kork-secrets-gcp` dependencies.
- `KubernetesSecretEngine` is gated behind `@ConditionalOnProperty("spinnaker.secrets.kubernetes.enabled")`, unlike the unconditional AWS/GCP secret engine beans, so the dependency alone isn't sufficient. This also sets that property in `halyard-web/config/halyard.yml` — Halyard's own process-level Spring config (loaded via the same `spring.config.name=spinnaker,halyard` mechanism every other Spinnaker service already uses for its own settings file), which is separate from the equivalent property inside a target deployment's `spinnaker-local.yml`.

This was raised with a maintainer directly, who gave the go-ahead:

> "encryptedFile is the "simplest" if it's a REAL file :wink: I don't mind adding it to halyard - I consider halyard dead, so I'm not as worried about pulls there... JUST be aware of the limitations... e.g. just a simple PR to add kork-secrets-k8s to halyard in the place i linked above would mostly enable it - don't forget it's CONDITIONAL though on properties - aka... some halyard process configuration to enable it"

## Known limitations

- **AWS provider account credentials** (`providers.aws.accounts[].accessKeyId`/`secretAccessKey`) are resolved locally inside Halyard via `AwsCredentialsProfileFactoryBuilder`, which calls `secretSessionManager.decrypt()` unconditionally to materialize a literal `~/.aws/credentials` file. There's no `encryptedFile:`-style deferral available for this field, so `encrypted:k8s!...` still cannot be used there even with this change.
- **Kubernetes provider `kubeconfigFile`** already works with `encryptedFile:k8s!...` (not `encrypted:k8s!...`) prior to this change too, since `FileService.isRemoteFile()` defers resolution to the deployed clouddriver instead of Halyard itself for the file-prefix variant. This PR additionally makes plain `encrypted:k8s!...` resolvable locally by Halyard for cases where local resolution is actually wanted (e.g. profile-file secrets, notification/artifact tokens).

## Test plan

- [x] Confirmed `kork-secrets-aws`/`kork-secrets-gcp` follow the identical dependency-declaration pattern already used in both `halyard-core.gradle` and `halyard-config.gradle`.
- [x] Verified `halyard/halyard-deploy` needs no direct change: it depends on `halyard-core`/`halyard-config` as projects, and Gradle `implementation` dependencies of a dependency land on the consumer's runtime classpath — the same reason AWS/GCP already work from `halyard-deploy` without being declared there directly.
- [x] Built `./gradlew :halyard:halyard-core:compileJava :halyard:halyard-config:compileJava --stacktrace` with this change applied — `BUILD SUCCESSFUL`, `kork-secrets-k8s` resolved and compiled cleanly via the composite build.
- [ ] Not yet verified end-to-end against a real `encrypted:k8s!...` reference inside a live `hal config generate`/`hal deploy apply` run — happy to follow up with that once this is reviewed, if useful.