### PR TITLE
fix(install): Use correct ARCH type for arm64 architecture during Rosco packer install

### DIFF
--- a/rosco/rosco-web/pkg_scripts/postInstall.sh
+++ b/rosco/rosco-web/pkg_scripts/postInstall.sh
@@ -19,6 +19,8 @@ fi
 ARCH=$(uname -m)
 if [ "$ARCH" = "x86_64" ]; then
   ARCH="amd64"
+elif [ "$ARCH" = "aarch64" ]; then
+  ARCH="arm64"
 fi
 
 # Get the PACKER_PLUGINS environment variable or set a default value


### PR DESCRIPTION
Resolves the following issue when installing the Roscoe Debian package on arm64 architecture:
```
Setting up spinnaker-rosco (2026.2.2)…
/var/lib/dpkg/info/spinnaker-rosco.postinst: 50: /usr/bin/packer: not found
--2026-07-15 09:57:41--  https://releases.hashicorp.com/packer/1.10.1/packer_1.10.1_linux_aarch64.zip
Resolving releases.hashicorp.com (releases.hashicorp.com)... 3.174.129.28, 3.174.129.56, 3.174.129.61, ...
Connecting to releases.hashicorp.com (releases.hashicorp.com)|3.174.129.28|:443... connected.
HTTP request sent, awaiting response... 404 Not Found
2026-07-15 09:57:42 ERROR 404: Not Found.

dpkg: error processing package spinnaker-rosco (--configure):
 old spinnaker-rosco package postinst maintainer script subprocess failed with exit status 8
Errors were encountered while processing:
 spinnaker-rosco
needrestart is being skipped since dpkg has failed
E: Sub-process /usr/bin/dpkg returned an error code (1)
! ERROR Error encountered running script. See above output for more
  details.
 ```