### PR TITLE
refactor(deck): remove Angular router facade consumers

### DIFF
--- a/deck-kayenta/src/initializeKayenta.spec.ts
+++ b/deck-kayenta/src/initializeKayenta.spec.ts
@@ -32,7 +32,7 @@ describe('initializeKayenta', () => {
 
     initializeKayenta(applicationState, uiRouter);
 
-    expect(registerKayentaDataSourceStubs).toHaveBeenCalledTimes(1);
+    expect(registerKayentaDataSourceStubs).toHaveBeenCalledWith(uiRouter);
     expect(registerKayentaStateStubs).toHaveBeenCalledWith(applicationState, uiRouter);
   });
 

--- a/deck-kayenta/src/initializeKayenta.ts
+++ b/deck-kayenta/src/initializeKayenta.ts
@@ -18,7 +18,7 @@ export function initializeKayenta(applicationState: ApplicationStateProvider, ui
   }
 
   initialized = true;
-  registerKayentaDataSourceStubs();
+  registerKayentaDataSourceStubs(uiRouter);
   registerKayentaStateStubs(applicationState, uiRouter);
 
   if (CanarySettings.stagesEnabled !== false) {

--- a/deck-kayenta/src/kayenta/canary.dataSource.bridge.ts
+++ b/deck-kayenta/src/kayenta/canary.dataSource.bridge.ts
@@ -30,8 +30,8 @@ export function bridgeKayentaDataSourceToReduxStore() {
     );
   };
 
-  stub.loadCanaryExecutions = (application: Application) => {
-    const listExecutionsRequest = listCanaryExecutions(application.name);
+  stub.loadCanaryExecutions = (application: Application, stateService) => {
+    const listExecutionsRequest = listCanaryExecutions(application.name, stateService);
 
     listExecutionsRequest.catch((error) => {
       canaryStore.dispatch(Creators.loadExecutionsFailure({ error }));

--- a/deck-kayenta/src/kayenta/canary.dataSource.stub.ts
+++ b/deck-kayenta/src/kayenta/canary.dataSource.stub.ts
@@ -3,17 +3,23 @@ import { CanarySettings } from 'kayenta/canary.settings';
 import { Application, ApplicationDataSourceRegistry } from '@spinnaker/core';
 
 import { getCanaryConfigSummaries, listJudges } from './service/canaryConfig.service';
+import type { ICanaryExecutionRouteService } from './service/canaryRun.service';
 import { listCanaryExecutions } from './service/canaryRun.service';
+
+interface ICanaryDataSourceRouter {
+  stateService: ICanaryExecutionRouteService;
+}
 
 // When the lazy portion loads, it overwrites these stub with implementation that bridges data to the redux store
 export const stub = {
-  loadCanaryExecutions: (application: Application) => listCanaryExecutions(application.name),
+  loadCanaryExecutions: (application: Application, stateService: ICanaryExecutionRouteService) =>
+    listCanaryExecutions(application.name, stateService),
   afterConfigsLoaded: (_application: Application): void => void 0,
   afterJudgesLoaded: (_application: Application): void => void 0,
   afterCanaryExecutionsLoaded: (_application: Application): void => void 0,
 };
 
-export function registerKayentaDataSourceStubs() {
+export function registerKayentaDataSourceStubs(uiRouter: ICanaryDataSourceRouter) {
   const onLoad = (app: Application, data: any) => Promise.resolve(data);
   const loadCanaryConfigs = (application: Application) => {
     return CanarySettings.showAllConfigs ? getCanaryConfigSummaries() : getCanaryConfigSummaries(application.name);
@@ -54,7 +60,7 @@ export function registerKayentaDataSourceStubs() {
     activeState: '**.report.**',
     category: 'delivery',
     requiresDataSource: 'canaryConfigs',
-    loader: (application) => stub.loadCanaryExecutions(application),
+    loader: (application) => stub.loadCanaryExecutions(application, uiRouter.stateService),
     onLoad,
     afterLoad: (application) => stub.afterCanaryExecutionsLoaded(application),
     lazy: true,

--- a/deck-kayenta/src/kayenta/canary.tsx
+++ b/deck-kayenta/src/kayenta/canary.tsx
@@ -1,3 +1,4 @@
+import type { UIRouter } from '@uirouter/core';
 import { UIView } from '@uirouter/react';
 import * as React from 'react';
 import { Provider, Store } from 'react-redux';
@@ -10,19 +11,27 @@ import { INITIALIZE } from './actions';
 import { CanarySettings } from './canary.settings';
 import { ICanaryConfigSummary, IJudge } from './domain';
 import Styleguide from './layout/styleguide';
-import { actionInterceptingMiddleware, asyncDispatchMiddleware, epicMiddleware } from './middleware';
-import { ICanaryState, rootReducer } from './reducers';
+import { actionInterceptingMiddleware, asyncDispatchMiddleware, createKayentaEpicMiddleware } from './middleware';
+import type { ICanaryState } from './reducers';
+import { rootReducer } from './reducers';
 
 export interface ICanaryProps {
   app: Application;
 }
 
-const middleware = [epicMiddleware, actionInterceptingMiddleware, asyncDispatchMiddleware];
+export let canaryStore: Store<ICanaryState>;
 
-export const canaryStore: Store<ICanaryState> = createStore<ICanaryState>(
-  rootReducer,
-  applyMiddleware(...(CanarySettings.reduxLogger ? [...middleware, logger] : middleware)),
-);
+export function initializeCanaryStore(uiRouter: UIRouter): void {
+  if (canaryStore) {
+    return;
+  }
+
+  const middleware = [createKayentaEpicMiddleware(uiRouter), actionInterceptingMiddleware, asyncDispatchMiddleware];
+  canaryStore = createStore<ICanaryState>(
+    rootReducer,
+    applyMiddleware(...(CanarySettings.reduxLogger ? [...middleware, logger] : middleware)),
+  );
+}
 
 export default class Canary extends React.Component<ICanaryProps> {
   private readonly store: Store<ICanaryState>;

--- a/deck-kayenta/src/kayenta/middleware/epics.ts
+++ b/deck-kayenta/src/kayenta/middleware/epics.ts
@@ -1,7 +1,9 @@
+import type { UIRouter } from '@uirouter/core';
 import * as Actions from 'kayenta/actions';
 import * as Creators from 'kayenta/actions/creators';
-import { ICanaryConfigUpdateResponse, KayentaAccountType } from 'kayenta/domain';
-import { ICanaryState } from 'kayenta/reducers';
+import type { ICanaryConfigUpdateResponse } from 'kayenta/domain';
+import { KayentaAccountType } from 'kayenta/domain';
+import type { ICanaryState } from 'kayenta/reducers';
 import { runSelector } from 'kayenta/selectors';
 import {
   createCanaryConfig,
@@ -12,8 +14,9 @@ import {
   updateCanaryConfig,
 } from 'kayenta/service/canaryConfig.service';
 import { listMetricsServiceMetadata } from 'kayenta/service/metricsServiceMetadata.service';
-import { Action, MiddlewareAPI } from 'redux';
-import { combineEpics, createEpicMiddleware, EpicMiddleware } from 'redux-observable';
+import type { Action, MiddlewareAPI } from 'redux';
+import type { EpicMiddleware } from 'redux-observable';
+import { combineEpics, createEpicMiddleware } from 'redux-observable';
 import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/observable/concat';
 import 'rxjs/add/observable/forkJoin';
@@ -24,8 +27,6 @@ import 'rxjs/add/operator/debounceTime';
 import 'rxjs/add/operator/filter';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/mapTo';
-
-import { AngularServices } from '@spinnaker/core';
 
 import { getCanaryRun, getMetricSetPair } from '../service/canaryRun.service';
 
@@ -43,7 +44,10 @@ const selectConfigEpic = (action$: Observable<Action & any>) =>
     .filter(typeMatches(Actions.LOAD_CONFIG_SUCCESS))
     .map((action) => Creators.selectConfig({ config: action.payload.config }));
 
-const saveConfigEpic = (action$: Observable<Action & any>, store: MiddlewareAPI<ICanaryState>) =>
+const saveConfigEpic = (uiRouter: UIRouter) => (
+  action$: Observable<Action & any>,
+  store: MiddlewareAPI<ICanaryState>,
+) =>
   action$.filter(typeMatches(Actions.SAVE_CONFIG_REQUEST)).concatMap(() => {
     const config = mapStateToConfig(store.getState());
     let saveAction: PromiseLike<ICanaryConfigUpdateResponse>;
@@ -57,7 +61,7 @@ const saveConfigEpic = (action$: Observable<Action & any>, store: MiddlewareAPI<
     return Observable.fromPromise(saveAction)
       .concatMap(({ canaryConfigId }) =>
         Observable.forkJoin(
-          AngularServices.$state.go('^.configDetail', { id: canaryConfigId, copy: false, new: false }),
+          uiRouter.stateService.go('^.configDetail', { id: canaryConfigId, copy: false, new: false }),
           store.getState().data.application.getDataSource('canaryConfigs').refresh(true),
         ).mapTo(Creators.saveConfigSuccess({ id: canaryConfigId })),
       )
@@ -71,12 +75,15 @@ const deleteConfigRequestEpic = (action$: Observable<Action & any>, store: Middl
       .catch((error: Error) => Observable.of(Creators.deleteConfigFailure({ error }))),
   );
 
-const deleteConfigSuccessEpic = (action$: Observable<Action & any>, store: MiddlewareAPI<ICanaryState>) =>
+const deleteConfigSuccessEpic = (uiRouter: UIRouter) => (
+  action$: Observable<Action & any>,
+  store: MiddlewareAPI<ICanaryState>,
+) =>
   action$
     .filter(typeMatches(Actions.DELETE_CONFIG_SUCCESS))
     .concatMap(() =>
       Observable.forkJoin(
-        AngularServices.$state.go('^.configDefault'),
+        uiRouter.stateService.go('^.configDefault'),
         // TODO: handle config summary load failure (in general, not just here).
         store.getState().data.application.getDataSource('canaryConfigs').refresh(true),
       ),
@@ -192,20 +199,21 @@ const loadKayentaAccountsEpic = (action$: Observable<Action & any>) =>
       .catch((error: Error) => Observable.of(Creators.loadKayentaAccountsFailure({ error }))),
   );
 
-const rootEpic = combineEpics(
-  loadConfigEpic,
-  selectConfigEpic,
-  saveConfigEpic,
-  deleteConfigRequestEpic,
-  deleteConfigSuccessEpic,
-  loadCanaryRunRequestEpic,
-  loadMetricSetPairEpic,
-  updateGraphiteMetricDescriptionFilterEpic,
-  updatePrometheusMetricDescriptionFilterEpic,
-  updateStackdriverMetricDescriptionFilterEpic,
-  updateDatadogMetricDescriptionFilterEpic,
-  loadMetricsServiceMetadataEpic,
-  loadKayentaAccountsEpic,
-);
-
-export const epicMiddleware: EpicMiddleware<Action & any, ICanaryState> = createEpicMiddleware(rootEpic);
+export const createKayentaEpicMiddleware = (uiRouter: UIRouter): EpicMiddleware<Action & any, ICanaryState> =>
+  createEpicMiddleware(
+    combineEpics(
+      loadConfigEpic,
+      selectConfigEpic,
+      saveConfigEpic(uiRouter),
+      deleteConfigRequestEpic,
+      deleteConfigSuccessEpic(uiRouter),
+      loadCanaryRunRequestEpic,
+      loadMetricSetPairEpic,
+      updateGraphiteMetricDescriptionFilterEpic,
+      updatePrometheusMetricDescriptionFilterEpic,
+      updateStackdriverMetricDescriptionFilterEpic,
+      updateDatadogMetricDescriptionFilterEpic,
+      loadMetricsServiceMetadataEpic,
+      loadKayentaAccountsEpic,
+    ),
+  );

--- a/deck-kayenta/src/kayenta/report/list/table.tsx
+++ b/deck-kayenta/src/kayenta/report/list/table.tsx
@@ -1,3 +1,4 @@
+import { useRouter } from '@uirouter/react';
 import { CanarySettings } from 'kayenta/canary.settings';
 import {
   CANARY_EXECUTION_NO_PIPELINE_STATUS,
@@ -16,7 +17,7 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 
 import type { Application } from '@spinnaker/core';
-import { AngularServices, relativeTime, Spinner, Tooltip } from '@spinnaker/core';
+import { relativeTime, Spinner, Tooltip } from '@spinnaker/core';
 
 import ConfigLink from './configLink';
 import Score from '../detail/score';
@@ -212,6 +213,10 @@ interface IExecutionListTableStateProps {
   executionsCount: number;
 }
 
+interface IExecutionCountNavigator {
+  go(state: string, params: { count: number }): unknown;
+}
+
 const TableRows = ({
   executions,
   application,
@@ -247,11 +252,12 @@ const TableRows = ({
   );
 };
 
-const updateExecutionsCount = (event: React.ChangeEvent<HTMLSelectElement>) => {
-  AngularServices.$state.go('.', { count: Number(event.target.value) });
+const updateExecutionsCount = (event: React.ChangeEvent<HTMLSelectElement>, stateService: IExecutionCountNavigator) => {
+  stateService.go('.', { count: Number(event.target.value) });
 };
 
 const ExecutionListTable = ({ executions, application, accounts, executionsCount }: IExecutionListTableStateProps) => {
+  const { stateService } = useRouter();
   React.useEffect(() => {
     const dataSource = application.getDataSource('canaryExecutions');
     if (!dataSource.active) {
@@ -274,7 +280,10 @@ const ExecutionListTable = ({ executions, application, accounts, executionsCount
           {countOptions.length > 1 && (
             <>
               <span className="sp-margin-s-right">Showing</span>
-              <select className="form-control input-sm" onChange={updateExecutionsCount}>
+              <select
+                className="form-control input-sm"
+                onChange={(event) => updateExecutionsCount(event, stateService)}
+              >
                 {countOptions.map((o) => (
                   <option selected={executionsCount === o} value={o}>
                     {o}

--- a/deck-kayenta/src/kayenta/service/canaryRun.service.spec.ts
+++ b/deck-kayenta/src/kayenta/service/canaryRun.service.spec.ts
@@ -1,0 +1,28 @@
+const mockGet = jest.fn(() => Promise.resolve([]));
+const mockQuery = jest.fn(() => ({ get: mockGet }));
+const mockPath = jest.fn(() => ({ query: mockQuery }));
+
+jest.mock('@spinnaker/core', () => ({
+  PipelineConfigService: {},
+  REST: jest.fn(() => ({ path: mockPath })),
+}));
+jest.mock('kayenta/canary.settings', () => ({ CanarySettings: {} }));
+
+import { listCanaryExecutions } from './canaryRun.service';
+
+describe('listCanaryExecutions', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('uses the explicitly provided route count', async () => {
+    await listCanaryExecutions('deck', { params: { count: 50 } });
+
+    expect(mockPath).toHaveBeenCalledWith('deck', 'executions');
+    expect(mockQuery).toHaveBeenCalledWith({ limit: 50 });
+  });
+
+  it('defaults the execution count when the route omits it', async () => {
+    await listCanaryExecutions('deck', { params: {} });
+
+    expect(mockQuery).toHaveBeenCalledWith({ limit: 20 });
+  });
+});

--- a/deck-kayenta/src/kayenta/service/canaryRun.service.ts
+++ b/deck-kayenta/src/kayenta/service/canaryRun.service.ts
@@ -7,7 +7,11 @@ import {
   IMetricSetPair,
 } from 'kayenta/domain';
 
-import { AngularServices, REST } from '@spinnaker/core';
+import { REST } from '@spinnaker/core';
+
+export interface ICanaryExecutionRouteService {
+  params: Record<string, number | undefined>;
+}
 
 export const getCanaryRun = (configId: string, canaryExecutionId: string): PromiseLike<ICanaryExecutionStatusResult> =>
   REST('/v2/canaries/canary')
@@ -42,8 +46,11 @@ export const getMetricSetPair = (metricSetPairListId: string, metricSetPairId: s
     .get()
     .then((list: IMetricSetPair[]) => list.find((pair) => pair.id === metricSetPairId));
 
-export const listCanaryExecutions = (application: string): PromiseLike<ICanaryExecutionStatusResult[]> => {
-  const limit = AngularServices.$stateParams.count || 20;
+export const listCanaryExecutions = (
+  application: string,
+  stateService: ICanaryExecutionRouteService,
+): PromiseLike<ICanaryExecutionStatusResult[]> => {
+  const limit = stateService.params.count || 20;
   return REST('/v2/canaries').path(application, 'executions').query({ limit }).get();
 };
 

--- a/deck-kayenta/src/kayenta/stages/kayentaStage/KayentaStageExecutionDetails.tsx
+++ b/deck-kayenta/src/kayenta/stages/kayentaStage/KayentaStageExecutionDetails.tsx
@@ -1,16 +1,11 @@
+import { useRouter } from '@uirouter/react';
 import { CanaryScore } from 'kayenta/components/canaryScore';
 import { KayentaAnalysisType } from 'kayenta/domain';
 import { get } from 'lodash';
 import React from 'react';
 
 import type { IExecutionDetailsSectionProps, IExecutionStage } from '@spinnaker/core';
-import {
-  AngularServices,
-  ExecutionDetailsSection,
-  robotToHuman,
-  StageFailureMessage,
-  timestamp,
-} from '@spinnaker/core';
+import { ExecutionDetailsSection, robotToHuman, StageFailureMessage, timestamp } from '@spinnaker/core';
 
 import CanaryRunSummaries from './canaryRunSummaries';
 import { KAYENTA_CANARY, RUN_CANARY } from './stageTypes';
@@ -55,6 +50,7 @@ export function KayentaStageExecutionDetails(props: IExecutionDetailsSectionProp
 }
 
 export function KayentaStageExecutionConfigDetails(props: IExecutionDetailsSectionProps) {
+  const { stateService } = useRouter();
   const { application, current, name, stage } = props;
   const canaryConfig = stage.context.canaryConfig || {};
   const firstScope = get(canaryConfig, 'scopes[0]', {});
@@ -90,7 +86,13 @@ export function KayentaStageExecutionConfigDetails(props: IExecutionDetailsSecti
             <div className="row">
               <div className="col-md-4 sm-label-right compact">Config Name</div>
               <div className="col-md-8" style={wordWrap}>
-                <a href={canaryConfigHref(canaryConfig.canaryConfigId)}>{canaryConfigName}</a>
+                <a
+                  href={stateService.href('home.applications.application.canary.canaryConfig.configDetail', {
+                    id: canaryConfig.canaryConfigId,
+                  })}
+                >
+                  {canaryConfigName}
+                </a>
               </div>
             </div>
             <DetailRow label="Analysis Type" value={robotToHuman(stage.context.analysisType)} />
@@ -186,10 +188,6 @@ function resolveControlAndExperimentNames(
     resolvedControl: get(stage, 'context.canaryConfig.scopes[0].controlScope'),
     resolvedExperiment: get(stage, 'context.canaryConfig.scopes[0].experimentScope'),
   };
-}
-
-function canaryConfigHref(id: string) {
-  return AngularServices.$state.href('home.applications.application.canary.canaryConfig.configDetail', { id });
 }
 
 KayentaStageExecutionDetails.title = 'canarySummary';

--- a/deck-kayenta/src/kayenta/stages/kayentaStage/canaryRunSummaries.tsx
+++ b/deck-kayenta/src/kayenta/stages/kayentaStage/canaryRunSummaries.tsx
@@ -1,3 +1,4 @@
+import { useRouter } from '@uirouter/react';
 import { CanaryScore } from 'kayenta/components/canaryScore';
 import Styleguide from 'kayenta/layout/styleguide';
 import { ITableColumn, NativeTable } from 'kayenta/layout/table';
@@ -5,7 +6,7 @@ import { get, has } from 'lodash';
 import * as React from 'react';
 
 import type { IStage } from '@spinnaker/core';
-import { AngularServices, CopyToClipboard, HoverablePopover, timestamp } from '@spinnaker/core';
+import { CopyToClipboard, HoverablePopover, timestamp } from '@spinnaker/core';
 
 import './canaryRunSummaries.less';
 
@@ -20,7 +21,12 @@ export interface ICanaryRunColumn {
   getContent: (run: IStage, firstScopeName?: string) => JSX.Element;
 }
 
+interface IReportHrefService {
+  go(state: string, params: { configId: string; runId: string }): unknown;
+}
+
 export default function CanaryRunSummaries({ canaryRuns, firstScopeName }: ICanarySummariesProps) {
+  const { stateService } = useRouter();
   const canaryRunColumns: Array<ITableColumn<IStage>> = [
     {
       label: 'Canary Result',
@@ -57,7 +63,7 @@ export default function CanaryRunSummaries({ canaryRuns, firstScopeName }: ICana
         return (
           <section className="horizontal text-center">
             <div className="flex-1">
-              <ReportLink canaryRun={run} />
+              <ReportLink canaryRun={run} stateService={stateService} />
             </div>
             <div className="flex-1">
               <HoverablePopover template={popoverTemplate}>
@@ -108,7 +114,7 @@ function CanaryRunTimestamps({ canaryRun, firstScopeName }: { canaryRun: IStage;
   );
 }
 
-function ReportLink({ canaryRun }: { canaryRun: IStage }) {
+function ReportLink({ canaryRun, stateService }: { canaryRun: IStage; stateService: IReportHrefService }) {
   if (
     !has(canaryRun, 'context.canaryConfigId') ||
     !has(canaryRun, 'context.canaryPipelineExecutionId') ||
@@ -118,7 +124,7 @@ function ReportLink({ canaryRun }: { canaryRun: IStage }) {
   }
 
   const onClick = () =>
-    AngularServices.$state.go('home.applications.application.canary.report.reportDetail', {
+    stateService.go('home.applications.application.canary.report.reportDetail', {
       configId: canaryRun.context.canaryConfigId,
       runId: canaryRun.context.canaryPipelineExecutionId,
     });

--- a/deck-kayenta/src/lazy.ts
+++ b/deck-kayenta/src/lazy.ts
@@ -4,12 +4,13 @@ import 'kayenta/report/detail/graph/semiotic';
 
 import { ApplicationStateProvider } from '@spinnaker/core';
 
-// This import has a side effect of instantiating the canary redux store
+import { initializeCanaryStore } from './kayenta/canary';
 import { bridgeKayentaDataSourceToReduxStore } from './kayenta/canary.dataSource.bridge';
 import { registerStates, registerTransitionHooks } from './kayenta/navigation/canary.states';
 
 export function lazyInitializeKayenta(applicationState: ApplicationStateProvider, uiRouter: UIRouter) {
   const { stateRegistry } = uiRouter;
+  initializeCanaryStore(uiRouter);
 
   // deregister the stub states, starting with the deepest children first
   stateRegistry

--- a/deck/packages/amazon/src/function/CreateLambdaFunction.tsx
+++ b/deck/packages/amazon/src/function/CreateLambdaFunction.tsx
@@ -1,16 +1,8 @@
 import { cloneDeep } from 'lodash';
 import React from 'react';
 
-import type { IFunctionModalProps } from '@spinnaker/core';
-import {
-  AngularServices,
-  FunctionWriter,
-  noop,
-  ReactModal,
-  TaskMonitor,
-  WizardModal,
-  WizardPage,
-} from '@spinnaker/core';
+import type { IFunctionModalProps, IRouterInjectedProps } from '@spinnaker/core';
+import { FunctionWriter, noop, ReactModal, TaskMonitor, withRouter, WizardModal, WizardPage } from '@spinnaker/core';
 
 import { ExecutionRole } from './configure/ExecutionRole';
 import { FunctionBasicInformation } from './configure/FunctionBasicInformation';
@@ -31,13 +23,16 @@ export interface IAmazonCreateFunctionState {
   taskMonitor: TaskMonitor;
 }
 
-export class CreateLambdaFunction extends React.Component<IAmazonCreateFunctionProps, IAmazonCreateFunctionState> {
+export class CreateLambdaFunctionComponent extends React.Component<
+  IAmazonCreateFunctionProps & IRouterInjectedProps,
+  IAmazonCreateFunctionState
+> {
   public static defaultProps: Partial<IAmazonCreateFunctionProps> = {
     closeModal: noop,
     dismissModal: noop,
   };
 
-  constructor(props: IAmazonCreateFunctionProps) {
+  constructor(props: IAmazonCreateFunctionProps & IRouterInjectedProps) {
     super(props);
     const functionTransformer = new AwsFunctionTransformer();
     const funcCommand = props.functionDef
@@ -81,10 +76,10 @@ export class CreateLambdaFunction extends React.Component<IAmazonCreateFunctionP
       provider: 'aws',
     };
 
-    if (!AngularServices.$state.includes('**.functionDetails')) {
-      AngularServices.$state.go('.functionDetails', newStateParams);
+    if (!this.props.stateService.includes('**.functionDetails')) {
+      this.props.stateService.go('.functionDetails', newStateParams);
     } else {
-      AngularServices.$state.go('^.functionDetails', newStateParams);
+      this.props.stateService.go('^.functionDetails', newStateParams);
     }
   }
 
@@ -234,3 +229,8 @@ export class CreateLambdaFunction extends React.Component<IAmazonCreateFunctionP
     );
   }
 }
+
+export const CreateLambdaFunction = Object.assign(
+  withRouter<IAmazonCreateFunctionProps & IRouterInjectedProps>(CreateLambdaFunctionComponent),
+  { show: CreateLambdaFunctionComponent.show },
+);

--- a/deck/packages/amazon/src/instance/details/AmazonInstanceDetails.spec.tsx
+++ b/deck/packages/amazon/src/instance/details/AmazonInstanceDetails.spec.tsx
@@ -1,14 +1,23 @@
-import { AngularServices } from '@spinnaker/core';
+import { ConfirmationModalService } from '@spinnaker/core';
 
-import { AmazonInstanceDetails } from './AmazonInstanceDetails';
+import { AWSProviderSettings } from '../../aws.settings';
+
+import {
+  AmazonInstanceActionsComponent,
+  AmazonInstanceDetailsComponent as AmazonInstanceDetails,
+} from './AmazonInstanceDetails';
 
 describe('AmazonInstanceDetails', () => {
-  let $state: any;
+  let adHocInfraWritesEnabled: boolean;
+  let stateService: any;
 
   beforeEach(() => {
-    $state = { go: jasmine.createSpy('go') };
-    spyOnProperty(AngularServices, '$state', 'get').and.returnValue($state);
+    adHocInfraWritesEnabled = AWSProviderSettings.adHocInfraWritesEnabled;
+    AWSProviderSettings.adHocInfraWritesEnabled = true;
+    stateService = { go: jasmine.createSpy('go'), includes: jasmine.createSpy('includes').and.returnValue(true) };
   });
+
+  afterEach(() => (AWSProviderSettings.adHocInfraWritesEnabled = adHocInfraWritesEnabled));
 
   it('closes details when required data sources fail before instance loading', () => {
     const readyFailure = new Error('server groups failed');
@@ -39,11 +48,32 @@ describe('AmazonInstanceDetails', () => {
     const component = new AmazonInstanceDetails({
       app,
       $stateParams: { account: 'test', instanceId: 'i-123', provider: 'aws', region: 'us-east-1' },
+      router: {},
+      stateParams: {},
+      stateService,
     } as any);
 
     component.componentDidMount();
 
-    expect($state.go).toHaveBeenCalledWith('^', { allowModalToStayOpen: true }, { location: 'replace' });
+    expect(stateService.go).toHaveBeenCalledWith('^', { allowModalToStayOpen: true }, { location: 'replace' });
     expect(app.serverGroups.onRefresh).not.toHaveBeenCalled();
+  });
+
+  it('closes terminated instance details through the injected state service', () => {
+    const confirmation = spyOn(ConfirmationModalService, 'confirm');
+    const instance = { account: 'test', health: [], instanceId: 'i-123', placement: {} } as any;
+    const actions = AmazonInstanceActionsComponent({
+      app: { attributes: {} } as any,
+      instance,
+      router: {} as any,
+      stateParams: {},
+      stateService,
+    }).props.actions;
+
+    actions.find(({ label }: any) => label === 'Terminate').triggerAction();
+    confirmation.calls.mostRecent().args[0].taskMonitorConfig.onTaskComplete();
+
+    expect(stateService.includes).toHaveBeenCalledWith('**.instanceDetails', { instanceId: 'i-123' });
+    expect(stateService.go).toHaveBeenCalledWith('^');
   });
 });

--- a/deck/packages/amazon/src/instance/details/AmazonInstanceDetails.tsx
+++ b/deck/packages/amazon/src/instance/details/AmazonInstanceDetails.tsx
@@ -1,9 +1,8 @@
 import { flatMap } from 'lodash';
 import React from 'react';
 
-import type { Application, IInstanceDetailsProps } from '@spinnaker/core';
+import type { Application, IInstanceDetailsProps, IRouterInjectedProps } from '@spinnaker/core';
 import {
-  AngularServices,
   CollapsibleSection,
   ConfirmationModalService,
   ConsoleOutputLink,
@@ -14,6 +13,7 @@ import {
   InstanceReader,
   RecentHistoryService,
   SETTINGS,
+  withRouter,
 } from '@spinnaker/core';
 
 import { AmazonInstanceInformation } from './AmazonInstanceInformation';
@@ -289,20 +289,21 @@ function canDeregisterFromTargetGroup(instance: IAmazonLoadedInstance): boolean 
   );
 }
 
-export function AmazonInstanceActions({
+export function AmazonInstanceActionsComponent({
   app,
   instance,
+  stateService,
 }: {
   app: Application;
   instance: IAmazonLoadedInstance;
-}): JSX.Element | null {
+} & IRouterInjectedProps): JSX.Element | null {
   if (!AWSProviderSettings.adHocInfraWritesEnabled) {
     return null;
   }
 
   const closeIfCurrentInstance = () => {
-    if (AngularServices.$state.includes('**.instanceDetails', { instanceId: instance.instanceId })) {
-      AngularServices.$state.go('^');
+    if (stateService.includes('**.instanceDetails', { instanceId: instance.instanceId })) {
+      stateService.go('^');
     }
   };
   const confirm = (
@@ -458,8 +459,8 @@ export function AmazonInstanceActions({
   return <InstanceActions actions={actions} />;
 }
 
-export class AmazonInstanceDetails extends React.Component<
-  IAmazonInstanceDetailsProps,
+export class AmazonInstanceDetailsComponent extends React.Component<
+  IAmazonInstanceDetailsProps & IRouterInjectedProps,
   { instance?: IAmazonLoadedInstance; loading: boolean }
 > {
   public state = { instance: this.props.initialInstance, loading: !this.props.initialInstance };
@@ -495,7 +496,7 @@ export class AmazonInstanceDetails extends React.Component<
   }
 
   private closeDetails(): void {
-    AngularServices.$state.go('^', { allowModalToStayOpen: true }, { location: 'replace' });
+    this.props.stateService.go('^', { allowModalToStayOpen: true }, { location: 'replace' });
   }
 
   public componentDidUpdate(prevProps: IAmazonInstanceDetailsProps): void {
@@ -517,8 +518,10 @@ export class AmazonInstanceDetails extends React.Component<
     }
   }
 
-  private getInstanceParams(props: IAmazonInstanceDetailsProps = this.props): IAmazonInstanceParams {
-    const params = props.instance || props.$stateParams;
+  private getInstanceParams(
+    props: IAmazonInstanceDetailsProps & Partial<IRouterInjectedProps> = this.props,
+  ): IAmazonInstanceParams {
+    const params = props.instance || props.$stateParams || props.stateParams;
     return {
       account: params?.account,
       instanceId: params?.instanceId,
@@ -572,7 +575,13 @@ export class AmazonInstanceDetails extends React.Component<
           />
           {!loading && instance && !instance.instanceIdNotFound && instance.placement && (
             <div className="actions">
-              <AmazonInstanceActions app={app} instance={instance} />
+              <AmazonInstanceActionsComponent
+                app={app}
+                instance={instance}
+                router={this.props.router}
+                stateParams={this.props.stateParams}
+                stateService={this.props.stateService}
+              />
               <InstanceInsights insights={instance.insightActions} instance={instance} />
             </div>
           )}
@@ -630,3 +639,6 @@ export class AmazonInstanceDetails extends React.Component<
     );
   }
 }
+
+export const AmazonInstanceActions = withRouter(AmazonInstanceActionsComponent);
+export const AmazonInstanceDetails = withRouter(AmazonInstanceDetailsComponent);

--- a/deck/packages/amazon/src/loadBalancer/AmazonLoadBalancersTag.spec.tsx
+++ b/deck/packages/amazon/src/loadBalancer/AmazonLoadBalancersTag.spec.tsx
@@ -1,0 +1,39 @@
+import { AmazonLoadBalancersTagComponent } from './AmazonLoadBalancersTag';
+
+describe('AmazonLoadBalancersTag', () => {
+  it('opens load balancer and target group details through the injected state service', () => {
+    const stateService = {
+      current: { name: 'home.applications.application.insight.clusters' },
+      go: jasmine.createSpy('go'),
+    };
+    const component = new AmazonLoadBalancersTagComponent({
+      application: {},
+      router: {},
+      serverGroup: { account: 'test', region: 'us-east-1', type: 'aws' },
+      stateParams: {},
+      stateService,
+    } as any);
+
+    (component as any).showLoadBalancerDetails({ name: 'app-lb' });
+    (component as any).showTargetGroupDetails({
+      account: 'test',
+      loadBalancerNames: ['app-lb'],
+      name: 'app-target',
+      region: 'us-east-1',
+    });
+
+    expect(stateService.go).toHaveBeenCalledWith('.loadBalancerDetails', {
+      accountId: 'test',
+      name: 'app-lb',
+      provider: 'aws',
+      region: 'us-east-1',
+    });
+    expect(stateService.go).toHaveBeenCalledWith('.targetGroupDetails', {
+      accountId: 'test',
+      loadBalancerName: 'app-lb',
+      name: 'app-target',
+      provider: 'aws',
+      region: 'us-east-1',
+    });
+  });
+});

--- a/deck/packages/amazon/src/loadBalancer/AmazonLoadBalancersTag.tsx
+++ b/deck/packages/amazon/src/loadBalancer/AmazonLoadBalancersTag.tsx
@@ -4,15 +4,15 @@
 import { sortBy } from 'lodash';
 import React from 'react';
 
-import type { ILoadBalancer, ILoadBalancersTagProps } from '@spinnaker/core';
+import type { ILoadBalancer, ILoadBalancersTagProps, IRouterInjectedProps } from '@spinnaker/core';
 import {
-  AngularServices,
   HealthCounts,
   HoverablePopover,
   LoadBalancerDataUtils,
   logger,
   Spinner,
   Tooltip,
+  withRouter,
 } from '@spinnaker/core';
 
 import { AmazonLoadBalancerDataUtils } from './amazonLoadBalancerDataUtils';
@@ -70,11 +70,14 @@ export interface IAmazonLoadBalancersTagState {
   isLoading: boolean;
 }
 
-export class AmazonLoadBalancersTag extends React.Component<ILoadBalancersTagProps, IAmazonLoadBalancersTagState> {
+export class AmazonLoadBalancersTagComponent extends React.Component<
+  ILoadBalancersTagProps & IRouterInjectedProps,
+  IAmazonLoadBalancersTagState
+> {
   private loadBalancersRefreshUnsubscribe: () => void;
   private mounted = false;
 
-  constructor(props: ILoadBalancersTagProps) {
+  constructor(props: ILoadBalancersTagProps & IRouterInjectedProps) {
     super(props);
     this.state = {
       loadBalancers: [],
@@ -84,11 +87,13 @@ export class AmazonLoadBalancersTag extends React.Component<ILoadBalancersTagPro
   }
 
   private showLoadBalancerDetails = (loadBalancer: ILoadBalancer): void => {
-    const { $state } = AngularServices;
+    const { stateService } = this.props;
     const serverGroup = this.props.serverGroup;
     logger.log({ category: 'Cluster Pod', action: `Load Load Balancer Details (multiple menu)` });
-    const nextState = $state.current.name.endsWith('.clusters') ? '.loadBalancerDetails' : '^.loadBalancerDetails';
-    $state.go(nextState, {
+    const nextState = stateService.current.name.endsWith('.clusters')
+      ? '.loadBalancerDetails'
+      : '^.loadBalancerDetails';
+    stateService.go(nextState, {
       region: serverGroup.region,
       accountId: serverGroup.account,
       name: loadBalancer.name,
@@ -97,10 +102,10 @@ export class AmazonLoadBalancersTag extends React.Component<ILoadBalancersTagPro
   };
 
   private showTargetGroupDetails = (targetGroup: ITargetGroup): void => {
-    const { $state } = AngularServices;
+    const { stateService } = this.props;
     logger.log({ category: 'Cluster Pod', action: `Load Target Group Details (multiple menu)` });
-    const nextState = $state.current.name.endsWith('.clusters') ? '.targetGroupDetails' : '^.targetGroupDetails';
-    $state.go(nextState, {
+    const nextState = stateService.current.name.endsWith('.clusters') ? '.targetGroupDetails' : '^.targetGroupDetails';
+    stateService.go(nextState, {
       region: targetGroup.region,
       accountId: targetGroup.account,
       name: targetGroup.name,
@@ -146,7 +151,7 @@ export class AmazonLoadBalancersTag extends React.Component<ILoadBalancersTagPro
     this.loadBalancersRefreshUnsubscribe();
   }
 
-  public render(): React.ReactElement<AmazonLoadBalancersTag> {
+  public render(): React.ReactElement {
     const { loadBalancers, targetGroups, isLoading } = this.state;
 
     const targetGroupCount = (targetGroups && targetGroups.length) || 0;
@@ -229,3 +234,5 @@ export class AmazonLoadBalancersTag extends React.Component<ILoadBalancersTagPro
     );
   }
 }
+
+export const AmazonLoadBalancersTag = withRouter(AmazonLoadBalancersTagComponent);

--- a/deck/packages/amazon/src/loadBalancer/TargetGroupDetails.spec.tsx
+++ b/deck/packages/amazon/src/loadBalancer/TargetGroupDetails.spec.tsx
@@ -1,13 +1,10 @@
-import { AngularServices } from '@spinnaker/core';
-
-import { TargetGroupDetails } from './TargetGroupDetails';
+import { TargetGroupDetailsComponent as TargetGroupDetails } from './TargetGroupDetails';
 
 describe('TargetGroupDetails', () => {
-  let $state: any;
+  let stateService: any;
 
   beforeEach(() => {
-    $state = { params: {}, go: jasmine.createSpy('go') };
-    spyOnProperty(AngularServices, '$state', 'get').and.returnValue($state);
+    stateService = { params: {}, go: jasmine.createSpy('go') };
   });
 
   function buildComponent(loadBalancers: any[]): TargetGroupDetails {
@@ -20,6 +17,9 @@ describe('TargetGroupDetails', () => {
       app,
       name: 'test-target-group',
       provider: 'aws',
+      router: {},
+      stateParams: {},
+      stateService,
       targetGroup: {
         accountId: 'test-account',
         loadBalancerName: 'test-load-balancer',
@@ -35,8 +35,8 @@ describe('TargetGroupDetails', () => {
 
     (component as any).extractTargetGroup();
 
-    expect($state.params.allowModalToStayOpen).toBe(true);
-    expect($state.go).toHaveBeenCalledWith('^', null, { location: 'replace' });
+    expect(stateService.params.allowModalToStayOpen).toBe(true);
+    expect(stateService.go).toHaveBeenCalledWith('^', null, { location: 'replace' });
   });
 
   it('auto-closes when the target group disappears', () => {
@@ -51,8 +51,8 @@ describe('TargetGroupDetails', () => {
 
     (component as any).extractTargetGroup();
 
-    expect($state.params.allowModalToStayOpen).toBe(true);
-    expect($state.go).toHaveBeenCalledWith('^', null, { location: 'replace' });
+    expect(stateService.params.allowModalToStayOpen).toBe(true);
+    expect(stateService.go).toHaveBeenCalledWith('^', null, { location: 'replace' });
   });
 
   it('does not update state after unmount when the target group still exists', () => {
@@ -93,6 +93,9 @@ describe('TargetGroupDetails', () => {
       app,
       name: 'test-target-group',
       provider: 'aws',
+      router: {},
+      stateParams: {},
+      stateService,
       targetGroup: {
         accountId: 'test-account',
         loadBalancerName: 'test-load-balancer',

--- a/deck/packages/amazon/src/loadBalancer/TargetGroupDetails.tsx
+++ b/deck/packages/amazon/src/loadBalancer/TargetGroupDetails.tsx
@@ -1,15 +1,15 @@
 import { UISref } from '@uirouter/react';
 import React from 'react';
 
-import type { Application } from '@spinnaker/core';
+import type { Application, IRouterInjectedProps } from '@spinnaker/core';
 import {
   AccountTag,
-  AngularServices,
   CollapsibleSection,
   CopyToClipboard,
   HealthCounts,
   ManagedResourceDetailsIndicator,
   Spinner,
+  withRouter,
 } from '@spinnaker/core';
 
 import type { IAmazonApplicationLoadBalancer, ITargetGroup } from '../domain';
@@ -42,7 +42,10 @@ function elbProtocol(loadBalancer: IAmazonApplicationLoadBalancer): string {
   return loadBalancer.listeners?.some((listener) => listener.protocol === 'HTTPS') ? 'https:' : 'http:';
 }
 
-export class TargetGroupDetails extends React.Component<ITargetGroupDetailsProps, IAmazonTargetGroupDetailsState> {
+export class TargetGroupDetailsComponent extends React.Component<
+  ITargetGroupDetailsProps & IRouterInjectedProps,
+  IAmazonTargetGroupDetailsState
+> {
   public state: IAmazonTargetGroupDetailsState = { loading: true };
 
   private unsubscribeFromRefresh: () => void;
@@ -101,12 +104,12 @@ export class TargetGroupDetails extends React.Component<ITargetGroupDetailsProps
       return;
     }
 
-    AngularServices.$state.params.allowModalToStayOpen = true;
-    AngularServices.$state.go('^', null, { location: 'replace' });
+    this.props.stateService.params.allowModalToStayOpen = true;
+    this.props.stateService.go('^', null, { location: 'replace' });
   };
 
   private closeDetails = (): void => {
-    AngularServices.$state.go('^');
+    this.props.stateService.go('^');
   };
 
   private renderHeader(): JSX.Element {
@@ -288,3 +291,5 @@ export class TargetGroupDetails extends React.Component<ITargetGroupDetailsProps
     );
   }
 }
+
+export const TargetGroupDetails = withRouter(TargetGroupDetailsComponent);

--- a/deck/packages/amazon/src/loadBalancer/configure/LoadBalancerTypes.ts
+++ b/deck/packages/amazon/src/loadBalancer/configure/LoadBalancerTypes.ts
@@ -5,9 +5,9 @@ import { CreateClassicLoadBalancer } from './classic/CreateClassicLoadBalancer';
 import type { IAmazonLoadBalancerUpsertCommand } from '../../domain';
 import { CreateNetworkLoadBalancer } from './network/CreateNetworkLoadBalancer';
 
-export interface ICloseableLoadBalancerModal extends React.ComponentClass<ILoadBalancerModalProps> {
+export type ICloseableLoadBalancerModal = React.ComponentType<ILoadBalancerModalProps> & {
   show: (props: ILoadBalancerModalProps) => Promise<IAmazonLoadBalancerUpsertCommand>;
-}
+};
 
 export interface IAmazonLoadBalancerConfig {
   type: 'network' | 'application' | 'classic';

--- a/deck/packages/amazon/src/loadBalancer/configure/application/CreateApplicationLoadBalancer.tsx
+++ b/deck/packages/amazon/src/loadBalancer/configure/application/CreateApplicationLoadBalancer.tsx
@@ -1,15 +1,15 @@
 import { cloneDeep, get } from 'lodash';
 import React from 'react';
 
-import type { ILoadBalancerModalProps } from '@spinnaker/core';
+import type { ILoadBalancerModalProps, IRouterInjectedProps } from '@spinnaker/core';
 import {
   AccountService,
-  AngularServices,
   FirewallLabels,
   LoadBalancerWriter,
   noop,
   ReactModal,
   TaskMonitor,
+  withRouter,
   WizardModal,
   WizardPage,
 } from '@spinnaker/core';
@@ -36,8 +36,8 @@ export interface ICreateApplicationLoadBalancerState {
   taskMonitor: TaskMonitor;
 }
 
-export class CreateApplicationLoadBalancer extends React.Component<
-  ICreateApplicationLoadBalancerProps,
+export class CreateApplicationLoadBalancerComponent extends React.Component<
+  ICreateApplicationLoadBalancerProps & IRouterInjectedProps,
   ICreateApplicationLoadBalancerState
 > {
   public static defaultProps: Partial<ICreateApplicationLoadBalancerProps> = {
@@ -54,7 +54,7 @@ export class CreateApplicationLoadBalancer extends React.Component<
     return ReactModal.show(CreateApplicationLoadBalancer, props, modalProps);
   }
 
-  constructor(props: ICreateApplicationLoadBalancerProps) {
+  constructor(props: ICreateApplicationLoadBalancerProps & IRouterInjectedProps) {
     super(props);
 
     const loadBalancerCommand = props.command
@@ -186,10 +186,10 @@ export class CreateApplicationLoadBalancer extends React.Component<
       provider: 'aws',
     };
 
-    if (!AngularServices.$state.includes('**.loadBalancerDetails')) {
-      AngularServices.$state.go('.loadBalancerDetails', newStateParams);
+    if (!this.props.stateService.includes('**.loadBalancerDetails')) {
+      this.props.stateService.go('.loadBalancerDetails', newStateParams);
     } else {
-      AngularServices.$state.go('^.loadBalancerDetails', newStateParams);
+      this.props.stateService.go('^.loadBalancerDetails', newStateParams);
     }
   }
 
@@ -335,3 +335,8 @@ export class CreateApplicationLoadBalancer extends React.Component<
     );
   }
 }
+
+export const CreateApplicationLoadBalancer = Object.assign(
+  withRouter<ICreateApplicationLoadBalancerProps & IRouterInjectedProps>(CreateApplicationLoadBalancerComponent),
+  { show: CreateApplicationLoadBalancerComponent.show },
+);

--- a/deck/packages/amazon/src/loadBalancer/configure/classic/CreateClassicLoadBalancer.tsx
+++ b/deck/packages/amazon/src/loadBalancer/configure/classic/CreateClassicLoadBalancer.tsx
@@ -2,15 +2,15 @@ import type { FormikErrors, FormikValues } from 'formik';
 import { cloneDeep, get } from 'lodash';
 import React from 'react';
 
-import type { ILoadBalancerModalProps } from '@spinnaker/core';
+import type { ILoadBalancerModalProps, IRouterInjectedProps } from '@spinnaker/core';
 import {
   AccountService,
-  AngularServices,
   FirewallLabels,
   LoadBalancerWriter,
   noop,
   ReactModal,
   TaskMonitor,
+  withRouter,
   WizardModal,
   WizardPage,
 } from '@spinnaker/core';
@@ -36,8 +36,8 @@ export interface ICreateClassicLoadBalancerState {
   taskMonitor: TaskMonitor;
 }
 
-export class CreateClassicLoadBalancer extends React.Component<
-  ICreateClassicLoadBalancerProps,
+export class CreateClassicLoadBalancerComponent extends React.Component<
+  ICreateClassicLoadBalancerProps & IRouterInjectedProps,
   ICreateClassicLoadBalancerState
 > {
   public static defaultProps: Partial<ICreateClassicLoadBalancerProps> = {
@@ -54,7 +54,7 @@ export class CreateClassicLoadBalancer extends React.Component<
     return ReactModal.show(CreateClassicLoadBalancer, props, modalProps);
   }
 
-  constructor(props: ICreateClassicLoadBalancerProps) {
+  constructor(props: ICreateClassicLoadBalancerProps & IRouterInjectedProps) {
     super(props);
 
     const loadBalancerCommand = props.command
@@ -149,10 +149,10 @@ export class CreateClassicLoadBalancer extends React.Component<
       provider: 'aws',
     };
 
-    if (!AngularServices.$state.includes('**.loadBalancerDetails')) {
-      AngularServices.$state.go('.loadBalancerDetails', newStateParams);
+    if (!this.props.stateService.includes('**.loadBalancerDetails')) {
+      this.props.stateService.go('.loadBalancerDetails', newStateParams);
     } else {
-      AngularServices.$state.go('^.loadBalancerDetails', newStateParams);
+      this.props.stateService.go('^.loadBalancerDetails', newStateParams);
     }
   }
 
@@ -203,7 +203,7 @@ export class CreateClassicLoadBalancer extends React.Component<
     return errors;
   };
 
-  public render(): React.ReactElement<CreateClassicLoadBalancer> {
+  public render(): React.ReactElement<CreateClassicLoadBalancerComponent> {
     const { app, dismissModal, forPipelineConfig, loadBalancer } = this.props;
     const { isNew, loadBalancerCommand, taskMonitor } = this.state;
 
@@ -280,3 +280,8 @@ export class CreateClassicLoadBalancer extends React.Component<
     );
   }
 }
+
+export const CreateClassicLoadBalancer = Object.assign(
+  withRouter<ICreateClassicLoadBalancerProps & IRouterInjectedProps>(CreateClassicLoadBalancerComponent),
+  { show: CreateClassicLoadBalancerComponent.show },
+);

--- a/deck/packages/amazon/src/loadBalancer/configure/network/CreateNetworkLoadBalancer.tsx
+++ b/deck/packages/amazon/src/loadBalancer/configure/network/CreateNetworkLoadBalancer.tsx
@@ -2,14 +2,14 @@ import type { FormikErrors } from 'formik';
 import { cloneDeep, every, get } from 'lodash';
 import React from 'react';
 
-import type { ILoadBalancerModalProps } from '@spinnaker/core';
+import type { ILoadBalancerModalProps, IRouterInjectedProps } from '@spinnaker/core';
 import {
   AccountService,
-  AngularServices,
   LoadBalancerWriter,
   noop,
   ReactModal,
   TaskMonitor,
+  withRouter,
   WizardModal,
   WizardPage,
 } from '@spinnaker/core';
@@ -34,8 +34,8 @@ export interface ICreateApplicationLoadBalancerState {
   taskMonitor: TaskMonitor;
 }
 
-export class CreateNetworkLoadBalancer extends React.Component<
-  ICreateNetworkLoadBalancerProps,
+export class CreateNetworkLoadBalancerComponent extends React.Component<
+  ICreateNetworkLoadBalancerProps & IRouterInjectedProps,
   ICreateApplicationLoadBalancerState
 > {
   public static defaultProps: Partial<ICreateNetworkLoadBalancerProps> = {
@@ -52,7 +52,7 @@ export class CreateNetworkLoadBalancer extends React.Component<
     return ReactModal.show(CreateNetworkLoadBalancer, props, modalProps);
   }
 
-  constructor(props: ICreateNetworkLoadBalancerProps) {
+  constructor(props: ICreateNetworkLoadBalancerProps & IRouterInjectedProps) {
     super(props);
 
     const loadBalancerCommand = props.loadBalancer
@@ -169,10 +169,10 @@ export class CreateNetworkLoadBalancer extends React.Component<
       provider: 'aws',
     };
 
-    if (!AngularServices.$state.includes('**.loadBalancerDetails')) {
-      AngularServices.$state.go('.loadBalancerDetails', newStateParams);
+    if (!this.props.stateService.includes('**.loadBalancerDetails')) {
+      this.props.stateService.go('.loadBalancerDetails', newStateParams);
     } else {
-      AngularServices.$state.go('^.loadBalancerDetails', newStateParams);
+      this.props.stateService.go('^.loadBalancerDetails', newStateParams);
     }
   }
 
@@ -301,3 +301,8 @@ export class CreateNetworkLoadBalancer extends React.Component<
     );
   }
 }
+
+export const CreateNetworkLoadBalancer = Object.assign(
+  withRouter<ICreateNetworkLoadBalancerProps & IRouterInjectedProps>(CreateNetworkLoadBalancerComponent),
+  { show: CreateNetworkLoadBalancerComponent.show },
+);

--- a/deck/packages/amazon/src/routerConsumers.spec.tsx
+++ b/deck/packages/amazon/src/routerConsumers.spec.tsx
@@ -1,0 +1,141 @@
+import { TaskMonitor } from '@spinnaker/core';
+
+import { CreateApplicationLoadBalancerComponent } from './loadBalancer/configure/application/CreateApplicationLoadBalancer';
+import { CreateClassicLoadBalancerComponent } from './loadBalancer/configure/classic/CreateClassicLoadBalancer';
+import { CreateNetworkLoadBalancerComponent } from './loadBalancer/configure/network/CreateNetworkLoadBalancer';
+import { CreateLambdaFunctionComponent } from './function/CreateLambdaFunction';
+import { AmazonSecurityGroupModalComponent } from './securityGroup/configure/AmazonSecurityGroupModal';
+import { AmazonCloneServerGroupModalComponent } from './serverGroup/configure/wizard/AmazonCloneServerGroupModal';
+
+describe('Amazon routed modal consumers', () => {
+  beforeEach(() => {
+    spyOn(TaskMonitor, 'modalInstanceEmulation').and.returnValue({
+      dismiss: jasmine.createSpy('dismiss'),
+      result: Promise.resolve(),
+    } as any);
+  });
+
+  function stateService(includedState: string) {
+    return {
+      go: jasmine.createSpy('go'),
+      includes: jasmine.createSpy('includes').and.callFake((state: string) => state === includedState),
+    };
+  }
+
+  [
+    ['application', CreateApplicationLoadBalancerComponent],
+    ['classic', CreateClassicLoadBalancerComponent],
+    ['network', CreateNetworkLoadBalancerComponent],
+  ].forEach(([type, Component]: [string, any]) => {
+    it(`navigates from the ${type} load balancer modal through its injected state service`, () => {
+      const state = stateService('**.loadBalancerDetails');
+      const modal = Object.create(Component.prototype) as any;
+      modal.props = { dismissModal: jasmine.createSpy('dismissModal'), stateService: state };
+      modal.state = {};
+      modal.setState = jasmine.createSpy('setState');
+
+      modal.onApplicationRefresh({
+        credentials: 'test-account',
+        name: 'fnord-main',
+        region: 'eu-west-1',
+        vpcId: 'vpc-1',
+      });
+
+      expect(state.go).toHaveBeenCalledWith('^.loadBalancerDetails', {
+        accountId: 'test-account',
+        name: 'fnord-main',
+        provider: 'aws',
+        region: 'eu-west-1',
+        vpcId: 'vpc-1',
+      });
+    });
+  });
+
+  it('navigates from the function modal through its injected state service', () => {
+    const state = stateService('');
+    const modal = Object.create(CreateLambdaFunctionComponent.prototype) as any;
+    modal.props = { dismissModal: jasmine.createSpy('dismissModal'), stateService: state };
+    modal.state = {};
+    modal.setState = jasmine.createSpy('setState');
+
+    modal.onApplicationRefresh({ credentials: 'test-account', name: 'fnord', region: 'eu-west-1', vpcId: 'vpc-1' });
+
+    expect(state.go).toHaveBeenCalledWith('.functionDetails', {
+      accountId: 'test-account',
+      name: 'fnord',
+      provider: 'aws',
+      region: 'eu-west-1',
+      vpcId: 'vpc-1',
+    });
+  });
+
+  it('navigates from the security group modal through its injected state service', () => {
+    const state = stateService('**.firewallDetails');
+    const refresh = jasmine.createSpy('refresh');
+    const closeModal = jasmine.createSpy('closeModal');
+    const modal = new AmazonSecurityGroupModalComponent({
+      app: { securityGroups: { refresh } },
+      closeModal,
+      dismissModal: jasmine.createSpy('dismissModal'),
+      mode: 'clone',
+      stateService: state,
+    } as any) as any;
+    modal.state = {
+      securityGroup: {
+        credentials: 'test-account',
+        name: 'fnord-firewall',
+        region: 'eu-west-1',
+        vpcId: 'vpc-1',
+      },
+    };
+
+    modal.onTaskComplete();
+
+    expect(refresh).toHaveBeenCalled();
+    expect(closeModal).toHaveBeenCalled();
+    expect(state.go).toHaveBeenCalledWith('^.firewallDetails', {
+      accountId: 'test-account',
+      name: 'fnord-firewall',
+      provider: 'aws',
+      region: 'eu-west-1',
+      vpcId: 'vpc-1',
+    });
+  });
+
+  it('navigates from the clone server group modal through its injected state service', () => {
+    const state = stateService('**.clusters');
+    const modal = new AmazonCloneServerGroupModalComponent({
+      application: { name: 'fnord' },
+      command: {
+        credentials: 'test-account',
+        region: 'eu-west-1',
+        viewState: { requiresTemplateSelection: true },
+      },
+      dismissModal: jasmine.createSpy('dismissModal'),
+      stateService: state,
+    } as any) as any;
+    modal.state = {
+      taskMonitor: {
+        task: {
+          execution: {
+            stages: [
+              {
+                context: { 'deploy.server.groups': { 'eu-west-1': 'fnord-main-v042' } },
+                type: 'cloneServerGroup',
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    modal.onApplicationRefresh();
+
+    expect(state.go).toHaveBeenCalledWith('.serverGroup', {
+      accountId: 'test-account',
+      provider: 'aws',
+      region: 'eu-west-1',
+      serverGroup: 'fnord-main-v042',
+    });
+  });
+});

--- a/deck/packages/amazon/src/securityGroup/configure/AmazonSecurityGroupModal.spec.tsx
+++ b/deck/packages/amazon/src/securityGroup/configure/AmazonSecurityGroupModal.spec.tsx
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme';
 import React from 'react';
 
 import {
-  AmazonSecurityGroupModal,
+  AmazonSecurityGroupModalComponent as AmazonSecurityGroupModal,
   initializeAmazonSecurityGroupForModal,
   isAmazonSecurityGroupValid,
 } from './AmazonSecurityGroupModal';

--- a/deck/packages/amazon/src/securityGroup/configure/AmazonSecurityGroupModal.tsx
+++ b/deck/packages/amazon/src/securityGroup/configure/AmazonSecurityGroupModal.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import { Button, Modal } from 'react-bootstrap';
 
-import type { Application, IModalComponentProps, ISecurityGroup } from '@spinnaker/core';
+import type { Application, IModalComponentProps, IRouterInjectedProps, ISecurityGroup } from '@spinnaker/core';
 import {
-  AngularServices,
   FirewallLabels,
   ModalClose,
   noop,
@@ -12,6 +11,7 @@ import {
   SubmitButton,
   TaskMonitor,
   TaskMonitorWrapper,
+  withRouter,
 } from '@spinnaker/core';
 
 export type AmazonSecurityGroupModalMode = 'create' | 'edit' | 'clone';
@@ -139,8 +139,8 @@ export function isAmazonSecurityGroupValid(securityGroup: any): boolean {
   );
 }
 
-export class AmazonSecurityGroupModal extends React.Component<
-  IAmazonSecurityGroupModalProps,
+export class AmazonSecurityGroupModalComponent extends React.Component<
+  IAmazonSecurityGroupModalProps & IRouterInjectedProps,
   IAmazonSecurityGroupModalState
 > {
   public static defaultProps: Partial<IAmazonSecurityGroupModalProps> = {
@@ -153,7 +153,7 @@ export class AmazonSecurityGroupModal extends React.Component<
     return ReactModal.show(AmazonSecurityGroupModal, props, { dialogClassName: 'modal-lg' });
   }
 
-  constructor(props: IAmazonSecurityGroupModalProps) {
+  constructor(props: IAmazonSecurityGroupModalProps & IRouterInjectedProps) {
     super(props);
     const app = this.getApplication(props);
     this.state = {
@@ -226,8 +226,8 @@ export class AmazonSecurityGroupModal extends React.Component<
     }
 
     const { securityGroup } = this.state;
-    AngularServices.$state.go(
-      AngularServices.$state.includes('**.firewallDetails') ? '^.firewallDetails' : '.firewallDetails',
+    this.props.stateService.go(
+      this.props.stateService.includes('**.firewallDetails') ? '^.firewallDetails' : '.firewallDetails',
       {
         accountId: accountFor(securityGroup),
         name: securityGroup.name,
@@ -436,3 +436,8 @@ export class AmazonSecurityGroupModal extends React.Component<
     );
   }
 }
+
+export const AmazonSecurityGroupModal = Object.assign(
+  withRouter<IAmazonSecurityGroupModalProps & IRouterInjectedProps>(AmazonSecurityGroupModalComponent),
+  { show: AmazonSecurityGroupModalComponent.show },
+);

--- a/deck/packages/amazon/src/securityGroup/details/AmazonSecurityGroupDetails.spec.tsx
+++ b/deck/packages/amazon/src/securityGroup/details/AmazonSecurityGroupDetails.spec.tsx
@@ -1,9 +1,24 @@
-import { AmazonSecurityGroupDetails } from './AmazonSecurityGroupDetails';
+import { AmazonSecurityGroupDetailsComponent as AmazonSecurityGroupDetails } from './AmazonSecurityGroupDetails';
 import { VpcReader } from '../../vpc/VpcReader';
 
 const tick = () => new Promise((resolve) => setTimeout(resolve));
 
 describe('AmazonSecurityGroupDetails', () => {
+  it('replaces missing details through the injected state service', () => {
+    const stateService = { go: jasmine.createSpy('go') };
+    const component = new AmazonSecurityGroupDetails({
+      app: { isStandalone: false },
+      resolvedSecurityGroup: { accountId: 'test-account', name: 'missing', region: 'us-west-2' },
+      router: {},
+      stateParams: {},
+      stateService,
+    } as any);
+
+    (component as any).autoClose();
+
+    expect(stateService.go).toHaveBeenCalledWith('^', { allowModalToStayOpen: true }, { location: 'replace' });
+  });
+
   it('does not update state when the VPC lookup resolves after unmount', async () => {
     const details = {
       accountId: 'test-account',

--- a/deck/packages/amazon/src/securityGroup/details/AmazonSecurityGroupDetails.tsx
+++ b/deck/packages/amazon/src/securityGroup/details/AmazonSecurityGroupDetails.tsx
@@ -3,7 +3,13 @@ import { groupBy, isEmpty } from 'lodash';
 import React from 'react';
 import { Dropdown, MenuItem } from 'react-bootstrap';
 
-import type { Application, ISecurityGroup, ISecurityGroupDetail, SecurityGroupReader } from '@spinnaker/core';
+import type {
+  Application,
+  IRouterInjectedProps,
+  ISecurityGroup,
+  ISecurityGroupDetail,
+  SecurityGroupReader,
+} from '@spinnaker/core';
 import {
   AccountTag,
   AddEntityTagLinks,
@@ -17,6 +23,7 @@ import {
   SecurityGroupWriter,
   SETTINGS,
   Spinner,
+  withRouter,
 } from '@spinnaker/core';
 
 import { IPRangeRules } from './IPRangeRules';
@@ -198,8 +205,8 @@ export function AmazonSecurityGroupActions({
   );
 }
 
-export class AmazonSecurityGroupDetails extends React.Component<
-  IAmazonSecurityGroupDetailsProps,
+export class AmazonSecurityGroupDetailsComponent extends React.Component<
+  IAmazonSecurityGroupDetailsProps & IRouterInjectedProps,
   IAmazonSecurityGroupDetailsState
 > {
   public state: IAmazonSecurityGroupDetailsState = { loading: true };
@@ -259,7 +266,7 @@ export class AmazonSecurityGroupDetails extends React.Component<
       this.setState({ loading: false, notFound: true });
       return;
     }
-    AngularServices.$state.go('^', { allowModalToStayOpen: true }, { location: 'replace' });
+    this.props.stateService.go('^', { allowModalToStayOpen: true }, { location: 'replace' });
   };
 
   private loadSecurityGroup = (): void => {
@@ -313,7 +320,7 @@ export class AmazonSecurityGroupDetails extends React.Component<
   };
 
   private closeDetails = (): void => {
-    AngularServices.$state.go('^');
+    this.props.stateService.go('^');
   };
 
   public render(): JSX.Element {
@@ -430,3 +437,5 @@ export class AmazonSecurityGroupDetails extends React.Component<
     );
   }
 }
+
+export const AmazonSecurityGroupDetails = withRouter(AmazonSecurityGroupDetailsComponent);

--- a/deck/packages/amazon/src/serverGroup/configure/wizard/AmazonCloneServerGroupModal.tsx
+++ b/deck/packages/amazon/src/serverGroup/configure/wizard/AmazonCloneServerGroupModal.tsx
@@ -1,13 +1,14 @@
 import { get } from 'lodash';
 import React from 'react';
 
-import type { Application, IModalComponentProps, IStage } from '@spinnaker/core';
+import type { Application, IModalComponentProps, IRouterInjectedProps, IStage } from '@spinnaker/core';
 import {
   AngularServices,
   FirewallLabels,
   noop,
   ReactModal,
   TaskMonitor,
+  withRouter,
   WizardModal,
   WizardPage,
 } from '@spinnaker/core';
@@ -38,8 +39,8 @@ export interface IAmazonCloneServerGroupModalState {
   taskMonitor: TaskMonitor;
 }
 
-export class AmazonCloneServerGroupModal extends React.Component<
-  IAmazonCloneServerGroupModalProps,
+export class AmazonCloneServerGroupModalComponent extends React.Component<
+  IAmazonCloneServerGroupModalProps & IRouterInjectedProps,
   IAmazonCloneServerGroupModalState
 > {
   public static defaultProps: Partial<IAmazonCloneServerGroupModalProps> = {
@@ -55,7 +56,7 @@ export class AmazonCloneServerGroupModal extends React.Component<
     return ReactModal.show(AmazonCloneServerGroupModal, props, modalProps);
   }
 
-  constructor(props: IAmazonCloneServerGroupModalProps) {
+  constructor(props: IAmazonCloneServerGroupModalProps & IRouterInjectedProps) {
     super(props);
 
     const requiresTemplateSelection = get(props, 'command.viewState.requiresTemplateSelection', false);
@@ -104,19 +105,19 @@ export class AmazonCloneServerGroupModal extends React.Component<
           provider: 'aws',
         };
         let transitionTo = '^.^.^.clusters.serverGroup';
-        if (AngularServices.$state.includes('**.clusters.serverGroup')) {
+        if (this.props.stateService.includes('**.clusters.serverGroup')) {
           // clone via details, all view
           transitionTo = '^.serverGroup';
         }
-        if (AngularServices.$state.includes('**.clusters.cluster.serverGroup')) {
+        if (this.props.stateService.includes('**.clusters.cluster.serverGroup')) {
           // clone or create with details open
           transitionTo = '^.^.serverGroup';
         }
-        if (AngularServices.$state.includes('**.clusters')) {
+        if (this.props.stateService.includes('**.clusters')) {
           // create new, no details open
           transitionTo = '.serverGroup';
         }
-        AngularServices.$state.go(transitionTo, newStateParams);
+        this.props.stateService.go(transitionTo, newStateParams);
       }
     }
   };
@@ -249,3 +250,8 @@ export class AmazonCloneServerGroupModal extends React.Component<
     );
   }
 }
+
+export const AmazonCloneServerGroupModal = Object.assign(
+  withRouter<IAmazonCloneServerGroupModalProps & IRouterInjectedProps>(AmazonCloneServerGroupModalComponent),
+  { show: AmazonCloneServerGroupModalComponent.show },
+);

--- a/deck/packages/amazon/src/serverGroup/configure/wizard/pages/ServerGroupBasicSettings.spec.tsx
+++ b/deck/packages/amazon/src/serverGroup/configure/wizard/pages/ServerGroupBasicSettings.spec.tsx
@@ -1,0 +1,39 @@
+import { ServerGroupBasicSettingsComponent } from './ServerGroupBasicSettings';
+
+describe('Amazon ServerGroupBasicSettings', () => {
+  it('opens the latest server group through the injected state service', () => {
+    const stateService = { go: jasmine.createSpy('go'), is: () => true };
+    const component = new ServerGroupBasicSettingsComponent({
+      app: {
+        clusters: [],
+        name: 'app',
+        serverGroups: {
+          data: [{ account: 'test', cluster: 'app-main', createdTime: 1, name: 'app-main-v001', region: 'us-east-1' }],
+        },
+      },
+      formik: {
+        values: {
+          amiName: 'ami',
+          credentials: 'test',
+          freeFormDetails: '',
+          region: 'us-east-1',
+          selectedProvider: 'aws',
+          stack: 'main',
+          viewState: { imageId: 'ami-123' },
+        },
+      },
+      router: {},
+      stateParams: {},
+      stateService,
+    } as any);
+
+    (component as any).navigateToLatestServerGroup();
+
+    expect(stateService.go).toHaveBeenCalledWith('.serverGroup', {
+      accountId: 'test',
+      provider: 'aws',
+      region: 'us-east-1',
+      serverGroup: 'app-main-v001',
+    });
+  });
+});

--- a/deck/packages/amazon/src/serverGroup/configure/wizard/pages/ServerGroupBasicSettings.tsx
+++ b/deck/packages/amazon/src/serverGroup/configure/wizard/pages/ServerGroupBasicSettings.tsx
@@ -2,10 +2,9 @@ import type { FormikErrors, FormikProps } from 'formik';
 import { Field } from 'formik';
 import React from 'react';
 
-import type { Application, IServerGroup, IWizardPageComponent } from '@spinnaker/core';
+import type { Application, IRouterInjectedProps, IServerGroup, IWizardPageComponent } from '@spinnaker/core';
 import {
   AccountSelectInput,
-  AngularServices,
   DeployingIntoManagedClusterWarning,
   DeploymentStrategySelector,
   HelpField,
@@ -16,6 +15,7 @@ import {
   ServerGroupNamePreview,
   SETTINGS,
   TaskReason,
+  withRouter,
 } from '@spinnaker/core';
 
 import { AmazonImageSelectInput } from '../../AmazonImageSelectInput';
@@ -42,10 +42,10 @@ export interface IServerGroupBasicSettingsState {
   latestServerGroup: IServerGroup;
 }
 
-export class ServerGroupBasicSettings
-  extends React.Component<IServerGroupBasicSettingsProps, IServerGroupBasicSettingsState>
+export class ServerGroupBasicSettingsComponent
+  extends React.Component<IServerGroupBasicSettingsProps & IRouterInjectedProps, IServerGroupBasicSettingsState>
   implements IWizardPageComponent<IAmazonServerGroupCommand> {
-  constructor(props: IServerGroupBasicSettingsProps) {
+  constructor(props: IServerGroupBasicSettingsProps & IRouterInjectedProps) {
     super(props);
     const {
       amiName,
@@ -184,11 +184,10 @@ export class ServerGroupBasicSettings
       serverGroup: latestServerGroup.name,
     };
 
-    const { $state } = AngularServices;
-    if ($state.is('home.applications.application.insight.clusters')) {
-      $state.go('.serverGroup', params);
+    if (this.props.stateService.is('home.applications.application.insight.clusters')) {
+      this.props.stateService.go('.serverGroup', params);
     } else {
-      $state.go('^.serverGroup', params);
+      this.props.stateService.go('^.serverGroup', params);
     }
   };
 
@@ -352,3 +351,5 @@ export class ServerGroupBasicSettings
     );
   }
 }
+
+export const ServerGroupBasicSettings = withRouter(ServerGroupBasicSettingsComponent);

--- a/deck/packages/amazon/src/serverGroup/details/AmazonServerGroupActions.spec.tsx
+++ b/deck/packages/amazon/src/serverGroup/details/AmazonServerGroupActions.spec.tsx
@@ -2,11 +2,16 @@ import { shallow } from 'enzyme';
 import React from 'react';
 
 import type { Application } from '@spinnaker/core';
-import { AngularServices, ConfirmationModalService, ManagedMenuItem } from '@spinnaker/core';
+import {
+  AngularServices,
+  ConfirmationModalService,
+  ManagedMenuItem,
+  ServerGroupWarningMessageService,
+} from '@spinnaker/core';
 
 import type { IAmazonServerGroupView } from '../../domain';
 import { AWSProviderSettings } from '../../aws.settings';
-import { AmazonServerGroupActions } from './AmazonServerGroupActions';
+import { AmazonServerGroupActionsComponent as AmazonServerGroupActions } from './AmazonServerGroupActions';
 import { AmazonRollbackServerGroupModal } from './rollback';
 
 describe('<AmazonServerGroupActions /> rollback integration', () => {
@@ -139,6 +144,32 @@ describe('<AmazonServerGroupActions /> rollback integration', () => {
     expect(confirm).toHaveBeenCalledTimes(1);
     expect(show).not.toHaveBeenCalled();
     expect(enable).not.toHaveBeenCalled();
+  });
+
+  it('closes destroyed server group details through the injected state service', () => {
+    const selected = buildServerGroup();
+    const stateService = { go: jasmine.createSpy('go'), includes: jasmine.createSpy('includes').and.returnValue(true) };
+    const confirm = spyOn(ConfirmationModalService, 'confirm');
+    spyOn(ServerGroupWarningMessageService, 'addDestroyWarningMessage');
+    const wrapper = shallow(
+      <AmazonServerGroupActions
+        app={buildApplication([selected])}
+        router={{} as any}
+        serverGroup={selected}
+        stateParams={{}}
+        stateService={stateService as any}
+      />,
+    );
+
+    action(wrapper, 'Destroy').prop('onClick')();
+    confirm.calls.mostRecent().args[0].taskMonitorConfig.onTaskComplete();
+
+    expect(stateService.includes).toHaveBeenCalledWith('**.serverGroup', {
+      accountId: 'test-account',
+      name: 'test-app-main-v002',
+      region: 'us-east-1',
+    });
+    expect(stateService.go).toHaveBeenCalledWith('^');
   });
 });
 

--- a/deck/packages/amazon/src/serverGroup/details/AmazonServerGroupActions.tsx
+++ b/deck/packages/amazon/src/serverGroup/details/AmazonServerGroupActions.tsx
@@ -2,7 +2,7 @@ import { get } from 'lodash';
 import React from 'react';
 import { Dropdown, MenuItem, Tooltip } from 'react-bootstrap';
 
-import type { IOwnerOption, IServerGroupActionsProps, IServerGroupJob } from '@spinnaker/core';
+import type { IOwnerOption, IRouterInjectedProps, IServerGroupActionsProps, IServerGroupJob } from '@spinnaker/core';
 import {
   AddEntityTagLinks,
   AngularServices,
@@ -12,6 +12,7 @@ import {
   Overridable,
   ServerGroupWarningMessageService,
   SETTINGS,
+  withRouter,
 } from '@spinnaker/core';
 
 import { AwsServices } from '../../aws.services';
@@ -42,7 +43,9 @@ export class AmazonServerGroupActionsResize extends React.Component<IAmazonResiz
   }
 }
 
-export class AmazonServerGroupActions extends React.Component<IAmazonServerGroupActionsProps> {
+export class AmazonServerGroupActionsComponent extends React.Component<
+  IAmazonServerGroupActionsProps & IRouterInjectedProps
+> {
   private isEnableLocked(): boolean {
     if (this.props.serverGroup.isDisabled) {
       const resizeTasks = (this.props.serverGroup.runningTasks || []).filter((task) =>
@@ -72,8 +75,8 @@ export class AmazonServerGroupActions extends React.Component<IAmazonServerGroup
       application: app,
       title: 'Destroying ' + serverGroup.name,
       onTaskComplete: () => {
-        if (AngularServices.$state.includes('**.serverGroup', stateParams)) {
-          AngularServices.$state.go('^');
+        if (this.props.stateService.includes('**.serverGroup', stateParams)) {
+          this.props.stateService.go('^');
         }
       },
     };
@@ -281,3 +284,5 @@ export class AmazonServerGroupActions extends React.Component<IAmazonServerGroup
     );
   }
 }
+
+export const AmazonServerGroupActions = withRouter(AmazonServerGroupActionsComponent);

--- a/deck/packages/app/scripts/angular-removal-guard.test.js
+++ b/deck/packages/app/scripts/angular-removal-guard.test.js
@@ -3,12 +3,16 @@ const { readdirSync, readFileSync } = require('node:fs');
 const path = require('node:path');
 const test = require('node:test');
 
-const workspaceRoot = path.resolve(__dirname, '../../..');
+const deckRoot = path.resolve(__dirname, '../../..');
+const repositoryRoot = path.resolve(deckRoot, '..');
 const coreSourceRoot = path.resolve(__dirname, '../../core/src');
+const routerConsumerRoots = [deckRoot, path.join(repositoryRoot, 'deck-kayenta/src')];
 const angularServicesPath = path.join(coreSourceRoot, 'angular/services.ts');
 const bridgePath = path.join(coreSourceRoot, 'navigation/legacyStateConfig.bridge.ts');
 const legacyImportPackage = ['ng', 'import'].join('');
 const routeProvider = /['"](?:stateConfigProvider|applicationStateProvider)['"]/;
+const routerFacadeMembers = ['$' + 'state', '$' + 'stateParams', '$' + 'uiRouter', 'state' + 'Events', 'h' + 'as'];
+const angularServicesName = 'Angular' + 'Services';
 
 function productionSourceFiles(directory) {
   return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
@@ -39,6 +43,26 @@ function workspaceSourceFiles(directory) {
     }
     return /\.(?:js|jsx|json|ts|tsx)$/.test(entry.name) ? [entryPath] : [];
   });
+}
+
+function usesRouterFacadeMember(source, member) {
+  if (source.includes(`${angularServicesName}.${member}`)) {
+    return true;
+  }
+
+  const escapedMember = member.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const indirectPropertyAccess = new RegExp(
+    `${angularServicesName}\\s*\\[\\s*['"]${escapedMember}['"]\\s*\\]|` +
+      `spyOnProperty\\(\\s*${angularServicesName}\\s*,\\s*['"]${escapedMember}['"]`,
+  );
+  if (indirectPropertyAccess.test(source)) {
+    return true;
+  }
+  const memberBinding = new RegExp(`(?:^|,)\\s*${escapedMember}(?:\\s*:|\\s*(?:,|$))`);
+  const destructuring = new RegExp(`(?:const|let|var)\\s*\\{([^{}]*)\\}\\s*=\\s*${angularServicesName}\\b`, 'g');
+  return Array.from(source.matchAll(destructuring), (match) => match[1]).some((bindings) =>
+    memberBinding.test(bindings),
+  );
 }
 
 test('Core routes do not depend on the legacy Angular state config bridge', () => {
@@ -73,10 +97,40 @@ test('AngularServices does not depend on the Angular global injector', () => {
   assert.doesNotMatch(source, /\$injector/);
 });
 
+test('AngularServices does not expose router facade members', () => {
+  const source = readFileSync(angularServicesPath, 'utf8');
+
+  routerFacadeMembers.forEach((member) => {
+    const escapedMember = member.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    assert.doesNotMatch(source, new RegExp(`(?:get\\s+)?${escapedMember}\\s*(?:\\(|\\{|:)`));
+  });
+});
+
 test('workspace source and dependency metadata do not reference the legacy Angular import bridge', () => {
-  const references = workspaceSourceFiles(workspaceRoot)
+  const references = workspaceSourceFiles(deckRoot)
     .filter((file) => readFileSync(file, 'utf8').includes(legacyImportPackage))
-    .map((file) => path.relative(workspaceRoot, file));
+    .map((file) => path.relative(deckRoot, file));
 
   assert.deepEqual(references, []);
+});
+
+test('Deck and Deck-Kayenta source and tests do not use AngularServices router facade members', () => {
+  const references = routerConsumerRoots
+    .flatMap((root) => workspaceSourceFiles(root))
+    .flatMap((file) => {
+      const source = readFileSync(file, 'utf8');
+      return routerFacadeMembers
+        .filter((member) => usesRouterFacadeMember(source, member))
+        .map((member) => `${path.relative(repositoryRoot, file)}: ${member}`);
+    });
+
+  assert.deepEqual(references, []);
+});
+
+test('router facade scan includes Deck functional tests', () => {
+  const scannedFiles = routerConsumerRoots
+    .flatMap((root) => workspaceSourceFiles(root))
+    .map((file) => path.relative(deckRoot, file));
+
+  assert.ok(scannedFiles.includes('test/functional/cypress/integration/core/bootstrap.spec.js'));
 });

--- a/deck/packages/app/src/canary/canary/CanaryExecutionSummary.spec.tsx
+++ b/deck/packages/app/src/canary/canary/CanaryExecutionSummary.spec.tsx
@@ -1,38 +1,56 @@
 import { shallow } from 'enzyme';
 import React from 'react';
 
-import { Markdown, AngularServices } from '@spinnaker/core';
+import { Markdown } from '@spinnaker/core';
 
-import { CanaryExecutionSummary } from './CanaryExecutionSummary';
+import { CanaryExecutionSummaryComponent } from './CanaryExecutionSummary';
 
 describe('CanaryExecutionSummary', () => {
-  beforeEach(() => {
-    spyOnProperty(AngularServices, '$stateParams', 'get').and.returnValue({});
-  });
+  const summaryProps = {
+    application: { executions: { data: [] } },
+    execution: { id: 'execution-id', isRunning: false, limitConcurrent: false, pipelineConfigId: 'pipeline-id' },
+    stage: { id: 'stage-id', name: 'Canary', isRunning: true, isCompleted: false },
+    stageSummary: {
+      endTime: 2,
+      masterStage: { context: { canary: { status: { status: 'SUCCEEDED' } } }, exceptions: [] },
+      masterStageIndex: 2,
+      name: 'Canary',
+      runningTimeInMs: 3,
+      stages: [],
+      startTime: 1,
+      type: 'canary',
+    },
+  } as any;
 
   it('renders comments through sanitized Markdown', () => {
     const comments = '<img src=x onerror=alert(1)> reviewer note';
-    const Component = CanaryExecutionSummary as React.ComponentType<any>;
     const component = shallow(
-      <Component
-        application={{ executions: { data: [] } }}
-        execution={{ id: 'execution-id', isRunning: false, limitConcurrent: false, pipelineConfigId: 'pipeline-id' }}
-        stage={{ id: 'stage-id', name: 'Canary', isRunning: true, isCompleted: false }}
-        stageSummary={{
-          comments,
-          endTime: 2,
-          masterStage: { context: { canary: { status: { status: 'SUCCEEDED' } } }, exceptions: [] },
-          masterStageIndex: 0,
-          name: 'Canary',
-          runningTimeInMs: 3,
-          stages: [],
-          startTime: 1,
-          type: 'canary',
-        }}
+      <CanaryExecutionSummaryComponent
+        {...({ router: {}, stateParams: {}, stateService: {} } as any)}
+        {...summaryProps}
+        stageSummary={{ ...summaryProps.stageSummary, comments }}
       />,
     );
 
     expect(component.find(Markdown).prop('message')).toBe(comments);
     expect(component.findWhere((node) => !!node.prop('dangerouslySetInnerHTML')).exists()).toBe(false);
+  });
+
+  it('navigates step details through the injected route', () => {
+    const go = jasmine.createSpy('go');
+    const component = shallow(
+      <CanaryExecutionSummaryComponent
+        {...summaryProps}
+        {...({
+          router: {},
+          stateParams: { stage: '3', step: '1', subStage: '4' },
+          stateService: { go },
+        } as any)}
+      />,
+    );
+
+    component.find('tbody tr').first().simulate('click');
+
+    expect(go).toHaveBeenCalledWith('.', { stage: 3, step: 2, subStage: 4 });
   });
 });

--- a/deck/packages/app/src/canary/canary/CanaryExecutionSummary.tsx
+++ b/deck/packages/app/src/canary/canary/CanaryExecutionSummary.tsx
@@ -1,15 +1,7 @@
 import React from 'react';
 
-import type { IStageSummaryProps } from '@spinnaker/core';
-import {
-  AngularServices,
-  ConfirmationModalService,
-  duration,
-  Markdown,
-  Registry,
-  REST,
-  timestamp,
-} from '@spinnaker/core';
+import type { IRouterInjectedProps, IStageSummaryProps } from '@spinnaker/core';
+import { ConfirmationModalService, duration, Markdown, Registry, REST, timestamp, withRouter } from '@spinnaker/core';
 
 import { EndCanaryModal } from './actions/EndCanaryModal';
 import { GenerateScoreModal } from './actions/GenerateScoreModal';
@@ -18,28 +10,35 @@ function canShowCanaryActions(status: string) {
   return status === 'LAUNCHED' || status === 'RUNNING' || status === 'DISABLED';
 }
 
-export function CanaryExecutionSummary({ application, execution, stage, stageSummary }: IStageSummaryProps) {
+export function CanaryExecutionSummaryComponent({
+  application,
+  execution,
+  stage,
+  stageSummary,
+  stateParams,
+  stateService,
+}: IStageSummaryProps & IRouterInjectedProps) {
   const canaryId = stageSummary.masterStage.context.canary?.id;
   const status = stageSummary.masterStage.context.canary?.status?.status;
   const isRestartable = (summaryStage: any) => {
     const stageConfig = Registry.pipeline.getStageConfig(summaryStage);
     return !!stageConfig && summaryStage.isRestarting !== true && !!stageConfig.restartable;
   };
-  const getCurrentStep = () => parseInt(AngularServices.$stateParams.step, 10);
+  const getCurrentStep = () => parseInt(stateParams.step, 10);
   const isStepCurrent = (index: number) => index === getCurrentStep();
   const toggleDetails = (index: number) => {
     const newStepDetails = getCurrentStep() === index ? null : index;
     if (newStepDetails !== null) {
       const newState = { step: newStepDetails } as any;
-      const selectedStage = parseInt(AngularServices.$stateParams.stage, 10);
+      const selectedStage = parseInt(stateParams.stage, 10);
       if (selectedStage) {
         newState.stage = selectedStage;
       }
-      const subStage = parseInt(AngularServices.$stateParams.subStage, 10);
+      const subStage = parseInt(stateParams.subStage, 10);
       if (subStage) {
         newState.subStage = subStage;
       }
-      AngularServices.$state.go('.', newState);
+      stateService.go('.', newState);
     }
   };
   const restartStage = () => {
@@ -163,3 +162,5 @@ export function CanaryExecutionSummary({ application, execution, stage, stageSum
     </div>
   );
 }
+
+export const CanaryExecutionSummary = withRouter(CanaryExecutionSummaryComponent);

--- a/deck/packages/app/src/canary/canary/canaryDeployment/CanaryDeploymentExecutionDetails.spec.tsx
+++ b/deck/packages/app/src/canary/canary/canaryDeployment/CanaryDeploymentExecutionDetails.spec.tsx
@@ -1,0 +1,19 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import { CanaryDeploymentExecutionDetailsComponent } from './CanaryDeploymentExecutionDetails';
+
+describe('CanaryDeploymentExecutionDetails', () => {
+  it('passes the injected project to deployment cluster links', () => {
+    const component = shallow(
+      <CanaryDeploymentExecutionDetailsComponent
+        {...({ router: {}, stateParams: { project: 'test-project' }, stateService: {} } as any)}
+        current={true}
+        name="deploymentDetails"
+        stage={{ context: {} } as any}
+      />,
+    );
+
+    expect(component.find('DeploymentDetails').prop('project')).toBe('test-project');
+  });
+});

--- a/deck/packages/app/src/canary/canary/canaryDeployment/CanaryDeploymentExecutionDetails.tsx
+++ b/deck/packages/app/src/canary/canary/canaryDeployment/CanaryDeploymentExecutionDetails.tsx
@@ -1,19 +1,19 @@
 import React from 'react';
 
-import type { IExecutionDetailsSectionProps } from '@spinnaker/core';
-import { AngularServices, ClusterState, ExecutionDetailsSection, timestamp, UrlBuilder } from '@spinnaker/core';
+import type { IExecutionDetailsSectionProps, IRouterInjectedProps } from '@spinnaker/core';
+import { ClusterState, ExecutionDetailsSection, timestamp, UrlBuilder, withRouter } from '@spinnaker/core';
 
 import { CanaryScore } from '../CanaryScore';
 import { HistoryTable } from '../../acaTask/AcaTaskExecutionDetails';
 import { getCanaryAnalysisHistory } from './canaryDeploymentHistory';
 
-function buildClusterUrl(stage: any, cluster: any) {
+function buildClusterUrl(stage: any, cluster: any, project: string) {
   const metadata: any = {
     type: 'clusters',
     application: stage.context.application,
     cluster: cluster.name,
     account: cluster.accountName,
-    project: AngularServices.$stateParams.project,
+    project,
   };
   metadata.href = UrlBuilder.buildFromMetadata(metadata);
   return metadata;
@@ -85,10 +85,12 @@ function CodeChanges({ stage }: IExecutionDetailsSectionProps) {
   );
 }
 
-function DeploymentDetails({ stage }: IExecutionDetailsSectionProps) {
+function DeploymentDetails({ stage, project }: IExecutionDetailsSectionProps & { project: string }) {
   const deployment = stage.context;
-  const baselineClusterUrl = deployment.baselineCluster ? buildClusterUrl(stage, deployment.baselineCluster) : null;
-  const canaryClusterUrl = deployment.canaryCluster ? buildClusterUrl(stage, deployment.canaryCluster) : null;
+  const baselineClusterUrl = deployment.baselineCluster
+    ? buildClusterUrl(stage, deployment.baselineCluster, project)
+    : null;
+  const canaryClusterUrl = deployment.canaryCluster ? buildClusterUrl(stage, deployment.canaryCluster, project) : null;
   return (
     <div className="canary-details">
       <div className="row">
@@ -186,7 +188,7 @@ function ClusterColumn({ title, cluster, clusterUrl }: { title: string; cluster:
   );
 }
 
-function CanaryDeploymentExecutionDetailsComponent(props: IExecutionDetailsSectionProps) {
+export function CanaryDeploymentExecutionDetailsComponent(props: IExecutionDetailsSectionProps & IRouterInjectedProps) {
   return (
     <ExecutionDetailsSection name={props.name} current={props.current}>
       {props.name === 'canaryAnalysisHistory' ? (
@@ -194,13 +196,13 @@ function CanaryDeploymentExecutionDetailsComponent(props: IExecutionDetailsSecti
       ) : props.name === 'codeChanges' ? (
         <CodeChanges {...props} />
       ) : (
-        <DeploymentDetails {...props} />
+        <DeploymentDetails {...props} project={props.stateParams.project} />
       )}
     </ExecutionDetailsSection>
   );
 }
 
-export const CanaryDeploymentExecutionDetails = Object.assign(CanaryDeploymentExecutionDetailsComponent, {
+export const CanaryDeploymentExecutionDetails = Object.assign(withRouter(CanaryDeploymentExecutionDetailsComponent), {
   title: 'canaryDeployment',
 });
 export const CanaryDeploymentAnalysisHistory = Object.assign(

--- a/deck/packages/azure/src/instance/details/AzureInstanceDetails.spec.tsx
+++ b/deck/packages/azure/src/instance/details/AzureInstanceDetails.spec.tsx
@@ -14,14 +14,17 @@ import {
 } from '@spinnaker/core';
 
 import {
-  AzureInstanceActions,
-  AzureInstanceDetails,
+  AzureInstanceActionsComponent as AzureInstanceActions,
+  AzureInstanceDetails as RoutedAzureInstanceDetails,
+  AzureInstanceDetailsComponent as AzureInstanceDetails,
   AzureInstanceInformationSection,
   loadAzureInstanceDetails,
 } from './AzureInstanceDetails';
 import { registerAzureProvider } from '../../azure.module';
 
 describe('AzureInstanceDetails', () => {
+  const stateService = { go: jasmine.createSpy('go'), includes: jasmine.createSpy('includes').and.returnValue(true) };
+  const routerProps = { router: {} as any, stateParams: {}, stateService: stateService as any };
   const instanceParams = {
     account: 'test-account',
     instanceId: 'i-123',
@@ -82,7 +85,7 @@ describe('AzureInstanceDetails', () => {
   }
 
   function actionLabels(instance: any): string[] {
-    return shallow(<AzureInstanceActions app={app()} instance={instance} />)
+    return shallow(<AzureInstanceActions {...routerProps} app={app()} instance={instance} />)
       .find(MenuItem)
       .map((item) => String(item.prop('children')).trim());
   }
@@ -216,9 +219,12 @@ describe('AzureInstanceDetails', () => {
   });
 
   it('renders the instance header and not-found state', () => {
-    const loaded = shallow(<AzureInstanceDetails app={app()} instance={instanceParams} initialInstance={details()} />);
+    const loaded = shallow(
+      <AzureInstanceDetails {...routerProps} app={app()} instance={instanceParams} initialInstance={details()} />,
+    );
     const notFound = shallow(
       <AzureInstanceDetails
+        {...routerProps}
         app={app()}
         instance={instanceParams}
         initialInstance={{ instanceIdNotFound: 'i-missing' } as any}
@@ -244,6 +250,7 @@ describe('AzureInstanceDetails', () => {
     );
     const wrapper = shallow(
       <AzureInstanceDetails
+        {...routerProps}
         app={application}
         instance={instanceParams}
         initialInstance={details({ instanceId: 'i-123', instanceType: 'old-type' })}
@@ -283,7 +290,7 @@ describe('AzureInstanceDetails', () => {
       loadBalancers: ['lb-1'],
       serverGroup: 'fnord-v001',
     } as any;
-    const wrapper = shallow(<AzureInstanceActions app={application} instance={instance} />);
+    const wrapper = shallow(<AzureInstanceActions {...routerProps} app={application} instance={instance} />);
 
     wrapper.find(MenuItem).forEach((item) => item.prop('onClick')({} as any));
 
@@ -296,6 +303,9 @@ describe('AzureInstanceDetails', () => {
     expect(InstanceWriter.deregisterInstanceFromLoadBalancer).toHaveBeenCalledWith(instance, application);
     expect(InstanceWriter.enableInstanceInDiscovery).toHaveBeenCalledWith(instance, application);
     expect(InstanceWriter.disableInstanceInDiscovery).toHaveBeenCalledWith(instance, application);
+    (ConfirmationModalService.confirm as jasmine.Spy).calls.first().args[0].taskMonitorConfig.onTaskComplete();
+    expect(stateService.includes).toHaveBeenCalledWith('**.instanceDetails', { instanceId: 'i-123' });
+    expect(stateService.go).toHaveBeenCalledWith('^');
   });
 
   it('renders load balancer actions based on load balancer health', () => {
@@ -345,7 +355,9 @@ describe('AzureInstanceDetails', () => {
   it('registers Azure React instance details with the provider registry', () => {
     registerAzureProvider();
 
-    expect(CloudProviderRegistry.getValue('azure', 'instance.details')).toBe(AzureInstanceDetails);
+    expect(CloudProviderRegistry.getValue('azure', 'instance.details').render).toBe(
+      (RoutedAzureInstanceDetails as any).render,
+    );
     expect(CloudProviderRegistry.getValue('azure', 'instance.detailsController')).toBeNull();
     expect(CloudProviderRegistry.getValue('azure', 'instance.detailsTemplateUrl')).toBeNull();
   });

--- a/deck/packages/azure/src/instance/details/AzureInstanceDetails.tsx
+++ b/deck/packages/azure/src/instance/details/AzureInstanceDetails.tsx
@@ -2,10 +2,9 @@ import { UISref } from '@uirouter/react';
 import React from 'react';
 import { Dropdown, MenuItem } from 'react-bootstrap';
 
-import type { Application, IInstanceDetailsProps } from '@spinnaker/core';
+import type { Application, IInstanceDetailsProps, IRouterInjectedProps } from '@spinnaker/core';
 import {
   AccountTag,
-  AngularServices,
   CollapsibleSection,
   ConfirmationModalService,
   InstanceDetailsHeader,
@@ -13,6 +12,7 @@ import {
   InstanceWriter,
   RecentHistoryService,
   timestamp,
+  withRouter,
 } from '@spinnaker/core';
 
 interface IAzureInstanceParams {
@@ -213,8 +213,8 @@ export async function loadAzureInstanceDetails({
   return loadedInstance;
 }
 
-export class AzureInstanceDetails extends React.Component<
-  IAzureInstanceDetailsProps,
+export class AzureInstanceDetailsComponent extends React.Component<
+  IAzureInstanceDetailsProps & IRouterInjectedProps,
   { instance?: IAzureLoadedInstance; loading: boolean }
 > {
   public state = { instance: this.props.initialInstance, loading: !this.props.initialInstance };
@@ -263,8 +263,10 @@ export class AzureInstanceDetails extends React.Component<
     }
   }
 
-  private getInstanceParams(props: IAzureInstanceDetailsProps = this.props): IAzureInstanceParams {
-    const params = props.instance || props.$stateParams;
+  private getInstanceParams(
+    props: IAzureInstanceDetailsProps & Partial<IRouterInjectedProps> = this.props,
+  ): IAzureInstanceParams {
+    const params = props.instance || props.$stateParams || props.stateParams;
     return {
       account: params?.account,
       instanceId: params?.instanceId,
@@ -286,7 +288,7 @@ export class AzureInstanceDetails extends React.Component<
       () => {
         if (!this.isUnmounted && requestId === this.activeRequestId) {
           this.setState({ loading: false });
-          AngularServices.$state.go('^');
+          this.props.stateService.go('^');
         }
       },
     );
@@ -308,7 +310,13 @@ export class AzureInstanceDetails extends React.Component<
           />
           {!loading && instance && !instance.instanceIdNotFound && (
             <div className="actions">
-              <AzureInstanceActions app={app} instance={instance} />
+              <AzureInstanceActionsComponent
+                app={app}
+                instance={instance}
+                router={this.props.router}
+                stateParams={this.props.stateParams}
+                stateService={this.props.stateService}
+              />
             </div>
           )}
         </div>
@@ -349,17 +357,18 @@ function canRegisterWithDiscovery(instance: IAzureLoadedInstance): boolean {
   return hasHealthState(instance, 'Discovery', 'OutOfService');
 }
 
-export function AzureInstanceActions({
+export function AzureInstanceActionsComponent({
   app,
   instance,
+  stateService,
 }: {
   app: Application;
   instance: IAzureLoadedInstance;
-}): JSX.Element {
+} & IRouterInjectedProps): JSX.Element {
   const loadBalancerNames = (instance.loadBalancers || []).join(' and ');
   const closeIfCurrentInstance = () => {
-    if (AngularServices.$state.includes('**.instanceDetails', { instanceId: instance.instanceId })) {
-      AngularServices.$state.go('^');
+    if (stateService.includes('**.instanceDetails', { instanceId: instance.instanceId })) {
+      stateService.go('^');
     }
   };
   const confirm = (
@@ -486,6 +495,9 @@ export function AzureInstanceActions({
     </Dropdown>
   );
 }
+
+export const AzureInstanceActions = withRouter(AzureInstanceActionsComponent);
+export const AzureInstanceDetails = withRouter(AzureInstanceDetailsComponent);
 
 export function AzureInstanceInformationSection({ instance }: { instance: IAzureLoadedInstance }): JSX.Element {
   return (

--- a/deck/packages/azure/src/loadBalancer/configure/AzureLoadBalancerModal.spec.tsx
+++ b/deck/packages/azure/src/loadBalancer/configure/AzureLoadBalancerModal.spec.tsx
@@ -4,7 +4,7 @@ import { AzureLoadBalancerTypes } from '../../utility';
 import { AzureLoadBalancerTransformer } from '../loadBalancer.transformer';
 import {
   applyAzureLoadBalancerTypeDefaults,
-  AzureLoadBalancerModal,
+  AzureLoadBalancerModalComponent as AzureLoadBalancerModal,
   findAzureVnetBySelectValue,
   formatInputValue,
   getAzureLoadBalancerTypeChoice,

--- a/deck/packages/azure/src/loadBalancer/configure/AzureLoadBalancerModal.tsx
+++ b/deck/packages/azure/src/loadBalancer/configure/AzureLoadBalancerModal.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
 import { Modal } from 'react-bootstrap';
 
-import type { Application, IModalComponentProps } from '@spinnaker/core';
+import type { Application, IModalComponentProps, IRouterInjectedProps } from '@spinnaker/core';
 import {
   AccountService,
-  AngularServices,
   LoadBalancerWriter,
   ModalClose,
   NameUtils,
@@ -14,6 +13,7 @@ import {
   SubmitButton,
   TaskMonitor,
   TaskMonitorWrapper,
+  withRouter,
 } from '@spinnaker/core';
 
 import { AzureLoadBalancerTransformer } from '../loadBalancer.transformer';
@@ -335,8 +335,8 @@ export function normalizeAzureLoadBalancerForSubmit(loadBalancer: any, loadBalan
   return normalized;
 }
 
-export class AzureLoadBalancerModal extends React.Component<
-  IAzureLoadBalancerModalProps,
+export class AzureLoadBalancerModalComponent extends React.Component<
+  IAzureLoadBalancerModalProps & IRouterInjectedProps,
   IAzureLoadBalancerModalState
 > {
   public static defaultProps: Partial<IAzureLoadBalancerModalProps> = {
@@ -352,7 +352,7 @@ export class AzureLoadBalancerModal extends React.Component<
   private mounted = false;
   private transformer = new AzureLoadBalancerTransformer(null);
 
-  constructor(props: IAzureLoadBalancerModalProps) {
+  constructor(props: IAzureLoadBalancerModalProps & IRouterInjectedProps) {
     super(props);
     const application = this.getApplication();
     const taskMonitor = new TaskMonitor({
@@ -453,10 +453,10 @@ export class AzureLoadBalancerModal extends React.Component<
       provider: 'azure',
     };
 
-    if (!AngularServices.$state.includes('**.loadBalancerDetails')) {
-      AngularServices.$state.go('.loadBalancerDetails', newStateParams);
+    if (!this.props.stateService.includes('**.loadBalancerDetails')) {
+      this.props.stateService.go('.loadBalancerDetails', newStateParams);
     } else {
-      AngularServices.$state.go('^.loadBalancerDetails', newStateParams);
+      this.props.stateService.go('^.loadBalancerDetails', newStateParams);
     }
   };
 
@@ -948,3 +948,8 @@ export class AzureLoadBalancerModal extends React.Component<
     );
   }
 }
+
+export const AzureLoadBalancerModal = Object.assign(
+  withRouter<IAzureLoadBalancerModalProps & IRouterInjectedProps>(AzureLoadBalancerModalComponent),
+  { show: AzureLoadBalancerModalComponent.show },
+);

--- a/deck/packages/azure/src/routerConsumers.spec.tsx
+++ b/deck/packages/azure/src/routerConsumers.spec.tsx
@@ -1,0 +1,78 @@
+import { TaskMonitor } from '@spinnaker/core';
+
+import { AzureLoadBalancerModalComponent } from './loadBalancer/configure/AzureLoadBalancerModal';
+import { AzureCloneServerGroupModalComponent } from './serverGroup/configure/wizard/AzureCloneServerGroupModal';
+
+describe('Azure routed modal consumers', () => {
+  beforeEach(() => {
+    spyOn(TaskMonitor, 'modalInstanceEmulation').and.returnValue({
+      dismiss: jasmine.createSpy('dismiss'),
+      result: Promise.resolve(),
+    } as any);
+  });
+
+  function stateService(includedState: string) {
+    return {
+      go: jasmine.createSpy('go'),
+      includes: jasmine.createSpy('includes').and.callFake((state: string) => state === includedState),
+    };
+  }
+
+  it('navigates from the load balancer modal through its injected state service', () => {
+    const state = stateService('**.loadBalancerDetails');
+    const modal = new AzureLoadBalancerModalComponent({
+      app: { defaultCredentials: {}, defaultRegions: {}, name: 'fnord' },
+      closeModal: jasmine.createSpy('closeModal'),
+      dismissModal: jasmine.createSpy('dismissModal'),
+      isNew: true,
+      stateService: state,
+    } as any) as any;
+    modal.mounted = true;
+    modal.state = {
+      loadBalancer: { credentials: 'test-account', name: 'fnord-main', region: 'westus' },
+    };
+
+    modal.onApplicationRefresh();
+
+    expect(state.go).toHaveBeenCalledWith('^.loadBalancerDetails', {
+      accountId: 'test-account',
+      name: 'fnord-main',
+      provider: 'azure',
+      region: 'westus',
+    });
+  });
+
+  it('navigates from the clone server group modal through its injected state service', () => {
+    const state = stateService('**.clusters.cluster.serverGroup');
+    const modal = new AzureCloneServerGroupModalComponent({
+      application: { name: 'fnord' },
+      command: { viewState: { requiresTemplateSelection: true } },
+      dismissModal: jasmine.createSpy('dismissModal'),
+      stateService: state,
+    } as any) as any;
+    modal.state = {
+      command: { credentials: 'test-account', region: 'westus' },
+      taskMonitor: {
+        task: {
+          execution: {
+            stages: [
+              {
+                context: { 'deploy.server.groups': { westus: 'fnord-main-v042' } },
+                type: 'cloneServerGroup',
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    modal.onApplicationRefresh();
+
+    expect(state.go).toHaveBeenCalledWith('^.^.serverGroup', {
+      accountId: 'test-account',
+      provider: 'azure',
+      region: 'westus',
+      serverGroup: 'fnord-main-v042',
+    });
+  });
+});

--- a/deck/packages/azure/src/securityGroup/configure/AzureSecurityGroupModal.spec.tsx
+++ b/deck/packages/azure/src/securityGroup/configure/AzureSecurityGroupModal.spec.tsx
@@ -1,11 +1,11 @@
-import { AccountService, NetworkReader, AngularServices, TaskMonitor } from '@spinnaker/core';
+import { AccountService, NetworkReader, TaskMonitor } from '@spinnaker/core';
 import { shallow } from 'enzyme';
 import React from 'react';
 import { Modal } from 'react-bootstrap';
 
 import {
   addSecurityRule,
-  AzureSecurityGroupModal,
+  AzureSecurityGroupModalComponent as AzureSecurityGroupModal,
   getAzureVnetSelectValue,
   initializeAzureSecurityGroupForModal,
   isAzureSecurityGroupValid,
@@ -506,7 +506,6 @@ describe('AzureSecurityGroupModal', () => {
       result: Promise.resolve(),
     } as any);
     const state = { go: jasmine.createSpy('go'), includes: jasmine.createSpy('includes').and.returnValue(false) };
-    spyOnProperty(AngularServices, '$state', 'get').and.returnValue(state as any);
     const onNextRefresh = jasmine
       .createSpy('onNextRefresh')
       .and.callFake((_scope: any, callback: () => void) => callback());
@@ -518,6 +517,7 @@ describe('AzureSecurityGroupModal', () => {
       dismissModal: jasmine.createSpy('dismissModal'),
       mode: 'clone',
       securityGroup: { accountId: 'test-account', name: 'fnord-sg', region: 'westus', vpcId: 'vnet-1' },
+      stateService: state,
     } as any) as any;
 
     modal.onTaskComplete();

--- a/deck/packages/azure/src/securityGroup/configure/AzureSecurityGroupModal.tsx
+++ b/deck/packages/azure/src/securityGroup/configure/AzureSecurityGroupModal.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
 import { Modal } from 'react-bootstrap';
 
-import type { Application, IModalComponentProps, ISecurityGroup } from '@spinnaker/core';
+import type { Application, IModalComponentProps, IRouterInjectedProps, ISecurityGroup } from '@spinnaker/core';
 import {
   AccountService,
-  AngularServices,
   ModalClose,
   NetworkReader,
   noop,
@@ -12,6 +11,7 @@ import {
   SubmitButton,
   TaskMonitor,
   TaskMonitorWrapper,
+  withRouter,
 } from '@spinnaker/core';
 
 import { AzureSecurityGroupWriter } from '../securityGroup.write.service';
@@ -353,8 +353,8 @@ export function initializeAzureSecurityGroupForModal(
   return securityGroup;
 }
 
-export class AzureSecurityGroupModal extends React.Component<
-  IAzureSecurityGroupModalProps,
+export class AzureSecurityGroupModalComponent extends React.Component<
+  IAzureSecurityGroupModalProps & IRouterInjectedProps,
   IAzureSecurityGroupModalState
 > {
   public static defaultProps: Partial<IAzureSecurityGroupModalProps> = {
@@ -367,7 +367,7 @@ export class AzureSecurityGroupModal extends React.Component<
     return ReactModal.show(AzureSecurityGroupModal, props, { dialogClassName: 'modal-lg' });
   }
 
-  constructor(props: IAzureSecurityGroupModalProps) {
+  constructor(props: IAzureSecurityGroupModalProps & IRouterInjectedProps) {
     super(props);
     const application = this.getApplication(props);
     this.state = {
@@ -413,8 +413,8 @@ export class AzureSecurityGroupModal extends React.Component<
     const showNewSecurityGroup = (): void => {
       const { securityGroup } = this.state;
       this.props.closeModal();
-      AngularServices.$state.go(
-        AngularServices.$state.includes('**.firewallDetails') ? '^.firewallDetails' : '.firewallDetails',
+      this.props.stateService.go(
+        this.props.stateService.includes('**.firewallDetails') ? '^.firewallDetails' : '.firewallDetails',
         {
           accountId: securityGroup.credentials || securityGroup.accountId || securityGroup.accountName,
           name: securityGroup.name,
@@ -757,3 +757,8 @@ export class AzureSecurityGroupModal extends React.Component<
     );
   }
 }
+
+export const AzureSecurityGroupModal = Object.assign(
+  withRouter<IAzureSecurityGroupModalProps & IRouterInjectedProps>(AzureSecurityGroupModalComponent),
+  { show: AzureSecurityGroupModalComponent.show },
+);

--- a/deck/packages/azure/src/securityGroup/details/AzureSecurityGroupDetails.spec.tsx
+++ b/deck/packages/azure/src/securityGroup/details/AzureSecurityGroupDetails.spec.tsx
@@ -8,7 +8,7 @@ import { AzureSecurityGroupModal } from '../configure/AzureSecurityGroupModal';
 import { AzureSecurityGroupWriter } from '../securityGroup.write.service';
 import {
   AzureSecurityGroupActions,
-  AzureSecurityGroupDetails,
+  AzureSecurityGroupDetailsComponent as AzureSecurityGroupDetails,
   AzureSecurityGroupInformationSection,
   AzureSecurityGroupRulesSection,
 } from './AzureSecurityGroupDetails';
@@ -52,6 +52,21 @@ describe('AzureSecurityGroupDetails', () => {
       vpcId: 'vnet-1',
     } as any;
   }
+
+  it('closes missing details through the injected state service', () => {
+    const stateService = { go: jasmine.createSpy('go') };
+    const component = new AzureSecurityGroupDetails({
+      app: app(),
+      resolvedSecurityGroup,
+      router: {},
+      stateParams: {},
+      stateService,
+    } as any);
+
+    (component as any).autoClose();
+
+    expect(stateService.go).toHaveBeenCalledWith('^');
+  });
 
   it('loads details with the core security group reader and renders basic sections', async () => {
     const securityGroupReader = {

--- a/deck/packages/azure/src/securityGroup/details/AzureSecurityGroupDetails.tsx
+++ b/deck/packages/azure/src/securityGroup/details/AzureSecurityGroupDetails.tsx
@@ -1,8 +1,14 @@
 import React from 'react';
 import { Dropdown, MenuItem } from 'react-bootstrap';
 
-import type { Application, IOverridableProps, ISecurityGroupDetail, SecurityGroupReader } from '@spinnaker/core';
-import { AccountTag, AngularServices, CollapsibleSection, ConfirmationModalService } from '@spinnaker/core';
+import type {
+  Application,
+  IOverridableProps,
+  IRouterInjectedProps,
+  ISecurityGroupDetail,
+  SecurityGroupReader,
+} from '@spinnaker/core';
+import { AccountTag, AngularServices, CollapsibleSection, ConfirmationModalService, withRouter } from '@spinnaker/core';
 
 import { AzureSecurityGroupModal } from '../configure/AzureSecurityGroupModal';
 import { AzureSecurityGroupWriter } from '../securityGroup.write.service';
@@ -31,8 +37,8 @@ interface IAzureSecurityGroupSectionProps {
   securityGroup: ISecurityGroupDetail & Record<string, any>;
 }
 
-export class AzureSecurityGroupDetails extends React.Component<
-  IAzureSecurityGroupDetailsProps,
+export class AzureSecurityGroupDetailsComponent extends React.Component<
+  IAzureSecurityGroupDetailsProps & IRouterInjectedProps,
   IAzureSecurityGroupDetailsState
 > {
   public state: IAzureSecurityGroupDetailsState = { loading: true };
@@ -117,11 +123,11 @@ export class AzureSecurityGroupDetails extends React.Component<
       this.props.autoClose();
       return;
     }
-    AngularServices.$state.go('^');
+    this.props.stateService.go('^');
   };
 
   private closeDetails = (): void => {
-    AngularServices.$state.go('^');
+    this.props.stateService.go('^');
   };
 
   public render(): JSX.Element {
@@ -170,6 +176,8 @@ export class AzureSecurityGroupDetails extends React.Component<
     );
   }
 }
+
+export const AzureSecurityGroupDetails = withRouter(AzureSecurityGroupDetailsComponent);
 
 function withResolvedCoordinates(securityGroup: any, resolvedSecurityGroup?: IAzureResolvedSecurityGroup): any {
   if (!resolvedSecurityGroup) {

--- a/deck/packages/azure/src/serverGroup/configure/wizard/AzureCloneServerGroupModal.spec.tsx
+++ b/deck/packages/azure/src/serverGroup/configure/wizard/AzureCloneServerGroupModal.spec.tsx
@@ -15,7 +15,10 @@ import React from 'react';
 
 import { registerAzureProvider } from '../../../azure.module';
 import { AzureServerGroupTransformer } from '../../serverGroup.transformer';
-import { AzureCloneServerGroupModal } from './AzureCloneServerGroupModal';
+import {
+  AzureCloneServerGroupModal as RoutedAzureCloneServerGroupModal,
+  AzureCloneServerGroupModalComponent as AzureCloneServerGroupModal,
+} from './AzureCloneServerGroupModal';
 import {
   ServerGroupAdvancedSettings,
   ServerGroupBasicSettings,
@@ -90,23 +93,16 @@ describe('AzureCloneServerGroupModal', () => {
   it('registers as the Azure clone server group modal', () => {
     registerAzureProvider();
 
-    expect(CloudProviderRegistry.getValue('azure', 'serverGroup.CloneServerGroupModal')).toBe(
-      AzureCloneServerGroupModal,
+    expect(CloudProviderRegistry.getValue('azure', 'serverGroup.CloneServerGroupModal').render).toBe(
+      (RoutedAzureCloneServerGroupModal as any).render,
     );
   });
 
   it('show opens the React wizard and resolves with the submitted pipeline command', async () => {
     const serverGroupCommand = command();
-    spyOn(ReactModal, 'show').and.callFake((Component: any, props: any) => {
-      const modal = new Component({
-        ...props,
-        closeModal: (result: any) => Promise.resolve(result),
-        dismissModal: () => null,
-      });
-      return Promise.resolve((modal as any).submit(serverGroupCommand));
-    });
+    spyOn(ReactModal, 'show').and.returnValue(Promise.resolve(serverGroupCommand));
 
-    const result = await AzureCloneServerGroupModal.show({
+    const result = await RoutedAzureCloneServerGroupModal.show({
       title: 'Configure',
       application,
       command: serverGroupCommand,
@@ -114,7 +110,7 @@ describe('AzureCloneServerGroupModal', () => {
 
     expect(result).toBe(serverGroupCommand);
     expect(ReactModal.show).toHaveBeenCalledWith(
-      AzureCloneServerGroupModal,
+      RoutedAzureCloneServerGroupModal,
       jasmine.objectContaining({ title: 'Configure', application, command: serverGroupCommand }),
       { dialogClassName: 'wizard-modal modal-lg' },
     );
@@ -123,17 +119,10 @@ describe('AzureCloneServerGroupModal', () => {
   it('cancel and dismiss reject without submitting or mutating the command', async () => {
     const serverGroupCommand = command({ viewState: { mode: 'clone' } });
     const original = JSON.stringify(serverGroupCommand);
-    spyOn(ReactModal, 'show').and.callFake((Component: any, props: any) => {
-      const modal = new Component({
-        ...props,
-        closeModal: () => Promise.resolve(),
-        dismissModal: () => Promise.reject('cancelled'),
-      });
-      return (modal.props as any).dismissModal();
-    });
+    spyOn(ReactModal, 'show').and.returnValue(Promise.reject('cancelled'));
 
     await expectAsync(
-      AzureCloneServerGroupModal.show({ title: 'Clone', application, command: serverGroupCommand } as any),
+      RoutedAzureCloneServerGroupModal.show({ title: 'Clone', application, command: serverGroupCommand } as any),
     ).toBeRejectedWith('cancelled');
 
     expect(JSON.stringify(serverGroupCommand)).toBe(original);

--- a/deck/packages/azure/src/serverGroup/configure/wizard/AzureCloneServerGroupModal.tsx
+++ b/deck/packages/azure/src/serverGroup/configure/wizard/AzureCloneServerGroupModal.tsx
@@ -1,7 +1,13 @@
 import { cloneDeep } from 'lodash';
 import React from 'react';
 
-import type { Application, IModalComponentProps, IStage, ITemplateSelectionText } from '@spinnaker/core';
+import type {
+  Application,
+  IModalComponentProps,
+  IRouterInjectedProps,
+  IStage,
+  ITemplateSelectionText,
+} from '@spinnaker/core';
 import {
   AngularServices,
   DeployInitializer,
@@ -9,6 +15,7 @@ import {
   noop,
   ReactModal,
   TaskMonitor,
+  withRouter,
   WizardModal,
   WizardPage,
 } from '@spinnaker/core';
@@ -41,8 +48,8 @@ interface IAzureCloneServerGroupModalState {
   templateSelectionText: ITemplateSelectionText;
 }
 
-export class AzureCloneServerGroupModal extends React.Component<
-  IAzureCloneServerGroupModalProps,
+export class AzureCloneServerGroupModalComponent extends React.Component<
+  IAzureCloneServerGroupModalProps & IRouterInjectedProps,
   IAzureCloneServerGroupModalState
 > {
   public static defaultProps: Partial<IAzureCloneServerGroupModalProps> = {
@@ -57,7 +64,7 @@ export class AzureCloneServerGroupModal extends React.Component<
     return ReactModal.show(AzureCloneServerGroupModal, props, { dialogClassName: 'wizard-modal modal-lg' });
   }
 
-  constructor(props: IAzureCloneServerGroupModalProps) {
+  constructor(props: IAzureCloneServerGroupModalProps & IRouterInjectedProps) {
     super(props);
     const requiresTemplateSelection = !!props.command.viewState?.requiresTemplateSelection;
     const workingCommand = cloneDeep(props.command);
@@ -128,16 +135,16 @@ export class AzureCloneServerGroupModal extends React.Component<
       const newServerGroupName = cloneStage.context['deploy.server.groups'][command.region];
       if (newServerGroupName) {
         let transitionTo = '^.^.^.clusters.serverGroup';
-        if (AngularServices.$state.includes('**.clusters.serverGroup')) {
+        if (this.props.stateService.includes('**.clusters.serverGroup')) {
           transitionTo = '^.serverGroup';
         }
-        if (AngularServices.$state.includes('**.clusters.cluster.serverGroup')) {
+        if (this.props.stateService.includes('**.clusters.cluster.serverGroup')) {
           transitionTo = '^.^.serverGroup';
         }
-        if (AngularServices.$state.includes('**.clusters')) {
+        if (this.props.stateService.includes('**.clusters')) {
           transitionTo = '.serverGroup';
         }
-        AngularServices.$state.go(transitionTo, {
+        this.props.stateService.go(transitionTo, {
           accountId: command.credentials,
           provider: 'azure',
           region: command.region,
@@ -313,3 +320,8 @@ export class AzureCloneServerGroupModal extends React.Component<
     );
   }
 }
+
+export const AzureCloneServerGroupModal = Object.assign(
+  withRouter<IAzureCloneServerGroupModalProps & IRouterInjectedProps>(AzureCloneServerGroupModalComponent),
+  { show: AzureCloneServerGroupModalComponent.show },
+);

--- a/deck/packages/azure/src/serverGroup/details/azureServerGroupDetails.spec.tsx
+++ b/deck/packages/azure/src/serverGroup/details/azureServerGroupDetails.spec.tsx
@@ -13,12 +13,15 @@ import { registerAzureProvider } from '../../azure.module';
 import { AzureServerGroupCommandBuilder } from '../configure/serverGroupCommandBuilder.service';
 import { AzureCloneServerGroupModal } from '../configure/wizard/AzureCloneServerGroupModal';
 import {
-  AzureServerGroupActions,
+  AzureServerGroupActions as RoutedAzureServerGroupActions,
+  AzureServerGroupActionsComponent as AzureServerGroupActions,
   azureServerGroupDetailsGetter,
   azureServerGroupDetailsSections,
 } from './azureServerGroupDetails';
 
 describe('Azure server group details', () => {
+  const stateService = { go: jasmine.createSpy('go'), includes: jasmine.createSpy('includes').and.returnValue(true) };
+  const routerProps = { router: {} as any, stateParams: {}, stateService: stateService as any };
   const serverGroupParams = {
     name: 'azure-v001',
     accountId: 'test-account',
@@ -135,7 +138,9 @@ describe('Azure server group details', () => {
     registerAzureProvider();
 
     expect(CloudProviderRegistry.getValue('azure', 'serverGroup.detailsGetter')).toBe(azureServerGroupDetailsGetter);
-    expect(CloudProviderRegistry.getValue('azure', 'serverGroup.detailsActions')).toBe(AzureServerGroupActions);
+    expect(CloudProviderRegistry.getValue('azure', 'serverGroup.detailsActions').render).toBe(
+      (RoutedAzureServerGroupActions as any).render,
+    );
     expect(CloudProviderRegistry.getValue('azure', 'serverGroup.detailsSections')).toEqual(
       azureServerGroupDetailsSections,
     );
@@ -150,7 +155,7 @@ describe('Azure server group details', () => {
     spyOn(ServerGroupWarningMessageService, 'addDestroyWarningMessage');
     spyOn(ServerGroupWarningMessageService, 'addDisableWarningMessage');
 
-    const wrapper = mount(<AzureServerGroupActions app={app} serverGroup={serverGroup as any} />);
+    const wrapper = mount(<AzureServerGroupActions {...routerProps} app={app} serverGroup={serverGroup as any} />);
     wrapper
       .find('a')
       .filterWhere((node) => node.text() === 'Destroy')
@@ -169,6 +174,8 @@ describe('Azure server group details', () => {
     expect(
       (ConfirmationModalService.confirm as jasmine.Spy).calls.allArgs().map(([params]) => params.buttonText),
     ).toEqual(['Destroy azure-v001', 'Disable azure-v001', 'Enable azure-v001']);
+    (ConfirmationModalService.confirm as jasmine.Spy).calls.first().args[0].taskMonitorConfig.onTaskComplete();
+    expect(stateService.go).toHaveBeenCalledWith('^');
   });
 
   it('builds a clone command before opening the clone wizard', async () => {
@@ -181,7 +188,7 @@ describe('Azure server group details', () => {
     );
     spyOn(AzureCloneServerGroupModal, 'show').and.returnValue(Promise.resolve());
 
-    const wrapper = mount(<AzureServerGroupActions app={app} serverGroup={serverGroup as any} />);
+    const wrapper = mount(<AzureServerGroupActions {...routerProps} app={app} serverGroup={serverGroup as any} />);
     wrapper
       .find('a')
       .filterWhere((node) => node.text() === 'Clone')
@@ -220,7 +227,7 @@ describe('Azure server group details', () => {
     spyOn(AzureImageReader.prototype, 'findImages').and.returnValue(Promise.resolve(images));
     spyOn(AzureCloneServerGroupModal, 'show').and.returnValue(Promise.resolve());
 
-    const wrapper = mount(<AzureServerGroupActions app={app} serverGroup={serverGroup as any} />);
+    const wrapper = mount(<AzureServerGroupActions {...routerProps} app={app} serverGroup={serverGroup as any} />);
     wrapper
       .find('a')
       .filterWhere((node) => node.text() === 'Clone')

--- a/deck/packages/azure/src/serverGroup/details/azureServerGroupDetails.tsx
+++ b/deck/packages/azure/src/serverGroup/details/azureServerGroupDetails.tsx
@@ -4,6 +4,7 @@ import { Observable } from 'rxjs';
 import type { Subscriber } from 'rxjs';
 
 import type {
+  IRouterInjectedProps,
   IServerGroupActionsProps,
   IServerGroupDetailsProps,
   IServerGroupDetailsSectionProps,
@@ -19,6 +20,7 @@ import {
   ServerGroupReader,
   ServerGroupWarningMessageService,
   timestamp,
+  withRouter,
 } from '@spinnaker/core';
 
 import { AzureServerGroupCommandBuilder } from '../configure/serverGroupCommandBuilder.service';
@@ -130,7 +132,11 @@ export function azureServerGroupDetailsGetter(props: IServerGroupDetailsProps, a
   });
 }
 
-export function AzureServerGroupActions({ app, serverGroup }: IServerGroupActionsProps) {
+export function AzureServerGroupActionsComponent({
+  app,
+  serverGroup,
+  stateService,
+}: IServerGroupActionsProps & IRouterInjectedProps) {
   const destroyServerGroup = (): void => {
     const stateParams = {
       name: serverGroup.name,
@@ -146,8 +152,8 @@ export function AzureServerGroupActions({ app, serverGroup }: IServerGroupAction
         application: app,
         title: `Destroying ${serverGroup.name}`,
         onTaskComplete: () => {
-          if (AngularServices.$state.includes('**.serverGroup', stateParams)) {
-            AngularServices.$state.go('^');
+          if (stateService.includes('**.serverGroup', stateParams)) {
+            stateService.go('^');
           }
         },
       },
@@ -248,6 +254,8 @@ export function AzureServerGroupActions({ app, serverGroup }: IServerGroupAction
     </Dropdown>
   );
 }
+
+export const AzureServerGroupActions = withRouter(AzureServerGroupActionsComponent);
 
 export function AzureServerGroupInformationSection({ serverGroup }: IServerGroupDetailsSectionProps) {
   return (

--- a/deck/packages/cloudfoundry/src/instance/details/CloudFoundryInstanceActions.tsx
+++ b/deck/packages/cloudfoundry/src/instance/details/CloudFoundryInstanceActions.tsx
@@ -2,8 +2,8 @@ import { cloneDeep } from 'lodash';
 import React from 'react';
 import { Dropdown } from 'react-bootstrap';
 
-import type { Application } from '@spinnaker/core';
-import { AngularServices, ConfirmationModalService, InstanceWriter } from '@spinnaker/core';
+import type { Application, IRouterInjectedProps } from '@spinnaker/core';
+import { ConfirmationModalService, InstanceWriter, withRouter } from '@spinnaker/core';
 
 import type { ICloudFoundryInstance } from '../../domain';
 
@@ -12,7 +12,9 @@ export interface ICloudFoundryInstanceActionsProps {
   instance: ICloudFoundryInstance;
 }
 
-export class CloudFoundryInstanceActions extends React.Component<ICloudFoundryInstanceActionsProps> {
+export class CloudFoundryInstanceActionsComponent extends React.Component<
+  ICloudFoundryInstanceActionsProps & IRouterInjectedProps
+> {
   private terminateInstance = () => {
     const { application, instance } = this.props;
     const instanceClone = cloneDeep(instance) as any;
@@ -21,9 +23,9 @@ export class CloudFoundryInstanceActions extends React.Component<ICloudFoundryIn
     const taskMonitor = {
       application: application,
       title: 'Terminating ' + instance.name,
-      onTaskComplete() {
-        if (AngularServices.$state.includes('**.serverGroup', { instanceId: instance.name })) {
-          AngularServices.$state.go('^');
+      onTaskComplete: () => {
+        if (this.props.stateService.includes('**.serverGroup', { instanceId: instance.name })) {
+          this.props.stateService.go('^');
         }
       },
     };
@@ -58,3 +60,5 @@ export class CloudFoundryInstanceActions extends React.Component<ICloudFoundryIn
     );
   }
 }
+
+export const CloudFoundryInstanceActions = withRouter(CloudFoundryInstanceActionsComponent);

--- a/deck/packages/cloudfoundry/src/loadBalancer/details/CloudFoundryLoadBalancerActions.tsx
+++ b/deck/packages/cloudfoundry/src/loadBalancer/details/CloudFoundryLoadBalancerActions.tsx
@@ -1,23 +1,25 @@
 import React from 'react';
 import { Dropdown } from 'react-bootstrap';
 
-import type { Application, ILoadBalancer, ILoadBalancerDeleteCommand } from '@spinnaker/core';
-import { AngularServices, ConfirmationModalService, LoadBalancerWriter } from '@spinnaker/core';
+import type { Application, ILoadBalancer, ILoadBalancerDeleteCommand, IRouterInjectedProps } from '@spinnaker/core';
+import { ConfirmationModalService, LoadBalancerWriter, withRouter } from '@spinnaker/core';
 
 export interface ICloudFoundryLoadBalancerActionsProps {
   application: Application;
   loadBalancer: ILoadBalancer;
 }
 
-export class CloudFoundryLoadBalancerActions extends React.Component<ICloudFoundryLoadBalancerActionsProps> {
+export class CloudFoundryLoadBalancerActionsComponent extends React.Component<
+  ICloudFoundryLoadBalancerActionsProps & IRouterInjectedProps
+> {
   private deleteLoadBalancer = () => {
     const { application, loadBalancer } = this.props;
     const taskMonitor = {
       application: application,
       title: 'Deleting ' + loadBalancer.name,
-      onTaskComplete() {
-        if (AngularServices.$state.includes('**.serverGroup', { instanceId: loadBalancer.name })) {
-          AngularServices.$state.go('^');
+      onTaskComplete: () => {
+        if (this.props.stateService.includes('**.serverGroup', { instanceId: loadBalancer.name })) {
+          this.props.stateService.go('^');
         }
       },
     };
@@ -58,3 +60,5 @@ export class CloudFoundryLoadBalancerActions extends React.Component<ICloudFound
     );
   }
 }
+
+export const CloudFoundryLoadBalancerActions = withRouter(CloudFoundryLoadBalancerActionsComponent);

--- a/deck/packages/cloudfoundry/src/routerActions.spec.tsx
+++ b/deck/packages/cloudfoundry/src/routerActions.spec.tsx
@@ -1,0 +1,76 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import { ConfirmationModalService, ServerGroupWarningMessageService } from '@spinnaker/core';
+
+import { CloudFoundryInstanceActionsComponent } from './instance/details/CloudFoundryInstanceActions';
+import { CloudFoundryLoadBalancerActionsComponent } from './loadBalancer/details/CloudFoundryLoadBalancerActions';
+import { CloudFoundryServerGroupActionsComponent } from './serverGroup/details/cloudFoundryServerGroupActions';
+
+describe('Cloud Foundry routed actions', () => {
+  const routerProps = (includes: jasmine.Spy, go: jasmine.Spy) =>
+    ({ router: {}, stateParams: {}, stateService: { go, includes } } as any);
+
+  it('closes instance details through the injected state service', () => {
+    const includes = jasmine.createSpy('includes').and.returnValue(true);
+    const go = jasmine.createSpy('go');
+    const confirm = spyOn(ConfirmationModalService, 'confirm');
+    const component = shallow(
+      <CloudFoundryInstanceActionsComponent
+        {...routerProps(includes, go)}
+        application={{} as any}
+        instance={{ account: 'test', name: 'instance-id' } as any}
+      />,
+    );
+
+    (component.instance() as any).terminateInstance();
+    confirm.calls.mostRecent().args[0].taskMonitorConfig.onTaskComplete();
+
+    expect(go).toHaveBeenCalledWith('^');
+  });
+
+  it('closes load balancer details through the injected state service', () => {
+    const includes = jasmine.createSpy('includes').and.returnValue(true);
+    const go = jasmine.createSpy('go');
+    const confirm = spyOn(ConfirmationModalService, 'confirm');
+    const component = shallow(
+      <CloudFoundryLoadBalancerActionsComponent
+        {...routerProps(includes, go)}
+        application={{} as any}
+        loadBalancer={{ account: 'test', name: 'route', region: 'test' } as any}
+      />,
+    );
+
+    (component.instance() as any).deleteLoadBalancer();
+    confirm.calls.mostRecent().args[0].taskMonitorConfig.onTaskComplete();
+
+    expect(go).toHaveBeenCalledWith('^');
+  });
+
+  it('closes server group details through the injected state service', () => {
+    const includes = jasmine.createSpy('includes').and.returnValue(true);
+    const go = jasmine.createSpy('go');
+    spyOn(ServerGroupWarningMessageService, 'addDestroyWarningMessage');
+    const confirm = spyOn(ConfirmationModalService, 'confirm');
+    const component = shallow(
+      <CloudFoundryServerGroupActionsComponent
+        {...routerProps(includes, go)}
+        app={{ attributes: {} } as any}
+        serverGroup={
+          {
+            account: 'test',
+            cloudProvider: 'cloudfoundry',
+            moniker: { cluster: 'app' },
+            name: 'app-v001',
+            region: 'test',
+          } as any
+        }
+      />,
+    );
+
+    (component.instance() as any).destroyServerGroup();
+    confirm.calls.mostRecent().args[0].taskMonitorConfig.onTaskComplete();
+
+    expect(go).toHaveBeenCalledWith('^');
+  });
+});

--- a/deck/packages/cloudfoundry/src/serverGroup/details/cloudFoundryServerGroupActions.tsx
+++ b/deck/packages/cloudfoundry/src/serverGroup/details/cloudFoundryServerGroupActions.tsx
@@ -2,7 +2,7 @@ import { filter, find, get, orderBy } from 'lodash';
 import React from 'react';
 import { Dropdown, Tooltip } from 'react-bootstrap';
 
-import type { IOwnerOption, IServerGroupActionsProps, IServerGroupJob } from '@spinnaker/core';
+import type { IOwnerOption, IRouterInjectedProps, IServerGroupActionsProps, IServerGroupJob } from '@spinnaker/core';
 import {
   AddEntityTagLinks,
   AngularServices,
@@ -10,6 +10,7 @@ import {
   ConfirmationModalService,
   ServerGroupWarningMessageService,
   SETTINGS,
+  withRouter,
 } from '@spinnaker/core';
 
 import { CloudFoundryServerGroupCommandBuilder } from '../configure';
@@ -28,7 +29,9 @@ export interface ICloudFoundryServerGroupJob extends IServerGroupJob {
   serverGroupId: string;
 }
 
-export class CloudFoundryServerGroupActions extends React.Component<ICloudFoundryServerGroupActionsProps> {
+export class CloudFoundryServerGroupActionsComponent extends React.Component<
+  ICloudFoundryServerGroupActionsProps & IRouterInjectedProps
+> {
   private isEnableLocked(): boolean {
     if (this.props.serverGroup.isDisabled) {
       const resizeTasks = (this.props.serverGroup.runningTasks || []).filter((task) =>
@@ -79,8 +82,8 @@ export class CloudFoundryServerGroupActions extends React.Component<ICloudFoundr
       application: app,
       title: 'Destroying ' + serverGroup.name,
       onTaskComplete: () => {
-        if (AngularServices.$state.includes('**.serverGroup', stateParams)) {
-          AngularServices.$state.go('^');
+        if (this.props.stateService.includes('**.serverGroup', stateParams)) {
+          this.props.stateService.go('^');
         }
       },
     };
@@ -363,3 +366,5 @@ export class CloudFoundryServerGroupActions extends React.Component<ICloudFoundr
     );
   }
 }
+
+export const CloudFoundryServerGroupActions = withRouter(CloudFoundryServerGroupActionsComponent);

--- a/deck/packages/cloudrun/src/loadBalancer/configure/wizard/CloudrunLoadBalancerModal.spec.tsx
+++ b/deck/packages/cloudrun/src/loadBalancer/configure/wizard/CloudrunLoadBalancerModal.spec.tsx
@@ -1,6 +1,6 @@
 import { TaskMonitor } from '@spinnaker/core';
 
-import { CloudrunLoadBalancerModal } from './CloudrunLoadBalancerModal';
+import { CloudrunLoadBalancerModalComponent as CloudrunLoadBalancerModal } from './CloudrunLoadBalancerModal';
 
 describe('CloudrunLoadBalancerModal', () => {
   beforeEach(() => {
@@ -16,6 +16,9 @@ describe('CloudrunLoadBalancerModal', () => {
       dismissModal: jasmine.createSpy('dismissModal'),
       isNew: false,
       loadBalancer: { name: 'service', account: 'test', region: 'us-central1' },
+      router: {},
+      stateParams: {},
+      stateService: { go: jasmine.createSpy('go'), includes: () => false },
       ...overrides,
     } as any;
 
@@ -42,5 +45,19 @@ describe('CloudrunLoadBalancerModal', () => {
     (modal as any).onApplicationRefresh();
 
     expect(modal.props.dismissModal).not.toHaveBeenCalled();
+  });
+
+  it('opens updated load balancer details through the injected state service', () => {
+    const modal = buildModal();
+    modal.state.loadBalancer = { credentials: 'test', name: 'service', region: 'us-central1' } as any;
+
+    (modal as any).onApplicationRefresh();
+
+    expect(modal.props.stateService.go).toHaveBeenCalledWith('.loadBalancerDetails', {
+      accountId: 'test',
+      name: 'service',
+      provider: 'cloudrun',
+      region: 'us-central1',
+    });
   });
 });

--- a/deck/packages/cloudrun/src/loadBalancer/configure/wizard/CloudrunLoadBalancerModal.tsx
+++ b/deck/packages/cloudrun/src/loadBalancer/configure/wizard/CloudrunLoadBalancerModal.tsx
@@ -1,15 +1,8 @@
 import { cloneDeep, difference, uniq } from 'lodash';
 import React from 'react';
 
-import type { ILoadBalancerModalProps } from '@spinnaker/core';
-import {
-  AngularServices,
-  HelpField,
-  LoadBalancerWriter,
-  ReactModal,
-  StageConstants,
-  TaskMonitor,
-} from '@spinnaker/core';
+import type { ILoadBalancerModalProps, IRouterInjectedProps } from '@spinnaker/core';
+import { HelpField, LoadBalancerWriter, ReactModal, StageConstants, TaskMonitor, withRouter } from '@spinnaker/core';
 
 import { LoadBalancerMessage } from '../../../common/LoadBalancerMessage';
 import type { ICloudrunLoadBalancer } from '../../../common/domain';
@@ -32,8 +25,8 @@ function allocationTotalIsValid(splitDescription: ICloudrunTrafficSplitDescripti
   );
 }
 
-export class CloudrunLoadBalancerModal extends React.Component<
-  ICloudrunLoadBalancerModalProps,
+export class CloudrunLoadBalancerModalComponent extends React.Component<
+  ICloudrunLoadBalancerModalProps & IRouterInjectedProps,
   ICloudrunLoadBalancerModalState
 > {
   public static show(props: ICloudrunLoadBalancerModalProps): Promise<CloudrunLoadBalancerUpsertDescription> {
@@ -43,7 +36,7 @@ export class CloudrunLoadBalancerModal extends React.Component<
   private transformer = new CloudrunLoadBalancerTransformer();
   private isUnmounted = false;
 
-  constructor(props: ICloudrunLoadBalancerModalProps) {
+  constructor(props: ICloudrunLoadBalancerModalProps & IRouterInjectedProps) {
     super(props);
     this.state = {
       loading: !props.isNew,
@@ -108,10 +101,10 @@ export class CloudrunLoadBalancerModal extends React.Component<
       region: loadBalancer.region,
       provider: 'cloudrun',
     };
-    if (!AngularServices.$state.includes('**.loadBalancerDetails')) {
-      AngularServices.$state.go('.loadBalancerDetails', newStateParams);
+    if (!this.props.stateService.includes('**.loadBalancerDetails')) {
+      this.props.stateService.go('.loadBalancerDetails', newStateParams);
     } else {
-      AngularServices.$state.go('^.loadBalancerDetails', newStateParams);
+      this.props.stateService.go('^.loadBalancerDetails', newStateParams);
     }
   };
 
@@ -186,6 +179,10 @@ export class CloudrunLoadBalancerModal extends React.Component<
     );
   }
 }
+
+export const CloudrunLoadBalancerModal = Object.assign(withRouter(CloudrunLoadBalancerModalComponent), {
+  show: CloudrunLoadBalancerModalComponent.show,
+});
 
 interface ICloudrunLoadBalancerBasicSettingsProps {
   loadBalancer: CloudrunLoadBalancerUpsertDescription;

--- a/deck/packages/cloudrun/src/pipeline/stages/deployManifest/manifestStatus/ManifestDetailsLink.spec.tsx
+++ b/deck/packages/cloudrun/src/pipeline/stages/deployManifest/manifestStatus/ManifestDetailsLink.spec.tsx
@@ -1,0 +1,35 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import { AccountService } from '@spinnaker/core';
+
+import { ManifestDetailsLinkComponent } from './ManifestDetailsLink';
+
+describe('Cloud Run ManifestDetailsLink', () => {
+  it('builds its link through the injected state service', async () => {
+    spyOn(AccountService, 'getAccountDetails').and.returnValue(
+      Promise.resolve({ spinnakerKindMap: { Service: 'unclassified' } } as any) as any,
+    );
+    const href = jasmine.createSpy('href').and.returnValue('#/manifest');
+    const component = shallow(
+      <ManifestDetailsLinkComponent
+        {...({ router: {}, stateParams: {}, stateService: { href } } as any)}
+        accountId="test-account"
+        linkName="Manifest"
+        manifest={{ manifest: { kind: 'Service', metadata: { annotations: {}, name: 'test-service' } } } as any}
+      />,
+    );
+
+    await Promise.resolve();
+    component.update();
+
+    expect(href).toHaveBeenCalledWith('home.applications.application.insight.clusters.cloudrunResource', {
+      accountId: 'test-account',
+      cloudrunResource: 'service test-service',
+      provider: 'cloudrun',
+      reg: '',
+      region: '_',
+    });
+    expect(component.find('a').prop('href')).toBe('#/manifest');
+  });
+});

--- a/deck/packages/cloudrun/src/pipeline/stages/deployManifest/manifestStatus/ManifestDetailsLink.tsx
+++ b/deck/packages/cloudrun/src/pipeline/stages/deployManifest/manifestStatus/ManifestDetailsLink.tsx
@@ -1,8 +1,8 @@
 import { get, trim } from 'lodash';
 import React from 'react';
 
-import type { IManifest } from '@spinnaker/core';
-import { AccountService, AngularServices } from '@spinnaker/core';
+import type { IManifest, IRouterInjectedProps } from '@spinnaker/core';
+import { AccountService, withRouter } from '@spinnaker/core';
 
 const UNMAPPED_K8S_RESOURCE_STATE_KEY = 'cloudrunResource';
 
@@ -16,14 +16,17 @@ export interface IManifestDetailsState {
   url: string;
 }
 
-export class ManifestDetailsLink extends React.Component<IManifestDetailsProps, IManifestDetailsState> {
+export class ManifestDetailsLinkComponent extends React.Component<
+  IManifestDetailsProps & IRouterInjectedProps,
+  IManifestDetailsState
+> {
   private spinnakerKindStateMap: { [k: string]: string } = {
     // keys from clouddriver's CloudrunSpinnakerKindMap
     serverGroupManagers: 'serverGroupManager',
     serverGroups: 'serverGroup',
   };
 
-  constructor(props: IManifestDetailsProps) {
+  constructor(props: IManifestDetailsProps & IRouterInjectedProps) {
     super(props);
     this.state = {
       url: '',
@@ -73,7 +76,7 @@ export class ManifestDetailsLink extends React.Component<IManifestDetailsProps, 
       const spinnakerKind = this.spinnakerKindFromCloudrunKind(kind, account.spinnakerKindMap);
       const stateKey = this.spinnakerKindStateMap[spinnakerKind] || UNMAPPED_K8S_RESOURCE_STATE_KEY;
       const params = this.getStateParams(stateKey);
-      const url = AngularServices.$state.href(`home.applications.application.insight.clusters.${stateKey}`, params);
+      const url = this.props.stateService.href(`home.applications.application.insight.clusters.${stateKey}`, params);
       this.setState({ url });
     });
   }
@@ -90,3 +93,5 @@ export class ManifestDetailsLink extends React.Component<IManifestDetailsProps, 
     }
   }
 }
+
+export const ManifestDetailsLink = withRouter(ManifestDetailsLinkComponent);

--- a/deck/packages/cloudrun/src/serverGroup/configure/wizard/BasicSettings.tsx
+++ b/deck/packages/cloudrun/src/serverGroup/configure/wizard/BasicSettings.tsx
@@ -1,8 +1,8 @@
 import type { FormikProps } from 'formik';
 import React from 'react';
 
-import type { Application, IAccount, IServerGroup } from '@spinnaker/core';
-import { AccountSelectInput, AngularServices, HelpField, NameUtils, ServerGroupNamePreview } from '@spinnaker/core';
+import type { Application, IAccount, IRouterInjectedProps, IServerGroup } from '@spinnaker/core';
+import { AccountSelectInput, HelpField, NameUtils, ServerGroupNamePreview, withRouter } from '@spinnaker/core';
 
 import type { ICloudrunServerGroupCommandData } from '../serverGroupCommandBuilder.service';
 
@@ -22,7 +22,7 @@ export interface IServerGroupBasicSettingsState {
   latestServerGroup: IServerGroup;
 }
 
-export function ServerGroupBasicSettings({
+export function ServerGroupBasicSettingsComponent({
   accounts,
   onAccountSelect,
   selectedAccount,
@@ -30,7 +30,8 @@ export function ServerGroupBasicSettings({
   onEnterStack,
   detailsChanged,
   app,
-}: IServerGroupBasicSettingsProps) {
+  stateService,
+}: IServerGroupBasicSettingsProps & IRouterInjectedProps) {
   const { values } = formik;
   const { stack = '', freeFormDetails } = values;
 
@@ -56,11 +57,10 @@ export function ServerGroupBasicSettings({
       serverGroup: latestServerGroup.name,
     };
 
-    const { $state } = AngularServices;
-    if ($state.is('home.applications.application.insight.clusters')) {
-      $state.go('.serverGroup', params);
+    if (stateService.is('home.applications.application.insight.clusters')) {
+      stateService.go('.serverGroup', params);
     } else {
-      $state.go('^.serverGroup', params);
+      stateService.go('^.serverGroup', params);
     }
   };
 
@@ -118,6 +118,8 @@ export function ServerGroupBasicSettings({
     </div>
   );
 }
+
+export const ServerGroupBasicSettings = withRouter(ServerGroupBasicSettingsComponent);
 
 export interface IWizardServerGroupBasicSettingsProps {
   formik: FormikProps<ICloudrunServerGroupCommandData>;

--- a/deck/packages/cloudrun/src/serverGroup/configure/wizard/serverGroupWizard.tsx
+++ b/deck/packages/cloudrun/src/serverGroup/configure/wizard/serverGroupWizard.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import type { Application, IModalComponentProps, IStage } from '@spinnaker/core';
-import { AngularServices, noop, ReactModal, TaskMonitor, WizardModal, WizardPage } from '@spinnaker/core';
+import type { Application, IModalComponentProps, IRouterInjectedProps, IStage } from '@spinnaker/core';
+import { AngularServices, noop, ReactModal, TaskMonitor, withRouter, WizardModal, WizardPage } from '@spinnaker/core';
 
 import { WizardServerGroupBasicSettings } from './BasicSettings';
 import { WizardServerGroupConfigFilesSettings } from './ConfigFiles';
@@ -23,8 +23,11 @@ export interface ICloudrunServerGroupModalState {
   taskMonitor: TaskMonitor;
 }
 
-export class ServerGroupWizard extends React.Component<ICloudrunServerGroupModalProps, ICloudrunServerGroupModalState> {
-  public static defaultProps: Partial<ICloudrunServerGroupModalProps> = {
+export class ServerGroupWizardComponent extends React.Component<
+  ICloudrunServerGroupModalProps & IRouterInjectedProps,
+  ICloudrunServerGroupModalState
+> {
+  public static defaultProps: Partial<ICloudrunServerGroupModalProps & IRouterInjectedProps> = {
     closeModal: noop,
     dismissModal: noop,
   };
@@ -37,7 +40,7 @@ export class ServerGroupWizard extends React.Component<ICloudrunServerGroupModal
     return ReactModal.show(ServerGroupWizard, props, modalProps);
   }
 
-  constructor(props: ICloudrunServerGroupModalProps) {
+  constructor(props: ICloudrunServerGroupModalProps & IRouterInjectedProps) {
     super(props);
     if (!props.command) {
       CloudrunServerGroupCommandBuilder.buildNewServerGroupCommand(props.application, 'cloudrun', 'create').then(
@@ -85,19 +88,19 @@ export class ServerGroupWizard extends React.Component<ICloudrunServerGroupModal
           provider: 'cloudrun',
         };
         let transitionTo = '^.^.^.clusters.serverGroup';
-        if (AngularServices.$state.includes('**.clusters.serverGroup')) {
+        if (this.props.stateService.includes('**.clusters.serverGroup')) {
           // clone via details, all view
           transitionTo = '^.serverGroup';
         }
-        if (AngularServices.$state.includes('**.clusters.cluster.serverGroup')) {
+        if (this.props.stateService.includes('**.clusters.cluster.serverGroup')) {
           // clone or create with details open
           transitionTo = '^.^.serverGroup';
         }
-        if (AngularServices.$state.includes('**.clusters')) {
+        if (this.props.stateService.includes('**.clusters')) {
           // create new, no details open
           transitionTo = '.serverGroup';
         }
-        AngularServices.$state.go(transitionTo, newStateParams);
+        this.props.stateService.go(transitionTo, newStateParams);
       }
     }
   };
@@ -151,3 +154,7 @@ export class ServerGroupWizard extends React.Component<ICloudrunServerGroupModal
     );
   }
 }
+
+export const ServerGroupWizard = Object.assign(withRouter(ServerGroupWizardComponent), {
+  show: ServerGroupWizardComponent.show,
+});

--- a/deck/packages/cloudrun/src/serverGroup/details/CloudrunServerGroupActions.tsx
+++ b/deck/packages/cloudrun/src/serverGroup/details/CloudrunServerGroupActions.tsx
@@ -1,13 +1,17 @@
 import React from 'react';
 import { Dropdown, MenuItem } from 'react-bootstrap';
 
-import type { IServerGroupActionsProps } from '@spinnaker/core';
-import { AngularServices, ConfirmationModalService } from '@spinnaker/core';
+import type { IRouterInjectedProps, IServerGroupActionsProps } from '@spinnaker/core';
+import { AngularServices, ConfirmationModalService, withRouter } from '@spinnaker/core';
 
 import { CloudrunHealth } from '../../common/cloudrunHealth';
 import type { ICloudrunServerGroup } from '../../interfaces';
 
-export function CloudrunServerGroupActions({ app, serverGroup }: IServerGroupActionsProps) {
+export function CloudrunServerGroupActionsComponent({
+  app,
+  serverGroup,
+  stateService,
+}: IServerGroupActionsProps & IRouterInjectedProps) {
   const cloudrunServerGroup = serverGroup as ICloudrunServerGroup;
   const canDestroyServerGroup = Boolean(
     cloudrunServerGroup && !cloudrunServerGroup.tags?.isLatest && cloudrunServerGroup.disabled,
@@ -22,8 +26,8 @@ export function CloudrunServerGroupActions({ app, serverGroup }: IServerGroupAct
       application: app,
       title: `Destroying ${cloudrunServerGroup.name}`,
       onTaskComplete: () => {
-        if (AngularServices.$state.includes('**.serverGroup', stateParams)) {
-          AngularServices.$state.go('^');
+        if (stateService.includes('**.serverGroup', stateParams)) {
+          stateService.go('^');
         }
       },
     };
@@ -72,3 +76,5 @@ export function CloudrunServerGroupActions({ app, serverGroup }: IServerGroupAct
     </Dropdown>
   );
 }
+
+export const CloudrunServerGroupActions = withRouter(CloudrunServerGroupActionsComponent);

--- a/deck/packages/cloudrun/src/serverGroup/routerConsumers.spec.tsx
+++ b/deck/packages/cloudrun/src/serverGroup/routerConsumers.spec.tsx
@@ -1,0 +1,114 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import { MenuItem } from 'react-bootstrap';
+
+import { ConfirmationModalService, ServerGroupNamePreview, TaskMonitor } from '@spinnaker/core';
+
+import { ServerGroupBasicSettingsComponent } from './configure/wizard/BasicSettings';
+import { ServerGroupWizardComponent } from './configure/wizard/serverGroupWizard';
+import { CloudrunServerGroupActionsComponent } from './details/CloudrunServerGroupActions';
+
+describe('Cloud Run server group router consumers', () => {
+  it('opens the latest server group through the injected state service', () => {
+    const go = jasmine.createSpy('go');
+    const component = shallow(
+      <ServerGroupBasicSettingsComponent
+        {...({ router: {}, stateParams: {}, stateService: { go, is: () => true } } as any)}
+        accounts={[]}
+        app={
+          {
+            clusters: [],
+            name: 'app',
+            serverGroups: {
+              data: [{ account: 'test', cluster: 'app-main', createdTime: 1, name: 'app-main-v001', region: 'us' }],
+            },
+          } as any
+        }
+        detailsChanged={() => undefined}
+        formik={
+          {
+            values: {
+              command: {
+                credentials: 'test',
+                region: 'us',
+                selectedProvider: 'cloudrun',
+                viewState: { mode: 'create' },
+              },
+              stack: 'main',
+            },
+          } as any
+        }
+        onAccountSelect={() => undefined}
+        onEnterStack={() => undefined}
+        selectedAccount="test"
+      />,
+    );
+
+    component.find(ServerGroupNamePreview).prop('navigateToLatestServerGroup')();
+
+    expect(go).toHaveBeenCalledWith('.serverGroup', {
+      accountId: 'test',
+      provider: 'cloudrun',
+      region: 'us',
+      serverGroup: 'app-main-v001',
+    });
+  });
+
+  it('closes destroyed server group details through the injected state service', () => {
+    const go = jasmine.createSpy('go');
+    const confirm = spyOn(ConfirmationModalService, 'confirm');
+    const component = shallow(
+      <CloudrunServerGroupActionsComponent
+        {...({ router: {}, stateParams: {}, stateService: { go, includes: () => true } } as any)}
+        app={{ attributes: {} } as any}
+        serverGroup={
+          {
+            account: 'test',
+            disabled: true,
+            name: 'app-v001',
+            region: 'us',
+            tags: { isLatest: false },
+          } as any
+        }
+      />,
+    );
+
+    component.find(MenuItem).first().simulate('click');
+    confirm.calls.mostRecent().args[0].taskMonitorConfig.onTaskComplete();
+
+    expect(go).toHaveBeenCalledWith('^');
+  });
+
+  it('opens a newly created server group through the injected state service', () => {
+    spyOn(TaskMonitor, 'modalInstanceEmulation').and.returnValue({ result: Promise.resolve() } as any);
+    const go = jasmine.createSpy('go');
+    const component = new ServerGroupWizardComponent({
+      application: { serverGroups: {} },
+      closeModal: () => undefined,
+      command: {
+        command: { credentials: 'test', region: 'us', viewState: { submitButtonLabel: 'Create' } },
+      },
+      dismissModal: () => undefined,
+      router: {},
+      stateParams: {},
+      stateService: { go, includes: (state: string) => state === '**.clusters' },
+      title: 'Create server group',
+    } as any);
+    component.state.taskMonitor = {
+      task: {
+        execution: {
+          stages: [{ context: { 'deploy.server.groups': { us: 'app-v001' } }, type: 'cloneServerGroup' }],
+        },
+      },
+    } as any;
+
+    (component as any).onApplicationRefresh();
+
+    expect(go).toHaveBeenCalledWith('.serverGroup', {
+      accountId: 'test',
+      provider: 'cloudrun',
+      region: 'us',
+      serverGroup: 'app-v001',
+    });
+  });
+});

--- a/deck/packages/core/src/angular/services.spec.ts
+++ b/deck/packages/core/src/angular/services.spec.ts
@@ -11,7 +11,7 @@ import { createLoadBalancerTransformer } from '../loadBalancer/loadBalancer.tran
 import { setDirectRouter } from '../navigation/directRouter';
 import { AngularServices } from './services';
 
-describe('AngularServices direct router fallback', () => {
+describe('AngularServices direct services', () => {
   const provider = 'serverGroupCommandBuilderTest';
 
   afterEach(() => {
@@ -24,49 +24,6 @@ describe('AngularServices direct router fallback', () => {
     InfrastructureCaches.destroyCaches();
     delete SETTINGS.providers[provider];
     (CloudProviderRegistry as any).providers.delete(provider);
-  });
-
-  it('returns the active direct UI Router when Angular is not bootstrapped', () => {
-    const router = new UIRouterReact();
-
-    setDirectRouter(router);
-
-    expect(AngularServices.$uiRouter).toBe(router as any);
-  });
-
-  it('reports the direct UI Router only while one is set', () => {
-    const router = new UIRouterReact();
-
-    setDirectRouter(null);
-    expect(AngularServices.has('$uiRouter')).toBe(false);
-    expect(AngularServices.has('unknownDirectService')).toBe(false);
-
-    setDirectRouter(router);
-
-    expect(AngularServices.has('$uiRouter')).toBe(true);
-    expect(AngularServices.has('unknownDirectService')).toBe(false);
-
-    setDirectRouter(null);
-
-    expect(AngularServices.has('$uiRouter')).toBe(false);
-    router.dispose();
-  });
-
-  it('returns the direct router state service when Angular state is not available', () => {
-    const router = new UIRouterReact();
-
-    setDirectRouter(router);
-
-    expect(AngularServices.$state).toBe(router.stateService as any);
-  });
-
-  it('returns direct router state params when Angular is not bootstrapped', () => {
-    const router = new UIRouterReact();
-    router.globals.params = { application: 'compute' } as any;
-
-    setDirectRouter(router);
-
-    expect(AngularServices.$stateParams.application).toBe('compute');
   });
 
   it('returns a direct infrastructure search service when Angular is not bootstrapped', () => {

--- a/deck/packages/core/src/angular/services.ts
+++ b/deck/packages/core/src/angular/services.ts
@@ -1,4 +1,3 @@
-import type { StateParams, StateService, UIRouter } from '@uirouter/core';
 import type { IDeferred, IQService, IRootScopeService, ITimeoutService } from 'angular';
 import type { IModalService, IModalStackService } from 'angular-ui-bootstrap';
 import { of as observableOf, Subject } from 'rxjs';
@@ -19,7 +18,6 @@ import { overrideRegistry } from '../overrideRegistry/override.registry';
 import type { PageTitleService } from '../pageTitle';
 import { ExecutionDetailsSectionService } from '../pipeline/details/executionDetailsSection.service';
 import { ExecutionService } from '../pipeline/service/execution.service';
-import type { StateEvents } from '../reactShims/state.events';
 import type {
   IProviderResultFormatter,
   ISearchResultFormatter,
@@ -164,30 +162,6 @@ class DirectPageTitleService {
   }
 }
 
-const noopSubscription = { unsubscribe: (): void => undefined };
-type NoopObservable = {
-  subscribe: () => typeof noopSubscription;
-  pipe: (...operators: unknown[]) => NoopObservable;
-};
-const noopObservable: NoopObservable = {
-  subscribe: () => noopSubscription,
-  pipe: () => noopObservable,
-};
-const directUiRouterFallback = ({
-  globals: {
-    current: { name: '' },
-    params: {},
-    params$: noopObservable,
-    start$: noopObservable,
-    success$: noopObservable,
-  },
-  transitionService: {
-    onBefore: () => (): void => undefined,
-    onStart: () => (): void => undefined,
-    onSuccess: () => (): void => undefined,
-  },
-} as unknown) as UIRouter;
-
 class AngularServiceAccessors {
   private runtime = createDeckRuntime();
   private directCacheInitializer: CacheInitializerService;
@@ -201,8 +175,6 @@ class AngularServiceAccessors {
   private directPageTitleService = new DirectPageTitleService();
   private directSecurityGroupReader: SecurityGroupReader;
   private directServerGroupWriter: ServerGroupWriter;
-  private directStateEvents: StateEvents;
-  private directStateEventsDeregister: Function;
 
   public bindRuntime(runtime: DeckRuntime): void {
     if (this.runtime === runtime) {
@@ -235,25 +207,11 @@ class AngularServiceAccessors {
   public get $timeout() {
     return (this.runtime.timeoutService as unknown) as ITimeoutService;
   }
-  public get $state() {
-    const directRouter = getDirectRouter();
-    if (!directRouter) {
-      throw new Error('Cannot access $state before the direct UI Router is initialized');
-    }
-
-    return directRouter.stateService as StateService;
-  }
-  public get $stateParams() {
-    return (getDirectRouter()?.globals.params || {}) as StateParams;
-  }
   public get $interpolate() {
     return this.runtime.interpolate;
   }
   public get $uibModal() {
     return directModalService;
-  }
-  public get $uiRouter() {
-    return ((getDirectRouter() as unknown) as UIRouter) || directUiRouterFallback;
   }
   public get cacheInitializer() {
     return this.getDirectCacheInitializer();
@@ -306,14 +264,6 @@ class AngularServiceAccessors {
   public get serverGroupWriter() {
     return this.getDirectServerGroupWriter();
   }
-  public get stateEvents() {
-    return this.getDirectStateEvents();
-  }
-
-  public has(serviceName: string): boolean {
-    return serviceName === '$uiRouter' && getDirectRouter() !== null;
-  }
-
   private getDirectCacheInitializer(): CacheInitializerService {
     if (!this.directCacheInitializer) {
       this.directCacheInitializer = new CacheInitializerService(
@@ -348,27 +298,6 @@ class AngularServiceAccessors {
     return this.directLoadBalancerReader;
   }
 
-  private getDirectStateEvents(): StateEvents {
-    if (!this.directStateEvents) {
-      const stateChangeSuccess = new Subject();
-      const locationChangeSuccess = new Subject<string>();
-      this.directStateEvents = ({ stateChangeSuccess, locationChangeSuccess } as unknown) as StateEvents;
-
-      const directRouter = getDirectRouter();
-      this.directStateEventsDeregister = directRouter?.transitionService.onSuccess({}, (transition: any) => {
-        stateChangeSuccess.next({
-          to: transition.to(),
-          toParams: transition.params('to'),
-          from: transition.from(),
-          fromParams: transition.params('from'),
-        });
-        locationChangeSuccess.next(window.location.href);
-      });
-    }
-
-    return this.directStateEvents;
-  }
-
   private getDirectClusterService(): ClusterService {
     if (!this.directClusterService) {
       this.directClusterService = new ClusterService(
@@ -383,7 +312,11 @@ class AngularServiceAccessors {
 
   private getDirectExecutionService(): ExecutionService {
     if (!this.directExecutionService) {
-      this.directExecutionService = new ExecutionService(this.$q, this.$state, this.$timeout);
+      const router = getDirectRouter();
+      if (!router) {
+        throw new Error('Cannot create ExecutionService before the direct UI Router is initialized');
+      }
+      this.directExecutionService = new ExecutionService(this.$q, router.stateService, this.$timeout);
     }
 
     return this.directExecutionService;
@@ -391,9 +324,13 @@ class AngularServiceAccessors {
 
   private getDirectExecutionDetailsSectionService(): ExecutionDetailsSectionService {
     if (!this.directExecutionDetailsSectionService) {
+      const router = getDirectRouter();
+      if (!router) {
+        throw new Error('Cannot create ExecutionDetailsSectionService before the direct UI Router is initialized');
+      }
       this.directExecutionDetailsSectionService = new ExecutionDetailsSectionService(
-        this.$stateParams,
-        this.$state as any,
+        router.globals.params,
+        router.stateService as any,
         this.$timeout,
       );
     }
@@ -439,8 +376,6 @@ class AngularServiceAccessors {
   }
 
   private resetRuntimeServices(): void {
-    this.directStateEventsDeregister?.();
-    this.directStateEventsDeregister = null;
     this.directCacheInitializer = null;
     this.directClusterService = null;
     this.directExecutionDetailsSectionService = null;
@@ -450,7 +385,6 @@ class AngularServiceAccessors {
     this.directLoadBalancerReader = null;
     this.directSecurityGroupReader = null;
     this.directServerGroupWriter = null;
-    this.directStateEvents = null;
   }
 }
 

--- a/deck/packages/core/src/application/config/ApplicationConfig.spec.tsx
+++ b/deck/packages/core/src/application/config/ApplicationConfig.spec.tsx
@@ -25,6 +25,8 @@ import { ClusterMatcher } from '../../cluster';
 import { ClusterMatches } from '../../widgets';
 import { ConfigSectionFooter } from './footer/ConfigSectionFooter';
 
+const routerProps = { stateService: { go: () => undefined } as any };
+
 describe('<ApplicationConfig />', () => {
   let originalFeatures: typeof SETTINGS.feature;
   let originalSlack: typeof SETTINGS.slack;
@@ -52,7 +54,7 @@ describe('<ApplicationConfig />', () => {
   it('renders application config sections directly in React without the Angular adapter', () => {
     const application = buildApplication();
 
-    const wrapper = shallow(<ApplicationConfigComponent app={application as any} />);
+    const wrapper = shallow(<ApplicationConfigComponent {...routerProps} app={application as any} />);
     wrapper.setState({ hasManagedResources: true });
 
     expect(wrapper.find(['Angular', 'JS', 'Adapter'].join('')).exists()).toBe(false);
@@ -90,11 +92,24 @@ describe('<ApplicationConfig />', () => {
     ).toBe(true);
   });
 
+  it('redirects missing applications using the injected state service', () => {
+    const stateService = { go: jasmine.createSpy('go') };
+
+    shallow(
+      <ApplicationConfigComponent
+        app={buildApplication({ notFound: true }) as any}
+        stateService={stateService as any}
+      />,
+    );
+
+    expect(stateService.go).toHaveBeenCalledWith('home.infrastructure', null, { location: 'replace' });
+  });
+
   it('renders NotificationsList with application notification props', () => {
     const notifications = [{ level: 'application', type: 'email', when: ['pipeline.failed'] }];
     const application = buildApplication({ attributes: { notifications } });
 
-    const wrapper = shallow(<ApplicationConfigComponent app={application as any} />);
+    const wrapper = shallow(<ApplicationConfigComponent {...routerProps} app={application as any} />);
     const notificationList = wrapper.find(NotificationsList);
 
     expect(
@@ -115,7 +130,7 @@ describe('<ApplicationConfig />', () => {
       attributes: { appGroup: 'payments', aliases: 'pay', email: 'user@example.com' },
     });
 
-    const wrapper = shallow(<ApplicationConfigComponent app={application as any} />);
+    const wrapper = shallow(<ApplicationConfigComponent {...routerProps} app={application as any} />);
     const attributes = wrapper.find(ApplicationAttributes).dive();
 
     expect(attributes.text()).toContain('Owner');
@@ -134,7 +149,7 @@ describe('<ApplicationConfig />', () => {
   it('renders only application attributes before the application is configured', () => {
     const application = buildApplication({ attributes: { email: null } });
 
-    const wrapper = shallow(<ApplicationConfigComponent app={application as any} />);
+    const wrapper = shallow(<ApplicationConfigComponent {...routerProps} app={application as any} />);
     const attributes = wrapper.find(ApplicationAttributes).dive();
 
     expect(wrapper.find(PageSection).map((section) => section.prop('label'))).toEqual(['Application Attributes']);
@@ -153,7 +168,7 @@ describe('<ApplicationConfig />', () => {
     const application = buildApplication();
     spyOn(ReactModal, 'show').and.returnValue(Promise.resolve(application.attributes));
 
-    const wrapper = shallow(<ApplicationConfigComponent app={application as any} />);
+    const wrapper = shallow(<ApplicationConfigComponent {...routerProps} app={application as any} />);
     const attributes = wrapper.find(ApplicationAttributes).dive();
 
     attributes
@@ -172,7 +187,7 @@ describe('<ApplicationConfig />', () => {
   it('renders configured sections after application attributes are saved', () => {
     const application = buildApplication({ attributes: { email: null } });
 
-    const wrapper = shallow(<ApplicationConfigComponent app={application as any} />);
+    const wrapper = shallow(<ApplicationConfigComponent {...routerProps} app={application as any} />);
 
     expect(wrapper.find(PageSection).map((section) => section.prop('label'))).toEqual(['Application Attributes']);
 
@@ -528,7 +543,7 @@ describe('<ApplicationConfig />', () => {
       },
     });
 
-    const wrapper = shallow(<ApplicationConfigComponent app={application as any} />);
+    const wrapper = shallow(<ApplicationConfigComponent {...routerProps} app={application as any} />);
     const attributes = wrapper.find(ApplicationAttributes).dive();
 
     expect(attributes.text()).toContain('Pager Duty');
@@ -542,7 +557,7 @@ describe('<ApplicationConfig />', () => {
   it('hides permissions when fiat is disabled', () => {
     const application = buildApplication({ attributes: { permissions: { READ: ['readers'] } } });
 
-    const wrapper = shallow(<ApplicationConfigComponent app={application as any} />);
+    const wrapper = shallow(<ApplicationConfigComponent {...routerProps} app={application as any} />);
     const attributes = wrapper.find(ApplicationAttributes).dive();
 
     expect(attributes.text()).not.toContain('Permissions');
@@ -553,7 +568,7 @@ describe('<ApplicationConfig />', () => {
     SETTINGS.feature = { ...SETTINGS.feature, fiatEnabled: true };
     const application = buildApplication({ attributes: { permissions: { READ: ['readers'] } } });
 
-    const wrapper = shallow(<ApplicationConfigComponent app={application as any} />);
+    const wrapper = shallow(<ApplicationConfigComponent {...routerProps} app={application as any} />);
     const attributes = wrapper.find(ApplicationAttributes).dive();
 
     expect(attributes.text()).toContain('Permissions');
@@ -563,7 +578,7 @@ describe('<ApplicationConfig />', () => {
   it('renders functional React sections instead of migration blockers', () => {
     const application = buildApplication();
 
-    const wrapper = shallow(<ApplicationConfigComponent app={application as any} />);
+    const wrapper = shallow(<ApplicationConfigComponent {...routerProps} app={application as any} />);
 
     expect(wrapper.text()).not.toContain('still backed by');
     expect(wrapper.find('ApplicationLinksConfig').exists()).toBe(true);
@@ -829,7 +844,7 @@ describe('<ApplicationConfig />', () => {
     const application = buildApplication();
     spyOn(ReactModal, 'show').and.returnValue(Promise.resolve(application.attributes.instanceLinks));
 
-    const wrapper = shallow(<ApplicationConfigComponent app={application as any} />);
+    const wrapper = shallow(<ApplicationConfigComponent {...routerProps} app={application as any} />);
     const links = wrapper.find('ApplicationLinksConfig').dive();
 
     links
@@ -848,7 +863,7 @@ describe('<ApplicationConfig />', () => {
   it('renders application links in the same horizontal form layout as other config sections', () => {
     const application = buildApplication();
 
-    const wrapper = shallow(<ApplicationConfigComponent app={application as any} />);
+    const wrapper = shallow(<ApplicationConfigComponent {...routerProps} app={application as any} />);
     const links = wrapper.find('ApplicationLinksConfig').dive();
 
     expect(links.find('.application-links-config.form-horizontal').exists()).toBe(true);
@@ -863,7 +878,7 @@ describe('<ApplicationConfig />', () => {
     const application = buildApplication();
     spyOn(ReactModal, 'show').and.returnValue(Promise.resolve(application.attributes.instanceLinks));
 
-    const wrapper = shallow(<ApplicationConfigComponent app={application as any} />);
+    const wrapper = shallow(<ApplicationConfigComponent {...routerProps} app={application as any} />);
     const links = wrapper.find('ApplicationLinksConfig').dive();
     links
       .find('button')
@@ -909,9 +924,9 @@ function buildApplication(overrides: any = {}) {
 }
 
 function mountChaosMonkeyConfig(application: any) {
-  const config = shallow(<ApplicationConfigComponent app={application} />, { disableLifecycleMethods: true }).find(
-    'ChaosMonkeyConfigSection',
-  );
+  const config = shallow(<ApplicationConfigComponent {...routerProps} app={application} />, {
+    disableLifecycleMethods: true,
+  }).find('ChaosMonkeyConfigSection');
   const ChaosMonkeyConfigSection = config.type() as React.ComponentType<{ application: any }>;
   return mount(<ChaosMonkeyConfigSection application={application} />);
 }

--- a/deck/packages/core/src/application/config/ApplicationConfig.tsx
+++ b/deck/packages/core/src/application/config/ApplicationConfig.tsx
@@ -1,3 +1,5 @@
+import type { StateService } from '@uirouter/core';
+import { useRouter } from '@uirouter/react';
 import { cloneDeep, get, has, set } from 'lodash';
 import React from 'react';
 import { Modal } from 'react-bootstrap';
@@ -5,7 +7,6 @@ import { Modal } from 'react-bootstrap';
 import { DeleteApplicationSection } from './DeleteApplicationSection';
 import type { IAccountDetails, IAggregatedAccounts } from '../../account/AccountService';
 import { AccountService } from '../../account/AccountService';
-import { AngularServices } from '../../angular/services';
 import type { Application } from '../application.model';
 import { ClusterMatcher } from '../../cluster';
 import { SETTINGS } from '../../config/settings';
@@ -43,6 +44,10 @@ export interface IApplicationConfigDetailsProps extends IOverridableProps {
   app: Application;
 }
 
+interface IApplicationConfigComponentProps extends IApplicationConfigDetailsProps {
+  stateService: StateService;
+}
+
 interface ISaveState {
   isSaving: boolean;
   saveError: boolean;
@@ -57,7 +62,7 @@ interface IApplicationConfigState {
 }
 
 export class ApplicationConfigComponent extends React.Component<
-  IApplicationConfigDetailsProps,
+  IApplicationConfigComponentProps,
   IApplicationConfigState
 > {
   public state: IApplicationConfigState = {
@@ -78,7 +83,7 @@ export class ApplicationConfigComponent extends React.Component<
     const { app } = this.props;
 
     if (app.notFound || app.hasError) {
-      AngularServices.$state.go('home.infrastructure', null, { location: 'replace' });
+      this.props.stateService.go('home.infrastructure', null, { location: 'replace' });
       return;
     }
 
@@ -139,11 +144,7 @@ export class ApplicationConfigComponent extends React.Component<
         }}
         data-sticky-headers={true}
       >
-        <PageNavigator
-          scrollableContainer="[data-sticky-headers]"
-          deepLinkParam="section"
-          reactInjector={AngularServices}
-        >
+        <PageNavigator scrollableContainer="[data-sticky-headers]" deepLinkParam="section">
           {this.renderSections()}
         </PageNavigator>
       </div>
@@ -221,7 +222,12 @@ export class ApplicationConfigComponent extends React.Component<
   }
 }
 
-export const ApplicationConfig = overridableComponent(ApplicationConfigComponent, 'applicationConfigView');
+const OverridableApplicationConfig = overridableComponent(ApplicationConfigComponent, 'applicationConfigView');
+
+export function ApplicationConfig(props: IApplicationConfigDetailsProps) {
+  const { stateService } = useRouter();
+  return <OverridableApplicationConfig {...props} stateService={stateService} />;
+}
 
 function getInitialNotifications(application: Application): INotification[] {
   const notifications = get(application, 'attributes.notifications', []);

--- a/deck/packages/core/src/application/config/DeleteApplicationSection.tsx
+++ b/deck/packages/core/src/application/config/DeleteApplicationSection.tsx
@@ -1,5 +1,5 @@
+import { useRouter } from '@uirouter/react';
 import React from 'react';
-import { AngularServices } from '../../angular/services';
 
 import type { Application } from '../application.model';
 import { ConfirmationModalService } from '../../confirmationModal';
@@ -11,13 +11,14 @@ export interface IDeleteApplicationSection {
 }
 
 export function DeleteApplicationSection(props: IDeleteApplicationSection) {
+  const { stateService } = useRouter();
   const { application } = props;
   const deleteApplication = (): void => {
     const taskMonitor = {
       application,
       title: `Deleting ${application.name}`,
       onTaskComplete: () => {
-        AngularServices.$state.go('home.infrastructure');
+        stateService.go('home.infrastructure');
       },
     };
 

--- a/deck/packages/core/src/application/search/Applications.spec.tsx
+++ b/deck/packages/core/src/application/search/Applications.spec.tsx
@@ -1,20 +1,23 @@
 import { shallow } from 'enzyme';
 import React from 'react';
 
-import { Applications } from './Applications';
+import { ApplicationsComponent } from './Applications';
 import { CreateApplicationModal } from '../modal/CreateApplicationModal';
 import { ApplicationReader } from '../service/ApplicationReader';
-import { AngularServices } from '../../angular/services';
 
 describe('Applications create deep link', () => {
+  const renderApplications = (stateParams: Record<string, any>, go = jasmine.createSpy('go')) => ({
+    go,
+    wrapper: shallow(
+      <ApplicationsComponent router={{} as any} stateParams={stateParams} stateService={{ go } as any} />,
+    ),
+  });
+
   it('opens the direct modal and routes to the created application', async () => {
-    const go = jasmine.createSpy('go');
-    spyOnProperty(AngularServices, '$stateParams', 'get').and.returnValue({ create: 'myapp' } as any);
-    spyOnProperty(AngularServices, '$state', 'get').and.returnValue({ go } as any);
     spyOn(ApplicationReader, 'listApplications').and.returnValue(Promise.resolve([]));
     spyOn(CreateApplicationModal, 'show').and.returnValue(Promise.resolve({ name: 'myapp' }) as any);
 
-    const wrapper = shallow(<Applications />);
+    const { go, wrapper } = renderApplications({ create: 'myapp' });
     await Promise.resolve();
     await Promise.resolve();
 
@@ -24,13 +27,10 @@ describe('Applications create deep link', () => {
   });
 
   it('clears the create query parameter when the direct modal is dismissed', async () => {
-    const go = jasmine.createSpy('go');
-    spyOnProperty(AngularServices, '$stateParams', 'get').and.returnValue({ create: 'myapp' } as any);
-    spyOnProperty(AngularServices, '$state', 'get').and.returnValue({ go } as any);
     spyOn(ApplicationReader, 'listApplications').and.returnValue(Promise.resolve([]));
     spyOn(CreateApplicationModal, 'show').and.returnValue(Promise.reject('cancel'));
 
-    const wrapper = shallow(<Applications />);
+    const { go, wrapper } = renderApplications({ create: 'myapp' });
     await Promise.resolve();
     await Promise.resolve();
 

--- a/deck/packages/core/src/application/search/Applications.tsx
+++ b/deck/packages/core/src/application/search/Applications.tsx
@@ -8,11 +8,12 @@ import { distinctUntilChanged, map, takeUntil } from 'rxjs/operators';
 import { ApplicationTable } from './ApplicationsTable';
 import { PaginationControls } from './PaginationControls';
 import type { IAccount } from '../../account';
-import { AngularServices } from '../../angular/services';
 import type { ICache } from '../../cache';
 import { ViewStateCache } from '../../cache';
 import { InsightMenu } from '../../insight/InsightMenu';
 import { CreateApplicationModal } from '../modal/CreateApplicationModal';
+import type { IRouterInjectedProps } from '../../navigation/routerContext';
+import { withRouter } from '../../navigation/routerContext';
 import type { IApplicationSummary } from '../service/ApplicationReader';
 import { ApplicationReader } from '../service/ApplicationReader';
 import { Spinner } from '../../widgets';
@@ -41,7 +42,7 @@ export interface IApplicationsState {
   pagination: IApplicationPagination;
 }
 
-export class Applications extends React.Component<{}, IApplicationsState> {
+export class ApplicationsComponent extends React.Component<IRouterInjectedProps, IApplicationsState> {
   private applicationsCache: ICache;
 
   private filter$ = new BehaviorSubject<string>(null);
@@ -49,7 +50,7 @@ export class Applications extends React.Component<{}, IApplicationsState> {
   private pagination$ = new BehaviorSubject<IApplicationPagination>(this.getDefaultPagination());
   private destroy$ = new Subject();
 
-  constructor(props: {}) {
+  constructor(props: IRouterInjectedProps) {
     super(props);
     this.applyCachedViewState();
     const pagination = this.getDefaultPagination();
@@ -120,27 +121,27 @@ export class Applications extends React.Component<{}, IApplicationsState> {
         },
       );
 
-    const { $stateParams, $state } = AngularServices;
-    const { create } = $stateParams as IApplicationsStateParams;
+    const { stateParams, stateService } = this.props;
+    const { create } = stateParams as IApplicationsStateParams;
     applicationSummaries$.subscribe((applications: IApplicationSummary[]) => {
       if (create) {
         const found = applications.find((app) => app.name === create);
         if (found) {
           if (found.email) {
             // Application already exists - redirect to app
-            $state.go('home.applications.application', { application: create, create: null });
+            stateService.go('home.applications.application', { application: create, create: null });
           } else {
             // Inferred application - redirect to config
-            $state.go('home.applications.application.config', { application: create, create: null });
+            stateService.go('home.applications.application.config', { application: create, create: null });
           }
         } else {
           CreateApplicationModal.show(create).then(
             (app) => {
-              $state.go('home.applications.application', { application: app.name, create: null });
+              stateService.go('home.applications.application', { application: app.name, create: null });
             },
             () => {
               // Clear out the query parameter if the dialog is dismissed
-              $state.go('home.applications', { create: null });
+              stateService.go('home.applications', { create: null });
             },
           );
         }
@@ -250,3 +251,6 @@ export class Applications extends React.Component<{}, IApplicationsState> {
     );
   }
 }
+
+export const Applications = withRouter(ApplicationsComponent);
+Applications.displayName = 'Applications';

--- a/deck/packages/core/src/application/service/applicationDataSource.ts
+++ b/deck/packages/core/src/application/service/applicationDataSource.ts
@@ -25,6 +25,7 @@ import { AngularServices } from '../../angular/services';
 
 import type { Application } from '../application.model';
 import type { IEntityTags } from '../../domain';
+import { getDirectRouter } from '../../navigation/directRouter';
 import type { IconNames } from '../../presentation';
 import { robotToHuman } from '../../presentation';
 import { FirewallLabels } from '../../securityGroup';
@@ -384,8 +385,9 @@ export class ApplicationDataSource<T = any> implements IDataSourceConfig<T> {
     }
 
     if (config.autoActivate) {
-      AngularServices.$uiRouter.transitionService.onSuccess({ entering: this.activeState }, () => this.activate());
-      AngularServices.$uiRouter.transitionService.onSuccess({ exiting: this.activeState }, () => this.deactivate());
+      const transitionService = getDirectRouter()?.transitionService;
+      transitionService?.onSuccess({ entering: this.activeState }, () => this.activate());
+      transitionService?.onSuccess({ exiting: this.activeState }, () => this.deactivate());
     }
 
     // While we can initialize these fields directly on the class to give them private/public

--- a/deck/packages/core/src/application/service/directDataSources.spec.ts
+++ b/deck/packages/core/src/application/service/directDataSources.spec.ts
@@ -19,6 +19,7 @@ import { registerServerGroupManagerDataSource } from '../../serverGroupManager/s
 import { registerTaskDataSources } from '../../task/task.dataSource';
 import { registerPipelineDataSources } from '../../pipeline/pipeline.dataSource';
 import { ExecutionService } from '../../pipeline/service/execution.service';
+import { getDirectRouter, setDirectRouter } from '../../navigation/directRouter';
 import { Application } from '../application.model';
 
 function getDataSourcesByKey(key: string): any[] {
@@ -288,6 +289,45 @@ describe('direct application data source registration', () => {
     await flushPromise(dataSource.ready());
 
     expect(dataSource.data).toEqual([]);
+  });
+
+  it('registers auto-activation hooks with the direct router', () => {
+    const previousRouter = getDirectRouter();
+    const onSuccess = jasmine.createSpy('onSuccess');
+
+    try {
+      setDirectRouter({ transitionService: { onSuccess } } as any);
+
+      new ApplicationDataSource(
+        { key: 'example', defaultData: [], activeState: '**.example.**', autoActivate: true },
+        {} as any,
+      );
+
+      expect(onSuccess.calls.allArgs()).toEqual([
+        [{ entering: '**.example.**' }, jasmine.any(Function)],
+        [{ exiting: '**.example.**' }, jasmine.any(Function)],
+      ]);
+    } finally {
+      setDirectRouter(previousRouter);
+    }
+  });
+
+  it('allows auto-activated data sources to be created before the direct router', () => {
+    const previousRouter = getDirectRouter();
+
+    try {
+      setDirectRouter(null);
+
+      expect(
+        () =>
+          new ApplicationDataSource(
+            { key: 'example', defaultData: [], activeState: '**.example.**', autoActivate: true },
+            {} as any,
+          ),
+      ).not.toThrow();
+    } finally {
+      setDirectRouter(previousRouter);
+    }
   });
 
   it('refreshes an application without Angular $q injection', async () => {

--- a/deck/packages/core/src/bootstrap/DeckRuntime.spec.ts
+++ b/deck/packages/core/src/bootstrap/DeckRuntime.spec.ts
@@ -1,3 +1,5 @@
+import { UIRouterReact } from '@uirouter/react';
+
 import { DeckRuntimeContext, createDeckRuntime } from './DeckRuntime';
 
 describe('createDeckRuntime', () => {
@@ -5,14 +7,17 @@ describe('createDeckRuntime', () => {
   afterEach(() => jasmine.clock().uninstall());
 
   it('assembles direct runtime dependencies', () => {
-    const runtime = createDeckRuntime();
+    const router = new UIRouterReact();
+    const runtime = createDeckRuntime(router);
 
+    expect(runtime.router).toBe(router);
     expect(runtime.promiseService).toEqual(jasmine.any(Function));
     expect(runtime.timeoutService).toEqual(jasmine.any(Function));
     expect(runtime.logger.error).toEqual(jasmine.any(Function));
     expect(runtime.interpolate).toEqual(jasmine.any(Function));
     expect(runtime.providerServiceDelegate).toBeDefined();
     expect(DeckRuntimeContext._currentValue).toBeNull();
+    router.dispose();
   });
 
   it('cancels pending runtime work when disposed', () => {

--- a/deck/packages/core/src/bootstrap/DeckRuntime.ts
+++ b/deck/packages/core/src/bootstrap/DeckRuntime.ts
@@ -1,3 +1,4 @@
+import type { UIRouterReact } from '@uirouter/react';
 import type { ILogService, IQService } from 'angular';
 import * as React from 'react';
 
@@ -9,6 +10,7 @@ import { interpolate } from '../utils/interpolate';
 import { createNativePromiseService } from '../utils/nativePromiseService';
 
 export interface DeckRuntime {
+  router: UIRouterReact | null;
   promiseService: IQService;
   timeoutService: CancellableTimeout;
   logger: ILogService;
@@ -19,11 +21,12 @@ export interface DeckRuntime {
 
 export const DeckRuntimeContext = React.createContext<DeckRuntime | null>(null);
 
-export function createDeckRuntime(): DeckRuntime {
+export function createDeckRuntime(router: UIRouterReact | null = null): DeckRuntime {
   const promiseService = createNativePromiseService();
   const timeoutService = createCancellableTimeout();
 
   return {
+    router,
     promiseService,
     timeoutService,
     logger: createDiagnosticLogger(),

--- a/deck/packages/core/src/bootstrap/bootstrapDeck.spec.tsx
+++ b/deck/packages/core/src/bootstrap/bootstrapDeck.spec.tsx
@@ -755,7 +755,7 @@ describe('bootstrapDeck', () => {
       });
 
       await bootstrapDeck(firstRoot);
-      const firstStateEvents = AngularServices.stateEvents;
+      const firstRouter = getDirectRouter();
       const scheduled = jasmine.createSpy('scheduled');
       AngularServices.$timeout(scheduled, 100);
 
@@ -767,7 +767,7 @@ describe('bootstrapDeck', () => {
       await bootstrapDeck(secondRoot);
 
       expect(scheduled).not.toHaveBeenCalled();
-      expect(AngularServices.stateEvents).not.toBe(firstStateEvents);
+      expect(getDirectRouter()).not.toBe(firstRouter);
     } finally {
       jasmine.clock().uninstall();
     }

--- a/deck/packages/core/src/bootstrap/bootstrapDeck.tsx
+++ b/deck/packages/core/src/bootstrap/bootstrapDeck.tsx
@@ -1,5 +1,4 @@
-import type { UIRouterReact } from '@uirouter/react';
-import { UIRouterContext } from '@uirouter/react';
+import { UIRouterContext, UIRouterReact } from '@uirouter/react';
 import * as React from 'react';
 import { render, unmountComponentAtNode } from 'react-dom';
 
@@ -96,10 +95,11 @@ async function runBootstrap(root: HTMLElement): Promise<void> {
 
   void initializeDynamicRuntimeMetadata();
   await initializePlugins();
-  const runtime = createDeckRuntime();
+  const router = new UIRouterReact();
+  const runtime = createDeckRuntime(router);
   AngularServices.bindRuntime(runtime);
   activeRuntime = runtime;
-  const router = configureRouter();
+  configureRouter(router);
   activeRouter = router;
   initializeState();
   initializeInfrastructureCaches();

--- a/deck/packages/core/src/cluster/AllClustersGroupings.spec.tsx
+++ b/deck/packages/core/src/cluster/AllClustersGroupings.spec.tsx
@@ -1,0 +1,71 @@
+import { Subject } from 'rxjs';
+
+import { AllClustersGroupingsComponent } from './AllClustersGroupings';
+import { initialize } from '../state';
+
+describe('AllClustersGroupings', () => {
+  beforeEach(() => initialize());
+
+  it('scrolls to the server group identified by the injected route params', () => {
+    const groupsUpdatedStream = new Subject<any[]>();
+    const scrollToRow = jasmine.createSpy('scrollToRow');
+    const component = new AllClustersGroupingsComponent({
+      app: {} as any,
+      initialized: true,
+      router: {} as any,
+      stateParams: {
+        accountId: 'account',
+        region: 'region',
+        serverGroup: 'server-group',
+      },
+      stateService: {} as any,
+    } as any);
+    component.state = {
+      ...component.state,
+      groups: [
+        {
+          subgroups: [
+            {
+              serverGroups: [{ account: 'account', name: 'server-group', region: 'region' }],
+            },
+          ],
+        } as any,
+      ],
+    };
+    (component as any).clusterFilterService = { groupsUpdatedStream };
+    (component as any).listRef = { scrollToRow };
+
+    (component as any).scrollToRow();
+    groupsUpdatedStream.next([]);
+
+    expect(scrollToRow).toHaveBeenCalledWith(0);
+  });
+
+  it('clears cached row heights after a relevant transition from the injected router', () => {
+    let onTransitionSuccess: (transition: any) => void;
+    const onSuccess = jasmine
+      .createSpy('onSuccess')
+      .and.callFake((_criteria: any, callback: (transition: any) => void) => {
+        onTransitionSuccess = callback;
+        return () => undefined;
+      });
+    const component = new AllClustersGroupingsComponent({
+      app: {} as any,
+      initialized: true,
+      router: { transitionService: { onSuccess } } as any,
+      stateParams: {},
+      stateService: {} as any,
+    });
+    const clearAll = spyOn((component as any).cellCache, 'clearAll');
+
+    component.componentDidMount();
+    onTransitionSuccess({
+      from: () => ({ name: 'previous' }),
+      params: () => ({}),
+      to: () => ({ name: 'home.applications.application.insight.clusters.instanceDetails' }),
+    });
+
+    expect(clearAll).toHaveBeenCalled();
+    component.componentWillUnmount();
+  });
+});

--- a/deck/packages/core/src/cluster/AllClustersGroupings.tsx
+++ b/deck/packages/core/src/cluster/AllClustersGroupings.tsx
@@ -9,7 +9,8 @@ import { AngularServices } from '../angular/services';
 import type { Application } from '../application';
 import type { IClusterGroup, IClusterSubgroup } from './filter/ClusterFilterService';
 import type { ISortFilter } from '../filterModel';
-import type { IStateChange } from '../reactShims';
+import type { IRouterInjectedProps, IRouterStateChange } from '../navigation/routerContext';
+import { stateChangeSuccess$, withRouter } from '../navigation/routerContext';
 import { ClusterState } from '../state';
 
 export interface IAllClustersGroupingsProps {
@@ -22,7 +23,10 @@ export interface IAllClustersGroupingsState {
   sortFilter: ISortFilter;
 }
 
-export class AllClustersGroupings extends React.Component<IAllClustersGroupingsProps, IAllClustersGroupingsState> {
+export class AllClustersGroupingsComponent extends React.Component<
+  IAllClustersGroupingsProps & IRouterInjectedProps,
+  IAllClustersGroupingsState
+> {
   private clusterFilterService = ClusterState.filterService;
   private clusterFilterModel = ClusterState.filterModel;
 
@@ -34,7 +38,7 @@ export class AllClustersGroupings extends React.Component<IAllClustersGroupingsP
 
   private listRef: List;
 
-  constructor(props: IAllClustersGroupingsProps) {
+  constructor(props: IAllClustersGroupingsProps & IRouterInjectedProps) {
     super(props);
     this.cellCache = new CellMeasurerCache({
       fixedWidth: true,
@@ -73,7 +77,7 @@ export class AllClustersGroupings extends React.Component<IAllClustersGroupingsP
     this.cellCache.clearAll();
   };
 
-  private handleRouteChange = (stateChange: IStateChange) => {
+  private handleRouteChange = (stateChange: IRouterStateChange) => {
     const { to } = stateChange;
     if (
       to.name === 'home.applications.application.insight.clusters.instanceDetails' ||
@@ -95,7 +99,7 @@ export class AllClustersGroupings extends React.Component<IAllClustersGroupingsP
       );
     };
     this.groupsSubscription = this.clusterFilterService.groupsUpdatedStream.subscribe(onGroupsChanged);
-    this.routeChangedSubscription = AngularServices.stateEvents.stateChangeSuccess.subscribe(this.handleRouteChange);
+    this.routeChangedSubscription = stateChangeSuccess$(this.props.router).subscribe(this.handleRouteChange);
 
     const getSortFilter = () => this.clusterFilterModel.asFilterModel.sortFilter;
     const onFilterChanged = ({ ...sortFilter }: any) => {
@@ -117,16 +121,16 @@ export class AllClustersGroupings extends React.Component<IAllClustersGroupingsP
   }
 
   private scrollToRow = () => {
-    const { $stateParams } = AngularServices;
-    // Automatically scroll server group into view if deep linkedif ($stateParams.serverGroup) {
+    const { stateParams } = this.props;
+    // Automatically scroll server group into view if deep linkedif (stateParams.serverGroup) {
     this.clusterFilterService.groupsUpdatedStream.pipe(take(1)).subscribe(() => {
       const scrollToRow = this.state.groups.findIndex((group) =>
         group.subgroups.some((subgroup) =>
           subgroup.serverGroups.some(
             (sg) =>
-              sg.account === $stateParams.accountId &&
-              sg.name === $stateParams.serverGroup &&
-              sg.region === $stateParams.region,
+              sg.account === stateParams.accountId &&
+              sg.name === stateParams.serverGroup &&
+              sg.region === stateParams.region,
           ),
         ),
       );
@@ -203,3 +207,6 @@ export class AllClustersGroupings extends React.Component<IAllClustersGroupingsP
     );
   }
 }
+
+export const AllClustersGroupings = withRouter(AllClustersGroupingsComponent);
+AllClustersGroupings.displayName = 'AllClustersGroupings';

--- a/deck/packages/core/src/cluster/clusterSearchResultType.spec.ts
+++ b/deck/packages/core/src/cluster/clusterSearchResultType.spec.ts
@@ -1,0 +1,38 @@
+import { of } from 'rxjs';
+
+import { UrlBuilder } from '../navigation';
+import { SearchStatus, searchResultTypeRegistry } from '../search';
+import './clusterSearchResultType';
+
+describe('cluster search result type', () => {
+  it('builds cluster links from result metadata', async () => {
+    const buildFromMetadata = spyOn(UrlBuilder, 'buildFromMetadata').and.returnValue(
+      '/clusters?acct=prod&q=cluster:payments',
+    );
+    const resultType = searchResultTypeRegistry.get('clusters');
+
+    const result = await resultType
+      .search(
+        {} as any,
+        of({
+          results: [
+            {
+              account: 'prod',
+              application: 'payments',
+              cluster: 'payments',
+              provider: 'aws',
+              stack: '',
+            },
+          ],
+          status: SearchStatus.FINISHED,
+          type: { id: 'serverGroups' },
+        } as any),
+      )
+      .toPromise();
+
+    expect(buildFromMetadata).toHaveBeenCalledWith(
+      jasmine.objectContaining({ account: 'prod', application: 'payments', cluster: 'payments', type: 'clusters' }),
+    );
+    expect(result.results[0].href).toBe('/clusters?acct=prod&q=cluster:payments');
+  });
+});

--- a/deck/packages/core/src/cluster/clusterSearchResultType.tsx
+++ b/deck/packages/core/src/cluster/clusterSearchResultType.tsx
@@ -2,10 +2,9 @@ import { uniqBy } from 'lodash';
 import React from 'react';
 import type { Observable } from 'rxjs';
 import { filter, first, map } from 'rxjs/operators';
-import { AngularServices } from '../angular/services';
 
 import type { IQueryParams } from '../navigation';
-import { Registry } from '../registry';
+import { UrlBuilder } from '../navigation';
 import type { ISearchColumn, ISearchResult, ISearchResults, ISearchResultSet } from '../search';
 import {
   AccountCell,
@@ -67,9 +66,8 @@ class ClustersSearchResultType extends SearchResultType<IClusterSearchResult> {
 
   private makeSearchResult(serverGroup: IServerGroupSearchResult): IClusterSearchResult {
     const type = this.id;
-    const urlBuilder = Registry.urlBuilder.getBuilder(type);
     const input = { type, ...serverGroup };
-    const href = urlBuilder.build(input, AngularServices.$state);
+    const href = UrlBuilder.buildFromMetadata(input);
 
     const { account, application, cluster, provider, stack } = serverGroup;
     return { account, application, cluster, provider, stack, displayName: cluster, href, type };

--- a/deck/packages/core/src/cluster/filter/ClusterFilterService.spec.ts
+++ b/deck/packages/core/src/cluster/filter/ClusterFilterService.spec.ts
@@ -4,6 +4,7 @@ import { cloneDeep, filter } from 'lodash';
 import type { Application } from '../../application/application.model';
 import { ApplicationModelBuilder } from '../../application/applicationModel.builder';
 import { CLUSTER_SERVICE } from '../cluster.service';
+import { getDirectRouter, setDirectRouter } from '../../navigation/directRouter';
 import { REACT_MODULE } from '../../reactShims';
 import * as State from '../../state';
 
@@ -17,8 +18,10 @@ describe('Service: clusterFilterService', function () {
   let applicationJSON: any;
   let groupedJSON: any;
   let application: Application;
+  let previousRouter: ReturnType<typeof getDirectRouter>;
 
   beforeEach(function () {
+    previousRouter = getDirectRouter();
     mock.module(CLUSTER_SERVICE, require('./mockApplicationData').name, 'ui.router', REACT_MODULE);
     mock.inject(function (_applicationJSON_: any, _groupedJSON_: any, _clusterService_: any) {
       clusterService = _clusterService_;
@@ -59,6 +62,8 @@ describe('Service: clusterFilterService', function () {
     application = this.buildApplication(applicationJSON);
     State.initialize();
   });
+
+  afterEach(() => setDirectRouter(previousRouter));
 
   describe('Updating the cluster group', function () {
     it('no filter: should be transformed', function (done) {
@@ -739,6 +744,26 @@ describe('Service: clusterFilterService', function () {
       ClusterState.filterService.clearFilters();
       expect(ClusterState.filterModel.asFilterModel.sortFilter.providerType).toBeUndefined();
       this.verifyTags([]);
+    });
+  });
+
+  describe('overriding filters from a URL', function () {
+    it('does not update cluster groups before the direct router is available', function () {
+      setDirectRouter(null);
+      const updateClusterGroups = spyOn(ClusterState.filterService, 'updateClusterGroups');
+
+      ClusterState.filterService.overrideFiltersForUrl({ href: '/clusters', application: 'app' });
+
+      expect(updateClusterGroups).not.toHaveBeenCalled();
+    });
+
+    it('updates cluster groups when the URL targets the direct router application', function () {
+      setDirectRouter({ stateService: { params: { application: 'app' } } } as any);
+      const updateClusterGroups = spyOn(ClusterState.filterService, 'updateClusterGroups');
+
+      ClusterState.filterService.overrideFiltersForUrl({ href: '/clusters', application: 'app' });
+
+      expect(updateClusterGroups).toHaveBeenCalled();
     });
   });
 

--- a/deck/packages/core/src/cluster/filter/ClusterFilterService.ts
+++ b/deck/packages/core/src/cluster/filter/ClusterFilterService.ts
@@ -1,14 +1,15 @@
 import { each, every, forOwn, groupBy, isEmpty, some, sortBy } from 'lodash';
 import { Debounce } from 'lodash-decorators';
 import { Subject } from 'rxjs';
-import { AngularServices } from '../../angular/services';
 
+import { AngularServices } from '../../angular/services';
 import type { Application } from '../../application/application.model';
 import type { ICluster, IEntityTags, IInstance, IManagedResourceSummary, IServerGroup } from '../../domain';
 import type { ISortFilter } from '../../filterModel';
 import { FilterModelService } from '../../filterModel';
 import type { ILabelFilter } from './labelFilterUtils';
 import { trueKeyObjectToLabelFilters } from './labelFilterUtils';
+import { getDirectRouter } from '../../navigation/directRouter';
 import { ClusterState } from '../../state';
 
 export interface IParentGrouping {
@@ -187,7 +188,7 @@ export class ClusterFilterService {
         category[result.category] = true;
         sortFilter.category = category;
       }
-      if (AngularServices.$stateParams.application === result.application) {
+      if (getDirectRouter()?.stateService.params.application === result.application) {
         this.updateClusterGroups();
       }
     }

--- a/deck/packages/core/src/cluster/filter/MultiselectModel.spec.ts
+++ b/deck/packages/core/src/cluster/filter/MultiselectModel.spec.ts
@@ -1,31 +1,45 @@
 import { MultiselectModel } from './MultiselectModel';
 import * as State from '../../state';
-import { AngularServices } from '../../angular/services';
+import { getDirectRouter, setDirectRouter } from '../../navigation/directRouter';
 
 const { ClusterState } = State;
 
 describe('Multiselect Model', () => {
   let multiselectModel: MultiselectModel;
-  beforeEach(() => (multiselectModel = new MultiselectModel()));
+  let previousFilterModel: any;
+
+  beforeEach(() => {
+    previousFilterModel = ClusterState.filterModel;
+    ClusterState.filterModel = { asFilterModel: { sortFilter: {} } } as any;
+    multiselectModel = new MultiselectModel();
+  });
+
+  afterEach(() => (ClusterState.filterModel = previousFilterModel));
 
   describe('navigation management', () => {
-    let result: any, currentStates: any[], currentParams: any;
+    let result: any, currentStates: any[], currentParams: any, previousRouter: any;
     beforeEach(() => {
+      previousRouter = getDirectRouter();
       ClusterState.filterModel.asFilterModel.sortFilter.multiselect = true;
       result = null;
       currentStates = [];
       currentParams = {};
 
-      spyOn(AngularServices.$state, 'includes').and.callFake((substate: any) => currentStates.includes(substate));
-      spyOn(AngularServices.$state, 'go').and.callFake((newState: any) => (result = newState));
-      spyOnProperty(AngularServices.$state, 'params', 'get').and.callFake(() => currentParams);
-      spyOnProperty(AngularServices.$state, '$current', 'get').and.callFake(() => {
-        if (currentStates.length) {
-          return { name: currentStates[currentStates.length - 1] };
-        }
-        return { name: '' };
-      });
+      setDirectRouter({
+        stateService: {
+          includes: (substate: any) => currentStates.includes(substate),
+          go: (newState: any) => (result = newState),
+          get params() {
+            return currentParams;
+          },
+          get $current() {
+            return { name: currentStates.length ? currentStates[currentStates.length - 1] : '' };
+          },
+        },
+      } as any);
     });
+
+    afterEach(() => setDirectRouter(previousRouter));
 
     describe('syncNavigation', () => {
       describe('instance selection', () => {

--- a/deck/packages/core/src/cluster/filter/MultiselectModel.ts
+++ b/deck/packages/core/src/cluster/filter/MultiselectModel.ts
@@ -1,9 +1,9 @@
 import { Subject } from 'rxjs';
-import { AngularServices } from '../../angular/services';
 
 import type { IServerGroup } from '../../domain';
 import type { IMultiInstanceGroup } from '../../instance/instance.write.service';
 import type { IMoniker } from '../../naming';
+import { getDirectRouter } from '../../navigation/directRouter';
 import { ClusterState } from '../../state';
 
 export interface IMultiselectServerGroup {
@@ -30,7 +30,7 @@ export class MultiselectModel {
   }
 
   public syncNavigation(): void {
-    const { $state } = AngularServices;
+    const $state = getDirectRouter()!.stateService;
     if (!ClusterState.filterModel.asFilterModel.sortFilter.multiselect && $state.params.multiselect) {
       $state.go('.', { multiselect: null }, { inherit: true });
     }
@@ -112,7 +112,7 @@ export class MultiselectModel {
     );
     if (!result) {
       // when creating a new group, include an instance ID if we're deep-linked into the details view
-      const params = AngularServices.$state.params;
+      const params = getDirectRouter()!.stateService.params;
       const instanceIds = (serverGroup.instances || [])
         .filter((instance) => instance.provider === params.provider && instance.id === params.instanceId)
         .map((instance) => instance.id);
@@ -145,7 +145,7 @@ export class MultiselectModel {
   }
 
   public toggleServerGroup(serverGroup: IServerGroup): void {
-    const { $state } = AngularServices;
+    const $state = getDirectRouter()!.stateService;
     if (!ClusterState.filterModel.asFilterModel.sortFilter.multiselect) {
       const params = {
         provider: serverGroup.type,
@@ -184,7 +184,7 @@ export class MultiselectModel {
   }
 
   public toggleInstance(serverGroup: IServerGroup, instanceId: string): void {
-    const { $state } = AngularServices;
+    const $state = getDirectRouter()!.stateService;
     if (!ClusterState.filterModel.asFilterModel.sortFilter.multiselect) {
       const params = { provider: serverGroup.type, instanceId };
       if (this.isClusterChildState()) {
@@ -226,6 +226,6 @@ export class MultiselectModel {
   }
 
   private isClusterChildState(): boolean {
-    return AngularServices.$state.$current.name.split('.').pop() !== 'clusters';
+    return getDirectRouter()!.stateService.$current.name.split('.').pop() !== 'clusters';
   }
 }

--- a/deck/packages/core/src/filterModel/FilterModelService.ts
+++ b/deck/packages/core/src/filterModel/FilterModelService.ts
@@ -1,7 +1,7 @@
 import { cloneDeep, forOwn, includes, isNil, pick, reduce, size, some } from 'lodash';
 
 import type { IFilterConfig, IFilterModel, ITrueKeyModel } from './IFilterModel';
-import { AngularServices } from '../angular/services';
+import { getDirectRouter } from '../navigation/directRouter';
 
 export class FilterModelService {
   public static configureFilterModel(filterModel: IFilterModel, filterModelConfig: IFilterConfig[]) {
@@ -33,7 +33,7 @@ export class FilterModelService {
     // Apply any mutations to the current sortFilter values as ui-router state params
     filterModel.applyParamsToUrl = () => {
       const toParams = FilterModelService.mapSortFilterToRouterParams(filterModel);
-      AngularServices.$state.go('.', toParams, { location: 'replace' });
+      getDirectRouter()?.stateService.go('.', toParams, { location: 'replace' });
     };
 
     return filterModel;
@@ -66,11 +66,12 @@ export class FilterModelService {
   }
 
   public static registerRouterHooks(filterModel: IFilterModel, stateGlob: string) {
-    if (!AngularServices.has('$uiRouter')) {
+    const router = getDirectRouter();
+    if (!router) {
       return;
     }
 
-    const { transitionService } = AngularServices.$uiRouter;
+    const { transitionService } = router;
     const filterParams = filterModel.config.map((cfg) => cfg.param);
     let savedParamsForScreen: any = {};
 

--- a/deck/packages/core/src/filterModel/filter.model.service.spec.js
+++ b/deck/packages/core/src/filterModel/filter.model.service.spec.js
@@ -3,7 +3,6 @@ import { FilterModelService } from './FilterModelService';
 import { REACT_MODULE } from '../reactShims';
 import { StateConfigProvider } from '../navigation';
 import { getDirectRouter, setDirectRouter } from '../navigation/directRouter';
-import { AngularServices } from '../angular/services';
 
 describe('Service: FilterModelService', function () {
   var filterModel;
@@ -483,7 +482,9 @@ describe('Service: FilterModelService', function () {
 
     describe('applyParamsToUrl', function () {
       it('should start a transition with params for all configured fields', function () {
-        const spy = spyOn(AngularServices.$state, 'go');
+        const previousRouter = getDirectRouter();
+        setDirectRouter($uiRouter);
+        const spy = spyOn($uiRouter.stateService, 'go');
         filterModelConfig = [
           { model: 'showInstances', type: 'boolean', displayOption: true },
           { model: 'search', type: 'string', param: 'q' },
@@ -493,6 +494,7 @@ describe('Service: FilterModelService', function () {
         filterModel.sortFilter.showInstances = true;
         filterModel.applyParamsToUrl();
         expect(spy).toHaveBeenCalledWith('.', { q: 'deck', showInstances: true }, jasmine.anything());
+        setDirectRouter(previousRouter);
       });
     });
   });

--- a/deck/packages/core/src/function/filter/FunctionFilters.tsx
+++ b/deck/packages/core/src/function/filter/FunctionFilters.tsx
@@ -2,12 +2,13 @@ import { chain, compact, debounce, map, uniq } from 'lodash';
 import React from 'react';
 import type { Subscription } from 'rxjs';
 
-import { AngularServices } from '../../angular/services';
 import type { Application } from '../../application';
 import { FilterSearch } from '../../cluster/filter/FilterSearch';
 import { FilterSection } from '../../cluster/filter/FilterSection';
 import type { ISortFilter } from '../../filterModel';
 import { digestDependentFilters, FilterCheckbox } from '../../filterModel';
+import type { IRouterInjectedProps } from '../../navigation/routerContext';
+import { locationChangeSuccess$, withRouter } from '../../navigation/routerContext';
 import { FunctionState } from '../../state';
 
 const poolValueCoordinates = [
@@ -45,13 +46,16 @@ export interface IFunctionFiltersState {
   regionHeadings: string[];
 }
 
-export class FunctionFilters extends React.Component<IFunctionFiltersProps, IFunctionFiltersState> {
+class FunctionFiltersComponent extends React.Component<
+  IFunctionFiltersProps & IRouterInjectedProps,
+  IFunctionFiltersState
+> {
   private debouncedUpdateFunctionGroups: () => void;
   private groupsUpdatedSubscription: Subscription;
   private functionsRefreshUnsubscribe: () => void;
   private locationChangeUnsubscribe: () => void;
 
-  constructor(props: IFunctionFiltersProps) {
+  constructor(props: IFunctionFiltersProps & IRouterInjectedProps) {
     super(props);
     this.state = {
       sortFilter: FunctionState.filterModel.asFilterModel.sortFilter,
@@ -77,7 +81,7 @@ export class FunctionFilters extends React.Component<IFunctionFiltersProps, IFun
 
     this.functionsRefreshUnsubscribe = app.functions.onRefresh(null, () => this.updateFunctionGroups());
 
-    const locationChangeSubscription = AngularServices.stateEvents.locationChangeSuccess.subscribe(() => {
+    const locationChangeSubscription = locationChangeSuccess$(this.props.router).subscribe(() => {
       FunctionState.filterModel.asFilterModel.activate();
       FunctionState.filterService.updateFunctionGroups(app);
     });
@@ -185,3 +189,6 @@ export class FunctionFilters extends React.Component<IFunctionFiltersProps, IFun
     );
   }
 }
+
+export const FunctionFilters = withRouter(FunctionFiltersComponent);
+FunctionFilters.displayName = 'FunctionFilters';

--- a/deck/packages/core/src/header/customBanner/CustomBanner.spec.tsx
+++ b/deck/packages/core/src/header/customBanner/CustomBanner.spec.tsx
@@ -1,7 +1,9 @@
 import { shallow } from 'enzyme';
 import React from 'react';
 
-import { CustomBanner } from './CustomBanner';
+import { UIRouterReact } from '@uirouter/react';
+
+import { CustomBannerComponent } from './CustomBanner';
 import { Application } from '../../application/application.model';
 import type { ICustomBannerConfig } from '../../application/config/customBanner/CustomBannerConfig';
 import { getTestBannerConfigs } from '../../application/config/customBanner/CustomBannerConfig.spec';
@@ -10,12 +12,16 @@ describe('<CustomBanner />', () => {
   let application: Application;
   let wrapper: any;
   let bannerConfigs: ICustomBannerConfig[];
+  let router: UIRouterReact;
 
   beforeEach(() => {
+    router = new UIRouterReact();
     application = new Application('my-app', null, []);
-    wrapper = shallow(<CustomBanner />);
+    wrapper = shallow(<CustomBannerComponent router={router} stateParams={{}} stateService={router.stateService} />);
     bannerConfigs = getTestBannerConfigs();
   });
+
+  afterEach(() => router.dispose());
 
   describe('view', () => {
     it('renders no banner by default', () => {

--- a/deck/packages/core/src/header/customBanner/CustomBanner.tsx
+++ b/deck/packages/core/src/header/customBanner/CustomBanner.tsx
@@ -1,9 +1,10 @@
 import { get } from 'lodash';
 import React from 'react';
 
-import { AngularServices } from '../../angular/services';
 import type { ICustomBannerConfig } from '../../application/config/customBanner/CustomBannerConfig';
 import { ApplicationReader } from '../../application/service/ApplicationReader';
+import type { IRouterInjectedProps } from '../../navigation/routerContext';
+import { withRouter } from '../../navigation/routerContext';
 import { Markdown } from '../../presentation/Markdown';
 import { noop } from '../../utils';
 
@@ -14,7 +15,7 @@ export interface ICustomBannerState {
   bannerConfig: ICustomBannerConfig;
 }
 
-export class CustomBanner extends React.Component<{}, ICustomBannerState> {
+export class CustomBannerComponent extends React.Component<IRouterInjectedProps, ICustomBannerState> {
   private locationChangeUnsubscribe: Function;
 
   public state = {
@@ -23,13 +24,12 @@ export class CustomBanner extends React.Component<{}, ICustomBannerState> {
   } as ICustomBannerState;
 
   public componentDidMount(): void {
-    this.locationChangeUnsubscribe = AngularServices.$uiRouter.transitionService.onSuccess({}, () =>
-      this.updateApplication(),
+    this.locationChangeUnsubscribe = this.props.router.transitionService.onSuccess({}, (transition) =>
+      this.updateApplication(transition.params('to').application),
     );
   }
 
-  private updateApplication(): void {
-    const applicationName: string = get(AngularServices, '$stateParams.application');
+  private updateApplication(applicationName: string = this.props.stateParams.application): void {
     if (applicationName !== this.state.applicationName) {
       this.setState({
         applicationName,
@@ -53,7 +53,7 @@ export class CustomBanner extends React.Component<{}, ICustomBannerState> {
     });
   }
 
-  public render(): React.ReactElement<CustomBanner> {
+  public render(): React.ReactElement<CustomBannerComponent> {
     const { bannerConfig } = this.state;
     if (bannerConfig == null) {
       return null;
@@ -75,3 +75,6 @@ export class CustomBanner extends React.Component<{}, ICustomBannerState> {
     this.locationChangeUnsubscribe();
   }
 }
+
+export const CustomBanner = withRouter(CustomBannerComponent);
+CustomBanner.displayName = 'CustomBanner';

--- a/deck/packages/core/src/insight/InsightLayout.tsx
+++ b/deck/packages/core/src/insight/InsightLayout.tsx
@@ -1,4 +1,4 @@
-import { UIView, useCurrentStateAndParams } from '@uirouter/react';
+import { UIView, useCurrentStateAndParams, useRouter } from '@uirouter/react';
 import React from 'react';
 import { useRecoilValue } from 'recoil';
 import { AngularServices } from '../angular/services';
@@ -32,6 +32,7 @@ export const isInsightDetailUrl = (href: string): boolean => {
 };
 
 export const InsightLayout = ({ app }: IInsightLayoutProps) => {
+  const router = useRouter();
   const [expandFilters, setExpandFilters] = React.useState(AngularServices.insightFilterStateModel.filtersExpanded);
   const [currentLocation, setCurrentLocation] = React.useState(window.location.href);
   const filterClass = expandFilters ? 'filters-expanded' : 'filters-collapsed';
@@ -44,21 +45,22 @@ export const InsightLayout = ({ app }: IInsightLayoutProps) => {
   const navClass = useRecoilValue(verticalNavExpandedAtom) ? 'nav-expanded' : 'nav-collapsed';
 
   const { state: hookState } = useCurrentStateAndParams();
-  const getCurrentState = (): IInsightState => AngularServices.$uiRouter.globals.current || hookState || {};
-  const [currentState, setCurrentState] = React.useState<IInsightState>(() => getCurrentState());
+  const [currentState, setCurrentState] = React.useState<IInsightState>(
+    () => hookState || router.globals.current || {},
+  );
 
   React.useEffect(() => {
-    setCurrentState(AngularServices.$uiRouter.globals.current || hookState || {});
+    setCurrentState(hookState || router.globals.current || {});
   }, [hookState]);
 
   React.useEffect(() => {
-    const removeTransitionHook = AngularServices.$uiRouter.transitionService.onSuccess({}, (transition: any) => {
+    const removeTransitionHook = router.transitionService.onSuccess({}, (transition: any) => {
       setCurrentState(transition.to() || {});
       setCurrentLocation(window.location.href);
     });
 
     return () => removeTransitionHook();
-  }, []);
+  }, [router]);
 
   React.useEffect(() => {
     const handleLocationChange = () => setCurrentLocation(window.location.href);

--- a/deck/packages/core/src/insight/InsightMenu.spec.tsx
+++ b/deck/packages/core/src/insight/InsightMenu.spec.tsx
@@ -6,14 +6,14 @@ import React from 'react';
 import { Button } from 'react-bootstrap';
 
 import type { IInsightMenuProps, IInsightMenuState } from './InsightMenu';
-import { InsightMenu } from './InsightMenu';
+import { InsightMenuComponent } from './InsightMenu';
 import { CreateApplicationModal } from '../application/modal/CreateApplicationModal';
-import { AngularServices } from '../angular/services';
 import type { CacheInitializerService } from '../cache/cacheInitializer.service';
 import { OverrideRegistry } from '../overrideRegistry/override.registry';
 
 describe('<InsightMenu />', () => {
   let component: ReactWrapper<IInsightMenuProps, IInsightMenuState>;
+  let go: jasmine.Spy;
 
   beforeEach(() => {
     mock.module(($provide: any) => {
@@ -24,15 +24,19 @@ describe('<InsightMenu />', () => {
     });
   });
   beforeEach(mock.inject());
+  beforeEach(() => (go = jasmine.createSpy('go')));
 
   function getNewMenu(params: object): ReactWrapper<IInsightMenuProps, any> {
     // Set defaults to zero so we only need to pass in the prop we want rendered
     const mergedParams = { ...{ createApp: false, createProject: false, refreshCaches: false }, ...params };
     return mount(
-      <InsightMenu
+      <InsightMenuComponent
         createApp={mergedParams.createApp}
         createProject={mergedParams.createProject}
         refreshCaches={mergedParams.refreshCaches}
+        router={{} as any}
+        stateParams={{}}
+        stateService={{ go } as any}
       />,
     );
   }
@@ -90,8 +94,6 @@ describe('<InsightMenu />', () => {
   });
 
   it('opens the direct application modal and routes after creation', async () => {
-    const go = jasmine.createSpy('go');
-    spyOnProperty(AngularServices, '$state', 'get').and.returnValue({ go } as any);
     spyOn(CreateApplicationModal, 'show').and.returnValue(Promise.resolve({ name: 'myapp' }) as any);
     component = getNewMenu({ createApp: true });
 

--- a/deck/packages/core/src/insight/InsightMenu.tsx
+++ b/deck/packages/core/src/insight/InsightMenu.tsx
@@ -5,6 +5,8 @@ import { AngularServices } from '../angular/services';
 
 import { CreateApplicationModal } from '../application/modal/CreateApplicationModal';
 import type { CacheInitializerService } from '../cache';
+import type { IRouterInjectedProps } from '../navigation/routerContext';
+import { withRouter } from '../navigation/routerContext';
 import { Overridable } from '../overrideRegistry';
 import { ConfigureProjectModal } from '../projects';
 
@@ -18,17 +20,16 @@ export interface IInsightMenuState {
   refreshingCache: boolean;
 }
 
-@Overridable('createInsightMenu')
-export class InsightMenu extends React.Component<IInsightMenuProps, IInsightMenuState> {
+export class InsightMenuComponent extends React.Component<IInsightMenuProps & IRouterInjectedProps, IInsightMenuState> {
   public static defaultProps: IInsightMenuProps = { createApp: true, createProject: true, refreshCaches: true };
 
   private $state: StateService;
   private cacheInitializer: CacheInitializerService;
 
-  constructor(props: IInsightMenuProps) {
+  constructor(props: IInsightMenuProps & IRouterInjectedProps) {
     super(props);
     this.state = {} as IInsightMenuState;
-    this.$state = AngularServices.$state;
+    this.$state = props.stateService;
     this.cacheInitializer = AngularServices.cacheInitializer;
   }
 
@@ -102,3 +103,7 @@ export class InsightMenu extends React.Component<IInsightMenuProps, IInsightMenu
     );
   }
 }
+
+const OverridableInsightMenu = Overridable('createInsightMenu')(InsightMenuComponent);
+export const InsightMenu = withRouter(OverridableInsightMenu);
+InsightMenu.displayName = 'InsightMenu';

--- a/deck/packages/core/src/instance/InstanceList.spec.tsx
+++ b/deck/packages/core/src/instance/InstanceList.spec.tsx
@@ -1,0 +1,50 @@
+import { Subject } from 'rxjs';
+
+import { InstanceListComponent } from './InstanceList';
+import { InstanceListBodyComponent } from './InstanceListBody';
+import { setDirectRouter } from '../navigation/directRouter';
+import { initialize } from '../state';
+
+describe('InstanceList router context', () => {
+  const serverGroup = {
+    account: 'account',
+    instances: [],
+    name: 'server-group',
+    region: 'region',
+    stringVal: 'server-group',
+    type: 'kubernetes',
+  } as any;
+
+  beforeEach(() => {
+    initialize();
+    const params = { instanceSort: 'launchTime', multiselect: false };
+    setDirectRouter({
+      globals: { params, params$: new Subject() },
+      stateService: { params },
+    } as any);
+  });
+
+  afterEach(() => setDirectRouter(null));
+
+  it('initializes the list from injected route params', () => {
+    const component = new InstanceListComponent({
+      serverGroup,
+      stateParams: { instanceSort: 'name', multiselect: true },
+    } as any);
+
+    expect(component.state.multiselect).toBe(true);
+    expect(component.state.instanceSort).toBe('name');
+  });
+
+  it('initializes the list body from injected route params', () => {
+    const component = new InstanceListBodyComponent({
+      instances: [],
+      serverGroup,
+      stateParams: { instanceId: 'instance-id', instanceSort: 'name', multiselect: true },
+    } as any);
+
+    expect(component.state.activeInstanceId).toBe('instance-id');
+    expect(component.state.multiselect).toBe(true);
+    expect(component.state.instanceSort).toBe('name');
+  });
+});

--- a/deck/packages/core/src/instance/InstanceList.tsx
+++ b/deck/packages/core/src/instance/InstanceList.tsx
@@ -4,8 +4,9 @@ import { Subject } from 'rxjs';
 import { distinctUntilChanged, map, takeUntil } from 'rxjs/operators';
 
 import { InstanceListBody } from './InstanceListBody';
-import { AngularServices } from '../angular/services';
 import type { IInstance, IServerGroup } from '../domain';
+import type { IRouterInjectedProps } from '../navigation/routerContext';
+import { withRouter } from '../navigation/routerContext';
 import { SortToggle } from '../presentation/sortToggle/SortToggle';
 import { ClusterState } from '../state';
 
@@ -31,20 +32,21 @@ interface IColumnWidths {
   cloudProvider: number;
 }
 
-export class InstanceList extends React.Component<IInstanceListProps, IInstanceListState> {
+export class InstanceListComponent extends React.Component<
+  IInstanceListProps & IRouterInjectedProps,
+  IInstanceListState
+> {
   private instanceGroup: any;
   private clusterFilterModel = ClusterState.filterModel.asFilterModel;
-  private $state = AngularServices.$state;
-  private $uiRouter = AngularServices.$uiRouter;
   private destroy$ = new Subject();
 
-  constructor(props: IInstanceListProps) {
+  constructor(props: IInstanceListProps & IRouterInjectedProps) {
     super(props);
     this.instanceGroup = ClusterState.multiselectModel.getOrCreateInstanceGroup(props.serverGroup);
     this.state = {
-      multiselect: this.$state.params.multiselect,
+      multiselect: props.stateParams.multiselect,
       allSelected: this.instanceGroup.selectAll,
-      instanceSort: this.$state.params.instanceSort,
+      instanceSort: props.stateParams.instanceSort,
     };
   }
 
@@ -53,16 +55,16 @@ export class InstanceList extends React.Component<IInstanceListProps, IInstanceL
       this.setState({ allSelected: this.instanceGroup.selectAll });
     });
 
-    this.$uiRouter.globals.params$
+    this.props.router.globals.params$
       .pipe(
-        map((params) => [params.multiselect, params.instanceSort]),
+        map((params) => ({ multiselect: params.multiselect, instanceSort: params.instanceSort })),
         distinctUntilChanged(isEqual),
         takeUntil(this.destroy$),
       )
-      .subscribe(() => {
+      .subscribe(({ multiselect, instanceSort }) => {
         this.setState({
-          multiselect: this.$state.params.multiselect,
-          instanceSort: this.$state.params.instanceSort,
+          multiselect,
+          instanceSort,
         });
       });
   }
@@ -194,3 +196,6 @@ export class InstanceList extends React.Component<IInstanceListProps, IInstanceL
     );
   }
 }
+
+export const InstanceList = withRouter(InstanceListComponent);
+InstanceList.displayName = 'InstanceList';

--- a/deck/packages/core/src/instance/InstanceListBody.tsx
+++ b/deck/packages/core/src/instance/InstanceListBody.tsx
@@ -3,9 +3,10 @@ import { isEqual } from 'lodash';
 import React from 'react';
 import { Subject } from 'rxjs';
 import { distinctUntilChanged, map, takeUntil } from 'rxjs/operators';
-import { AngularServices } from '../angular/services';
 
 import type { IInstance, ILoadBalancerHealth, IServerGroup } from '../domain';
+import type { IRouterInjectedProps } from '../navigation/routerContext';
+import { withRouter } from '../navigation/routerContext';
 import { Tooltip } from '../presentation';
 import { ClusterState } from '../state';
 import { timestamp } from '../utils/timeFormatters';
@@ -24,45 +25,49 @@ export interface IInstanceListBodyState {
   instanceSort?: string;
 }
 
-export class InstanceListBody extends React.Component<IInstanceListBodyProps, IInstanceListBodyState> {
-  private $uiRouter = AngularServices.$uiRouter;
-  private $state = AngularServices.$state;
+export class InstanceListBodyComponent extends React.Component<
+  IInstanceListBodyProps & IRouterInjectedProps,
+  IInstanceListBodyState
+> {
   private destroy$ = new Subject();
 
-  constructor(props: IInstanceListBodyProps) {
+  constructor(props: IInstanceListBodyProps & IRouterInjectedProps) {
     super(props);
     this.state = {
       selectedInstanceIds: this.getSelectedInstanceIds(),
-      activeInstanceId: this.$state.params.instanceId,
-      multiselect: this.$state.params.multiselect,
-      instanceSort: this.$state.params.instanceSort,
+      activeInstanceId: props.stateParams.instanceId,
+      multiselect: props.stateParams.multiselect,
+      instanceSort: props.stateParams.instanceSort,
     };
   }
 
   public componentDidMount() {
     ClusterState.multiselectModel.instancesStream.pipe(takeUntil(this.destroy$)).subscribe(() => {
-      this.setState({ selectedInstanceIds: this.getSelectedInstanceIds() });
+      this.setState({ selectedInstanceIds: this.getSelectedInstanceIds(this.state.multiselect) });
     });
 
-    this.$uiRouter.globals.params$
+    this.props.router.globals.params$
       .pipe(
-        map((params) => [params.instanceId, params.multiselect, params.instanceSort]),
+        map((params) => ({
+          instanceId: params.instanceId,
+          multiselect: params.multiselect,
+          instanceSort: params.instanceSort,
+        })),
         distinctUntilChanged(isEqual),
         takeUntil(this.destroy$),
       )
-      .subscribe(() => {
-        const { params } = this.$state;
+      .subscribe(({ instanceId, multiselect, instanceSort }) => {
         this.setState({
-          activeInstanceId: params.instanceId,
-          multiselect: params.multiselect,
-          instanceSort: params.instanceSort,
+          activeInstanceId: instanceId,
+          multiselect,
+          instanceSort,
         });
       });
   }
 
-  private getSelectedInstanceIds(): string[] {
+  private getSelectedInstanceIds(multiselect = this.props.stateParams.multiselect): string[] {
     const { instances, serverGroup } = this.props;
-    if (this.$state.params.multiselect) {
+    if (multiselect) {
       return instances
         .filter((i) => ClusterState.multiselectModel.instanceIsSelected(serverGroup, i.id))
         .map((i) => i.id);
@@ -185,7 +190,7 @@ export class InstanceListBody extends React.Component<IInstanceListBodyProps, II
 
     return (
       <tr key={instance.id} data-instance-id={instance.id} className={rowClass}>
-        {this.$state.params.multiselect && (
+        {this.state.multiselect && (
           <td className="no-hover">
             <input type="checkbox" checked={this.state.selectedInstanceIds.includes(instance.id)} />
           </td>
@@ -246,3 +251,6 @@ export class InstanceListBody extends React.Component<IInstanceListBodyProps, II
     );
   }
 }
+
+export const InstanceListBody = withRouter(InstanceListBodyComponent);
+InstanceListBody.displayName = 'InstanceListBody';

--- a/deck/packages/core/src/instance/details/InstanceDetailsPane.tsx
+++ b/deck/packages/core/src/instance/details/InstanceDetailsPane.tsx
@@ -1,9 +1,9 @@
-import { UISref } from '@uirouter/react';
+import { UISref, useCurrentStateAndParams } from '@uirouter/react';
 import React from 'react';
-import { AngularServices } from '../../angular/services';
 
 export const InstanceDetailsPane = (props: { children: React.ReactNode }) => {
-  const isStandalone = AngularServices.$uiRouter.globals.current.name === 'instanceDetails';
+  const { state } = useCurrentStateAndParams();
+  const isStandalone = state.name === 'instanceDetails';
 
   return (
     <div className="details-panel">

--- a/deck/packages/core/src/loadBalancer/LoadBalancers.tsx
+++ b/deck/packages/core/src/loadBalancer/LoadBalancers.tsx
@@ -4,7 +4,6 @@ import type { Subscription } from 'rxjs';
 
 import { CreateLoadBalancerButton } from './CreateLoadBalancerButton';
 import { LoadBalancerPod } from './LoadBalancerPod';
-import { AngularServices } from '../angular/services';
 import type { Application } from '../application/application.model';
 import { BannerContainer } from '../banner';
 import type { ILoadBalancerGroup } from '../domain';
@@ -12,6 +11,8 @@ import type { IFilterTag } from '../filterModel/FilterTags';
 import { FilterTags } from '../filterModel/FilterTags';
 import type { ISortFilter } from '../filterModel/IFilterModel';
 import { HelpField } from '../help';
+import type { IRouterInjectedProps } from '../navigation/routerContext';
+import { withRouter } from '../navigation/routerContext';
 import { LoadBalancerState } from '../state';
 import { Spinner } from '../widgets/spinners/Spinner';
 
@@ -27,19 +28,19 @@ export interface ILoadBalancersState {
   showInstances: boolean;
 }
 
-export class LoadBalancers extends React.Component<ILoadBalancersProps, ILoadBalancersState> {
+class LoadBalancersComponent extends React.Component<ILoadBalancersProps & IRouterInjectedProps, ILoadBalancersState> {
   private groupsUpdatedListener: Subscription;
   private loadBalancersRefreshUnsubscribe: () => any;
 
-  constructor(props: ILoadBalancersProps) {
+  constructor(props: ILoadBalancersProps & IRouterInjectedProps) {
     super(props);
-    const { $stateParams } = AngularServices;
+    const { stateParams } = props;
     this.state = {
       initialized: false,
       groups: [],
       tags: [],
-      showServerGroups: !$stateParams.hideServerGroups || true,
-      showInstances: $stateParams.showInstances || false,
+      showServerGroups: !stateParams.hideServerGroups || true,
+      showInstances: stateParams.showInstances || false,
     };
   }
 
@@ -96,7 +97,7 @@ export class LoadBalancers extends React.Component<ILoadBalancersProps, ILoadBal
     if (state.showInstances) {
       params.showInstances = true;
     }
-    AngularServices.$state.go('.', params);
+    this.props.stateService.go('.', params);
   }
 
   private handleInputChange = (event: any): void => {
@@ -116,7 +117,7 @@ export class LoadBalancers extends React.Component<ILoadBalancersProps, ILoadBal
     this.updateLoadBalancerGroups();
   };
 
-  public render(): React.ReactElement<LoadBalancers> {
+  public render(): React.ReactElement<LoadBalancersComponent> {
     const groupings = this.state.initialized ? (
       <div>
         {this.state.groups.map((group) => (
@@ -202,3 +203,6 @@ export class LoadBalancers extends React.Component<ILoadBalancersProps, ILoadBal
     );
   }
 }
+
+export const LoadBalancers = withRouter(LoadBalancersComponent);
+LoadBalancers.displayName = 'LoadBalancers';

--- a/deck/packages/core/src/loadBalancer/LoadBalancersTag.spec.tsx
+++ b/deck/packages/core/src/loadBalancer/LoadBalancersTag.spec.tsx
@@ -1,3 +1,4 @@
+import { UIRouterContext, UIRouterReact } from '@uirouter/react';
 import type { ReactWrapper } from 'enzyme';
 import { mount } from 'enzyme';
 import React from 'react';
@@ -14,9 +15,10 @@ describe('<LoadBalancersTag />', () => {
   const lb1 = { name: 'lb1', account: 'prod', region: 'us-east-1', vpcId: 'vpc-1' };
   const lb2 = { name: 'lb2', account: 'prod', region: 'us-east-1' };
 
-  let application: Application, component: ReactWrapper<ILoadBalancersTagProps, any>;
+  let application: Application, component: ReactWrapper<any, any>, router: UIRouterReact;
 
   beforeEach(async () => {
+    router = new UIRouterReact();
     application = ApplicationModelBuilder.createApplicationForTests('app', {
       key: 'loadBalancers',
       loader: () => Promise.resolve(application.loadBalancers.data),
@@ -25,6 +27,18 @@ describe('<LoadBalancersTag />', () => {
     });
     await application.loadBalancers.refresh();
   });
+
+  afterEach(() => {
+    component?.unmount();
+    router.dispose();
+  });
+
+  const mountTag = (props: ILoadBalancersTagProps) =>
+    mount(
+      <UIRouterContext.Provider value={router}>
+        <LoadBalancersTag {...props} />
+      </UIRouterContext.Provider>,
+    );
 
   it('extracts single load balancer from data', async () => {
     const serverGroup = {
@@ -38,7 +52,7 @@ describe('<LoadBalancersTag />', () => {
     application.getDataSource('loadBalancers').data = [lb1, lb2];
 
     const props: ILoadBalancersTagProps = { application, serverGroup };
-    component = mount(<LoadBalancersTag {...props} />);
+    component = mountTag(props);
 
     await Promise.resolve();
     await Promise.resolve();
@@ -59,7 +73,7 @@ describe('<LoadBalancersTag />', () => {
 
     const props: ILoadBalancersTagProps = { application, serverGroup };
     const popoverContainerEl = document.createElement('div');
-    component = mount(<LoadBalancersTag {...props} container={popoverContainerEl} />);
+    component = mountTag({ ...props, container: popoverContainerEl });
 
     await act(async () => {
       await Promise.resolve();

--- a/deck/packages/core/src/loadBalancer/LoadBalancersTag.tsx
+++ b/deck/packages/core/src/loadBalancer/LoadBalancersTag.tsx
@@ -2,10 +2,11 @@ import { sortBy } from 'lodash';
 import React from 'react';
 
 import type { ILoadBalancersTagProps } from './LoadBalancersTagWrapper';
-import { AngularServices } from '../angular/services';
 import type { ILoadBalancer } from '../domain';
 import { HealthCounts } from '../healthCounts/HealthCounts';
 import { LoadBalancerDataUtils } from './loadBalancerDataUtils';
+import type { IRouterInjectedProps } from '../navigation/routerContext';
+import { withRouter } from '../navigation/routerContext';
 import { HoverablePopover } from '../presentation';
 import { Tooltip } from '../presentation/Tooltip';
 import { logger } from '../utils';
@@ -58,10 +59,13 @@ export interface ILoadBalancersTagState {
   isLoading: boolean;
 }
 
-export class LoadBalancersTag extends React.Component<ILoadBalancersTagProps, ILoadBalancersTagState> {
+class LoadBalancersTagComponent extends React.Component<
+  ILoadBalancersTagProps & IRouterInjectedProps,
+  ILoadBalancersTagState
+> {
   private loadBalancersRefreshUnsubscribe: () => void;
 
-  constructor(props: ILoadBalancersTagProps) {
+  constructor(props: ILoadBalancersTagProps & IRouterInjectedProps) {
     super(props);
     this.state = {
       loadBalancers: [],
@@ -69,11 +73,13 @@ export class LoadBalancersTag extends React.Component<ILoadBalancersTagProps, IL
     };
   }
   private showLoadBalancerDetails = (loadBalancer: ILoadBalancer): void => {
-    const { $state } = AngularServices;
+    const { stateService } = this.props;
     const serverGroup = this.props.serverGroup;
     logger.log({ category: 'Cluster Pod', action: `Load Load Balancer Details (multiple menu)` });
-    const nextState = $state.current.name.endsWith('.clusters') ? '.loadBalancerDetails' : '^.loadBalancerDetails';
-    $state.go(nextState, {
+    const nextState = stateService.current.name.endsWith('.clusters')
+      ? '.loadBalancerDetails'
+      : '^.loadBalancerDetails';
+    stateService.go(nextState, {
       region: serverGroup.region,
       accountId: serverGroup.account,
       name: loadBalancer.name,
@@ -104,7 +110,7 @@ export class LoadBalancersTag extends React.Component<ILoadBalancersTagProps, IL
     this.loadBalancersRefreshUnsubscribe();
   }
 
-  public render(): React.ReactElement<LoadBalancersTag> {
+  public render(): React.ReactElement<LoadBalancersTagComponent> {
     const { loadBalancers, isLoading } = this.state;
 
     const totalCount = loadBalancers.length;
@@ -169,3 +175,6 @@ export class LoadBalancersTag extends React.Component<ILoadBalancersTagProps, IL
     );
   }
 }
+
+export const LoadBalancersTag = withRouter(LoadBalancersTagComponent);
+LoadBalancersTag.displayName = 'LoadBalancersTag';

--- a/deck/packages/core/src/loadBalancer/filter/LoadBalancerFilters.tsx
+++ b/deck/packages/core/src/loadBalancer/filter/LoadBalancerFilters.tsx
@@ -2,12 +2,13 @@ import { chain, cloneDeep, compact, debounce, map, uniq } from 'lodash';
 import React from 'react';
 import type { Subscription } from 'rxjs';
 
-import { AngularServices } from '../../angular/services';
 import type { Application } from '../../application';
 import { FilterSearch } from '../../cluster/filter/FilterSearch';
 import { FilterSection } from '../../cluster/filter/FilterSection';
 import type { ISortFilter } from '../../filterModel';
 import { digestDependentFilters, FilterCheckbox } from '../../filterModel';
+import type { IRouterInjectedProps } from '../../navigation/routerContext';
+import { locationChangeSuccess$, withRouter } from '../../navigation/routerContext';
 import { LoadBalancerState } from '../../state';
 
 const poolValueCoordinates = [
@@ -75,13 +76,16 @@ export interface ILoadBalancerFiltersState {
   detailHeadings: string[];
 }
 
-export class LoadBalancerFilters extends React.Component<ILoadBalancerFiltersProps, ILoadBalancerFiltersState> {
+class LoadBalancerFiltersComponent extends React.Component<
+  ILoadBalancerFiltersProps & IRouterInjectedProps,
+  ILoadBalancerFiltersState
+> {
   private debouncedUpdateLoadBalancerGroups: () => void;
   private groupsUpdatedSubscription: Subscription;
   private loadBalancersRefreshUnsubscribe: () => void;
   private locationChangeUnsubscribe: () => void;
 
-  constructor(props: ILoadBalancerFiltersProps) {
+  constructor(props: ILoadBalancerFiltersProps & IRouterInjectedProps) {
     super(props);
     this.state = {
       sortFilter: LoadBalancerState.filterModel.asFilterModel.sortFilter,
@@ -111,7 +115,7 @@ export class LoadBalancerFilters extends React.Component<ILoadBalancerFiltersPro
 
     this.loadBalancersRefreshUnsubscribe = app.loadBalancers.onRefresh(null, () => this.updateLoadBalancerGroups());
 
-    const locationChangeSubscription = AngularServices.stateEvents.locationChangeSuccess.subscribe(() => {
+    const locationChangeSubscription = locationChangeSuccess$(this.props.router).subscribe(() => {
       LoadBalancerState.filterModel.asFilterModel.activate();
       LoadBalancerState.filterService.updateLoadBalancerGroups(app);
     });
@@ -322,3 +326,6 @@ export class LoadBalancerFilters extends React.Component<ILoadBalancerFiltersPro
     );
   }
 }
+
+export const LoadBalancerFilters = withRouter(LoadBalancerFiltersComponent);
+LoadBalancerFilters.displayName = 'LoadBalancerFilters';

--- a/deck/packages/core/src/managed/externals/ManagedResourceDetailsIndicator.tsx
+++ b/deck/packages/core/src/managed/externals/ManagedResourceDetailsIndicator.tsx
@@ -1,6 +1,6 @@
+import { useRouter } from '@uirouter/react';
 import React from 'react';
 import { Dropdown, MenuItem } from 'react-bootstrap';
-import { AngularServices } from '../../angular/services';
 
 import type { Application } from '../../application';
 import { SETTINGS } from '../../config/settings';
@@ -31,6 +31,7 @@ export const ManagedResourceDetailsIndicator = ({
   resourceSummary,
   application,
 }: IManagedResourceDetailsIndicatorProps) => {
+  const { stateService } = useRouter();
   if (!resourceSummary) {
     return null;
   }
@@ -63,7 +64,7 @@ export const ManagedResourceDetailsIndicator = ({
   const appPausedHelpContent = `
     <p>Resource management is currently disabled for the entire application.
     <a
-      href=${AngularServices.$state.href('home.applications.application.config', {
+      href=${stateService.href('home.applications.application.config', {
         section: 'managed-resources',
       })}
     >

--- a/deck/packages/core/src/navigation/UrlBuilder.spec.ts
+++ b/deck/packages/core/src/navigation/UrlBuilder.spec.ts
@@ -1,0 +1,30 @@
+import { setDirectRouter } from './directRouter';
+import { UrlBuilder } from './UrlBuilder';
+import { Registry } from '../registry';
+
+describe('UrlBuilder', () => {
+  afterEach(() => setDirectRouter(null));
+
+  it('builds metadata URLs with the direct router state service', () => {
+    const href = jasmine.createSpy('href').and.returnValue('/applications/payments');
+    const stateService = { href } as any;
+    const build = jasmine
+      .createSpy('build')
+      .and.callFake((input: any, injectedStateService: any) =>
+        injectedStateService.href(
+          'home.applications.application',
+          { application: input.application },
+          { inherit: false },
+        ),
+      );
+    Registry.urlBuilder.register('direct-router-test', { build });
+    setDirectRouter({ stateService } as any);
+
+    const input = { application: 'payments', type: 'direct-router-test' };
+    const result = UrlBuilder.buildFromMetadata(input);
+
+    expect(build).toHaveBeenCalledWith(input, stateService);
+    expect(href).toHaveBeenCalledWith('home.applications.application', { application: 'payments' }, { inherit: false });
+    expect(result).toBe('/applications/payments');
+  });
+});

--- a/deck/packages/core/src/navigation/UrlBuilder.ts
+++ b/deck/packages/core/src/navigation/UrlBuilder.ts
@@ -1,7 +1,7 @@
 import type { StateService } from '@uirouter/core';
 import { isDate, isObject, isUndefined } from 'lodash';
 
-import { AngularServices } from '../angular/services';
+import { getDirectRouter } from './directRouter';
 import type { ITask } from '../domain';
 import { NameUtils } from '../naming';
 import { Registry } from '../registry';
@@ -42,7 +42,7 @@ interface IClusterFilter {
 }
 
 function getStateService(): StateService {
-  return AngularServices.$state as StateService;
+  return getDirectRouter()!.stateService;
 }
 
 class UrlBuilderUtils {

--- a/deck/packages/core/src/navigation/index.ts
+++ b/deck/packages/core/src/navigation/index.ts
@@ -1,5 +1,7 @@
 export * from './state.provider';
 export * from './rootState.registration';
+export * from './routerContext';
+export * from './directRouter';
 export * from './UrlBuilderRegistry';
 export * from './UrlBuilder';
 export * from './urlParser';

--- a/deck/packages/core/src/navigation/router.spec.ts
+++ b/deck/packages/core/src/navigation/router.spec.ts
@@ -5,13 +5,13 @@ import React from 'react';
 
 import { ApplicationDataSourceRegistry } from '../application/service/ApplicationDataSourceRegistry';
 import { ApplicationReader } from '../application/service/ApplicationReader';
-import { AngularServices } from '../angular/services';
 import { RecentHistoryService } from '../history';
 import { PageTitleService } from '../pageTitle';
 import { SpinErrorBoundary } from '../presentation';
 import { ProjectReader } from '../projects/service/ProjectReader';
 import './coreRoutes';
 import { getDirectRouter, setDirectRouter } from './directRouter';
+import { stateChangeSuccess$ } from './routerContext';
 import { registerRouteLifecycles } from './routeLifecycles';
 import { configureRouter, startRouter } from './router';
 import {
@@ -194,9 +194,7 @@ describe('configureRouter', () => {
 
     const router = createRouter();
     const stateChanges: string[] = [];
-    const subscription = AngularServices.stateEvents.stateChangeSuccess.subscribe(({ to }) =>
-      stateChanges.push(to.name),
-    );
+    const subscription = stateChangeSuccess$(router).subscribe(({ to }) => stateChanges.push(to.name));
 
     try {
       await router.stateService.go('home.registeredRoot');

--- a/deck/packages/core/src/navigation/router.ts
+++ b/deck/packages/core/src/navigation/router.ts
@@ -16,8 +16,7 @@ import {
 } from './state.provider';
 import { StateHelper } from './stateHelper.provider';
 
-export function configureRouter(): UIRouterReact {
-  const router = new UIRouterReact();
+export function configureRouter(router = new UIRouterReact()): UIRouterReact {
   try {
     router.plugin(servicesPlugin);
     router.plugin(hashLocationPlugin);

--- a/deck/packages/core/src/navigation/routerContext.spec.tsx
+++ b/deck/packages/core/src/navigation/routerContext.spec.tsx
@@ -1,0 +1,121 @@
+import { hashLocationPlugin, servicesPlugin, UIRouterContext, UIRouterReact } from '@uirouter/react';
+import { UIRouterRxPlugin } from '@uirouter/rx';
+import { mount } from 'enzyme';
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+
+import type { IRouterInjectedProps } from './routerContext';
+import { locationChangeSuccess$, stateChangeSuccess$, withRouter } from './routerContext';
+
+describe('direct router context', () => {
+  const routers: UIRouterReact[] = [];
+
+  function createRouter(): UIRouterReact {
+    const router = new UIRouterReact();
+    router.plugin(servicesPlugin);
+    router.plugin(hashLocationPlugin);
+    router.plugin(UIRouterRxPlugin);
+    router.stateRegistry.register({ name: 'root', url: '/root?value' });
+    router.stateRegistry.register({ name: 'root.child', url: '/child' });
+    routers.push(router);
+    return router;
+  }
+
+  afterEach(() => routers.splice(0).forEach((router) => router.dispose()));
+
+  it('injects the active state service and reactively updates params from router context', async () => {
+    interface IProbeProps extends IRouterInjectedProps {
+      values: string[];
+    }
+    class Probe extends React.Component<IProbeProps> {
+      public render(): React.ReactNode {
+        const { stateParams, stateService, values } = this.props;
+        values.push(stateParams.value);
+        return <a href={stateService.href('.child')}>{stateService.includes('root') ? stateParams.value : ''}</a>;
+      }
+    }
+    const RoutedProbe = withRouter(Probe);
+    const router = createRouter();
+    const values: string[] = [];
+    await router.stateService.go('root', { value: 'first' }, { location: false });
+    const wrapper = mount(
+      <UIRouterContext.Provider value={router}>
+        <RoutedProbe values={values} />
+      </UIRouterContext.Provider>,
+    );
+
+    expect(wrapper.find('a').prop('href')).toContain('/root/child');
+    expect(wrapper.find('a').text()).toBe('first');
+
+    await act(async () => {
+      await router.stateService.go('.', { value: 'second' }, { location: false, reload: true });
+    });
+    wrapper.update();
+
+    expect(values).toContain('second');
+    expect(wrapper.find('a').text()).toBe('second');
+    wrapper.unmount();
+  });
+
+  it('forwards refs to routed class components', () => {
+    class Probe extends React.Component<IRouterInjectedProps> {
+      public value = 'probe';
+
+      public render(): React.ReactNode {
+        return null;
+      }
+    }
+    const RoutedProbe = withRouter(Probe);
+    const router = createRouter();
+    const ref = React.createRef<Probe>();
+
+    const wrapper = mount(
+      <UIRouterContext.Provider value={router}>
+        <RoutedProbe ref={ref} />
+      </UIRouterContext.Provider>,
+    );
+
+    expect(ref.current?.value).toBe('probe');
+    wrapper.unmount();
+  });
+
+  it('maps successful transitions to the legacy payload without observing after unsubscribe', async () => {
+    const router = createRouter();
+    const changes: any[] = [];
+    const locations: string[] = [];
+    const stateSubscription = stateChangeSuccess$(router).subscribe((change) => changes.push(change));
+    const locationSubscription = locationChangeSuccess$(router).subscribe((location) => locations.push(location));
+
+    await router.stateService.go('root', { value: 'first' }, { location: false });
+
+    expect(changes[0].to.name).toBe('root');
+    expect(changes[0].toParams.value).toBe('first');
+    expect(changes[0].fromParams).toEqual({});
+    expect(locations[0]).toBe(window.location.href);
+
+    stateSubscription.unsubscribe();
+    locationSubscription.unsubscribe();
+    await router.stateService.go('.', { value: 'second' }, { location: false, reload: true });
+
+    expect(changes).toHaveSize(1);
+    expect(locations).toHaveSize(1);
+  });
+
+  it('observes only the explicitly configured router after disposal and reconfiguration', async () => {
+    const firstRouter = createRouter();
+    const firstChanges: string[] = [];
+    const firstSubscription = stateChangeSuccess$(firstRouter).subscribe(({ to }) => firstChanges.push(to.name));
+    await firstRouter.stateService.go('root', {}, { location: false });
+
+    firstSubscription.unsubscribe();
+    firstRouter.dispose();
+    const secondRouter = createRouter();
+    const secondChanges: string[] = [];
+    const secondSubscription = stateChangeSuccess$(secondRouter).subscribe(({ to }) => secondChanges.push(to.name));
+    await secondRouter.stateService.go('root.child', {}, { location: false });
+
+    expect(firstChanges).toEqual(['root']);
+    expect(secondChanges).toEqual(['root.child']);
+    secondSubscription.unsubscribe();
+  });
+});

--- a/deck/packages/core/src/navigation/routerContext.tsx
+++ b/deck/packages/core/src/navigation/routerContext.tsx
@@ -1,0 +1,54 @@
+import type { RawParams, StateDeclaration, StateService, UIRouter } from '@uirouter/core';
+import { useCurrentStateAndParams, useRouter } from '@uirouter/react';
+import React from 'react';
+import { Observable } from 'rxjs';
+
+export interface IRouterInjectedProps {
+  router: UIRouter;
+  stateParams: RawParams;
+  stateService: StateService;
+}
+
+export interface IRouterStateChange {
+  to: StateDeclaration;
+  from: StateDeclaration;
+  toParams: RawParams;
+  fromParams: RawParams;
+}
+
+export function withRouter<P extends IRouterInjectedProps>(
+  Component: React.ComponentType<P>,
+): React.ForwardRefExoticComponent<
+  React.PropsWithoutRef<React.PropsWithChildren<Omit<P, keyof IRouterInjectedProps>>> & React.RefAttributes<any>
+> {
+  type OuterProps = React.PropsWithChildren<Omit<P, keyof IRouterInjectedProps>>;
+  const RouterContextWrapper = React.forwardRef<any, OuterProps>((props, ref) => {
+    const router = useRouter();
+    const { params } = useCurrentStateAndParams();
+    const RoutedComponent = Component as any;
+    return (
+      <RoutedComponent {...props} ref={ref} router={router} stateParams={params} stateService={router.stateService} />
+    );
+  });
+  RouterContextWrapper.displayName = `withRouter(${Component.displayName || Component.name || 'Component'})`;
+  return RouterContextWrapper;
+}
+
+export function stateChangeSuccess$(router: UIRouter): Observable<IRouterStateChange> {
+  return new Observable((subscriber) =>
+    router.transitionService.onSuccess({}, (transition) =>
+      subscriber.next({
+        to: transition.to(),
+        toParams: transition.params('to'),
+        from: transition.from(),
+        fromParams: transition.params('from'),
+      }),
+    ),
+  );
+}
+
+export function locationChangeSuccess$(router: UIRouter): Observable<string> {
+  return new Observable((subscriber) =>
+    router.transitionService.onSuccess({}, () => subscriber.next(window.location.href)),
+  );
+}

--- a/deck/packages/core/src/orchestratedItem/orchestratedItem.transformer.spec.ts
+++ b/deck/packages/core/src/orchestratedItem/orchestratedItem.transformer.spec.ts
@@ -1,6 +1,12 @@
 import { OrchestratedItemTransformer } from './orchestratedItem.transformer';
+import { getDirectRouter, setDirectRouter } from '../navigation/directRouter';
 
 describe('orchestratedItem transformer', () => {
+  let previousRouter: ReturnType<typeof getDirectRouter>;
+
+  beforeEach(() => (previousRouter = getDirectRouter()));
+  afterEach(() => setDirectRouter(previousRouter));
+
   describe('failure message extraction', () => {
     const getMessage = (obj: any) => {
       OrchestratedItemTransformer.defineProperties(obj);
@@ -229,6 +235,50 @@ describe('orchestratedItem transformer', () => {
 
     it('returns null if no failure message is present', () => {
       expect(getMessage({ status: 'SUCCEEDED' })).toBe(null);
+    });
+
+    it('links to the task holding an orchestration lock', () => {
+      const href = jasmine.createSpy('href').and.returnValue('#/task');
+      setDirectRouter({ stateService: { href } } as any);
+
+      const message = getMessage({
+        context: {
+          exception: {
+            exceptionType: 'LockFailureException',
+            details: { currentLockValue: { application: 'app', id: 'task-id', type: 'orchestration' } },
+          },
+        },
+      });
+
+      expect(href).toHaveBeenCalledWith('home.applications.application.tasks.taskDetails', {
+        application: 'app',
+        taskId: 'task-id',
+      });
+      expect(message).toBe(
+        'Failed to acquire lock. An <a href="#/task">existing task</a> is currently operating on the cluster.',
+      );
+    });
+
+    it('links to the pipeline holding a pipeline lock', () => {
+      const href = jasmine.createSpy('href').and.returnValue('#/pipeline');
+      setDirectRouter({ stateService: { href } } as any);
+
+      const message = getMessage({
+        context: {
+          exception: {
+            exceptionType: 'LockFailureException',
+            details: { currentLockValue: { application: 'app', id: 'execution-id', type: 'pipeline' } },
+          },
+        },
+      });
+
+      expect(href).toHaveBeenCalledWith('home.applications.application.pipelines.executionDetails.execution', {
+        application: 'app',
+        executionId: 'execution-id',
+      });
+      expect(message).toBe(
+        'Failed to acquire lock. An <a href="#/pipeline">existing pipeline</a> is currently operating on the cluster.',
+      );
     });
   });
 });

--- a/deck/packages/core/src/orchestratedItem/orchestratedItem.transformer.ts
+++ b/deck/packages/core/src/orchestratedItem/orchestratedItem.transformer.ts
@@ -3,6 +3,7 @@ import { get, isNil } from 'lodash';
 import { AngularServices } from '../angular/services';
 
 import type { IOrchestratedItem, IOrchestratedItemVariable, ITask, ITaskStep } from '../domain';
+import { getDirectRouter } from '../navigation/directRouter';
 
 export class OrchestratedItemTransformer {
   public static addRunningTime(item: any): void {
@@ -173,18 +174,19 @@ export class OrchestratedItemTransformer {
     if (generalException) {
       const details: any = generalException.details;
       if (details && details.currentLockValue) {
+        const stateService = getDirectRouter()!.stateService;
         let typeDisplay: string;
         let linkUrl: string;
 
         if (details.currentLockValue.type === 'orchestration') {
           typeDisplay = 'task';
-          linkUrl = AngularServices.$state.href('home.applications.application.tasks.taskDetails', {
+          linkUrl = stateService.href('home.applications.application.tasks.taskDetails', {
             application: details.currentLockValue.application,
             taskId: details.currentLockValue.id,
           });
         } else {
           typeDisplay = 'pipeline';
-          linkUrl = AngularServices.$state.href('home.applications.application.pipelines.executionDetails.execution', {
+          linkUrl = stateService.href('home.applications.application.pipelines.executionDetails.execution', {
             application: details.currentLockValue.application,
             executionId: details.currentLockValue.id,
           });

--- a/deck/packages/core/src/pagerDuty/PageModal.tsx
+++ b/deck/packages/core/src/pagerDuty/PageModal.tsx
@@ -3,11 +3,12 @@ import React from 'react';
 import { Button, Modal } from 'react-bootstrap';
 
 import type { IPageButtonProps } from './PageButton';
-import { AngularServices } from '../angular/services';
 import type { Application } from '../application';
 import { ApplicationModelBuilder } from '../application';
 import { SETTINGS } from '../config';
 import { SubmitButton } from '../modal';
+import type { IRouterInjectedProps } from '../navigation/routerContext';
+import { withRouter } from '../navigation/routerContext';
 import type { IPagerDutyService } from './pagerDuty.read.service';
 import { PagerDutyWriter } from './pagerDuty.write.service';
 import { TaskMonitor, TaskMonitorWrapper } from '../task';
@@ -28,8 +29,8 @@ export interface IPageModalState {
   taskMonitor: TaskMonitor;
 }
 
-export class PageModal extends React.Component<IPageModalProps, IPageModalState> {
-  constructor(props: IPageModalProps) {
+class PageModalComponent extends React.Component<IPageModalProps & IRouterInjectedProps, IPageModalState> {
+  constructor(props: IPageModalProps & IRouterInjectedProps) {
     super(props);
     this.state = this.getDefaultState(props);
   }
@@ -40,14 +41,8 @@ export class PageModal extends React.Component<IPageModalProps, IPageModalState>
     }
   }
 
-  private getDefaultState(props: IPageModalProps): IPageModalState {
-    const {
-      $uiRouter: {
-        globals: {
-          params: { subject, details },
-        },
-      },
-    } = AngularServices;
+  private getDefaultState(props: IPageModalProps & IRouterInjectedProps): IPageModalState {
+    const { subject, details } = props.stateParams;
     const defaultSubject = subject || get(SETTINGS, 'pagerDuty.defaultSubject', 'Urgent Issue');
     const defaultDetails = details || get(SETTINGS, 'pagerDuty.defaultDetails', '');
 
@@ -69,13 +64,13 @@ export class PageModal extends React.Component<IPageModalProps, IPageModalState>
 
   private handleSubjectChanged = (event: any): void => {
     const value = event.target.value;
-    AngularServices.$state.go('.', { subject: value }, { location: 'replace' });
+    this.props.stateService.go('.', { subject: value }, { location: 'replace' });
     this.setState({ subject: value });
   };
 
   private handleDetailsChanged = (event: any): void => {
     const value = event.target.value;
-    AngularServices.$state.go('.', { details: value }, { location: 'replace' });
+    this.props.stateService.go('.', { details: value }, { location: 'replace' });
     this.setState({ details: value });
   };
 
@@ -180,3 +175,6 @@ export class PageModal extends React.Component<IPageModalProps, IPageModalState>
     );
   }
 }
+
+export const PageModal = withRouter(PageModalComponent);
+PageModal.displayName = 'PageModal';

--- a/deck/packages/core/src/pagerDuty/Pager.spec.tsx
+++ b/deck/packages/core/src/pagerDuty/Pager.spec.tsx
@@ -1,0 +1,75 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import { PagerComponent } from './Pager';
+
+describe('Pager', () => {
+  it('initializes filters from injected route params', () => {
+    const component = shallow(
+      <PagerComponent
+        {...({
+          router: {},
+          stateParams: {
+            app: 'test-app',
+            by: 'last',
+            direction: 'DESC',
+            hideNoApps: true,
+            keys: ['service-key'],
+            q: 'injected query',
+          },
+          stateService: {},
+        } as any)}
+      />,
+      { disableLifecycleMethods: true },
+    );
+
+    expect(component.state()).toEqual(
+      jasmine.objectContaining({
+        app: 'test-app',
+        filterString: 'injected query',
+        hideNoApps: true,
+        initialKeys: ['service-key'],
+        sortBy: 'last',
+        sortDirection: 'DESC',
+      }),
+    );
+  });
+
+  it('updates sorting through the injected state service', () => {
+    const injectedGo = jasmine.createSpy('injectedGo');
+
+    const component = shallow(
+      <PagerComponent {...({ router: {}, stateParams: {}, stateService: { go: injectedGo } } as any)} />,
+      { disableLifecycleMethods: true },
+    );
+
+    (component.instance() as PagerComponent).sort({ sortBy: 'last', sortDirection: 'DESC' });
+
+    expect(injectedGo).toHaveBeenCalledWith('.', { by: 'last', direction: 'DESC' });
+  });
+
+  it('updates selected service keys through the injected state service', () => {
+    const injectedGo = jasmine.createSpy('injectedGo');
+    const component = shallow(
+      <PagerComponent {...({ router: {}, stateParams: {}, stateService: { go: injectedGo } } as any)} />,
+      { disableLifecycleMethods: true },
+    );
+    const service = { integration_key: 'service-key' } as any;
+
+    (component.instance() as any).selectedChanged(service, true);
+
+    expect(injectedGo).toHaveBeenCalledWith('.', { keys: ['service-key'] });
+  });
+
+  it('updates application visibility through the injected state service', () => {
+    const injectedGo = jasmine.createSpy('injectedGo');
+    const component = shallow(
+      <PagerComponent {...({ router: {}, stateParams: {}, stateService: { go: injectedGo } } as any)} />,
+      { disableLifecycleMethods: true },
+    );
+
+    (component.instance() as any).handleHideNoAppsChanged({ target: { checked: true } });
+
+    expect(injectedGo).toHaveBeenCalledWith('.', { hideNoApps: true });
+  });
+});

--- a/deck/packages/core/src/pagerDuty/Pager.tsx
+++ b/deck/packages/core/src/pagerDuty/Pager.tsx
@@ -10,10 +10,11 @@ import { AutoSizer, CellMeasurer, CellMeasurerCache, Column, SortDirection, Tabl
 import { forkJoin as observableForkJoin, from as observableFrom } from 'rxjs';
 
 import { PageButton } from './PageButton';
-import { AngularServices } from '../angular/services';
 import type { IApplicationSummary } from '../application';
 import { ApplicationReader } from '../application';
 import { SETTINGS } from '../config';
+import type { IRouterInjectedProps } from '../navigation/routerContext';
+import { withRouter } from '../navigation/routerContext';
 import { Overridable } from '../overrideRegistry';
 import type { IOnCall, IPagerDutyService } from './pagerDuty.read.service';
 import { PagerDutyReader } from './pagerDuty.read.service';
@@ -85,7 +86,7 @@ class PagerBanner extends React.Component {
   }
 }
 
-export class Pager extends React.Component<IPagerProps, IPagerState> {
+export class PagerComponent extends React.Component<IPagerProps & IRouterInjectedProps, IPagerState> {
   private cache = new CellMeasurerCache({
     defaultHeight: 50,
     fixedWidth: true,
@@ -93,19 +94,19 @@ export class Pager extends React.Component<IPagerProps, IPagerState> {
   private allData: IOnCallsByService[] = [];
   private searchApi = new SearchApi();
 
-  constructor(props: IPagerProps) {
+  constructor(props: IPagerProps & IRouterInjectedProps) {
     super(props);
 
-    const { $stateParams } = AngularServices;
+    const { stateParams } = props;
     this.state = {
       accountName: (SETTINGS.pagerDuty && SETTINGS.pagerDuty.accountName) || '',
-      app: $stateParams.app || '',
-      filterString: $stateParams.q || '',
-      hideNoApps: $stateParams.hideNoApps || false,
+      app: stateParams.app || '',
+      filterString: stateParams.q || '',
+      hideNoApps: stateParams.hideNoApps || false,
       notFoundApps: [],
-      initialKeys: $stateParams.keys || [],
-      sortBy: $stateParams.by || 'service',
-      sortDirection: $stateParams.direction || SortDirection.ASC,
+      initialKeys: stateParams.keys || [],
+      sortBy: stateParams.by || 'service',
+      sortDirection: stateParams.direction || SortDirection.ASC,
       sortedData: [],
       selectedKeys: new Map(),
     };
@@ -147,7 +148,7 @@ export class Pager extends React.Component<IPagerProps, IPagerState> {
     const { sortedData } = this.state;
 
     if (sortBy !== this.state.sortBy || sortDirection !== this.state.sortDirection) {
-      AngularServices.$state.go('.', { by: sortBy, direction: sortDirection });
+      this.props.stateService.go('.', { by: sortBy, direction: sortDirection });
       this.sortList(sortedData, sortBy, sortDirection);
       this.cache.clearAll();
       this.setState({ sortedData, sortBy, sortDirection });
@@ -210,7 +211,7 @@ export class Pager extends React.Component<IPagerProps, IPagerState> {
       this.setState({ selectedKeys });
     }
 
-    AngularServices.$state.go('.', {
+    this.props.stateService.go('.', {
       app,
       q: filterString,
       by: sortBy,
@@ -293,7 +294,7 @@ export class Pager extends React.Component<IPagerProps, IPagerState> {
   private selectedChanged = (service: IPagerDutyService, value: boolean): void => {
     const { selectedKeys } = this.state;
     value ? selectedKeys.set(service.integration_key, service) : selectedKeys.delete(service.integration_key);
-    AngularServices.$state.go('.', { keys: Array.from(selectedKeys.keys()) });
+    this.props.stateService.go('.', { keys: Array.from(selectedKeys.keys()) });
     this.setState({ selectedKeys });
   };
 
@@ -459,7 +460,7 @@ export class Pager extends React.Component<IPagerProps, IPagerState> {
   private handleHideNoAppsChanged = (event: React.ChangeEvent<HTMLInputElement>): void => {
     const hideNoApps = event.target.checked;
     this.setState({ hideNoApps });
-    AngularServices.$state.go('.', { hideNoApps });
+    this.props.stateService.go('.', { hideNoApps });
   };
 
   private rowClicked = (info: RowMouseEventHandlerParams): void => {
@@ -629,3 +630,5 @@ export class Pager extends React.Component<IPagerProps, IPagerState> {
     );
   }
 }
+
+export const Pager = withRouter(PagerComponent);

--- a/deck/packages/core/src/pipeline/config/CreatePipeline.tsx
+++ b/deck/packages/core/src/pipeline/config/CreatePipeline.tsx
@@ -1,7 +1,7 @@
+import { useRouter } from '@uirouter/react';
 import { get } from 'lodash';
 import React from 'react';
 import { Dropdown } from 'react-bootstrap';
-import { AngularServices } from '../../angular/services';
 
 import type { Application } from '../../application';
 import { CreatePipelineButton } from '../create/CreatePipelineButton';
@@ -73,13 +73,13 @@ export class CreatePipeline extends React.Component<ICreatePipelineProps> {
 }
 
 const Pipeline = (props: { pipeline: any; type: 'pipeline' | 'strategy' }): JSX.Element => {
+  const { stateService } = useRouter();
   const clicked = () => {
     logger.log({ category: 'Pipelines', action: `Configure ${props.type} (via top level)` });
-    const { $state } = AngularServices;
-    if (!$state.current.name.includes('.executions.execution')) {
-      $state.go('^.pipelineConfig', { pipelineId: props.pipeline.id });
+    if (!stateService.current.name.includes('.executions.execution')) {
+      stateService.go('^.pipelineConfig', { pipelineId: props.pipeline.id });
     } else {
-      $state.go('^.^.pipelineConfig', { pipelineId: props.pipeline.id });
+      stateService.go('^.^.pipelineConfig', { pipelineId: props.pipeline.id });
     }
   };
   return (

--- a/deck/packages/core/src/pipeline/config/PipelineConfigPage.spec.tsx
+++ b/deck/packages/core/src/pipeline/config/PipelineConfigPage.spec.tsx
@@ -1,3 +1,4 @@
+import { UIRouterContext, UIRouterReact } from '@uirouter/react';
 import { mount } from 'enzyme';
 import { cloneDeep } from 'lodash';
 import React from 'react';
@@ -17,7 +18,7 @@ import { PipelineConfigActions } from './actions/PipelineConfigActions';
 import {
   applyStageConfigDefaults,
   COMMON_STAGE_FIELDS,
-  PipelineConfigPage,
+  PipelineConfigPageComponent,
   STAGE_IDENTITY_FIELDS,
 } from './PipelineConfigPage';
 import { PipelineGraph } from './graph/PipelineGraph';
@@ -33,6 +34,21 @@ describe('PipelineConfigPage', () => {
   let $stateParams: { executionId?: string; new?: string; pipelineId?: string };
   let fiatEnabled: boolean;
   let providerRenderStates: boolean[];
+  let router: UIRouterReact;
+  let stateGo: jasmine.Spy;
+  let transitionCleanup: jasmine.Spy;
+  let transitionOnBefore: jasmine.Spy;
+
+  const PipelineConfigPage = (props: any) => (
+    <UIRouterContext.Provider value={router}>
+      <PipelineConfigPageComponent
+        {...props}
+        router={router}
+        stateParams={$stateParams}
+        stateService={{ go: stateGo } as any}
+      />
+    </UIRouterContext.Provider>
+  );
 
   const AwsStageConfig = () => <div className="aws-stage-config">AWS stage config</div>;
   const EcsStageConfig = ({ stage }: { stage: any }) => {
@@ -272,7 +288,10 @@ describe('PipelineConfigPage', () => {
 
   beforeEach(() => {
     $stateParams = {};
-    spyOnProperty(AngularServices, '$stateParams', 'get').and.returnValue($stateParams as any);
+    router = new UIRouterReact();
+    stateGo = jasmine.createSpy('stateGo');
+    transitionCleanup = jasmine.createSpy('transitionCleanup');
+    transitionOnBefore = spyOn(router.transitionService, 'onBefore').and.returnValue(transitionCleanup);
     fiatEnabled = SETTINGS.feature.fiatEnabled;
     providerRenderStates = [];
     Registry.reinitialize();
@@ -283,6 +302,7 @@ describe('PipelineConfigPage', () => {
   });
 
   afterEach(() => {
+    router.dispose();
     SETTINGS.feature = { ...SETTINGS.feature, fiatEnabled };
     Registry.reinitialize();
     ViewStateCache.get('pipelineConfig').removeAll();
@@ -303,6 +323,23 @@ describe('PipelineConfigPage', () => {
     expect(wrapper.find('.pipeline-config-heading h3').text()).toContain('Requested Pipeline');
 
     wrapper.unmount();
+  });
+
+  it('uses the injected router for transition guarding and back navigation', async () => {
+    const requested = pipeline('target-id', 'Requested Pipeline');
+    const app = createApp([requested]);
+    $stateParams.pipelineId = requested.id;
+
+    const wrapper = mount(<PipelineConfigPage app={app} />);
+    await flush();
+    wrapper.update();
+
+    wrapper.find('.btn-configure').simulate('click');
+    expect(stateGo).toHaveBeenCalledWith('^.executions');
+    expect(transitionOnBefore).toHaveBeenCalledWith({}, jasmine.any(Function));
+
+    wrapper.unmount();
+    expect(transitionCleanup).toHaveBeenCalled();
   });
 
   it('renders the React pipeline config layout wrappers', async () => {
@@ -630,7 +667,6 @@ describe('PipelineConfigPage', () => {
     const plan = { ...pipeline(requested.id, requested.name), stages: [] } as IPipeline;
     const app = createApp([requested]);
     $stateParams.pipelineId = requested.id;
-    spyOn(AngularServices, 'has').and.returnValue(false);
     spyOn(PipelineTemplateReader, 'getPipelinePlan').and.returnValue(Promise.resolve(plan));
 
     const wrapper = mount(<PipelineConfigPage app={app} />);

--- a/deck/packages/core/src/pipeline/config/PipelineConfigPage.tsx
+++ b/deck/packages/core/src/pipeline/config/PipelineConfigPage.tsx
@@ -25,6 +25,8 @@ import { CopyStageModal } from './copyStage/CopyStageModal';
 import type { IExpectedArtifact, INotification, IPipeline, IStage, IStageTypeConfig } from '../../domain';
 import { PipelineGraph } from './graph/PipelineGraph';
 import type { IPipelineGraphNode } from './graph/pipelineGraph.service';
+import type { IRouterInjectedProps } from '../../navigation/routerContext';
+import { withRouter } from '../../navigation/routerContext';
 import { NotificationsList } from '../../notification';
 import { Markdown, PageNavigator, PageSection, ReactModal, ReactSelectInput } from '../../presentation';
 import { Registry } from '../../registry';
@@ -205,9 +207,9 @@ function buildStageRoleOptions(permissions: any): any[] {
   }));
 }
 
-function useUnsavedChangeGuard(isDirty: boolean): void {
+function useUnsavedChangeGuard(router: IRouterInjectedProps['router'], isDirty: boolean): void {
   React.useEffect(() => {
-    const removeTransitionGuard = AngularServices.$uiRouter.transitionService.onBefore({}, () => {
+    const removeTransitionGuard = router.transitionService.onBefore({}, () => {
       if (isDirty && !window.confirm(warningMessage)) {
         return false;
       }
@@ -225,7 +227,7 @@ function useUnsavedChangeGuard(isDirty: boolean): void {
       removeTransitionGuard();
       window.onbeforeunload = undefined;
     };
-  }, [isDirty]);
+  }, [router, isDirty]);
 }
 
 async function refreshDataSource(dataSource: any, force?: boolean): Promise<void> {
@@ -660,7 +662,7 @@ function PipelineStageConfig({
           </button>
         </div>
       </div>
-      <PageNavigator scrollableContainer=".pipeline-config-page" hideNavigation={true} reactInjector={AngularServices}>
+      <PageNavigator scrollableContainer=".pipeline-config-page" hideNavigation={true}>
         <PageSection pageKey="stage" label={`${label} Configuration`}>
           <div className="stage-details">{renderStageDetails()}</div>
         </PageSection>
@@ -755,8 +757,13 @@ function PipelineStageConfig({
   );
 }
 
-export function PipelineConfigPage({ app, className }: IPipelineConfigPageProps) {
-  const params = AngularServices.$stateParams;
+export function PipelineConfigPageComponent({
+  app,
+  className,
+  router,
+  stateParams: params,
+  stateService,
+}: IPipelineConfigPageProps & IRouterInjectedProps) {
   const pipelineId = params.pipelineId as string;
   const executionId = params.executionId as string;
   const isNew = params.new as string;
@@ -945,7 +952,7 @@ export function PipelineConfigPage({ app, className }: IPipelineConfigPageProps)
     }
   }, [app.name, model?.pipeline?.id, viewState?.section, viewState?.stageIndex]);
 
-  useUnsavedChangeGuard(!!viewState?.isDirty);
+  useUnsavedChangeGuard(router, !!viewState?.isDirty);
 
   const markDirty = (pipeline = model?.pipeline) => {
     if (!pipeline || !viewState?.original) {
@@ -1223,7 +1230,7 @@ export function PipelineConfigPage({ app, className }: IPipelineConfigPageProps)
   const saveTemplate = (template: any) => {
     return PipelineTemplateWriter.savePipelineTemplateV2(template).then((response) => {
       const id = response.variables.find((variable: any) => variable.key === 'pipelineTemplate.id').value;
-      AngularServices.$state.go('home.pipeline-templates.pipeline-templates-detail', {
+      stateService.go('home.pipeline-templates.pipeline-templates-detail', {
         templateId: PipelineTemplateV2Service.idForTemplate({ id }),
       });
       return true;
@@ -1274,7 +1281,7 @@ export function PipelineConfigPage({ app, className }: IPipelineConfigPageProps)
             <div className="pipeline-config-heading">
               <div className="config-heading-row">
                 <h3>
-                  <a className="btn btn-configure" onClick={() => AngularServices.$state.go('^.executions')}>
+                  <a className="btn btn-configure" onClick={() => stateService.go('^.executions')}>
                     <span className="glyphicon glyphicon glyphicon-circle-arrow-left" />
                   </a>{' '}
                   <a className="nav-popover">{pipeline.name}</a>
@@ -1460,3 +1467,5 @@ export function PipelineConfigPage({ app, className }: IPipelineConfigPageProps)
     </div>
   );
 }
+
+export const PipelineConfigPage = withRouter(PipelineConfigPageComponent);

--- a/deck/packages/core/src/pipeline/config/actions/delete/DeletePipelineModal.tsx
+++ b/deck/packages/core/src/pipeline/config/actions/delete/DeletePipelineModal.tsx
@@ -1,3 +1,4 @@
+import { useRouter } from '@uirouter/react';
 import { get, isEmpty, set } from 'lodash';
 import React from 'react';
 import { Modal } from 'react-bootstrap';
@@ -16,6 +17,7 @@ export interface IDeletePipelineModalProps extends IModalComponentProps {
 }
 
 export function DeletePipelineModal(props: IDeletePipelineModalProps) {
+  const { stateService } = useRouter();
   const [errorMessage, setErrorMessage] = React.useState<string>(null);
   const [deleteError, setDeleteError] = React.useState<boolean>(false);
   const [deleting, setDeleting] = React.useState<boolean>(false);
@@ -42,7 +44,7 @@ export function DeletePipelineModal(props: IDeletePipelineModalProps) {
         if (!isEmpty(idsToUpdatedIndices)) {
           PipelineConfigService.reorderPipelines(application.name, idsToUpdatedIndices, isPipelineStrategy);
         }
-        AngularServices.$state.go('^.executions', null, { location: 'replace' });
+        stateService.go('^.executions', null, { location: 'replace' });
         closeModal();
       },
       (response) => {

--- a/deck/packages/core/src/pipeline/config/stages/cloneServerGroup/CloneServerGroupExecutionDetails.spec.tsx
+++ b/deck/packages/core/src/pipeline/config/stages/cloneServerGroup/CloneServerGroupExecutionDetails.spec.tsx
@@ -1,0 +1,37 @@
+import { CloneServerGroupExecutionDetailsComponent } from './CloneServerGroupExecutionDetails';
+import { setDirectRouter } from '../../../../navigation/directRouter';
+
+describe('CloneServerGroupExecutionDetails', () => {
+  beforeEach(() => {
+    const params = { project: 'facade-project' };
+    setDirectRouter({ globals: { params }, stateService: { params, href: () => '' } } as any);
+  });
+
+  afterEach(() => setDirectRouter(null));
+
+  it('uses the injected project route param for deployed server group links', () => {
+    const component = new CloneServerGroupExecutionDetailsComponent({
+      stage: {
+        context: {
+          application: 'application',
+          cloudProvider: 'aws',
+          credentials: 'account',
+          'kato.tasks': [
+            {
+              resultObjects: {
+                deploy: { serverGroupNames: ['us-east-1:server-group'] },
+              },
+            },
+          ],
+        },
+      },
+      stateParams: { project: 'injected-project' },
+    } as any);
+    spyOn(component, 'setState');
+
+    (component as any).addDeployedArtifacts(component.props);
+
+    const deployResults = (component.setState as jasmine.Spy).calls.mostRecent().args[0].deployResults;
+    expect(deployResults[0].project).toBe('injected-project');
+  });
+});

--- a/deck/packages/core/src/pipeline/config/stages/cloneServerGroup/CloneServerGroupExecutionDetails.tsx
+++ b/deck/packages/core/src/pipeline/config/stages/cloneServerGroup/CloneServerGroupExecutionDetails.tsx
@@ -2,11 +2,12 @@ import { find, get } from 'lodash';
 import React from 'react';
 
 import { AccountTag } from '../../../../account';
-import { AngularServices } from '../../../../angular/services';
 import type { IExecutionDetailsSectionProps } from '../common';
 import { ExecutionDetailsSection } from '../common';
 import { StageFailureMessage } from '../../../details';
 import { UrlBuilder } from '../../../../navigation';
+import type { IRouterInjectedProps } from '../../../../navigation/routerContext';
+import { withRouter } from '../../../../navigation/routerContext';
 import { ClusterState } from '../../../../state';
 
 export interface IDeployResult {
@@ -24,18 +25,18 @@ export interface ICloneServerGroupExecutionDetailsState {
   deployResults: IDeployResult[];
 }
 
-export class CloneServerGroupExecutionDetails extends React.Component<
-  IExecutionDetailsSectionProps,
+export class CloneServerGroupExecutionDetailsComponent extends React.Component<
+  IExecutionDetailsSectionProps & IRouterInjectedProps,
   ICloneServerGroupExecutionDetailsState
 > {
   public static title = 'cloneServerGroupConfig';
 
-  constructor(props: IExecutionDetailsSectionProps) {
+  constructor(props: IExecutionDetailsSectionProps & IRouterInjectedProps) {
     super(props);
     this.state = { deployResults: [] };
   }
 
-  private addDeployedArtifacts(props: IExecutionDetailsSectionProps): void {
+  private addDeployedArtifacts(props: IExecutionDetailsSectionProps & IRouterInjectedProps): void {
     const context = get(props, 'stage.context', {} as any);
     const tasks = context['kato.tasks'] ?? [];
     if (tasks.length === 0) {
@@ -60,7 +61,7 @@ export class CloneServerGroupExecutionDetails extends React.Component<
           account: context.credentials,
           region,
           provider: context.cloudProvider ?? 'aws',
-          project: AngularServices.$stateParams.project,
+          project: props.stateParams.project,
         };
         result.href = UrlBuilder.buildFromMetadata(result);
         return result;
@@ -73,7 +74,7 @@ export class CloneServerGroupExecutionDetails extends React.Component<
     this.addDeployedArtifacts(this.props);
   }
 
-  public componentWillReceiveProps(nextProps: IExecutionDetailsSectionProps) {
+  public componentWillReceiveProps(nextProps: IExecutionDetailsSectionProps & IRouterInjectedProps) {
     if (nextProps.stage !== this.props.stage) {
       this.addDeployedArtifacts(nextProps);
     }
@@ -126,6 +127,10 @@ export class CloneServerGroupExecutionDetails extends React.Component<
     );
   }
 }
+
+export const CloneServerGroupExecutionDetails = Object.assign(withRouter(CloneServerGroupExecutionDetailsComponent), {
+  title: CloneServerGroupExecutionDetailsComponent.title,
+});
 
 const DeployedServerGroup = (props: { result: IDeployResult }): JSX.Element => {
   const deployClicked = (event: React.MouseEvent<HTMLAnchorElement>) => {

--- a/deck/packages/core/src/pipeline/config/stages/common/ExecutionBarLabel.spec.tsx
+++ b/deck/packages/core/src/pipeline/config/stages/common/ExecutionBarLabel.spec.tsx
@@ -1,0 +1,17 @@
+import { ExecutionBarLabelComponent } from './ExecutionBarLabel';
+
+describe('ExecutionBarLabel', () => {
+  it('uses injected route params to include the active grouped stage name', () => {
+    const component = new ExecutionBarLabelComponent({
+      stage: {
+        groupStages: [{ name: 'Child stage' }],
+        index: 987654,
+        name: 'Parent stage',
+        type: 'group',
+      },
+      stateParams: { stage: '987654', subStage: '0' },
+    } as any);
+
+    expect((component as any).getRenderableStageName()).toBe('Parent stage: Child stage');
+  });
+});

--- a/deck/packages/core/src/pipeline/config/stages/common/ExecutionBarLabel.tsx
+++ b/deck/packages/core/src/pipeline/config/stages/common/ExecutionBarLabel.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import { OverlayTrigger, Tooltip } from 'react-bootstrap';
-import { AngularServices } from '../../../../angular/services';
 
+import { AngularServices } from '../../../../angular/services';
 import type { IExecutionStageLabelProps } from '../../../../domain';
 import { ExecutionWindowActions } from '../executionWindows/ExecutionWindowActions';
+import type { IRouterInjectedProps } from '../../../../navigation/routerContext';
+import { withRouter } from '../../../../navigation/routerContext';
 import { HoverablePopover } from '../../../../presentation/HoverablePopover';
 import { SkipConditionWait } from '../waitForCondition/SkipConditionWait';
 import { Spinner } from '../../../../widgets/spinners/Spinner';
@@ -19,10 +21,13 @@ export interface IExecutionBarLabelState {
   hydrated: boolean;
 }
 
-export class ExecutionBarLabel extends React.Component<IExecutionBarLabelProps, IExecutionBarLabelState> {
+export class ExecutionBarLabelComponent extends React.Component<
+  IExecutionBarLabelProps & IRouterInjectedProps,
+  IExecutionBarLabelState
+> {
   private mounted = false;
 
-  constructor(props: IExecutionBarLabelProps) {
+  constructor(props: IExecutionBarLabelProps & IRouterInjectedProps) {
     super(props);
     this.state = {
       hydrated: props.execution && props.execution.hydrated,
@@ -99,11 +104,10 @@ export class ExecutionBarLabel extends React.Component<IExecutionBarLabelProps, 
   };
 
   private getRenderableStageName(): string {
-    const { stage } = this.props;
+    const { stage, stateParams } = this.props;
     let stageName = stage.name ? stage.name : stage.type;
-    const params = AngularServices.$uiRouter.globals.params;
-    if (stage.type === 'group' && stage.groupStages && stage.index === Number(params.stage)) {
-      const subStageIndex = Number(params.subStage);
+    if (stage.type === 'group' && stage.groupStages && stage.index === Number(stateParams.stage)) {
+      const subStageIndex = Number(stateParams.subStage);
       if (!Number.isNaN(subStageIndex)) {
         const activeStage = stage.groupStages[subStageIndex];
         if (activeStage) {
@@ -142,3 +146,6 @@ export class ExecutionBarLabel extends React.Component<IExecutionBarLabelProps, 
     return <span>{this.getRenderableStageName()}</span>;
   }
 }
+
+export const ExecutionBarLabel = withRouter(ExecutionBarLabelComponent);
+ExecutionBarLabel.displayName = 'ExecutionBarLabel';

--- a/deck/packages/core/src/pipeline/config/stages/common/StepExecutionDetails.spec.tsx
+++ b/deck/packages/core/src/pipeline/config/stages/common/StepExecutionDetails.spec.tsx
@@ -1,0 +1,38 @@
+import { StepExecutionDetailsComponent } from './StepExecutionDetails';
+import { setDirectRouter } from '../../../../navigation/directRouter';
+
+describe('StepExecutionDetails router context', () => {
+  beforeEach(() => {
+    const params = { details: 'facade-details' };
+    setDirectRouter({ globals: { params }, stateService: { params } } as any);
+  });
+
+  afterEach(() => setDirectRouter(null));
+
+  it('synchronizes the current section from injected route params', () => {
+    const component = new StepExecutionDetailsComponent({
+      detailsSections: [],
+      stateParams: { details: 'injected-details' },
+    } as any);
+    spyOn(component, 'setState');
+
+    component.updateCurrentSection();
+
+    expect(component.setState).toHaveBeenCalledWith({ currentSection: 'injected-details' });
+  });
+
+  it('synchronizes the current section from the next routed props', () => {
+    const component = new StepExecutionDetailsComponent({
+      detailsSections: [],
+      stateParams: { details: 'first-details' },
+    } as any);
+    spyOn(component, 'setState');
+
+    component.componentWillReceiveProps({
+      detailsSections: [],
+      stateParams: { details: 'second-details' },
+    } as any);
+
+    expect(component.setState).toHaveBeenCalledWith({ currentSection: 'second-details' });
+  });
+});

--- a/deck/packages/core/src/pipeline/config/stages/common/StepExecutionDetails.tsx
+++ b/deck/packages/core/src/pipeline/config/stages/common/StepExecutionDetails.tsx
@@ -1,13 +1,18 @@
 import { isEqual } from 'lodash';
 import React from 'react';
-import { AngularServices } from '../../../../angular/services';
 
+import { AngularServices } from '../../../../angular/services';
 import { ExecutionDetailsSectionNav } from '../../../details';
 import type { IExecutionDetailsProps, IExecutionDetailsState } from '../../../../domain';
+import type { IRouterInjectedProps } from '../../../../navigation/routerContext';
+import { withRouter } from '../../../../navigation/routerContext';
 import { SpinErrorBoundary } from '../../../../presentation';
 
-export class StepExecutionDetails extends React.Component<IExecutionDetailsProps, IExecutionDetailsState> {
-  constructor(props: IExecutionDetailsProps) {
+export class StepExecutionDetailsComponent extends React.Component<
+  IExecutionDetailsProps & IRouterInjectedProps,
+  IExecutionDetailsState
+> {
+  constructor(props: IExecutionDetailsProps & IRouterInjectedProps) {
     super(props);
     this.state = {
       configSections: this.getDetailsSections(props).map((s) => s.title),
@@ -19,16 +24,19 @@ export class StepExecutionDetails extends React.Component<IExecutionDetailsProps
     return props.detailsSections.filter((section) => !section.shouldShow || section.shouldShow(props));
   }
 
-  public updateCurrentSection(): void {
-    const currentSection = AngularServices.$stateParams.details;
+  public updateCurrentSection(props: IExecutionDetailsProps & IRouterInjectedProps = this.props): void {
+    const currentSection = props.stateParams.details;
     if (this.state.currentSection !== currentSection) {
       this.setState({ currentSection });
     }
   }
 
-  public syncDetails(configSections: string[]): void {
+  public syncDetails(
+    configSections: string[],
+    props: IExecutionDetailsProps & IRouterInjectedProps = this.props,
+  ): void {
     AngularServices.executionDetailsSectionService.synchronizeSection(configSections, () =>
-      this.updateCurrentSection(),
+      this.updateCurrentSection(props),
     );
   }
 
@@ -36,14 +44,13 @@ export class StepExecutionDetails extends React.Component<IExecutionDetailsProps
     this.syncDetails(this.state.configSections);
   }
 
-  public componentWillReceiveProps(nextProps: IExecutionDetailsProps): void {
+  public componentWillReceiveProps(nextProps: IExecutionDetailsProps & IRouterInjectedProps): void {
     const configSections = this.getDetailsSections(nextProps).map((s) => s.title);
     if (!isEqual(this.state.configSections, configSections)) {
       this.setState({ configSections });
-      this.syncDetails(configSections);
-    } else {
-      this.updateCurrentSection();
+      this.syncDetails(configSections, nextProps);
     }
+    this.updateCurrentSection(nextProps);
   }
 
   public render() {
@@ -61,3 +68,5 @@ export class StepExecutionDetails extends React.Component<IExecutionDetailsProps
     );
   }
 }
+
+export const StepExecutionDetails = withRouter(StepExecutionDetailsComponent);

--- a/deck/packages/core/src/pipeline/config/stages/deploy/DeployExecutionDetails.spec.ts
+++ b/deck/packages/core/src/pipeline/config/stages/deploy/DeployExecutionDetails.spec.ts
@@ -1,7 +1,13 @@
 import { CloudProviderRegistry } from '../../../../cloudProvider/CloudProviderRegistry';
 import type { IExecutionStage } from '../../../../domain';
+import { setDirectRouter } from '../../../../navigation/directRouter';
 import { UrlBuilder } from '../../../../navigation/UrlBuilder';
-import { getDeployedServerGroups, getDeployWaitingMessages, hasDeployChanges } from './DeployExecutionDetails';
+import {
+  DeployExecutionDetailsComponent,
+  getDeployedServerGroups,
+  getDeployWaitingMessages,
+  hasDeployChanges,
+} from './DeployExecutionDetails';
 
 describe('DeployExecutionDetails helpers', () => {
   let originalGetValue: typeof CloudProviderRegistry.getValue;
@@ -12,8 +18,12 @@ describe('DeployExecutionDetails helpers', () => {
   });
 
   beforeEach(() => {
+    const params = { project: 'facade-project' };
+    setDirectRouter({ globals: { params }, stateService: { params, href: () => 'facade-config' } } as any);
     spyOn(UrlBuilder, 'buildFromMetadata').and.returnValue('#/server-group');
   });
+
+  afterEach(() => setDirectRouter(null));
 
   afterAll(() => {
     CloudProviderRegistry.getValue = originalGetValue;
@@ -67,6 +77,34 @@ describe('DeployExecutionDetails helpers', () => {
       expect(deployed.length).toBe(2);
       expect(deployed[0].serverGroup).toBe('deployedWest');
       expect(deployed[1].serverGroup).toBe('deployedEast');
+    });
+
+    it('uses the injected project route param for deployed server group links', () => {
+      const component = new DeployExecutionDetailsComponent({
+        application: {},
+        stage: createStage({
+          application: 'fnord',
+          account: 'test',
+          cloudProvider: 'aws',
+          'kato.tasks': [{ resultObjects: [{ serverGroupNameByRegion: { 'us-west-1': 'deployedWest' } }] }],
+        }),
+        stateParams: { project: 'injected-project' },
+      } as any);
+
+      expect(component.state.deployed[0].project).toBe('injected-project');
+    });
+
+    it('uses the injected state service for the application config link', () => {
+      const href = jasmine.createSpy().and.returnValue('injected-config');
+      const component = new DeployExecutionDetailsComponent({
+        application: { name: 'fnord' },
+        stage: createStage(),
+        stateParams: {},
+        stateService: { href },
+      } as any);
+
+      expect((component as any).getConfigHref()).toBe('injected-config');
+      expect(href).toHaveBeenCalledWith('home.applications.application.config', { application: 'fnord' });
     });
   });
 

--- a/deck/packages/core/src/pipeline/config/stages/deploy/DeployExecutionDetails.tsx
+++ b/deck/packages/core/src/pipeline/config/stages/deploy/DeployExecutionDetails.tsx
@@ -3,7 +3,6 @@ import { Duration } from 'luxon';
 import React from 'react';
 
 import { AccountTag } from '../../../../account/AccountTag';
-import { AngularServices } from '../../../../angular/services';
 import type { Application } from '../../../../application';
 import { CloudProviderRegistry } from '../../../../cloudProvider/CloudProviderRegistry';
 import type { IExecutionDetailsSectionProps } from '../common';
@@ -16,6 +15,8 @@ import { HealthCounts } from '../../../../healthCounts/HealthCounts';
 import { HelpContentsRegistry } from '../../../../help';
 import { NameUtils } from '../../../../naming/nameUtils';
 import { UrlBuilder } from '../../../../navigation/UrlBuilder';
+import type { IRouterInjectedProps } from '../../../../navigation/routerContext';
+import { withRouter } from '../../../../navigation/routerContext';
 import { Markdown } from '../../../../presentation/Markdown';
 import { ViewScalingActivitiesLink } from '../../../../serverGroup/details/scalingActivities/ViewScalingActivitiesLink';
 import { ServerGroupReader } from '../../../../serverGroup/serverGroupReader.service';
@@ -161,26 +162,26 @@ export function getDeployWaitingMessages(
   return waitingMessages;
 }
 
-export class DeployExecutionDetails extends React.Component<
-  IExecutionDetailsSectionProps,
+export class DeployExecutionDetailsComponent extends React.Component<
+  IExecutionDetailsSectionProps & IRouterInjectedProps,
   IDeployExecutionDetailsState
 > {
   public static title = 'deploymentConfig';
 
-  constructor(props: IExecutionDetailsSectionProps) {
+  constructor(props: IExecutionDetailsSectionProps & IRouterInjectedProps) {
     super(props);
     this.state = this.buildState(props);
   }
 
-  public componentDidUpdate(prevProps: IExecutionDetailsSectionProps): void {
+  public componentDidUpdate(prevProps: IExecutionDetailsSectionProps & IRouterInjectedProps): void {
     if (prevProps.stage !== this.props.stage) {
       this.setState(this.buildState(this.props));
     }
   }
 
-  private buildState(props: IExecutionDetailsSectionProps): IDeployExecutionDetailsState {
+  private buildState(props: IExecutionDetailsSectionProps & IRouterInjectedProps): IDeployExecutionDetailsState {
     const context = props.stage.context || {};
-    const deployed = getDeployedServerGroups(props.stage, AngularServices.$stateParams.project);
+    const deployed = getDeployedServerGroups(props.stage, props.stateParams.project);
     return {
       customStuckDeployGuide: HelpContentsRegistry.getHelpField('execution.stuckDeploy.guide'),
       deployed,
@@ -192,7 +193,7 @@ export class DeployExecutionDetails extends React.Component<
   private getConfigHref(): string {
     const applicationName = this.props.application && this.props.application.name;
     return applicationName
-      ? AngularServices.$state.href('home.applications.application.config', { application: applicationName })
+      ? this.props.stateService.href('home.applications.application.config', { application: applicationName })
       : null;
   }
 
@@ -315,6 +316,10 @@ export class DeployExecutionDetails extends React.Component<
     );
   }
 }
+
+export const DeployExecutionDetails = Object.assign(withRouter(DeployExecutionDetailsComponent), {
+  title: DeployExecutionDetailsComponent.title,
+});
 
 export class DeployChangesExecutionDetails extends React.Component<
   IExecutionDetailsSectionProps,

--- a/deck/packages/core/src/pipeline/config/stages/webhook/WebhookExecutionDetails.spec.tsx
+++ b/deck/packages/core/src/pipeline/config/stages/webhook/WebhookExecutionDetails.spec.tsx
@@ -52,6 +52,6 @@ describe('WebhookExecutionDetails', () => {
     expect(links.at(0).prop('rel')).toBe('noopener noreferrer');
     expect(links.at(1).prop('href')).toBe('https://example.test/progress/1');
     expect(component.find('.webhook-progress-message').prop('style')).toEqual({ whiteSpace: 'pre-line' });
-    expect(component.html()).not.toContain('href="javascript:alert(1)"');
+    expect(links.map((link) => link.prop('href'))).not.toContain('javascript:alert(1)');
   });
 });

--- a/deck/packages/core/src/pipeline/config/templates/v2/PipelineTemplatesV2.spec.tsx
+++ b/deck/packages/core/src/pipeline/config/templates/v2/PipelineTemplatesV2.spec.tsx
@@ -1,0 +1,57 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import { PipelineTemplatesV2Component } from './PipelineTemplatesV2';
+import { PipelineTemplateReader } from '../PipelineTemplateReader';
+
+describe('PipelineTemplatesV2', () => {
+  it('initializes the selected template from injected route params', () => {
+    const component = shallow(
+      <PipelineTemplatesV2Component
+        {...({
+          router: {},
+          stateParams: { templateId: 'injected-template' },
+          stateService: {},
+        } as any)}
+      />,
+      { disableLifecycleMethods: true },
+    );
+
+    expect(component.state('viewTemplateVersion')).toBe('injected-template');
+  });
+
+  it('dismisses template details through the injected state service', () => {
+    const injectedGo = jasmine.createSpy('injectedGo');
+    const component = shallow(
+      <PipelineTemplatesV2Component {...({ router: {}, stateParams: {}, stateService: { go: injectedGo } } as any)} />,
+      { disableLifecycleMethods: true },
+    );
+
+    (component.instance() as any).dismissDetailsModal();
+
+    expect(injectedGo).toHaveBeenCalledWith('home.pipeline-templates');
+  });
+
+  it('observes route changes through the injected router', () => {
+    const injectedUnsubscribe = jasmine.createSpy('injectedUnsubscribe');
+    const injectedOnSuccess = jasmine.createSpy('injectedOnSuccess').and.returnValue(injectedUnsubscribe);
+    spyOn(PipelineTemplateReader, 'getV2PipelineTemplateList').and.returnValue(Promise.resolve({}));
+    const component = shallow(
+      <PipelineTemplatesV2Component
+        {...({
+          router: { transitionService: { onSuccess: injectedOnSuccess } },
+          stateParams: {},
+          stateService: {},
+        } as any)}
+      />,
+      { disableLifecycleMethods: true },
+    );
+    const instance = component.instance() as PipelineTemplatesV2Component;
+
+    instance.componentDidMount();
+    instance.componentWillUnmount();
+
+    expect(injectedOnSuccess).toHaveBeenCalledWith({}, jasmine.any(Function));
+    expect(injectedUnsubscribe).toHaveBeenCalled();
+  });
+});

--- a/deck/packages/core/src/pipeline/config/templates/v2/PipelineTemplatesV2.tsx
+++ b/deck/packages/core/src/pipeline/config/templates/v2/PipelineTemplatesV2.tsx
@@ -8,16 +8,16 @@ import type { Subscription } from 'rxjs';
 import { DeletePipelineTemplateV2Modal } from './DeletePipelineTemplateV2Modal';
 import { PipelineTemplateReader } from '../PipelineTemplateReader';
 import { ShowPipelineTemplateJsonModal } from '../../actions/templateJson/ShowPipelineTemplateJsonModal';
-import { AngularServices } from '../../../../angular/services';
 import { CreatePipelineFromTemplate } from './createPipelineFromTemplate';
 import type {
   IPipelineTemplateV2,
   IPipelineTemplateV2Collections,
   IPipelineTemplateV2VersionSelections,
 } from '../../../../domain/IPipelineTemplateV2';
+import type { IRouterInjectedProps, IRouterStateChange } from '../../../../navigation/routerContext';
+import { stateChangeSuccess$, withRouter } from '../../../../navigation/routerContext';
 import { PipelineTemplateV2Service } from './pipelineTemplateV2.service';
 import { ReactSelectInput } from '../../../../presentation';
-import type { IStateChange } from '../../../../reactShims';
 
 import './PipelineTemplatesV2.less';
 
@@ -42,7 +42,7 @@ export const PipelineTemplatesV2Error = (props: { message: string }) => {
   );
 };
 
-export class PipelineTemplatesV2 extends React.Component<{}, IPipelineTemplatesV2State> {
+export class PipelineTemplatesV2Component extends React.Component<IRouterInjectedProps, IPipelineTemplatesV2State> {
   private routeChangedSubscription: Subscription = null;
 
   public state: IPipelineTemplatesV2State = {
@@ -50,13 +50,13 @@ export class PipelineTemplatesV2 extends React.Component<{}, IPipelineTemplatesV
     searchValue: '',
     selectedTemplate: null,
     templates: {},
-    viewTemplateVersion: AngularServices.$stateParams.templateId,
+    viewTemplateVersion: this.props.stateParams.templateId,
     templateVersionSelections: {},
   };
 
   public componentDidMount() {
     this.fetchTemplates();
-    this.routeChangedSubscription = AngularServices.stateEvents.stateChangeSuccess.subscribe(this.onRouteChanged);
+    this.routeChangedSubscription = stateChangeSuccess$(this.props.router).subscribe(this.onRouteChanged);
   }
 
   public componentWillUnmount() {
@@ -77,7 +77,7 @@ export class PipelineTemplatesV2 extends React.Component<{}, IPipelineTemplatesV
     );
   }
 
-  private onRouteChanged = (stateChange: IStateChange) => {
+  private onRouteChanged = (stateChange: IRouterStateChange) => {
     const { to, toParams } = stateChange;
     if (to.name === 'home.pipeline-templates') {
       this.setState({ viewTemplateVersion: null });
@@ -112,7 +112,7 @@ export class PipelineTemplatesV2 extends React.Component<{}, IPipelineTemplatesV
   };
 
   private dismissDetailsModal = () => {
-    AngularServices.$state.go('home.pipeline-templates');
+    this.props.stateService.go('home.pipeline-templates');
   };
 
   private onSearchFieldChanged = (event: React.SyntheticEvent<HTMLInputElement>) => {
@@ -313,3 +313,5 @@ export class PipelineTemplatesV2 extends React.Component<{}, IPipelineTemplatesV
     );
   }
 }
+
+export const PipelineTemplatesV2 = withRouter(PipelineTemplatesV2Component);

--- a/deck/packages/core/src/pipeline/config/templates/v2/createPipelineFromTemplate/CreatePipelineFromTemplate.spec.tsx
+++ b/deck/packages/core/src/pipeline/config/templates/v2/createPipelineFromTemplate/CreatePipelineFromTemplate.spec.tsx
@@ -1,0 +1,28 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import { CreatePipelineFromTemplateComponent } from './CreatePipelineFromTemplate';
+import { CreatePipelineModal } from '../../../../create';
+
+describe('CreatePipelineFromTemplate', () => {
+  it('opens a saved pipeline through the injected state service', () => {
+    const injectedGo = jasmine.createSpy('injectedGo');
+    const component = shallow(
+      <CreatePipelineFromTemplateComponent
+        {...({ router: {}, stateParams: {}, stateService: { go: injectedGo } } as any)}
+        closeModalCallback={() => undefined}
+        template={{} as any}
+      />,
+      { disableLifecycleMethods: true },
+    );
+    component.setState({ applicationSelectionComplete: true, loadedApplication: { name: 'test-app' } });
+
+    (component.find(CreatePipelineModal).prop('pipelineSavedCallback') as (id: string) => void)('pipeline-id');
+
+    expect(injectedGo).toHaveBeenCalledWith('home.applications.application.pipelines.pipelineConfig', {
+      application: 'test-app',
+      pipelineId: 'pipeline-id',
+      new: 1,
+    });
+  });
+});

--- a/deck/packages/core/src/pipeline/config/templates/v2/createPipelineFromTemplate/CreatePipelineFromTemplate.tsx
+++ b/deck/packages/core/src/pipeline/config/templates/v2/createPipelineFromTemplate/CreatePipelineFromTemplate.tsx
@@ -5,12 +5,13 @@ import { from as observableFrom, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
 import ApplicationSelector from '../ApplicationSelector';
-import { AngularServices } from '../../../../../angular/services';
 import type { Application, IApplicationSummary } from '../../../../../application';
 import { ApplicationReader } from '../../../../../application';
 import { CreatePipelineModal } from '../../../../create';
 import type { IPipelineTemplateV2 } from '../../../../../domain/IPipelineTemplateV2';
 import { SubmitButton } from '../../../../../modal/buttons/SubmitButton';
+import type { IRouterInjectedProps } from '../../../../../navigation/routerContext';
+import { withRouter } from '../../../../../navigation/routerContext';
 import { Spinner } from '../../../../../widgets/spinners/Spinner';
 
 import './createPipelineFromTemplate.less';
@@ -30,8 +31,8 @@ interface ICreatePipelineFromTemplateState {
   submitting: boolean;
 }
 
-export class CreatePipelineFromTemplate extends React.Component<
-  ICreatePipelineFromTemplateProps,
+export class CreatePipelineFromTemplateComponent extends React.Component<
+  ICreatePipelineFromTemplateProps & IRouterInjectedProps,
   ICreatePipelineFromTemplateState
 > {
   public state: ICreatePipelineFromTemplateState = {
@@ -101,8 +102,11 @@ export class CreatePipelineFromTemplate extends React.Component<
   };
 
   private goToPipelineConfig = (application: string, id: string) => {
-    const { $state } = AngularServices;
-    $state.go('home.applications.application.pipelines.pipelineConfig', { application, pipelineId: id, new: 1 });
+    this.props.stateService.go('home.applications.application.pipelines.pipelineConfig', {
+      application,
+      pipelineId: id,
+      new: 1,
+    });
   };
 
   public render() {
@@ -168,3 +172,5 @@ export class CreatePipelineFromTemplate extends React.Component<
     );
   }
 }
+
+export const CreatePipelineFromTemplate = withRouter(CreatePipelineFromTemplateComponent);

--- a/deck/packages/core/src/pipeline/config/triggers/Triggers.tsx
+++ b/deck/packages/core/src/pipeline/config/triggers/Triggers.tsx
@@ -5,7 +5,6 @@ import { MetadataPageContent } from './MetadataPageContent';
 import { NotificationsPageContent } from './NotificationsPageContent';
 import { ParametersPageContent } from './ParametersPageContent';
 import { TriggersPageContent } from './TriggersPageContent';
-import { AngularServices } from '../../../angular/services';
 import type { Application } from '../../../application';
 import type { IPipeline } from '../../../domain';
 import { PageNavigator, PageSection } from '../../../presentation';
@@ -26,7 +25,7 @@ export function Triggers(props: ITriggersProps) {
   const revertCountKLUDGE = props.revertCount;
 
   return (
-    <PageNavigator scrollableContainer=".pipeline-config-page" reactInjector={AngularServices}>
+    <PageNavigator scrollableContainer=".pipeline-config-page">
       <PageSection pageKey="concurrent" label="Execution Options" visible={!pipeline.strategy}>
         <ExecutionOptionsPageContent {...props} />
       </PageSection>

--- a/deck/packages/core/src/pipeline/create/CreatePipelineButton.tsx
+++ b/deck/packages/core/src/pipeline/create/CreatePipelineButton.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 
 import { CreatePipelineModal } from './CreatePipelineModal';
-import { AngularServices } from '../../angular/services';
 import type { Application } from '../../application';
+import type { IRouterInjectedProps } from '../../navigation/routerContext';
+import { withRouter } from '../../navigation/routerContext';
 import { Tooltip } from '../../presentation/Tooltip';
 import { logger } from '../../utils';
 
@@ -15,8 +16,11 @@ export interface ICreatePipelineButtonState {
   showCreatePipelineModal: boolean;
 }
 
-export class CreatePipelineButton extends React.Component<ICreatePipelineButtonProps, ICreatePipelineButtonState> {
-  constructor(props: ICreatePipelineButtonProps) {
+class CreatePipelineButtonComponent extends React.Component<
+  ICreatePipelineButtonProps & IRouterInjectedProps,
+  ICreatePipelineButtonState
+> {
+  constructor(props: ICreatePipelineButtonProps & IRouterInjectedProps) {
     super(props);
 
     this.state = {
@@ -34,11 +38,11 @@ export class CreatePipelineButton extends React.Component<ICreatePipelineButtonP
   };
 
   private goToPipelineConfig = (id: string) => {
-    const { $state } = AngularServices;
-    if (!$state.current.name.includes('.executions.execution')) {
-      $state.go('^.pipelineConfig', { pipelineId: id });
+    const { stateService } = this.props;
+    if (!stateService.current.name.includes('.executions.execution')) {
+      stateService.go('^.pipelineConfig', { pipelineId: id });
     } else {
-      $state.go('^.^.pipelineConfig', { pipelineId: id });
+      stateService.go('^.^.pipelineConfig', { pipelineId: id });
     }
   };
 
@@ -71,3 +75,6 @@ export class CreatePipelineButton extends React.Component<ICreatePipelineButtonP
     );
   }
 }
+
+export const CreatePipelineButton = withRouter(CreatePipelineButtonComponent);
+CreatePipelineButton.displayName = 'CreatePipelineButton';

--- a/deck/packages/core/src/pipeline/details/ExecutionDetailsSectionNav.tsx
+++ b/deck/packages/core/src/pipeline/details/ExecutionDetailsSectionNav.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import type { Subscription } from 'rxjs';
-import { AngularServices } from '../../angular/services';
 
+import type { IRouterInjectedProps } from '../../navigation/routerContext';
+import { withRouter } from '../../navigation/routerContext';
 import { robotToHuman } from '../../presentation/robotToHumanFilter/robotToHuman.filter';
 import { logger } from '../../utils';
 
@@ -13,52 +13,48 @@ export interface IExecutionDetailsSectionNavState {
   activeSection: string;
 }
 
-export class ExecutionDetailsSectionNav extends React.Component<
-  IExecutionDetailsSectionNavProps,
+export class ExecutionDetailsSectionNavComponent extends React.Component<
+  IExecutionDetailsSectionNavProps & IRouterInjectedProps,
   IExecutionDetailsSectionNavState
 > {
-  private stateChangeSuccessSubscription: Subscription;
-
-  public constructor(props: IExecutionDetailsSectionNavProps) {
+  public constructor(props: IExecutionDetailsSectionNavProps & IRouterInjectedProps) {
     super(props);
     this.state = this.getState(props);
   }
 
-  public componentDidMount(): void {
-    this.stateChangeSuccessSubscription = AngularServices.stateEvents.stateChangeSuccess.subscribe(() =>
-      this.setState(this.getState(this.props)),
-    );
-  }
-
-  private getState(props: IExecutionDetailsSectionNavProps): IExecutionDetailsSectionNavState {
-    const { $stateParams } = AngularServices;
-    const activeSection = $stateParams.details || props.sections[0];
+  private getState(props: IExecutionDetailsSectionNavProps & IRouterInjectedProps): IExecutionDetailsSectionNavState {
+    const activeSection = props.stateParams.details || props.sections[0];
     return { activeSection };
   }
 
-  public componentWillReceiveProps(nextProps: IExecutionDetailsSectionNavProps): void {
+  public componentWillReceiveProps(nextProps: IExecutionDetailsSectionNavProps & IRouterInjectedProps): void {
     this.setState(this.getState(nextProps));
-  }
-
-  public componentWillUnmount(): void {
-    this.stateChangeSuccessSubscription.unsubscribe();
   }
 
   public render() {
     return (
       <ul className="nav nav-pills">
         {this.props.sections.map((section) => (
-          <Section key={section} section={section} active={this.state.activeSection === section} />
+          <Section
+            key={section}
+            section={section}
+            active={this.state.activeSection === section}
+            stateService={this.props.stateService}
+          />
         ))}
       </ul>
     );
   }
 }
 
-const Section = (props: { section: string; active: boolean }): JSX.Element => {
+const Section = (props: {
+  section: string;
+  active: boolean;
+  stateService: IRouterInjectedProps['stateService'];
+}): JSX.Element => {
   const clicked = () => {
     logger.log({ category: 'Pipeline', action: 'Execution details section selected', data: { label: props.section } });
-    AngularServices.$state.go('.', { details: props.section });
+    props.stateService.go('.', { details: props.section });
   };
   return (
     <li>
@@ -68,3 +64,5 @@ const Section = (props: { section: string; active: boolean }): JSX.Element => {
     </li>
   );
 };
+
+export const ExecutionDetailsSectionNav = withRouter(ExecutionDetailsSectionNavComponent);

--- a/deck/packages/core/src/pipeline/details/SingleExecutionDetails.tsx
+++ b/deck/packages/core/src/pipeline/details/SingleExecutionDetails.tsx
@@ -1,4 +1,4 @@
-import { UISref, useCurrentStateAndParams } from '@uirouter/react';
+import { UISref, useCurrentStateAndParams, useRouter } from '@uirouter/react';
 import { set } from 'lodash';
 import React, { useEffect, useState } from 'react';
 import { AngularServices } from '../../angular/services';
@@ -59,6 +59,7 @@ export function SingleExecutionDetails(props: ISingleExecutionDetailsProps) {
   const scheduler = SchedulerFactory.createScheduler(5000);
   const { sortFilter } = ExecutionState.filterModel.asFilterModel;
   const { app } = props;
+  const { stateService } = useRouter();
 
   const [showDurations, setShowDurations] = useState(sortFilter.showDurations);
   const { params } = useCurrentStateAndParams();
@@ -136,7 +137,7 @@ export function SingleExecutionDetails(props: ISingleExecutionDetailsProps) {
     }).then((command) => {
       const { executionService } = AngularServices;
       executionService.startAndMonitorPipeline(application, command.pipelineName, command.trigger);
-      AngularServices.$state.go('^.^.executions');
+      stateService.go('^.^.executions');
     });
   };
 

--- a/deck/packages/core/src/pipeline/details/StageExecutionDetails.tsx
+++ b/deck/packages/core/src/pipeline/details/StageExecutionDetails.tsx
@@ -3,10 +3,11 @@ import type { Subscription } from 'rxjs';
 
 import { StageSummary } from './StageSummary';
 import { StepDetails } from './StepDetails';
-import { AngularServices } from '../../angular/services';
 import type { Application } from '../../application/application.model';
 import type { IExecution, IExecutionStage, IExecutionStageSummary, IStageTypeConfig } from '../../domain';
 import { ExecutionFilterService } from '../filter/executionFilter.service';
+import type { IRouterInjectedProps } from '../../navigation/routerContext';
+import { withRouter } from '../../navigation/routerContext';
 import { SpinErrorBoundary } from '../../presentation';
 import { Registry } from '../../registry';
 
@@ -26,6 +27,7 @@ export interface IStageExecutionDetailsState {
 }
 
 export interface IExecutionStateParams {
+  executionId?: string;
   stage?: number;
   subStage?: number;
   step?: number;
@@ -33,17 +35,19 @@ export interface IExecutionStateParams {
   refId?: string;
 }
 
-export class StageExecutionDetails extends React.Component<IStageExecutionDetailsProps, IStageExecutionDetailsState> {
+export class StageExecutionDetailsComponent extends React.Component<
+  IStageExecutionDetailsProps & IRouterInjectedProps,
+  IStageExecutionDetailsState
+> {
   public static defaultProps: Partial<IStageExecutionDetailsProps> = {
     standalone: false,
   };
 
   private groupsUpdatedSubscription: Subscription;
-  private locationChangeUnsubscribe: Function;
 
-  constructor(props: IStageExecutionDetailsProps) {
+  constructor(props: IStageExecutionDetailsProps & IRouterInjectedProps) {
     super(props);
-    this.state = this.getUpdatedState();
+    this.state = this.getUpdatedState(props);
   }
 
   private getStageParamsFromStageId(stageId: string, summaries: IExecutionStageSummary[]): IExecutionStateParams {
@@ -126,40 +130,43 @@ export class StageExecutionDetails extends React.Component<IStageExecutionDetail
     return { stage, subStage };
   }
 
-  private getCurrentStage(summaries: IExecutionStageSummary[]): { stage: number; subStage: number } {
-    const { $state, $stateParams } = AngularServices;
-    if ($stateParams.stageId) {
-      const params = this.getStageParamsFromStageId($stateParams.stageId, summaries);
+  private getCurrentStage(
+    summaries: IExecutionStageSummary[],
+    props: IStageExecutionDetailsProps & IRouterInjectedProps,
+  ): { stage: number; subStage: number } {
+    const { stateParams, stateService } = props;
+    if (stateParams.stageId) {
+      const params = this.getStageParamsFromStageId(stateParams.stageId, summaries);
       if (params) {
-        $state.go('.', params, { location: 'replace' });
+        stateService.go('.', params, { location: 'replace' });
         return { stage: params.stage, subStage: params.subStage };
       }
     }
-    if ($stateParams.refId) {
-      const params = this.getStageParamsFromRefId($stateParams.refId, summaries);
+    if (stateParams.refId) {
+      const params = this.getStageParamsFromRefId(stateParams.refId, summaries);
       if (params) {
-        $state.go('.', params, { location: 'replace' });
+        stateService.go('.', params, { location: 'replace' });
         return { stage: params.stage, subStage: params.subStage };
       }
     }
 
-    const stateStage = parseInt($stateParams.stage, 10);
-    const stateSubStage = $stateParams.subStage !== undefined ? parseInt($stateParams.subStage, 10) : undefined;
+    const stateStage = parseInt(stateParams.stage, 10);
+    const stateSubStage = stateParams.subStage !== undefined ? parseInt(stateParams.subStage, 10) : undefined;
     const { stage, subStage } = this.validateStageExists(summaries, stateStage, stateSubStage);
     if (stage !== stateStage || subStage !== stateSubStage) {
-      $state.go('.', { stage, subStage }, { location: 'replace' });
+      stateService.go('.', { stage, subStage }, { location: 'replace' });
     }
 
     return { stage, subStage };
   }
 
-  private getCurrentStep() {
-    return parseInt(AngularServices.$stateParams.step, 10);
+  private getCurrentStep(props: IStageExecutionDetailsProps & IRouterInjectedProps) {
+    return parseInt(props.stateParams.step, 10);
   }
 
-  private getStageSummary() {
-    const stages = this.props.execution.stageSummaries || [];
-    const { stage, subStage } = this.getCurrentStage(stages);
+  private getStageSummary(props: IStageExecutionDetailsProps & IRouterInjectedProps) {
+    const stages = props.execution.stageSummaries || [];
+    const { stage, subStage } = this.getCurrentStage(stages, props);
     let currentStage = null;
     if (stage !== undefined) {
       currentStage = stages[stage];
@@ -170,53 +177,61 @@ export class StageExecutionDetails extends React.Component<IStageExecutionDetail
     return currentStage;
   }
 
-  private getDetailsStageConfig(stageSummary: IExecutionStageSummary): IStageTypeConfig {
-    if (stageSummary && AngularServices.$stateParams.step !== undefined) {
-      const step = stageSummary.stages[this.getCurrentStep()] || stageSummary.masterStage;
+  private getDetailsStageConfig(
+    stageSummary: IExecutionStageSummary,
+    props: IStageExecutionDetailsProps & IRouterInjectedProps,
+  ): IStageTypeConfig {
+    if (stageSummary && props.stateParams.step !== undefined) {
+      const step = stageSummary.stages[this.getCurrentStep(props)] || stageSummary.masterStage;
       return Registry.pipeline.getStageConfig(step);
     }
     return null;
   }
 
-  private getSummaryStageConfig(stageSummary: IExecutionStageSummary): IStageTypeConfig {
-    if (stageSummary && AngularServices.$stateParams.stage !== undefined) {
+  private getSummaryStageConfig(
+    stageSummary: IExecutionStageSummary,
+    props: IStageExecutionDetailsProps & IRouterInjectedProps,
+  ): IStageTypeConfig {
+    if (stageSummary && props.stateParams.stage !== undefined) {
       return Registry.pipeline.getStageConfig(stageSummary);
     }
     return {} as IStageTypeConfig;
   }
 
-  public getUpdatedState(): IStageExecutionDetailsState {
-    const stageSummary = this.getStageSummary();
+  public getUpdatedState(
+    props: IStageExecutionDetailsProps & IRouterInjectedProps = this.props,
+  ): IStageExecutionDetailsState {
+    if (props.stateParams.executionId && props.stateParams.executionId !== props.execution.id) {
+      return {} as IStageExecutionDetailsState;
+    }
+
+    const stageSummary = this.getStageSummary(props);
     if (stageSummary) {
-      const stage = stageSummary.stages[this.getCurrentStep()] || stageSummary.masterStage;
-      const summaryStageConfig = this.getSummaryStageConfig(stageSummary);
-      const detailsStageConfig = this.getDetailsStageConfig(stageSummary);
+      const stage = stageSummary.stages[this.getCurrentStep(props)] || stageSummary.masterStage;
+      const summaryStageConfig = this.getSummaryStageConfig(stageSummary, props);
+      const detailsStageConfig = this.getDetailsStageConfig(stageSummary, props);
       return { stageSummary, stage, summaryStageConfig, detailsStageConfig };
     }
     return {} as IStageExecutionDetailsState;
   }
 
-  public updateStage() {
-    this.setState(this.getUpdatedState());
+  public updateStage(props: IStageExecutionDetailsProps & IRouterInjectedProps = this.props) {
+    this.setState(this.getUpdatedState(props));
   }
 
   public componentDidMount(): void {
-    this.locationChangeUnsubscribe = AngularServices.$uiRouter.transitionService.onSuccess({}, () =>
-      this.updateStage(),
-    );
     // Since stages and tasks can get updated without the reference to the execution changing, subscribe to the execution updated stream here too
     this.groupsUpdatedSubscription = ExecutionFilterService.groupsUpdatedStream.subscribe(() => this.updateStage());
 
     this.updateStage();
   }
 
-  public componentWillReceiveProps() {
-    this.updateStage();
+  public componentWillReceiveProps(nextProps: IStageExecutionDetailsProps & IRouterInjectedProps) {
+    this.updateStage(nextProps);
   }
 
   public componentWillUnmount(): void {
     this.groupsUpdatedSubscription.unsubscribe();
-    this.locationChangeUnsubscribe();
   }
 
   public render() {
@@ -239,3 +254,7 @@ export class StageExecutionDetails extends React.Component<IStageExecutionDetail
     );
   }
 }
+
+export const StageExecutionDetails = withRouter<IStageExecutionDetailsProps & IRouterInjectedProps>(
+  StageExecutionDetailsComponent,
+);

--- a/deck/packages/core/src/pipeline/details/StageFailureMessage.spec.tsx
+++ b/deck/packages/core/src/pipeline/details/StageFailureMessage.spec.tsx
@@ -1,0 +1,21 @@
+import { getStageFailureRoute } from './StageFailureMessage';
+
+describe('StageFailureMessage', () => {
+  it('builds failed-stage navigation from the injected state service', () => {
+    const stateService = { current: { name: 'home.applications.application.pipelines.execution' } } as any;
+
+    expect(getStageFailureRoute(stateService, 42, 7)).toEqual({
+      params: { executionId: 42, stageId: 7 },
+      state: 'home.applications.application.pipelines.execution',
+    });
+  });
+
+  it('omits an absent parent execution id from failed-stage navigation', () => {
+    const stateService = { current: { name: 'home.applications.application.pipelines.execution' } } as any;
+
+    expect(getStageFailureRoute(stateService, undefined, 7)).toEqual({
+      params: { stageId: 7 },
+      state: 'home.applications.application.pipelines.execution',
+    });
+  });
+});

--- a/deck/packages/core/src/pipeline/details/StageFailureMessage.tsx
+++ b/deck/packages/core/src/pipeline/details/StageFailureMessage.tsx
@@ -1,10 +1,12 @@
+import type { StateService } from '@uirouter/core';
 import { UISref } from '@uirouter/react';
 import { get } from 'lodash';
 import React from 'react';
-import { AngularServices } from '../../angular/services';
 
 import type { IExecutionStage, ITaskStep } from '../../domain';
 import { EventBus } from '../../event/EventBus';
+import type { IRouterInjectedProps } from '../../navigation/routerContext';
+import { withRouter } from '../../navigation/routerContext';
 import { Overridable } from '../../overrideRegistry';
 import { Markdown, robotToHuman } from '../../presentation';
 import { TrafficGuardHelperLink } from '../../task/TrafficGuardHelperLink';
@@ -27,13 +29,28 @@ export enum StageFailureMessages {
   NO_REASON_PROVIDED = 'No reason provided.',
 }
 
+export function getStageFailureRoute(
+  stateService: StateService,
+  failedExecutionId: number,
+  failedStageId: number,
+): { state: string; params: { executionId?: number; stageId: number } } {
+  const params: { executionId?: number; stageId: number } = { stageId: failedStageId };
+  if (failedExecutionId !== undefined) {
+    params.executionId = failedExecutionId;
+  }
+  return { state: stateService.current.name, params };
+}
+
 @Overridable('stageFailureMessage')
-export class StageFailureMessage extends React.Component<IStageFailureMessageProps, IStageFailureMessageState> {
+export class StageFailureMessageComponent extends React.Component<
+  IStageFailureMessageProps & IRouterInjectedProps,
+  IStageFailureMessageState
+> {
   public static defaultProps: Partial<IStageFailureMessageProps> = {
     messages: [],
   };
 
-  constructor(props: IStageFailureMessageProps) {
+  constructor(props: IStageFailureMessageProps & IRouterInjectedProps) {
     super(props);
     this.state = this.getState(props);
   }
@@ -104,13 +121,7 @@ export class StageFailureMessage extends React.Component<IStageFailureMessagePro
       }
 
       if (failedStageId !== undefined) {
-        const currentState = AngularServices.$state.current;
-        const params: any = {
-          stageId: failedStageId,
-        };
-        if (failedExecutionId !== undefined) {
-          params.executionId = failedExecutionId;
-        }
+        const route = getStageFailureRoute(this.props.stateService, failedExecutionId, failedStageId);
 
         return (
           <div className="row">
@@ -118,7 +129,7 @@ export class StageFailureMessage extends React.Component<IStageFailureMessagePro
               <div className="alert alert-danger">
                 <div>
                   Stage{' '}
-                  <UISref to={currentState.name} params={params}>
+                  <UISref to={route.state} params={route.params}>
                     <a>{failedStageName}</a>
                   </UISref>{' '}
                   failed.
@@ -129,9 +140,13 @@ export class StageFailureMessage extends React.Component<IStageFailureMessagePro
         );
       }
 
-      EventBus.publish('stage-failure-message:no-reason', { params: { ...AngularServices.$state.params } });
+      EventBus.publish('stage-failure-message:no-reason', { params: { ...this.props.stateParams } });
     }
 
     return null;
   }
 }
+
+export const StageFailureMessage = withRouter<IStageFailureMessageProps & IRouterInjectedProps>(
+  StageFailureMessageComponent,
+);

--- a/deck/packages/core/src/pipeline/details/StageSummaryWrapper.tsx
+++ b/deck/packages/core/src/pipeline/details/StageSummaryWrapper.tsx
@@ -6,6 +6,8 @@ import type { Application } from '../../application';
 import { ConfirmationModalService } from '../../confirmationModal';
 import type { IExecution, IExecutionStage, IExecutionStageSummary } from '../../domain';
 import type { IStage } from '../../domain';
+import type { IRouterInjectedProps } from '../../navigation/routerContext';
+import { withRouter } from '../../navigation/routerContext';
 import { Markdown } from '../../presentation/Markdown';
 import { robotToHuman } from '../../presentation/robotToHumanFilter/robotToHuman.filter';
 import { Registry } from '../../registry/Registry';
@@ -19,8 +21,8 @@ export interface IStageSummaryWrapperProps {
   stageSummary: IExecutionStageSummary;
 }
 
-export function StageSummaryWrapper(props: IStageSummaryWrapperProps) {
-  const { application, execution, stage, stageSummary } = props;
+export function StageSummaryWrapperComponent(props: IStageSummaryWrapperProps & IRouterInjectedProps) {
+  const { application, execution, stage, stageSummary, stateParams, stateService } = props;
 
   const renderStepLabel = (step: IStage) => {
     const StepLabelComponent = Registry.pipeline.getStageConfig(step)?.executionStepLabelComponent;
@@ -31,7 +33,7 @@ export function StageSummaryWrapper(props: IStageSummaryWrapperProps) {
     );
   };
 
-  const getCurrentStep = () => parseInt(AngularServices.$stateParams.step, 10);
+  const getCurrentStep = () => parseInt(stateParams.step, 10);
   const getTopLevelStage = (): IExecutionStage => {
     let parentStageId = stage.parentStageId;
     let topLevelStage = stage;
@@ -132,15 +134,15 @@ export function StageSummaryWrapper(props: IStageSummaryWrapperProps) {
     }
 
     const newState = { step: index } as any;
-    const stageIndex = parseInt(AngularServices.$stateParams.stage, 10);
+    const stageIndex = parseInt(stateParams.stage, 10);
     if (stageIndex) {
       newState.stage = stageIndex;
     }
-    const subStage = parseInt(AngularServices.$stateParams.subStage, 10);
+    const subStage = parseInt(stateParams.subStage, 10);
     if (subStage) {
       newState.subStage = subStage;
     }
-    AngularServices.$state.go('.', newState);
+    stateService.go('.', newState);
   };
 
   const topLevelStage = getTopLevelStage();
@@ -217,3 +219,5 @@ export function StageSummaryWrapper(props: IStageSummaryWrapperProps) {
     </div>
   );
 }
+
+export const StageSummaryWrapper = withRouter(StageSummaryWrapperComponent);

--- a/deck/packages/core/src/pipeline/details/StepExecutionDetailsWrapper.tsx
+++ b/deck/packages/core/src/pipeline/details/StepExecutionDetailsWrapper.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 
 import { StageFailureMessage } from './StageFailureMessage';
-import { AngularServices } from '../../angular/services';
 import type { Application } from '../../application';
 import { ExecutionStepDetails } from '../config/stages/common/ExecutionStepDetails';
 import type { IExecution, IExecutionStage, IStageTypeConfig } from '../../domain';
+import type { IRouterInjectedProps } from '../../navigation/routerContext';
+import { withRouter } from '../../navigation/routerContext';
 
 export interface IStepExecutionDetailsWrapperProps {
   application: Application;
@@ -16,7 +17,7 @@ export interface IStepExecutionDetailsWrapperProps {
   sourceUrl: string;
 }
 
-export function StepExecutionDetailsWrapper(props: IStepExecutionDetailsWrapperProps) {
+export function StepExecutionDetailsWrapperComponent(props: IStepExecutionDetailsWrapperProps & IRouterInjectedProps) {
   const { application, config, configSections, execution, provider, stage } = props;
   const ExecutionDetailsComponent = config?.executionDetailsComponent;
 
@@ -26,7 +27,7 @@ export function StepExecutionDetailsWrapper(props: IStepExecutionDetailsWrapperP
         application={application}
         config={config}
         configSections={configSections}
-        currentSection={AngularServices.$stateParams.details}
+        currentSection={props.stateParams.details}
         execution={execution}
         provider={provider || ''}
         stage={stage}
@@ -45,3 +46,5 @@ export function StepExecutionDetailsWrapper(props: IStepExecutionDetailsWrapperP
     </div>
   );
 }
+
+export const StepExecutionDetailsWrapper = withRouter(StepExecutionDetailsWrapperComponent);

--- a/deck/packages/core/src/pipeline/details/reactBridgeWrappers.spec.tsx
+++ b/deck/packages/core/src/pipeline/details/reactBridgeWrappers.spec.tsx
@@ -3,16 +3,22 @@ import React from 'react';
 
 import { AngularServices } from '../../angular/services';
 import { ConfirmationModalService } from '../../confirmationModal';
+import { setDirectRouter } from '../../navigation/directRouter';
 import { Registry } from '../../registry/Registry';
-import { ExecutionDetailsSectionNav } from './ExecutionDetailsSectionNav';
+import { ExecutionDetailsSectionNav, ExecutionDetailsSectionNavComponent } from './ExecutionDetailsSectionNav';
+import { StageExecutionDetailsComponent } from './StageExecutionDetails';
 import { StageFailureMessage } from './StageFailureMessage';
 import { StageSummary } from './StageSummary';
-import { StageSummaryWrapper } from './StageSummaryWrapper';
+import { StageSummaryWrapper, StageSummaryWrapperComponent } from './StageSummaryWrapper';
 import { StepDetails } from './StepDetails';
-import { StepExecutionDetailsWrapper } from './StepExecutionDetailsWrapper';
+import { StepExecutionDetailsWrapper, StepExecutionDetailsWrapperComponent } from './StepExecutionDetailsWrapper';
 import { ExecutionStepDetails } from '../config/stages/common/ExecutionStepDetails';
 
 describe('pipeline details bridge wrappers', () => {
+  const routerProps = { router: {} as any, stateParams: {}, stateService: {} as any };
+
+  afterEach(() => setDirectRouter(null));
+
   it('renders the direct StageSummaryWrapper for Angular summary templates', () => {
     const props = {
       application: {} as any,
@@ -35,14 +41,14 @@ describe('pipeline details bridge wrappers', () => {
     spyOn(Registry.pipeline, 'getStageConfig').and.returnValue({
       executionStepLabelComponent: CustomStepLabel,
     } as any);
-    spyOnProperty(AngularServices, '$stateParams', 'get').and.returnValue({ step: '1' } as any);
-
     const component = mount(
-      <StageSummaryWrapper
+      <StageSummaryWrapperComponent
+        {...routerProps}
         application={{ attributes: {} } as any}
         execution={{ stages: [] } as any}
         sourceUrl="template.html"
         stage={{ context: {}, type: 'deploy' } as any}
+        stateParams={{ step: '1' }}
         stageSummary={
           {
             comments: '**approved**',
@@ -64,10 +70,9 @@ describe('pipeline details bridge wrappers', () => {
   });
 
   it('sanitizes stage summary markdown comments', () => {
-    spyOnProperty(AngularServices, '$stateParams', 'get').and.returnValue({} as any);
-
     const component = mount(
-      <StageSummaryWrapper
+      <StageSummaryWrapperComponent
+        {...routerProps}
         application={{ attributes: {} } as any}
         execution={{ stages: [] } as any}
         sourceUrl="template.html"
@@ -88,17 +93,152 @@ describe('pipeline details bridge wrappers', () => {
     expect(comments).not.toContain('<script>');
   });
 
-  it('toggles stage summary details through UI Router params and preserves stage indices', () => {
-    const go = jasmine.createSpy('go');
-    spyOnProperty(AngularServices, '$stateParams', 'get').and.returnValue({
-      stage: '2',
-      subStage: '3',
-      step: '0',
-    } as any);
-    spyOnProperty(AngularServices, '$state', 'get').and.returnValue({ go } as any);
+  it('tracks the active execution details section from injected route params', () => {
+    const component = shallow(
+      <ExecutionDetailsSectionNavComponent
+        {...({
+          router: {},
+          sections: ['firstSection', 'secondSection'],
+          stateParams: { details: 'firstSection' },
+          stateService: {},
+        } as any)}
+      />,
+    );
+
+    const activeSection = () =>
+      component
+        .find('Section')
+        .filterWhere((section) => section.prop('active'))
+        .prop('section');
+
+    expect(activeSection()).toBe('firstSection');
+
+    component.setProps({ stateParams: { details: 'secondSection' } } as any);
+
+    expect(activeSection()).toBe('secondSection');
+  });
+
+  it('navigates execution details sections through the injected state service', () => {
+    const injectedGo = jasmine.createSpy('injectedGo');
+
+    const component = shallow(
+      <ExecutionDetailsSectionNavComponent
+        {...({
+          router: {},
+          sections: ['firstSection', 'secondSection'],
+          stateParams: {},
+          stateService: { go: injectedGo },
+        } as any)}
+      />,
+    );
+
+    component.find('Section').at(1).dive().find('a').simulate('click');
+
+    expect(injectedGo).toHaveBeenCalledWith('.', { details: 'secondSection' });
+  });
+
+  it('resolves deep-linked stages through injected route params and state service', () => {
+    const injectedGo = jasmine.createSpy('injectedGo');
+    const firstSummary = { stages: [], type: 'wait' } as any;
+    const secondSummary = {
+      masterStage: { id: 'master-stage', type: 'deploy' },
+      stages: [{ id: 'task-stage', type: 'deploy' }],
+      type: 'deploy',
+    } as any;
+
+    const component = shallow(
+      <StageExecutionDetailsComponent
+        {...({ router: {}, stateParams: { stageId: 'task-stage' }, stateService: { go: injectedGo } } as any)}
+        application={{} as any}
+        execution={{ stageSummaries: [firstSummary, secondSummary] } as any}
+      />,
+      { disableLifecycleMethods: true },
+    );
+
+    expect(injectedGo).toHaveBeenCalledWith(
+      '.',
+      { stage: 1, subStage: undefined, step: 0, stageId: null },
+      { location: 'replace' },
+    );
+    expect(component.find(StageSummary).prop('stageSummary')).toBe(secondSummary);
+  });
+
+  it('selects the next routed stage immediately when route props change', () => {
+    const firstSummary = {
+      masterStage: { id: 'first-master', type: 'deploy' },
+      stages: [{ id: 'first-task', type: 'deploy' }],
+      type: 'deploy',
+    } as any;
+    const secondSummary = {
+      masterStage: { id: 'second-master', type: 'deploy' },
+      stages: [{ id: 'second-task', type: 'deploy' }],
+      type: 'deploy',
+    } as any;
+    const component = shallow(
+      <StageExecutionDetailsComponent
+        {...({
+          router: {},
+          stateParams: { stageId: 'first-task' },
+          stateService: { go: jasmine.createSpy('go') },
+        } as any)}
+        application={{} as any}
+        execution={{ stageSummaries: [{ stages: [] }, firstSummary, secondSummary] } as any}
+      />,
+      { disableLifecycleMethods: true },
+    );
+
+    component.setProps({ stateParams: { stageId: 'second-task' } } as any);
+
+    expect(component.find(StageSummary).prop('stageSummary')).toBe(secondSummary);
+  });
+
+  it('waits for routed props before selecting a stage from a different execution', () => {
+    const injectedGo = jasmine.createSpy('injectedGo');
+    const firstSummary = {
+      masterStage: { id: 'first-master', type: 'deploy' },
+      stages: [{ id: 'first-task', type: 'deploy' }],
+      type: 'deploy',
+    } as any;
+    const secondSummary = {
+      masterStage: { id: 'second-master', type: 'deploy' },
+      stages: [{ id: 'second-task', type: 'deploy' }],
+      type: 'deploy',
+    } as any;
+    const firstExecution = { id: 'first-execution', stageSummaries: [firstSummary] } as any;
+    const secondExecution = { id: 'second-execution', stageSummaries: [{ stages: [] }, secondSummary] } as any;
+    const initialProps = {
+      application: {} as any,
+      execution: firstExecution,
+      router: {},
+      stateParams: { executionId: 'first-execution', stage: '0', step: '0' },
+      stateService: { go: injectedGo },
+    } as any;
+
+    const component = shallow(<StageExecutionDetailsComponent {...initialProps} />, { disableLifecycleMethods: true });
+    const instance = component.instance() as StageExecutionDetailsComponent;
+
+    injectedGo.calls.reset();
+    instance.componentWillReceiveProps({
+      ...initialProps,
+      stateParams: { executionId: 'second-execution', stage: '1', step: '0' },
+    });
+
+    expect(injectedGo).not.toHaveBeenCalled();
+
+    component.setProps({
+      execution: secondExecution,
+      stateParams: { executionId: 'second-execution', stage: '1', step: '0' },
+    });
+
+    expect(component.find(StageSummary).prop('stageSummary')).toBe(secondSummary);
+  });
+
+  it('toggles stage summary details through the injected router and preserves stage indices', () => {
+    const injectedGo = jasmine.createSpy('injectedGo');
 
     const component = mount(
-      <StageSummaryWrapper
+      <StageSummaryWrapperComponent
+        {...routerProps}
         application={{ attributes: {} } as any}
         execution={{ stages: [] } as any}
         sourceUrl="template.html"
@@ -111,12 +251,14 @@ describe('pipeline details bridge wrappers', () => {
             ],
           } as any
         }
+        stateParams={{ stage: '2', subStage: '3', step: '0' }}
+        stateService={{ go: injectedGo } as any}
       />,
     );
 
     component.find('tr.clickable').at(1).simulate('click');
 
-    expect(go).toHaveBeenCalledWith('.', { stage: 2, step: 1, subStage: 3 });
+    expect(injectedGo).toHaveBeenCalledWith('.', { stage: 2, step: 1, subStage: 3 });
   });
 
   it('confirms manual skip against the top-level stage', async () => {
@@ -132,7 +274,8 @@ describe('pipeline details bridge wrappers', () => {
     spyOnProperty(AngularServices, 'executionService', 'get').and.returnValue(executionService as any);
 
     const component = mount(
-      <StageSummaryWrapper
+      <StageSummaryWrapperComponent
+        {...routerProps}
         application={{ attributes: {} } as any}
         execution={
           {
@@ -172,7 +315,8 @@ describe('pipeline details bridge wrappers', () => {
 
   it('renders StepExecutionDetailsWrapper default execution details without section nav', () => {
     const component = shallow(
-      <StepExecutionDetailsWrapper
+      <StepExecutionDetailsWrapperComponent
+        {...routerProps}
         application={{} as any}
         configSections={['Task Status']}
         execution={{} as any}
@@ -195,7 +339,8 @@ describe('pipeline details bridge wrappers', () => {
     );
 
     const component = shallow(
-      <StepExecutionDetailsWrapper
+      <StepExecutionDetailsWrapperComponent
+        {...routerProps}
         application={{} as any}
         config={{ executionDetailsComponent: CustomExecutionDetails } as any}
         configSections={['Custom']}
@@ -214,13 +359,37 @@ describe('pipeline details bridge wrappers', () => {
     expect(component.find(ExecutionStepDetails).exists()).toBe(false);
   });
 
+  it('passes the injected details route param to custom step execution details', () => {
+    const params = { details: 'facade-details' };
+    setDirectRouter({ globals: { params }, stateService: { params } } as any);
+    const CustomExecutionDetails = () => null;
+
+    const component = shallow(
+      <StepExecutionDetailsWrapperComponent
+        {...routerProps}
+        {...({
+          application: {},
+          config: { executionDetailsComponent: CustomExecutionDetails },
+          configSections: ['Custom'],
+          execution: {},
+          sourceUrl: 'template.html',
+          stage: {},
+          stateParams: { details: 'injected-details' },
+        } as any)}
+      />,
+    );
+
+    expect(component.find(CustomExecutionDetails).prop('currentSection')).toBe('injected-details');
+  });
+
   it('passes config sections to custom StepExecutionDetailsWrapper components so they can render section nav', () => {
     const CustomExecutionDetails = ({ configSections }: any) => (
       <ExecutionDetailsSectionNav sections={configSections} />
     );
 
     const component = shallow(
-      <StepExecutionDetailsWrapper
+      <StepExecutionDetailsWrapperComponent
+        {...routerProps}
         application={{} as any}
         config={{ executionDetailsComponent: CustomExecutionDetails } as any}
         configSections={['Custom', 'Tasks']}

--- a/deck/packages/core/src/pipeline/executions/ExecutionNotFound.tsx
+++ b/deck/packages/core/src/pipeline/executions/ExecutionNotFound.tsx
@@ -1,9 +1,9 @@
+import { useCurrentStateAndParams } from '@uirouter/react';
 import React from 'react';
-import { AngularServices } from '../../angular/services';
 
 import { NotFound } from '../../notfound/NotFound';
 
 export function ExecutionNotFound() {
-  const { params } = AngularServices.$state;
+  const { params } = useCurrentStateAndParams();
   return <NotFound type="Execution" entityId={params.executionId} />;
 }

--- a/deck/packages/core/src/pipeline/executions/Executions.spec.tsx
+++ b/deck/packages/core/src/pipeline/executions/Executions.spec.tsx
@@ -1,12 +1,13 @@
 import { mock, noop } from 'angular';
+import { UIRouterContext, UIRouterReact } from '@uirouter/react';
 import type { ReactWrapper } from 'enzyme';
-import { mount } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import { set } from 'lodash';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 
 import type { IExecutionsProps, IExecutionsState } from './Executions';
-import { Executions } from './Executions';
+import { ExecutionsComponent } from './Executions';
 import type { Application } from '../../application';
 import { ApplicationModelBuilder } from '../../application/applicationModel.builder';
 import { ViewStateCache } from '../../cache';
@@ -15,10 +16,13 @@ import { OVERRIDE_REGISTRY } from '../../overrideRegistry';
 import { REACT_MODULE } from '../../reactShims';
 import * as State from '../../state';
 import { Spinner } from '../../widgets/spinners/Spinner';
+import { ManualExecutionModal } from '../manualExecution';
 
 describe('<Executions/>', () => {
   let component: ReactWrapper<IExecutionsProps, IExecutionsState>;
   let application: Application;
+  let router: UIRouterReact;
+  let routerProps: any;
 
   async function settleInitialization() {
     await act(async () => {
@@ -41,9 +45,18 @@ describe('<Executions/>', () => {
       application.pipelineConfigs.loaded = true;
     }
 
-    component = mount(<Executions app={application} />);
+    component = mount(
+      <UIRouterContext.Provider value={router}>
+        <ExecutionsComponent {...routerProps} app={application} />
+      </UIRouterContext.Provider>,
+    );
   }
 
+  beforeEach(() => {
+    component = null;
+    router = new UIRouterReact();
+    routerProps = { router, stateParams: {}, stateService: { go: jasmine.createSpy('injectedGo') } };
+  });
   beforeEach(mock.module(INSIGHT_FILTER_STATE_MODEL, REACT_MODULE, OVERRIDE_REGISTRY));
   beforeEach(() => jasmine.clock().install());
   beforeEach(
@@ -64,6 +77,7 @@ describe('<Executions/>', () => {
       await Promise.resolve();
     });
     component?.unmount();
+    router.dispose();
     jasmine.clock().uninstall();
   });
 
@@ -75,5 +89,44 @@ describe('<Executions/>', () => {
     await settleInitialization();
 
     expect(component.find(Spinner).length).toBe(0);
+  });
+
+  it('clears the manual execution param through the injected state service', () => {
+    const executionComponent = shallow(<ExecutionsComponent {...routerProps} app={application} />, {
+      disableLifecycleMethods: true,
+    });
+
+    (executionComponent.instance() as any).clearManualExecutionParam();
+
+    expect(routerProps.stateService.go).toHaveBeenCalledWith(
+      '.',
+      { startManualExecution: null },
+      { inherit: true, location: 'replace' },
+    );
+  });
+
+  it('starts a deep-linked manual execution from injected route params', async () => {
+    const pipeline = { id: 'pipeline-id', name: 'Test Pipeline' };
+    routerProps.stateParams = { startManualExecution: pipeline.id };
+    const showModal = spyOn(ManualExecutionModal, 'show').and.returnValue(Promise.reject());
+    set(application, 'executions.activate', noop);
+    set(application, 'pipelineConfigs.activate', noop);
+    application.executions.data = [];
+    application.executions.loaded = true;
+    application.pipelineConfigs.data = [pipeline] as any;
+    application.pipelineConfigs.loaded = true;
+    const executionComponent = shallow(<ExecutionsComponent {...routerProps} app={application} />, {
+      disableLifecycleMethods: true,
+    });
+    const instance = executionComponent.instance() as ExecutionsComponent;
+
+    instance.componentDidMount();
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    instance.componentWillUnmount();
+
+    expect(showModal).toHaveBeenCalledWith(jasmine.objectContaining({ application, pipeline }));
   });
 });

--- a/deck/packages/core/src/pipeline/executions/Executions.tsx
+++ b/deck/packages/core/src/pipeline/executions/Executions.tsx
@@ -1,8 +1,8 @@
 import { get } from 'lodash';
 import React from 'react';
 import type { Subscription } from 'rxjs';
-import { AngularServices } from '../../angular/services';
 
+import { AngularServices } from '../../angular/services';
 import type { Application } from '../../application';
 import type { IDefaultTagFilterConfig } from '../../application/config/defaultTagFilter/DefaultTagFilterConfig';
 import { CreatePipeline } from '../config/CreatePipeline';
@@ -14,7 +14,10 @@ import { ExecutionFilterService } from '../filter/executionFilter.service';
 import type { IFilterTag, ISortFilter } from '../../filterModel';
 import { FilterCollapse, FilterTags } from '../../filterModel';
 import { ManualExecutionModal } from '../manualExecution';
-import { Overridable } from '../../overrideRegistry';
+import type { IRouterInjectedProps } from '../../navigation/routerContext';
+import { withRouter } from '../../navigation/routerContext';
+import type { IOverridableProps } from '../../overrideRegistry';
+import { overridableComponent } from '../../overrideRegistry';
 import { Tooltip } from '../../presentation/Tooltip';
 import { SchedulerFactory } from '../../scheduler';
 import type { IScheduler } from '../../scheduler/SchedulerFactory';
@@ -25,7 +28,7 @@ import { Spinner } from '../../widgets/spinners/Spinner';
 
 import './executions.less';
 
-export interface IExecutionsProps {
+export interface IExecutionsProps extends IOverridableProps {
   app: Application;
 }
 
@@ -45,8 +48,7 @@ const forwardedExecutions = new Set();
 // This ensures we only forward to permalink on landing, not on future refreshes
 let disableForwarding = false;
 
-@Overridable('PipelineExecutions')
-export class Executions extends React.Component<IExecutionsProps, IExecutionsState> {
+export class ExecutionsComponent extends React.Component<IExecutionsProps & IRouterInjectedProps, IExecutionsState> {
   private executionsRefreshUnsubscribe: Function;
   private groupsUpdatedSubscription: Subscription;
   private insightFilterStateModel = AngularServices.insightFilterStateModel;
@@ -54,7 +56,7 @@ export class Executions extends React.Component<IExecutionsProps, IExecutionsSta
 
   private filterCountOptions = [1, 2, 5, 10, 20, 30, 40, 50, 100, 200];
 
-  constructor(props: IExecutionsProps) {
+  constructor(props: IExecutionsProps & IRouterInjectedProps) {
     super(props);
 
     this.state = {
@@ -187,22 +189,23 @@ export class Executions extends React.Component<IExecutionsProps, IExecutionsSta
   }
 
   private clearManualExecutionParam(): void {
-    AngularServices.$state.go('.', { startManualExecution: null }, { inherit: true, location: 'replace' });
+    this.props.stateService.go('.', { startManualExecution: null }, { inherit: true, location: 'replace' });
   }
 
   private handleAgedOutExecutions(executionId: string, forwardToPermalink: boolean): void {
-    const { $state, executionService } = AngularServices;
+    const { executionService } = AngularServices;
+    const { stateParams, stateService } = this.props;
     if (forwardToPermalink && executionId && !forwardedExecutions.has(executionId)) {
       // We only want to forward to permalink on initial load
       executionService.getExecution(executionId).then(() => {
-        const detailsState = $state.current.name.replace('executions.execution', 'executionDetails.execution');
-        const { stage, step, details } = $state.params;
+        const detailsState = stateService.current.name.replace('executions.execution', 'executionDetails.execution');
+        const { stage, step, details } = stateParams;
         forwardedExecutions.add(executionId);
-        $state.go(detailsState, { executionId, stage, step, details });
+        stateService.go(detailsState, { executionId, stage, step, details });
       });
     } else {
       // Handles the case where we already forwarded once and user navigated back, so do not forward again.
-      $state.go('.^');
+      stateService.go('.^');
     }
   }
 
@@ -232,11 +235,11 @@ export class Executions extends React.Component<IExecutionsProps, IExecutionsSta
         this.normalizeExecutionNames();
 
         // if an execution was selected but is no longer present, navigate up
-        const { $state } = AngularServices;
-        if ($state.params.executionId) {
+        const { executionId } = this.props.stateParams;
+        if (executionId) {
           const executions: IExecution[] = app.executions.data;
-          if (executions.every((e) => e.id !== $state.params.executionId)) {
-            this.handleAgedOutExecutions($state.params.executionId, !disableForwarding);
+          if (executions.every((e) => e.id !== executionId)) {
+            this.handleAgedOutExecutions(executionId, !disableForwarding);
           }
         }
         // After the very first refresh interval (landing), we do not want to forward the user to the permalink
@@ -249,7 +252,7 @@ export class Executions extends React.Component<IExecutionsProps, IExecutionsSta
 
     Promise.all([app.executions.ready(), app.pipelineConfigs.ready()]).then(() => {
       this.updateExecutionGroups();
-      const nameOrIdToStart = AngularServices.$stateParams.startManualExecution;
+      const { startManualExecution: nameOrIdToStart } = this.props.stateParams;
       if (nameOrIdToStart) {
         const toStart = app.pipelineConfigs.data.find((p: IPipeline) => [p.id, p.name].includes(nameOrIdToStart));
         if (toStart) {
@@ -302,7 +305,7 @@ export class Executions extends React.Component<IExecutionsProps, IExecutionsSta
     logger.log({ category: 'Pipelines', action: 'Toggle Durations', data: { label: checked.toString() } });
   };
 
-  public render(): React.ReactElement<Executions> {
+  public render(): React.ReactElement {
     const { app } = this.props;
     const { filtersExpanded, loading, sortFilter, tags, triggeringExecution, reloadingForFilters } = this.state;
 
@@ -461,3 +464,6 @@ export class Executions extends React.Component<IExecutionsProps, IExecutionsSta
     return null;
   }
 }
+
+const OverridableExecutions = overridableComponent(ExecutionsComponent, 'PipelineExecutions');
+export const Executions = withRouter<IExecutionsProps & IRouterInjectedProps>(OverridableExecutions);

--- a/deck/packages/core/src/pipeline/executions/execution/Execution.spec.tsx
+++ b/deck/packages/core/src/pipeline/executions/execution/Execution.spec.tsx
@@ -1,0 +1,118 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import { ExecutionComponent } from './Execution';
+import { AngularServices } from '../../../angular/services';
+import { setDirectRouter } from '../../../navigation/directRouter';
+import { ExecutionState } from '../../../state';
+
+describe('Execution', () => {
+  const application = { name: 'test-app', pipelineConfigs: { data: [] } } as any;
+  const execution = {
+    deploymentTargets: [],
+    hydrated: true,
+    id: 'execution-id',
+    runningTimeInMs: 0,
+    stageSummaries: [],
+    stages: [],
+    status: 'SUCCEEDED',
+  } as any;
+  let previousFilterModel: any;
+
+  beforeEach(() => {
+    previousFilterModel = ExecutionState.filterModel;
+    ExecutionState.filterModel = { asFilterModel: { sortFilter: { groupBy: 'name' } } } as any;
+    setDirectRouter({
+      globals: { params: { executionId: 'other-execution', stage: '9', subStage: '8' } },
+      stateService: { includes: () => false },
+    } as any);
+    spyOnProperty(AngularServices, 'executionService', 'get').and.returnValue({} as any);
+  });
+
+  afterEach(() => {
+    ExecutionState.filterModel = previousFilterModel;
+    setDirectRouter(null);
+  });
+
+  it('derives its initial view from the injected route', () => {
+    const component = shallow(
+      <ExecutionComponent
+        {...({
+          router: {},
+          stateParams: { executionId: 'execution-id', stage: '2', subStage: '3' },
+          stateService: { includes: () => true },
+        } as any)}
+        application={application}
+        execution={execution}
+        pipelineConfig={null}
+      />,
+      { disableLifecycleMethods: true },
+    );
+
+    expect(component.state('showingDetails')).toBe(true);
+    expect(component.state('viewState')).toEqual(
+      jasmine.objectContaining({ activeStageId: 2, activeSubStageId: 3, executionId: 'execution-id' }),
+    );
+    expect((component.instance() as ExecutionComponent).isActive({ index: 2 } as any)).toBe(true);
+  });
+
+  it('updates its view from injected route transitions', () => {
+    let transitionHandler: (transition: any) => void;
+    const unsubscribe = jasmine.createSpy('unsubscribe');
+    const onSuccess = jasmine.createSpy('onSuccess').and.callFake((_criteria, callback) => {
+      transitionHandler = callback;
+      return unsubscribe;
+    });
+    const component = shallow(
+      <ExecutionComponent
+        {...({
+          router: { transitionService: { onSuccess } },
+          stateParams: { executionId: 'other-execution' },
+          stateService: { includes: () => true },
+        } as any)}
+        application={application}
+        execution={execution}
+        pipelineConfig={null}
+      />,
+      { disableLifecycleMethods: true },
+    );
+    const instance = component.instance() as ExecutionComponent;
+    instance.componentDidMount();
+
+    transitionHandler({
+      from: () => ({ name: 'executions' }),
+      params: (target: string) =>
+        target === 'to'
+          ? { executionId: 'execution-id', stage: '4', subStage: '5' }
+          : { executionId: 'other-execution' },
+      to: () => ({ name: 'executions.execution' }),
+    });
+
+    expect(component.state('showingDetails')).toBe(true);
+    expect(component.state('viewState')).toEqual(jasmine.objectContaining({ activeStageId: 4, activeSubStageId: 5 }));
+    instance.componentWillUnmount();
+    expect(unsubscribe).toHaveBeenCalled();
+  });
+
+  it('configures the pipeline through the injected state service', () => {
+    const go = jasmine.createSpy('go');
+    const stopPropagation = jasmine.createSpy('stopPropagation');
+    const component = shallow(
+      <ExecutionComponent
+        {...({ router: {}, stateParams: {}, stateService: { go, includes: () => false } } as any)}
+        application={application}
+        execution={{ ...execution, pipelineConfigId: 'pipeline-id' }}
+        pipelineConfig={null}
+      />,
+      { disableLifecycleMethods: true },
+    );
+
+    (component.instance() as any).handleConfigureClicked({ stopPropagation });
+
+    expect(go).toHaveBeenCalledWith('^.pipelineConfig', {
+      application: 'test-app',
+      pipelineId: 'pipeline-id',
+    });
+    expect(stopPropagation).toHaveBeenCalled();
+  });
+});

--- a/deck/packages/core/src/pipeline/executions/execution/Execution.tsx
+++ b/deck/packages/core/src/pipeline/executions/execution/Execution.tsx
@@ -19,7 +19,10 @@ import { ConfirmationModalService } from '../../../confirmationModal';
 import { StageExecutionDetails } from '../../details/StageExecutionDetails';
 import type { IExecution, IExecutionStageSummary, IPipeline, IRestartDetails } from '../../../domain';
 import type { ISortFilter } from '../../../filterModel';
-import { Overridable } from '../../../overrideRegistry';
+import type { IRouterInjectedProps } from '../../../navigation/routerContext';
+import { stateChangeSuccess$, withRouter } from '../../../navigation/routerContext';
+import type { IOverridableProps } from '../../../overrideRegistry';
+import { overridableComponent } from '../../../overrideRegistry';
 import { Tooltip } from '../../../presentation/Tooltip';
 import { ExecutionState } from '../../../state';
 import { ExecutionCancellationReason } from '../../status/ExecutionCancellationReason';
@@ -30,7 +33,7 @@ import { duration, timestamp } from '../../../utils/timeFormatters';
 
 import './execution.less';
 
-export interface IExecutionProps {
+export interface IExecutionProps extends IOverridableProps {
   application: Application;
   execution: IExecution;
   descendantExecutionId?: string;
@@ -64,8 +67,7 @@ const findChildIndex = (child: string, execution: IExecution) => {
   return result;
 };
 
-@Overridable('PipelineExecution')
-export class Execution extends React.PureComponent<IExecutionProps, IExecutionState> {
+export class ExecutionComponent extends React.PureComponent<IExecutionProps & IRouterInjectedProps, IExecutionState> {
   public static defaultProps: Partial<IExecutionProps> = {
     dataSourceKey: 'executions',
     cancelHelpText: 'Cancel execution',
@@ -75,21 +77,21 @@ export class Execution extends React.PureComponent<IExecutionProps, IExecutionSt
   private runningTime: OrchestratedItemRunningTime;
   private wrapperRef = React.createRef<HTMLDivElement>();
 
-  constructor(props: IExecutionProps) {
+  constructor(props: IExecutionProps & IRouterInjectedProps) {
     super(props);
     const { execution, standalone } = this.props;
-    const { $stateParams } = AngularServices;
+    const { stateParams } = this.props;
 
     const initialViewState = {
-      activeStageId: Number($stateParams.stage),
-      activeSubStageId: Number($stateParams.subStage),
-      executionId: $stateParams.executionId,
+      activeStageId: Number(stateParams.stage),
+      activeSubStageId: Number(stateParams.subStage),
+      executionId: stateParams.executionId,
       canTriggerPipelineManually: false,
       canConfigure: false,
     };
 
     // Used when rendering ancestors in SingleExecutionView to mark descendents as "selected"
-    if ($stateParams.executionId !== props.execution.id && props.descendantExecutionId) {
+    if (stateParams.executionId !== props.execution.id && props.descendantExecutionId) {
       initialViewState.activeStageId = findChildIndex(props.descendantExecutionId, props.execution);
     }
 
@@ -123,7 +125,7 @@ export class Execution extends React.PureComponent<IExecutionProps, IExecutionSt
 
     if (this.state.showingDetails !== shouldShowDetails) {
       this.setState({
-        showingDetails: this.invalidateShowingDetails(this.props, shouldScroll),
+        showingDetails: this.invalidateShowingDetails(this.props, shouldScroll, toParams),
         viewState: newViewState,
       });
     } else {
@@ -133,11 +135,12 @@ export class Execution extends React.PureComponent<IExecutionProps, IExecutionSt
     }
   }
 
-  private invalidateShowingDetails(props = this.props, forceScroll = false): boolean {
-    const { $state, $stateParams, executionService } = AngularServices;
+  private invalidateShowingDetails(props = this.props, forceScroll = false, stateParams = props.stateParams): boolean {
+    const { executionService } = AngularServices;
+    const { stateService } = props;
     const { execution, application, standalone } = props;
     const showing =
-      standalone === true || (execution.id === $stateParams.executionId && $state.includes('**.execution.**'));
+      standalone === true || (execution.id === stateParams.executionId && stateService.includes('**.execution.**'));
     if (showing && !execution.hydrated) {
       executionService.hydrate(application, execution).then(() => {
         this.setState({ showingDetails: true }, () => this.scrollIntoView(forceScroll));
@@ -156,7 +159,7 @@ export class Execution extends React.PureComponent<IExecutionProps, IExecutionSt
     }
 
     // When execution.id doesn't match, we're' rendering the ancestors in <SingleExecutionDetails>
-    if (this.props.execution.id !== AngularServices.$stateParams.executionId) {
+    if (this.props.execution.id !== this.props.stateParams.executionId) {
       return (
         this.props.descendantExecutionId &&
         stage &&
@@ -164,7 +167,7 @@ export class Execution extends React.PureComponent<IExecutionProps, IExecutionSt
         stage.masterStage?.context?.executionId === this.props.descendantExecutionId
       );
     }
-    return this.state.showingDetails && Number(AngularServices.$stateParams.stage) === stage.index;
+    return this.state.showingDetails && Number(this.props.stateParams.stage) === stage.index;
   }
 
   public toggleDetails = (stageIndex?: number, subIndex?: number): void => {
@@ -192,7 +195,7 @@ export class Execution extends React.PureComponent<IExecutionProps, IExecutionSt
       submitMethod: () =>
         executionService.deleteExecution(this.props.application, this.props.execution.id).then(() => {
           if (this.props.standalone) {
-            AngularServices.$state.go('^');
+            this.props.stateService.go('^');
           }
         }),
     });
@@ -238,14 +241,12 @@ export class Execution extends React.PureComponent<IExecutionProps, IExecutionSt
     this.runningTime = new OrchestratedItemRunningTime(execution, (time: number) =>
       this.setState({ runningTimeInMs: time }),
     );
-    this.stateChangeSuccessSubscription = AngularServices.stateEvents.stateChangeSuccess.subscribe(
-      ({ toParams, fromParams }) => {
-        this.updateViewStateDetails(toParams, fromParams);
-      },
+    this.stateChangeSuccessSubscription = stateChangeSuccess$(this.props.router).subscribe(({ toParams, fromParams }) =>
+      this.updateViewStateDetails(toParams, fromParams),
     );
   }
 
-  public componentWillReceiveProps(nextProps: IExecutionProps): void {
+  public componentWillReceiveProps(nextProps: IExecutionProps & IRouterInjectedProps): void {
     if (nextProps.execution !== this.props.execution) {
       this.runningTime.checkStatus(nextProps.execution);
       this.setState({
@@ -306,7 +307,7 @@ export class Execution extends React.PureComponent<IExecutionProps, IExecutionSt
   private handleConfigureClicked = (e: React.MouseEvent<HTMLElement>): void => {
     const { application, execution } = this.props;
     logger.log({ category: 'Execution', action: 'Configuration' });
-    AngularServices.$state.go('^.pipelineConfig', {
+    this.props.stateService.go('^.pipelineConfig', {
       application: application.name,
       pipelineId: execution.pipelineConfigId,
     });
@@ -342,7 +343,7 @@ export class Execution extends React.PureComponent<IExecutionProps, IExecutionSt
       pipelineConfig,
     } = this.props;
     const { pipelinesUrl, restartDetails, showingDetails, sortFilter, viewState } = this.state;
-    const { $state, $stateParams } = AngularServices;
+    const { stateParams, stateService } = this.props;
 
     const accountLabels = this.props.execution.deploymentTargets.map((account) => (
       <AccountTag key={account} account={account} />
@@ -429,7 +430,7 @@ export class Execution extends React.PureComponent<IExecutionProps, IExecutionSt
                     {' ('}
                     waiting on{' '}
                     <UISref
-                      to={`${$state.current.name.endsWith('.execution') ? '^' : ''}.^.executions`}
+                      to={`${stateService.current.name.endsWith('.execution') ? '^' : ''}.^.executions`}
                       params={{ pipeline: execution.name, status: 'RUNNING' }}
                     >
                       <a>RUNNING</a>
@@ -523,7 +524,7 @@ export class Execution extends React.PureComponent<IExecutionProps, IExecutionSt
             <PipelineGraph execution={execution} onNodeClick={this.handleNodeClick} viewState={viewState} />
           </div>
         )}
-        {showingDetails && (!standalone || execution.id === $stateParams.executionId) && (
+        {showingDetails && (!standalone || execution.id === stateParams.executionId) && (
           <div className="execution-details-container">
             <StageExecutionDetails execution={execution} application={application} standalone={standalone} />
             <div className="permalinks">
@@ -541,3 +542,6 @@ export class Execution extends React.PureComponent<IExecutionProps, IExecutionSt
     );
   }
 }
+
+const OverridableExecution = overridableComponent(ExecutionComponent, 'PipelineExecution');
+export const Execution = withRouter<IExecutionProps & IRouterInjectedProps>(OverridableExecution);

--- a/deck/packages/core/src/pipeline/executions/execution/ExecutionPermalink.tsx
+++ b/deck/packages/core/src/pipeline/executions/execution/ExecutionPermalink.tsx
@@ -1,6 +1,7 @@
+import { useRouter } from '@uirouter/react';
 import React from 'react';
-import { AngularServices } from '../../../angular/services';
 
+import { locationChangeSuccess$ } from '../../../navigation/routerContext';
 import { CopyToClipboard, logger } from '../../../utils';
 
 export interface IExecutionPermalinkProps {
@@ -8,18 +9,19 @@ export interface IExecutionPermalinkProps {
 }
 
 export const ExecutionPermalink = ({ standalone }: IExecutionPermalinkProps) => {
+  const router = useRouter();
   const asPermalink = (link: string) => (standalone ? link : link.replace('/executions', '/executions/details'));
 
   const [url, setUrl] = React.useState(asPermalink(location.href));
 
   React.useEffect(() => {
-    const subscription = AngularServices.stateEvents.locationChangeSuccess.subscribe((newUrl) => {
+    const subscription = locationChangeSuccess$(router).subscribe((newUrl) => {
       if (url !== newUrl) {
         setUrl(asPermalink(newUrl));
       }
     });
     return () => subscription.unsubscribe();
-  }, []);
+  }, [router]);
 
   const handlePermalinkClick = (): void => {
     logger.log({ category: 'Pipeline', action: 'Permalink clicked' });

--- a/deck/packages/core/src/pipeline/executions/executionGroup/ExecutionGroup.spec.tsx
+++ b/deck/packages/core/src/pipeline/executions/executionGroup/ExecutionGroup.spec.tsx
@@ -1,0 +1,120 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import { Subject } from 'rxjs';
+
+import { ExecutionGroupComponent } from './ExecutionGroup';
+import { AngularServices } from '../../../angular/services';
+import { CollapsibleSectionStateCache } from '../../../cache';
+import { ExecutionState } from '../../../state';
+
+describe('ExecutionGroup', () => {
+  const application = {
+    name: 'test-app',
+    pipelineConfigs: { data: [] },
+    pipelineLocks: { data: [], onRefresh: jasmine.createSpy('onRefresh').and.returnValue(() => undefined) },
+    strategyConfigs: { data: [] },
+  } as any;
+  const group = { executions: [], heading: 'Pipeline', runningExecutions: [] } as any;
+  let previousFilterModel: any;
+
+  beforeEach(() => {
+    previousFilterModel = ExecutionState.filterModel;
+    ExecutionState.filterModel = {
+      asFilterModel: { sortFilter: { groupBy: 'name' } },
+      expandSubject: new Subject<boolean>(),
+    } as any;
+    spyOn(CollapsibleSectionStateCache, 'isSet').and.returnValue(false);
+    spyOnProperty(AngularServices, 'executionService', 'get').and.returnValue({
+      getSectionCacheKey: () => 'section-key',
+    } as any);
+  });
+
+  afterEach(() => {
+    ExecutionState.filterModel = previousFilterModel;
+  });
+
+  it('configures the pipeline through the injected state service', () => {
+    const injectedGo = jasmine.createSpy('injectedGo');
+    const stateName = 'home.applications.application.pipelines.executions';
+    const component = shallow(
+      <ExecutionGroupComponent
+        {...({
+          router: {},
+          stateParams: {},
+          stateService: { current: { name: stateName }, go: injectedGo, includes: () => false },
+        } as any)}
+        application={application}
+        group={group}
+        parent={null}
+      />,
+      { disableLifecycleMethods: true },
+    );
+
+    (component.instance() as any).configure('pipeline-id');
+
+    expect(injectedGo).toHaveBeenCalledWith('^.pipelineConfig', { pipelineId: 'pipeline-id' });
+  });
+
+  it('observes route changes through the injected router', () => {
+    const injectedUnsubscribe = jasmine.createSpy('injectedUnsubscribe');
+    const injectedOnSuccess = jasmine.createSpy('injectedOnSuccess').and.returnValue(injectedUnsubscribe);
+    const component = shallow(
+      <ExecutionGroupComponent
+        {...({
+          router: { transitionService: { onSuccess: injectedOnSuccess } },
+          stateParams: {},
+          stateService: { includes: () => false },
+        } as any)}
+        application={application}
+        group={group}
+        parent={null}
+      />,
+      { disableLifecycleMethods: true },
+    );
+    const instance = component.instance() as ExecutionGroupComponent;
+
+    instance.componentDidMount();
+    instance.componentWillUnmount();
+
+    expect(injectedOnSuccess).toHaveBeenCalledWith({}, jasmine.any(Function));
+    expect(injectedUnsubscribe).toHaveBeenCalled();
+  });
+
+  it('expands and marks the group from transition target params', () => {
+    let transitionSuccess: (transition: any) => void;
+    const injectedOnSuccess = jasmine
+      .createSpy('injectedOnSuccess')
+      .and.callFake((_criteria: any, callback: (transition: any) => void) => {
+        transitionSuccess = callback;
+        return () => undefined;
+      });
+    (CollapsibleSectionStateCache.isSet as jasmine.Spy).and.returnValue(true);
+    spyOn(CollapsibleSectionStateCache, 'isExpanded').and.returnValue(false);
+    const component = shallow(
+      <ExecutionGroupComponent
+        {...({
+          router: { transitionService: { onSuccess: injectedOnSuccess } },
+          stateParams: {},
+          stateService: { includes: () => true },
+        } as any)}
+        application={application}
+        group={{ ...group, executions: [{ id: 'execution-id', deploymentTargets: [] }] }}
+        parent={null}
+      />,
+      { disableLifecycleMethods: true },
+    );
+    const instance = component.instance() as ExecutionGroupComponent;
+    instance.componentDidMount();
+
+    transitionSuccess({
+      from: () => ({}),
+      params: () => ({ executionId: 'execution-id' }),
+      to: () => ({}),
+    });
+
+    expect(component.state('open')).toBe(true);
+    expect(component.state('showingDetails')).toBe(true);
+    expect(component.find('.execution-group').hasClass('showing-details')).toBe(true);
+    instance.componentWillUnmount();
+  });
+});

--- a/deck/packages/core/src/pipeline/executions/executionGroup/ExecutionGroup.tsx
+++ b/deck/packages/core/src/pipeline/executions/executionGroup/ExecutionGroup.tsx
@@ -25,7 +25,10 @@ import { EntityNotifications } from '../../../entityTag/notifications/EntityNoti
 import { Execution } from '../execution/Execution';
 import { ExecutionAction } from '../executionAction/ExecutionAction';
 import { ManualExecutionModal } from '../../manualExecution';
-import { Overridable } from '../../../overrideRegistry';
+import type { IRouterInjectedProps } from '../../../navigation/routerContext';
+import { stateChangeSuccess$, withRouter } from '../../../navigation/routerContext';
+import type { IOverridableProps } from '../../../overrideRegistry';
+import { overridableComponent } from '../../../overrideRegistry';
 import type { Placement } from '../../../presentation/Placement';
 import { Popover } from '../../../presentation/Popover';
 import { ExecutionState } from '../../../state';
@@ -40,7 +43,7 @@ import './executionGroup.less';
 
 const ACCOUNT_TAG_OVERFLOW_LIMIT = SETTINGS.accountTagLimit ?? 1;
 
-export interface IExecutionGroupProps {
+export interface IExecutionGroupProps extends IOverridableProps {
   group: IExecutionGroup;
   application: Application;
   parent: HTMLDivElement;
@@ -59,15 +62,17 @@ export interface IExecutionGroupState {
   placement: Placement;
 }
 
-@Overridable('PipelineExecutionGroup')
-export class ExecutionGroup extends React.PureComponent<IExecutionGroupProps, IExecutionGroupState> {
+export class ExecutionGroupComponent extends React.PureComponent<
+  IExecutionGroupProps & IRouterInjectedProps,
+  IExecutionGroupState
+> {
   public state: IExecutionGroupState;
   private expandUpdatedSubscription: Subscription;
   private stateChangeSuccessSubscription: Subscription;
   private destroy$ = new Subject();
   private headerRef = React.createRef<HTMLDivElement>();
 
-  constructor(props: IExecutionGroupProps) {
+  constructor(props: IExecutionGroupProps & IRouterInjectedProps) {
     super(props);
     const { group, application } = props;
     const strategyConfig = application.strategyConfigs.data.find((c: IPipeline) => c.name === group.heading);
@@ -94,24 +99,24 @@ export class ExecutionGroup extends React.PureComponent<IExecutionGroupProps, IE
     };
   }
 
-  private isShowingDetails(): boolean {
-    const { $state, $stateParams } = AngularServices;
+  private isShowingDetails(routeParams = this.props.stateParams): boolean {
+    const { stateService } = this.props;
     return this.props.group.executions.some(
-      (execution: IExecution) => execution.id === $stateParams.executionId && $state.includes('**.execution.**'),
+      (execution: IExecution) => execution.id === routeParams.executionId && stateService.includes('**.execution.**'),
     );
   }
 
   public configure(id: string): void {
-    const { $state } = AngularServices;
-    if (!$state.current.name.includes('.executions.execution')) {
-      $state.go('^.pipelineConfig', { pipelineId: id });
+    const { stateService } = this.props;
+    if (!stateService.current.name.includes('.executions.execution')) {
+      stateService.go('^.pipelineConfig', { pipelineId: id });
     } else {
-      $state.go('^.^.pipelineConfig', { pipelineId: id });
+      stateService.go('^.^.pipelineConfig', { pipelineId: id });
     }
   }
 
   private hideDetails(): void {
-    AngularServices.$state.go('.^');
+    this.props.stateService.go('.^');
   }
 
   private getSectionCacheKey(): string {
@@ -174,19 +179,18 @@ export class ExecutionGroup extends React.PureComponent<IExecutionGroupProps, IE
   }
 
   public componentDidMount(): void {
-    const { stateEvents } = AngularServices;
     this.expandUpdatedSubscription = ExecutionState.filterModel.expandSubject.subscribe((expanded) => {
       if (this.state.open !== expanded) {
         this.toggle();
       }
     });
-    this.stateChangeSuccessSubscription = stateEvents.stateChangeSuccess.subscribe(() => {
+    this.stateChangeSuccessSubscription = stateChangeSuccess$(this.props.router).subscribe(({ toParams }) => {
       // If the heading is collapsed, but we've clicked on a link to an execution in this group, expand the group
-      const showingDetails = this.isShowingDetails();
-      if (this.isShowingDetails() && !this.state.open) {
-        this.toggle();
-      }
-      if (showingDetails !== this.state.showingDetails) {
+      const showingDetails = this.isShowingDetails(toParams);
+      if (showingDetails && !this.state.open) {
+        CollapsibleSectionStateCache.setExpanded(this.getSectionCacheKey(), true);
+        this.setState({ open: true, showingDetails: true });
+      } else if (showingDetails !== this.state.showingDetails) {
         this.setState({ showingDetails });
       }
     });
@@ -272,7 +276,7 @@ export class ExecutionGroup extends React.PureComponent<IExecutionGroupProps, IE
     );
   }
 
-  public render(): React.ReactElement<ExecutionGroup> {
+  public render(): React.ReactElement {
     const { group } = this.props;
     const { displayExecutionActions, pipelineConfig, triggeringExecution, showingDetails, placement } = this.state;
     const pipelineDisabled = pipelineConfig && pipelineConfig.disabled;
@@ -416,3 +420,6 @@ export class ExecutionGroup extends React.PureComponent<IExecutionGroupProps, IE
     );
   }
 }
+
+const OverridableExecutionGroup = overridableComponent(ExecutionGroupComponent, 'PipelineExecutionGroup');
+export const ExecutionGroup = withRouter<IExecutionGroupProps & IRouterInjectedProps>(OverridableExecutionGroup);

--- a/deck/packages/core/src/pipeline/executions/executionGroup/ExecutionGroups.spec.tsx
+++ b/deck/packages/core/src/pipeline/executions/executionGroup/ExecutionGroups.spec.tsx
@@ -1,0 +1,88 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import { ExecutionGroupsComponent } from './ExecutionGroups';
+import { ExecutionState } from '../../../state';
+
+describe('ExecutionGroups', () => {
+  const group = { executions: [{ id: 'execution-id' }], heading: 'Pipeline', runningExecutions: [] } as any;
+  const application = {
+    executions: { onRefresh: jasmine.createSpy('onRefresh').and.returnValue(() => undefined) },
+  } as any;
+  let previousFilterModel: any;
+
+  beforeEach(() => {
+    previousFilterModel = ExecutionState.filterModel;
+    ExecutionState.filterModel = { asFilterModel: { groups: [group] } } as any;
+  });
+
+  afterEach(() => {
+    ExecutionState.filterModel = previousFilterModel;
+  });
+
+  it('shows details from injected route state when the execution is present', () => {
+    const component = shallow(
+      <ExecutionGroupsComponent
+        {...({
+          router: { transitionService: { onSuccess: () => () => undefined } },
+          stateParams: { executionId: 'execution-id' },
+          stateService: { includes: () => true },
+        } as any)}
+        application={application}
+      />,
+    );
+
+    expect(component.find('.executions').hasClass('showing-details')).toBe(true);
+    component.unmount();
+  });
+
+  it('observes route changes through the injected router', () => {
+    const injectedUnsubscribe = jasmine.createSpy('injectedUnsubscribe');
+    const injectedOnSuccess = jasmine.createSpy('injectedOnSuccess').and.returnValue(injectedUnsubscribe);
+    const component = shallow(
+      <ExecutionGroupsComponent
+        {...({
+          router: { transitionService: { onSuccess: injectedOnSuccess } },
+          stateParams: {},
+          stateService: { includes: () => false },
+        } as any)}
+        application={application}
+      />,
+    );
+
+    component.unmount();
+
+    expect(injectedOnSuccess).toHaveBeenCalledWith({}, jasmine.any(Function));
+    expect(injectedUnsubscribe).toHaveBeenCalled();
+  });
+
+  it('marks details as shown from transition target params', () => {
+    let transitionSuccess: (transition: any) => void;
+    const component = shallow(
+      <ExecutionGroupsComponent
+        {...({
+          router: {
+            transitionService: {
+              onSuccess: (_criteria: any, callback: (transition: any) => void) => {
+                transitionSuccess = callback;
+                return () => undefined;
+              },
+            },
+          },
+          stateParams: {},
+          stateService: { includes: () => true },
+        } as any)}
+        application={application}
+      />,
+    );
+
+    transitionSuccess({
+      from: () => ({}),
+      params: () => ({ executionId: 'execution-id' }),
+      to: () => ({}),
+    });
+
+    expect(component.find('.executions').hasClass('showing-details')).toBe(true);
+    component.unmount();
+  });
+});

--- a/deck/packages/core/src/pipeline/executions/executionGroup/ExecutionGroups.tsx
+++ b/deck/packages/core/src/pipeline/executions/executionGroup/ExecutionGroups.tsx
@@ -2,11 +2,12 @@ import React from 'react';
 import type { Subscription } from 'rxjs';
 
 import { ExecutionGroup } from './ExecutionGroup';
-import { AngularServices } from '../../../angular/services';
 import type { Application } from '../../../application/application.model';
 import { BannerContainer } from '../../../banner';
 import type { IExecutionGroup } from '../../../domain';
 import { ExecutionFilterService } from '../../filter/executionFilter.service';
+import type { IRouterInjectedProps } from '../../../navigation/routerContext';
+import { stateChangeSuccess$, withRouter } from '../../../navigation/routerContext';
 import { ExecutionState } from '../../../state';
 
 import './executionGroups.less';
@@ -21,17 +22,19 @@ export interface IExecutionGroupsState {
   container?: HTMLDivElement; // need to pass the container down to children to use as root for IntersectionObserver
 }
 
-export class ExecutionGroups extends React.Component<IExecutionGroupsProps, IExecutionGroupsState> {
+export class ExecutionGroupsComponent extends React.Component<
+  IExecutionGroupsProps & IRouterInjectedProps,
+  IExecutionGroupsState
+> {
   private applicationRefreshUnsubscribe: () => void;
   private groupsUpdatedSubscription: Subscription;
   private stateChangeSuccessSubscription: Subscription;
 
-  constructor(props: IExecutionGroupsProps) {
+  constructor(props: IExecutionGroupsProps & IRouterInjectedProps) {
     super(props);
-    const { stateEvents } = AngularServices;
     this.state = {
       groups: ExecutionState.filterModel.asFilterModel.groups,
-      showingDetails: AngularServices.$state.includes('**.execution'),
+      showingDetails: props.stateService.includes('**.execution'),
     };
 
     this.applicationRefreshUnsubscribe = props.application.executions.onRefresh(null, () => {
@@ -45,16 +48,16 @@ export class ExecutionGroups extends React.Component<IExecutionGroupsProps, IExe
         this.setState({ groups: newGroups });
       }
     });
-    this.stateChangeSuccessSubscription = stateEvents.stateChangeSuccess.subscribe(() => {
-      const detailsShown = this.showingDetails();
+    this.stateChangeSuccessSubscription = stateChangeSuccess$(props.router).subscribe(({ toParams }) => {
+      const detailsShown = this.showingDetails(toParams);
       if (detailsShown !== this.state.showingDetails) {
         this.setState({ showingDetails: detailsShown });
       }
     });
   }
 
-  private showingDetails(): boolean {
-    const { executionId } = AngularServices.$stateParams;
+  private showingDetails(routeParams = this.props.stateParams): boolean {
+    const { executionId } = routeParams;
     // showingDetails() is just used to set a class ('.showing-details') on the wrapper around the execution groups.
     // the effect of this class is that, when an execution is deep linked, all the other execution groups have a partial
     // opacity (except when hovering over them).
@@ -63,7 +66,7 @@ export class ExecutionGroups extends React.Component<IExecutionGroupsProps, IExe
     if (!executionId || this.state.groups.every((g) => g.executions.every((e) => e.id !== executionId))) {
       return false;
     }
-    return AngularServices.$state.includes('**.execution');
+    return this.props.stateService.includes('**.execution');
   }
 
   private setContainer = (container: HTMLDivElement) => {
@@ -85,7 +88,7 @@ export class ExecutionGroups extends React.Component<IExecutionGroupsProps, IExe
     }
   }
 
-  public render(): React.ReactElement<ExecutionGroups> {
+  public render(): React.ReactElement {
     const { groups = [], container, showingDetails } = this.state;
     const hasGroups = groups.length > 0;
     const className = `row pipelines executions ${showingDetails ? 'showing-details' : ''}`;
@@ -149,3 +152,5 @@ export class ExecutionGroups extends React.Component<IExecutionGroupsProps, IExe
     );
   }
 }
+
+export const ExecutionGroups = withRouter(ExecutionGroupsComponent);

--- a/deck/packages/core/src/pipeline/filter/ExecutionFilterModel.ts
+++ b/deck/packages/core/src/pipeline/filter/ExecutionFilterModel.ts
@@ -1,6 +1,5 @@
 import { extend } from 'lodash';
 import { Subject } from 'rxjs';
-import { AngularServices } from '../../angular/services';
 
 import type { ICache } from '../../cache';
 import { ViewStateCache } from '../../cache';
@@ -8,6 +7,7 @@ import { SETTINGS } from '../../config/settings';
 import type { IExecutionGroup } from '../../domain';
 import { FilterModelService } from '../../filterModel';
 import type { IFilterConfig, IFilterModel } from '../../filterModel/IFilterModel';
+import { getDirectRouter } from '../../navigation/directRouter';
 
 export const filterModelConfig: IFilterConfig[] = [
   { model: 'awaitingJudgement', type: 'boolean', clearValue: false },
@@ -38,7 +38,7 @@ export class ExecutionFilterModel {
   public expandSubject: Subject<boolean> = new Subject<boolean>();
 
   constructor() {
-    const { transitionService } = AngularServices.$uiRouter;
+    const transitionService = getDirectRouter()?.transitionService;
 
     this.configViewStateCache =
       ViewStateCache.get('executionFilters') ||
@@ -51,7 +51,7 @@ export class ExecutionFilterModel {
     FilterModelService.registerRouterHooks(this.asFilterModel, '**.application.pipelines.executions.**');
     this.asFilterModel.activate();
 
-    transitionService.onBefore(
+    transitionService?.onBefore(
       {
         entering: (state) =>
           !!(

--- a/deck/packages/core/src/pipeline/filter/ExecutionFilters.tsx
+++ b/deck/packages/core/src/pipeline/filter/ExecutionFilters.tsx
@@ -5,7 +5,6 @@ import React from 'react';
 import type { SortEnd } from 'react-sortable-hoc';
 import { arrayMove, SortableContainer, SortableElement, SortableHandle } from 'react-sortable-hoc';
 import type { Subscription } from 'rxjs';
-import { AngularServices } from '../../angular/services';
 
 import type { Application } from '../../application';
 import { FilterSearch } from '../../cluster/filter/FilterSearch';
@@ -14,6 +13,8 @@ import { PipelineConfigService } from '../config/services/PipelineConfigService'
 import type { IExecution, IPipeline, IPipelineTag } from '../../domain';
 import { ExecutionFilterService } from './executionFilter.service';
 import type { IFilterTag } from '../../filterModel';
+import type { IRouterInjectedProps } from '../../navigation/routerContext';
+import { withRouter } from '../../navigation/routerContext';
 import { ExecutionState } from '../../state';
 import { logger } from '../../utils';
 
@@ -42,13 +43,16 @@ const DragHandle = SortableHandle(() => (
   <span className="pipeline-drag-handle clickable glyphicon glyphicon-resize-vertical" />
 ));
 
-export class ExecutionFilters extends React.Component<IExecutionFiltersProps, IExecutionFiltersState> {
+class ExecutionFiltersComponent extends React.Component<
+  IExecutionFiltersProps & IRouterInjectedProps,
+  IExecutionFiltersState
+> {
   private executionsRefreshUnsubscribe: () => void;
   private groupsUpdatedSubscription: Subscription;
   private locationChangeUnsubscribe: Function;
   private pipelineConfigsRefreshUnsubscribe: () => void;
 
-  constructor(props: IExecutionFiltersProps) {
+  constructor(props: IExecutionFiltersProps & IRouterInjectedProps) {
     super(props);
 
     const searchString = ExecutionState.filterModel.asFilterModel.sortFilter.filter;
@@ -78,7 +82,7 @@ export class ExecutionFilters extends React.Component<IExecutionFiltersProps, IE
     });
 
     this.initialize();
-    this.locationChangeUnsubscribe = AngularServices.$uiRouter.transitionService.onSuccess({}, () => {
+    this.locationChangeUnsubscribe = this.props.router.transitionService.onSuccess({}, () => {
       ExecutionState.filterModel.asFilterModel.activate();
       ExecutionFilterService.updateExecutionGroups(application);
     });
@@ -332,6 +336,9 @@ export class ExecutionFilters extends React.Component<IExecutionFiltersProps, IE
     );
   }
 }
+
+export const ExecutionFilters = withRouter(ExecutionFiltersComponent);
+ExecutionFilters.displayName = 'ExecutionFilters';
 
 const FilterCheckbox = (props: {
   tag: IFilterTag;

--- a/deck/packages/core/src/presentation/ReactModal.spec.tsx
+++ b/deck/packages/core/src/presentation/ReactModal.spec.tsx
@@ -1,6 +1,10 @@
+import { UIRouterContext, UIRouterReact } from '@uirouter/react';
 import React from 'react';
 import ReactDOM from 'react-dom';
 
+import { setDirectRouter } from '../navigation/directRouter';
+import type { IRouterInjectedProps } from '../navigation/routerContext';
+import { withRouter } from '../navigation/routerContext';
 import type { IModalComponentProps } from './modal';
 import { ReactModal } from './ReactModal';
 
@@ -12,6 +16,9 @@ const getLastRender = (renders: React.ReactElement[]): React.ReactElement =>
 const flushPromises = (): Promise<void> => Promise.resolve();
 
 describe('ReactModal', () => {
+  beforeEach(() => setDirectRouter(null));
+  afterEach(() => setDirectRouter(null));
+
   it('resolves after the modal exit completes', async () => {
     const renders: React.ReactElement[] = [];
     spyOn(ReactDOM, 'render').and.callFake((element) => {
@@ -68,5 +75,42 @@ describe('ReactModal', () => {
     await flushPromises();
     expect(rejectedValue).toBe('cancelled');
     expect(unmountSpy).toHaveBeenCalled();
+  });
+});
+
+describe('ReactModal router context', () => {
+  let router: UIRouterReact;
+
+  beforeEach(() => {
+    router = new UIRouterReact();
+    setDirectRouter(router);
+  });
+
+  afterEach(() => {
+    setDirectRouter(null);
+    router.dispose();
+  });
+
+  it('provides the direct router to routed modal components', () => {
+    const renders: React.ReactElement[] = [];
+    spyOn(ReactDOM, 'render').and.callFake((element) => {
+      renders.push(element as React.ReactElement);
+      return null;
+    });
+
+    const RoutedModalComponent = withRouter(
+      class extends React.Component<IModalComponentProps & IRouterInjectedProps> {
+        public render(): React.ReactNode {
+          return null;
+        }
+      },
+    );
+
+    ReactModal.show(RoutedModalComponent, {} as any, { animation: false });
+
+    const provider = getLastRender(renders);
+    expect(provider.type).toBe(UIRouterContext.Provider);
+    expect(provider.props.value).toBe(router);
+    expect(provider.props.children.props.children.type).toBe(RoutedModalComponent);
   });
 });

--- a/deck/packages/core/src/presentation/ReactModal.tsx
+++ b/deck/packages/core/src/presentation/ReactModal.tsx
@@ -1,9 +1,11 @@
+import { UIRouterContext } from '@uirouter/react';
 import React from 'react';
 import type { ModalProps } from 'react-bootstrap';
 import { Modal } from 'react-bootstrap';
 import ReactDOM from 'react-dom';
 
 import type { IModalComponentProps } from './modal';
+import { getDirectRouter } from '../navigation/directRouter';
 
 /** An imperative service for showing a react component as a modal */
 export class ReactModal {
@@ -70,10 +72,14 @@ export class ReactModal {
       const handleDismiss = destroy(reject);
 
       function render() {
-        ReactDOM.render(
+        const router = getDirectRouter();
+        const modal = (
           <Modal show={show} {...(modalProps as ModalProps)} onExited={onExited}>
             <ModalComponent {...componentProps} dismissModal={handleDismiss} closeModal={handleClose} />
-          </Modal>,
+          </Modal>
+        );
+        ReactDOM.render(
+          router ? <UIRouterContext.Provider value={router}>{modal}</UIRouterContext.Provider> : modal,
           mountNode,
         );
       }

--- a/deck/packages/core/src/presentation/navigation/PageNavigator.spec.tsx
+++ b/deck/packages/core/src/presentation/navigation/PageNavigator.spec.tsx
@@ -1,3 +1,4 @@
+import { UIRouterContext, UIRouterReact } from '@uirouter/react';
 import { mount } from 'enzyme';
 import $ from 'jquery';
 import React from 'react';
@@ -7,33 +8,35 @@ import { PageSection } from './PageSection';
 
 describe('PageNavigator', () => {
   let host: HTMLElement;
+  let router: UIRouterReact;
 
   beforeEach(() => {
+    router = new UIRouterReact();
     host = document.createElement('div');
     document.body.appendChild(host);
   });
 
   afterEach(() => {
     $.fx.off = false;
+    router.dispose();
     host.remove();
   });
 
   it('scrolls to the selected section in direct React usage', () => {
     $.fx.off = true;
     const wrapper = mount(
-      <div className="container" style={{ height: 60, overflowY: 'scroll' }}>
-        <PageNavigator
-          scrollableContainer=".container"
-          reactInjector={{ $state: { go: () => undefined }, $stateParams: {} }}
-        >
-          <PageSection pageKey="one" label="One">
-            <div style={{ height: 100 }} />
-          </PageSection>
-          <PageSection pageKey="two" label="Two">
-            <div style={{ height: 100 }} />
-          </PageSection>
-        </PageNavigator>
-      </div>,
+      <UIRouterContext.Provider value={router}>
+        <div className="container" style={{ height: 60, overflowY: 'scroll' }}>
+          <PageNavigator scrollableContainer=".container">
+            <PageSection pageKey="one" label="One">
+              <div style={{ height: 100 }} />
+            </PageSection>
+            <PageSection pageKey="two" label="Two">
+              <div style={{ height: 100 }} />
+            </PageSection>
+          </PageNavigator>
+        </div>
+      </UIRouterContext.Provider>,
       { attachTo: host },
     );
     wrapper.update();
@@ -48,16 +51,15 @@ describe('PageNavigator', () => {
 
   it('loads navigation styles for direct React usage', () => {
     const wrapper = mount(
-      <div className="container" style={{ height: 60, overflowY: 'scroll' }}>
-        <PageNavigator
-          scrollableContainer=".container"
-          reactInjector={{ $state: { go: () => undefined }, $stateParams: {} }}
-        >
-          <PageSection pageKey="one" label="One">
-            <div style={{ height: 100 }} />
-          </PageSection>
-        </PageNavigator>
-      </div>,
+      <UIRouterContext.Provider value={router}>
+        <div className="container" style={{ height: 60, overflowY: 'scroll' }}>
+          <PageNavigator scrollableContainer=".container">
+            <PageSection pageKey="one" label="One">
+              <div style={{ height: 100 }} />
+            </PageSection>
+          </PageNavigator>
+        </div>
+      </UIRouterContext.Provider>,
       { attachTo: host },
     );
     wrapper.update();

--- a/deck/packages/core/src/presentation/navigation/PageNavigator.tsx
+++ b/deck/packages/core/src/presentation/navigation/PageNavigator.tsx
@@ -1,6 +1,8 @@
 import { isFunction, throttle } from 'lodash';
 import React from 'react';
 
+import type { IRouterInjectedProps } from '../../navigation/routerContext';
+import { withRouter } from '../../navigation/routerContext';
 import { ScrollToService } from '../../utils/scrollTo/scrollTo.service';
 import { UUIDGenerator } from '../../utils/uuid.service';
 
@@ -17,10 +19,6 @@ export interface IPageNavigatorProps {
   scrollableContainer: string;
   deepLinkParam?: string;
   hideNavigation?: boolean;
-  reactInjector: {
-    $state: { go: (...args: any[]) => void };
-    $stateParams: Record<string, any>;
-  };
 }
 
 export interface IPageNavigatorState {
@@ -29,12 +27,12 @@ export interface IPageNavigatorState {
   pages: INavigationPage[];
 }
 
-export class PageNavigator extends React.Component<IPageNavigatorProps, IPageNavigatorState> {
+class PageNavigatorComponent extends React.Component<IPageNavigatorProps & IRouterInjectedProps, IPageNavigatorState> {
   private element: JQuery;
   private container: any;
   private navigator: any;
 
-  constructor(props: IPageNavigatorProps) {
+  constructor(props: IPageNavigatorProps & IRouterInjectedProps) {
     super(props);
     this.state = {
       id: UUIDGenerator.generateUuid(),
@@ -53,8 +51,8 @@ export class PageNavigator extends React.Component<IPageNavigatorProps, IPageNav
       );
     }
     this.navigator = this.element.find('.page-navigation');
-    if (deepLinkParam && this.props.reactInjector.$stateParams[deepLinkParam]) {
-      this.setCurrentSection(this.props.reactInjector.$stateParams[deepLinkParam]);
+    if (deepLinkParam && this.props.stateParams[deepLinkParam]) {
+      this.setCurrentSection(this.props.stateParams[deepLinkParam]);
     }
 
     const pages = React.Children.map(children, (child: any) => {
@@ -128,7 +126,7 @@ export class PageNavigator extends React.Component<IPageNavigatorProps, IPageNav
   private syncLocation(key: string): void {
     const { deepLinkParam } = this.props;
     if (deepLinkParam) {
-      this.props.reactInjector.$state.go('.', { [deepLinkParam]: key }, { notify: false, location: 'replace' });
+      this.props.stateService.go('.', { [deepLinkParam]: key }, { notify: false, location: 'replace' });
     }
   }
 
@@ -188,3 +186,6 @@ export class PageNavigator extends React.Component<IPageNavigatorProps, IPageNav
     );
   }
 }
+
+export const PageNavigator = withRouter(PageNavigatorComponent);
+PageNavigator.displayName = 'PageNavigator';

--- a/deck/packages/core/src/projects/dashboard/pipeline/ProjectPipeline.tsx
+++ b/deck/packages/core/src/projects/dashboard/pipeline/ProjectPipeline.tsx
@@ -1,9 +1,10 @@
 import { has } from 'lodash';
 import React from 'react';
-import { AngularServices } from '../../../angular/services';
 
 import type { Application } from '../../../application/application.model';
 import type { IExecution } from '../../../domain';
+import type { IRouterInjectedProps } from '../../../navigation/routerContext';
+import { withRouter } from '../../../navigation/routerContext';
 import { ExecutionBuildLink } from '../../../pipeline/executionBuild/ExecutionBuildLink';
 import { ExecutionMarker } from '../../../pipeline/executions/execution/ExecutionMarker';
 import { timestamp } from '../../../utils/timeFormatters';
@@ -21,8 +22,11 @@ export interface IProjectPipelineState {
   stageWidth: string;
 }
 
-export class ProjectPipeline extends React.Component<IProjectPipelineProps, IProjectPipelineState> {
-  constructor(props: IProjectPipelineProps) {
+class ProjectPipelineComponent extends React.Component<
+  IProjectPipelineProps & IRouterInjectedProps,
+  IProjectPipelineState
+> {
+  constructor(props: IProjectPipelineProps & IRouterInjectedProps) {
     super(props);
     this.state = {
       hasBuildInfo:
@@ -35,14 +39,14 @@ export class ProjectPipeline extends React.Component<IProjectPipelineProps, IPro
   }
 
   private handleExecutionTitleClick = (): void => {
-    AngularServices.$state.go('^.application.pipelines.executions.execution', {
+    this.props.stateService.go('^.application.pipelines.executions.execution', {
       application: this.props.execution.application,
       executionId: this.props.execution.id,
     });
   };
 
   private handleStageClick = (stageIndex: number) => {
-    AngularServices.$state.go('^.application.pipelines.executionDetails.execution', {
+    this.props.stateService.go('^.application.pipelines.executionDetails.execution', {
       application: this.props.execution.application,
       executionId: this.props.execution.id,
       stage: stageIndex,
@@ -74,3 +78,6 @@ export class ProjectPipeline extends React.Component<IProjectPipelineProps, IPro
     );
   }
 }
+
+export const ProjectPipeline = withRouter(ProjectPipelineComponent);
+ProjectPipeline.displayName = 'ProjectPipeline';

--- a/deck/packages/core/src/search/global/GlobalSearch.tsx
+++ b/deck/packages/core/src/search/global/GlobalSearch.tsx
@@ -10,6 +10,8 @@ import { AngularServices } from '../../angular/services';
 import type { IChildComponentProps } from '../infrastructure/RecentlyViewedItems';
 import { RecentlyViewedItems } from '../infrastructure/RecentlyViewedItems';
 import type { ISearchResultSet } from '../infrastructure/infrastructureSearch.service';
+import type { IRouterInjectedProps } from '../../navigation/routerContext';
+import { withRouter } from '../../navigation/routerContext';
 import { Tooltip } from '../../presentation/Tooltip';
 import type { ISearchResult } from '../search.service';
 import { searchRank } from '../searchRank.filter';
@@ -31,7 +33,7 @@ export interface IGlobalSearchState {
   categories: ISearchResultSet[];
 }
 
-export class GlobalSearch extends React.Component<{}, IGlobalSearchState> {
+class GlobalSearchComponent extends React.Component<IRouterInjectedProps, IGlobalSearchState> {
   private container: HTMLElement;
   private searchField: HTMLInputElement;
   private resultRefs: HTMLElement[][];
@@ -39,7 +41,7 @@ export class GlobalSearch extends React.Component<{}, IGlobalSearchState> {
   private query$ = new Subject<string>();
   private destroy$ = new Subject();
 
-  constructor(props: {}) {
+  constructor(props: IRouterInjectedProps) {
     super(props);
     this.state = {
       showDropdown: false,
@@ -141,16 +143,16 @@ export class GlobalSearch extends React.Component<{}, IGlobalSearchState> {
         this.focusFirstSearchResult();
       }
     } else if (key === 'Enter') {
-      const { $state } = AngularServices;
+      const { stateService } = this.props;
       if (this.state.categories) {
         const matchingQueryResult = findMatchingApplicationResultToQuery(this.state.categories, this.state.query);
         if (matchingQueryResult) {
-          $state.go('home.applications.application', {
+          stateService.go('home.applications.application', {
             application: matchingQueryResult.result.application,
           });
           this.hideDropdown();
         } else {
-          $state.go('home.search', getSearchQueryParams(this.state.query));
+          stateService.go('home.search', getSearchQueryParams(this.state.query));
         }
       }
 
@@ -382,3 +384,6 @@ export class GlobalSearch extends React.Component<{}, IGlobalSearchState> {
     );
   };
 }
+
+export const GlobalSearch = withRouter(GlobalSearchComponent);
+GlobalSearch.displayName = 'GlobalSearch';

--- a/deck/packages/core/src/search/infrastructure/SearchV1.spec.tsx
+++ b/deck/packages/core/src/search/infrastructure/SearchV1.spec.tsx
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme';
 import React from 'react';
 import { BehaviorSubject } from 'rxjs';
 
-import { SearchV1 } from './SearchV1';
+import { SearchV1Component as SearchV1 } from './SearchV1';
 import { SearchResult } from './SearchResult';
 import type { ISearchResultSet } from './infrastructureSearch.service';
 import { AngularServices } from '../../angular/services';
@@ -31,12 +31,15 @@ describe('SearchV1', () => {
   let go: jasmine.Spy;
   let wrapper: ShallowWrapper | undefined;
 
+  const renderSearch = () =>
+    shallow(
+      <SearchV1 router={{ globals: { params$ } } as any} stateParams={params$.value} stateService={{ go } as any} />,
+    );
+
   beforeEach(() => {
     params$ = new BehaviorSubject({ q: null, route: null });
     query = jasmine.createSpy('query').and.returnValue(Promise.resolve([]));
     go = jasmine.createSpy('go');
-    spyOnProperty(AngularServices, '$state', 'get').and.callFake(() => ({ go, params: params$.value } as any));
-    spyOnProperty(AngularServices, '$uiRouter', 'get').and.returnValue({ globals: { params$ } } as any);
     spyOnProperty(AngularServices, 'infrastructureSearchService', 'get').and.returnValue({
       getSearcher: () => ({ query }),
     } as any);
@@ -58,7 +61,7 @@ describe('SearchV1', () => {
         resultSet('serverGroups', [{ href: '#/server', displayName: 'Server', provider: 'aws', type: 'serverGroups' }]),
       ]),
     );
-    wrapper = shallow(<SearchV1 />);
+    wrapper = renderSearch();
     const instance = wrapper.instance() as SearchV1;
 
     instance.handleQueryChange('ab');
@@ -85,7 +88,7 @@ describe('SearchV1', () => {
       new Promise((resolve) => (resolveSecond = resolve)),
       new Promise((resolve) => (resolveThird = resolve)),
     );
-    wrapper = shallow(<SearchV1 />);
+    wrapper = renderSearch();
     const instance = wrapper.instance() as SearchV1;
 
     instance.handleQueryChange('first');
@@ -111,7 +114,7 @@ describe('SearchV1', () => {
   it('ignores an in-flight result after the query becomes too short', async () => {
     let resolveSearch: (value: ISearchResultSet[]) => void;
     query.and.returnValue(new Promise((resolve) => (resolveSearch = resolve)));
-    wrapper = shallow(<SearchV1 />);
+    wrapper = renderSearch();
     const instance = wrapper.instance() as SearchV1;
 
     instance.handleQueryChange('first');
@@ -136,7 +139,7 @@ describe('SearchV1', () => {
         ]),
       ]),
     );
-    wrapper = shallow(<SearchV1 />);
+    wrapper = renderSearch();
     const instance = wrapper.instance() as SearchV1;
     instance.handleQueryChange('app');
     jasmine.clock().tick(301);
@@ -150,7 +153,7 @@ describe('SearchV1', () => {
   });
 
   it('shows recent history for a blank query', () => {
-    wrapper = shallow(<SearchV1 />);
+    wrapper = renderSearch();
 
     expect(wrapper.find(RecentlyViewedItems).exists()).toBe(true);
     expect(query).not.toHaveBeenCalled();
@@ -162,7 +165,7 @@ describe('SearchV1', () => {
       Promise.resolve([resultSet('applications', [{ displayName: 'initial', href: '#/one-shot-result' }])]),
       Promise.resolve([resultSet('applications', [{ displayName: 'later', href: '#/unexpected-result' }])]),
     );
-    wrapper = shallow(<SearchV1 />);
+    wrapper = renderSearch();
     const instance = wrapper.instance() as SearchV1;
     const navigateToResult = spyOn<any>(instance, 'navigateToResult');
 
@@ -184,7 +187,7 @@ describe('SearchV1', () => {
       new Promise((resolve) => (resolveLater = resolve)),
     );
     params$.next({ q: 'initial', route: true });
-    wrapper = shallow(<SearchV1 />);
+    wrapper = renderSearch();
     const instance = wrapper.instance() as SearchV1;
     const navigateToResult = spyOn<any>(instance, 'navigateToResult');
     jasmine.clock().tick(301);
@@ -211,7 +214,7 @@ describe('SearchV1', () => {
       new Promise((resolve) => (resolveLater = resolve)),
     );
     params$.next({ q: 'initial', route: true });
-    wrapper = shallow(<SearchV1 />);
+    wrapper = renderSearch();
     const instance = wrapper.instance() as SearchV1;
     const navigateToResult = spyOn<any>(instance, 'navigateToResult');
     jasmine.clock().tick(301);

--- a/deck/packages/core/src/search/infrastructure/SearchV1.tsx
+++ b/deck/packages/core/src/search/infrastructure/SearchV1.tsx
@@ -9,6 +9,8 @@ import { SearchResultPods } from './SearchResultPods';
 import { AngularServices } from '../../angular/services';
 import type { ISearchResultSet } from './infrastructureSearch.service';
 import { InsightMenu } from '../../insight/InsightMenu';
+import type { IRouterInjectedProps } from '../../navigation/routerContext';
+import { withRouter } from '../../navigation/routerContext';
 import type { ISearchResult } from '../search.service';
 import { SearchService } from '../search.service';
 import { searchRank } from '../searchRank.filter';
@@ -28,11 +30,9 @@ export interface ISearchV1State {
   showMinLengthWarning: boolean;
 }
 
-export class SearchV1 extends React.Component<{}, ISearchV1State> {
-  private $state = AngularServices.$state;
-  private $uiRouter = AngularServices.$uiRouter;
+export class SearchV1Component extends React.Component<IRouterInjectedProps, ISearchV1State> {
   private search = AngularServices.infrastructureSearchService.getSearcher();
-  private autoNavigateQuery: string | null = this.$state.params.route ? this.$state.params.q || '' : null;
+  private autoNavigateQuery: string | null = this.props.stateParams.route ? this.props.stateParams.q || '' : null;
   private destroy$ = new Subject<void>();
   private query$ = new Subject<string>();
 
@@ -40,7 +40,7 @@ export class SearchV1 extends React.Component<{}, ISearchV1State> {
     categories: [],
     moreResults: false,
     projects: [],
-    query: this.$state.params.q || '',
+    query: this.props.stateParams.q || '',
     searching: false,
     showMinLengthWarning: false,
   };
@@ -59,7 +59,7 @@ export class SearchV1 extends React.Component<{}, ISearchV1State> {
       )
       .subscribe(({ query, resultSets }) => this.handleResults(query, resultSets));
 
-    this.$uiRouter.globals.params$
+    this.props.router.globals.params$
       .pipe(
         map((params) => params.q || ''),
         distinctUntilChanged(),
@@ -72,7 +72,7 @@ export class SearchV1 extends React.Component<{}, ISearchV1State> {
       });
 
     if (this.autoNavigateQuery !== null) {
-      this.$state.go('.', { route: null }, { location: 'replace' });
+      this.props.stateService.go('.', { route: null }, { location: 'replace' });
     }
 
     this.updatePageTitle(this.state.query);
@@ -138,7 +138,7 @@ export class SearchV1 extends React.Component<{}, ISearchV1State> {
   }
 
   private updateLocation(query: string): void {
-    this.$state.go('.', { q: query || null, route: null }, { location: 'replace' });
+    this.props.stateService.go('.', { q: query || null, route: null }, { location: 'replace' });
   }
 
   private navigateToResult(href: string): void {
@@ -281,3 +281,5 @@ export class SearchV1 extends React.Component<{}, ISearchV1State> {
     );
   }
 }
+
+export const SearchV1 = withRouter(SearchV1Component);

--- a/deck/packages/core/src/search/infrastructure/SearchV2.spec.tsx
+++ b/deck/packages/core/src/search/infrastructure/SearchV2.spec.tsx
@@ -1,0 +1,36 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import { BehaviorSubject } from 'rxjs';
+
+import { SearchV2Component } from './SearchV2';
+import { AngularServices } from '../../angular/services';
+
+describe('SearchV2', () => {
+  beforeEach(() => {
+    spyOnProperty(AngularServices, 'pageTitleService', 'get').and.returnValue({
+      handleRoutingSuccess: jasmine.createSpy('handleRoutingSuccess'),
+    } as any);
+  });
+
+  it('uses injected route state for tab selection and filter navigation', () => {
+    const go = jasmine.createSpy('go');
+    const component = shallow(
+      <SearchV2Component
+        router={{ globals: { params$: new BehaviorSubject({ tab: 'applications' }) } } as any}
+        stateParams={{ tab: 'applications' }}
+        stateService={{ go } as any}
+      />,
+      { disableLifecycleMethods: true },
+    );
+
+    expect(component.state('selectedTab')).toBe('applications');
+
+    (component.instance() as SearchV2Component).handleFilterChange([{ key: 'name', text: 'payments' } as any]);
+
+    expect(go).toHaveBeenCalledWith(
+      '.',
+      { account: undefined, key: undefined, name: 'payments', region: undefined, stack: undefined },
+      { location: 'replace' },
+    );
+  });
+});

--- a/deck/packages/core/src/search/infrastructure/SearchV2.tsx
+++ b/deck/packages/core/src/search/infrastructure/SearchV2.tsx
@@ -11,6 +11,8 @@ import type { ISearchResultSet } from '../infrastructure/infrastructureSearch.se
 import { InfrastructureSearchServiceV2 } from '../infrastructure/infrastructureSearchV2.service';
 import { InsightMenu } from '../../insight/InsightMenu';
 import type { IQueryParams } from '../../navigation';
+import type { IRouterInjectedProps } from '../../navigation/routerContext';
+import { withRouter } from '../../navigation/routerContext';
 import { SearchResults, searchResultTypeRegistry, SearchStatus } from '../searchResult';
 import type { ITag } from '../../widgets';
 import { Search } from '../widgets';
@@ -26,10 +28,7 @@ export interface ISearchV2State {
   refreshingCache: boolean;
 }
 
-export class SearchV2 extends React.Component<{}, ISearchV2State> {
-  private $state = AngularServices.$state;
-  private $uiRouter = AngularServices.$uiRouter;
-
+export class SearchV2Component extends React.Component<IRouterInjectedProps, ISearchV2State> {
   private searchResultTypes = searchResultTypeRegistry.getAll();
 
   private INITIAL_RESULTS: ISearchResultSet[] = this.searchResultTypes.map((type) => ({
@@ -40,11 +39,11 @@ export class SearchV2 extends React.Component<{}, ISearchV2State> {
 
   private destroy$ = new Subject();
 
-  constructor(props: {}) {
+  constructor(props: IRouterInjectedProps) {
     super(props);
 
     this.state = {
-      selectedTab: this.$state.params.tab,
+      selectedTab: props.stateParams.tab,
       params: {},
       resultSets: this.INITIAL_RESULTS,
       isSearching: false,
@@ -70,7 +69,7 @@ export class SearchV2 extends React.Component<{}, ISearchV2State> {
     // auto-navigation only happens via shortcut links, and we only do it if there is exactly one result, e.g
     // when searching for an instance ID
     const autoNavigate = window.location.href.endsWith('route=true');
-    this.$uiRouter.globals.params$
+    this.props.router.globals.params$
       .pipe(
         map((stateParams) => this.getApiFilterParams(stateParams)),
         tap((params: IQueryParams) => this.setState({ params })),
@@ -117,7 +116,7 @@ export class SearchV2 extends React.Component<{}, ISearchV2State> {
         () => this.setState({ isSearching: false }),
       );
 
-    this.$uiRouter.globals.params$
+    this.props.router.globals.params$
       .pipe(
         map((params) => params.tab),
         distinctUntilChanged(),
@@ -144,7 +143,7 @@ export class SearchV2 extends React.Component<{}, ISearchV2State> {
     );
 
     if (found.tabId) {
-      this.$state.go('.', { tab: found.tabId });
+      this.props.stateService.go('.', { tab: found.tabId });
     }
   }
 
@@ -155,7 +154,7 @@ export class SearchV2 extends React.Component<{}, ISearchV2State> {
   public handleFilterChange = (filters: ITag[]) => {
     const blankApiParams = API_PARAMS.reduce((acc, key) => ({ ...acc, [key]: undefined }), {});
     const newParams = filters.reduce((params, filter) => ({ ...params, [filter.key]: filter.text }), blankApiParams);
-    this.$state.go('.', newParams, { location: 'replace' });
+    this.props.stateService.go('.', newParams, { location: 'replace' });
   };
 
   public render() {
@@ -193,3 +192,5 @@ export class SearchV2 extends React.Component<{}, ISearchV2State> {
     );
   }
 }
+
+export const SearchV2 = withRouter(SearchV2Component);

--- a/deck/packages/core/src/search/infrastructure/infrastructure.states.spec.ts
+++ b/deck/packages/core/src/search/infrastructure/infrastructure.states.spec.ts
@@ -24,7 +24,7 @@ describe('infrastructure states', () => {
     const errorBoundary = shallow(React.createElement(view.component));
 
     expect(errorBoundary.type()).toBe(SpinErrorBoundary);
-    expect(errorBoundary.prop('children').type).toBe(SearchV1);
+    expect(errorBoundary.prop('children').type.displayName).toBe(SearchV1.displayName);
     expect(view.$type).toBe('react');
     expect(view.controller).toBeUndefined();
     expect(view.template).toBeUndefined();
@@ -41,7 +41,7 @@ describe('infrastructure states', () => {
     const errorBoundary = shallow(React.createElement(view.component));
 
     expect(errorBoundary.type()).toBe(SpinErrorBoundary);
-    expect(errorBoundary.prop('children').type).toBe(SearchV2);
+    expect(errorBoundary.prop('children').type.displayName).toBe(SearchV2.displayName);
     expect(view.$type).toBe('react');
     expect(view.controller).toBeUndefined();
     expect(view.template).toBeUndefined();

--- a/deck/packages/core/src/securityGroup/SecurityGroup.tsx
+++ b/deck/packages/core/src/securityGroup/SecurityGroup.tsx
@@ -1,7 +1,6 @@
-import { UISref } from '@uirouter/react';
+import { UISref, useRouter } from '@uirouter/react';
 import classNames from 'classnames';
 import * as React from 'react';
-import { AngularServices } from '../angular/services';
 
 import type { Application } from '../application';
 import { CloudProviderLogo } from '../cloudProvider';
@@ -134,9 +133,10 @@ const LoadBalancers = ({ securityGroup }: { securityGroup: ISecurityGroup }) => 
 };
 
 export const SecurityGroup = (props: ISecurityGroupProps) => {
+  const { stateService } = useRouter();
   const params = getSecurityGroupDetailsParams(props.securityGroup, props.application);
   // don't use <UISrefActive> - it picks up load balancer and server groups details!
-  const active = AngularServices.$state.includes('**.firewallDetails', params);
+  const active = stateService.includes('**.firewallDetails', params);
   return (
     <UISref to=".firewallDetails" params={params}>
       <div className={classNames('pod-subgroup clickable clickable-row clearfix', { active })}>

--- a/deck/packages/core/src/serverGroup/ServerGroup.router.spec.tsx
+++ b/deck/packages/core/src/serverGroup/ServerGroup.router.spec.tsx
@@ -1,0 +1,43 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import { ServerGroupComponent } from './ServerGroup';
+
+describe('server group router bridge', () => {
+  const application = {} as any;
+  const serverGroup = {
+    account: 'test-account',
+    buildInfo: { images: [] },
+    instances: [],
+    name: 'test-v001',
+    region: 'test-region',
+    type: 'kubernetes',
+  } as any;
+  const sortFilter = { multiselect: false, showAllInstances: false } as any;
+
+  const props = (includes: jasmine.Spy) =>
+    ({
+      application,
+      cluster: 'test',
+      hasDiscovery: false,
+      hasLoadBalancers: false,
+      router: {},
+      serverGroup,
+      sortFilter,
+      stateParams: {},
+      stateService: { includes },
+    } as any);
+
+  it('selects a server group through the injected state service', () => {
+    const includes = jasmine.createSpy('includes').and.returnValue(true);
+    const component = shallow(<ServerGroupComponent {...props(includes)} />, { disableLifecycleMethods: true });
+
+    expect(component.state('isSelected')).toBe(true);
+    expect(includes).toHaveBeenCalledWith('**.serverGroup', {
+      accountId: 'test-account',
+      provider: 'kubernetes',
+      region: 'test-region',
+      serverGroup: 'test-v001',
+    });
+  });
+});

--- a/deck/packages/core/src/serverGroup/ServerGroup.tsx
+++ b/deck/packages/core/src/serverGroup/ServerGroup.tsx
@@ -12,6 +12,8 @@ import type { IInstance, IServerGroup } from '../domain';
 import type { ISortFilter } from '../filterModel';
 import { InstanceList } from '../instance/InstanceList';
 import { Instances } from '../instance/Instances';
+import type { IRouterInjectedProps } from '../navigation/routerContext';
+import { stateChangeSuccess$, withRouter } from '../navigation/routerContext';
 import { ClusterState } from '../state';
 import { logger, ScrollToService } from '../utils';
 
@@ -47,11 +49,11 @@ export interface IServerGroupState {
   isMultiSelected: boolean; // multiselect mode
 }
 
-export class ServerGroup extends React.Component<IServerGroupProps, IServerGroupState> {
+export class ServerGroupComponent extends React.Component<IServerGroupProps & IRouterInjectedProps, IServerGroupState> {
   private stateChangeSubscription: Subscription;
   private serverGroupsSubscription: Subscription;
 
-  constructor(props: IServerGroupProps) {
+  constructor(props: IServerGroupProps & IRouterInjectedProps) {
     super(props);
     this.state = this.getState(props);
   }
@@ -123,7 +125,7 @@ export class ServerGroup extends React.Component<IServerGroupProps, IServerGroup
       provider: serverGroup.type,
     };
 
-    return AngularServices.$state.includes('**.serverGroup', params);
+    return this.props.stateService.includes('**.serverGroup', params);
   }
 
   private isMultiSelected(multiselect: boolean, serverGroup: IServerGroup) {
@@ -147,7 +149,7 @@ export class ServerGroup extends React.Component<IServerGroupProps, IServerGroup
     this.serverGroupsSubscription = serverGroupsStream
       .pipe(merge(instancesStream))
       .subscribe(this.onServerGroupsChanged);
-    this.stateChangeSubscription = AngularServices.$uiRouter.globals.success$.subscribe(this.onStateChanged);
+    this.stateChangeSubscription = stateChangeSuccess$(this.props.router).subscribe(this.onStateChanged);
     this.onStateChanged();
   }
 
@@ -156,7 +158,7 @@ export class ServerGroup extends React.Component<IServerGroupProps, IServerGroup
     this.serverGroupsSubscription.unsubscribe();
   }
 
-  public componentWillReceiveProps(nextProps: IServerGroupProps) {
+  public componentWillReceiveProps(nextProps: IServerGroupProps & IRouterInjectedProps) {
     this.setState(this.getState(nextProps));
   }
 
@@ -230,3 +232,5 @@ export class ServerGroup extends React.Component<IServerGroupProps, IServerGroup
     );
   }
 }
+
+export const ServerGroup = withRouter(ServerGroupComponent);

--- a/deck/packages/core/src/serverGroup/details/ServerGroupDetails.tsx
+++ b/deck/packages/core/src/serverGroup/details/ServerGroupDetails.tsx
@@ -6,20 +6,26 @@ import { takeUntil } from 'rxjs/operators';
 import { RunningTasks } from './RunningTasks';
 import type { IServerGroupDetailsProps, IServerGroupDetailsState } from './ServerGroupDetailsWrapper';
 import { ServerGroupInsightActions } from './ServerGroupInsightActions';
-import { AngularServices } from '../../angular/services';
 import { CloudProviderLogo } from '../../cloudProvider/CloudProviderLogo';
 import { SETTINGS } from '../../config/settings';
 import type { IServerGroup } from '../../domain';
 import { EntityNotifications } from '../../entityTag/notifications/EntityNotifications';
 import { ManagedResourceDetailsIndicator } from '../../managed';
+import type { IRouterInjectedProps } from '../../navigation/routerContext';
+import { withRouter } from '../../navigation/routerContext';
 import { timestamp } from '../../utils/timeFormatters';
 import { Spinner } from '../../widgets/spinners/Spinner';
 
-export class ServerGroupDetails extends React.Component<IServerGroupDetailsProps, IServerGroupDetailsState> {
+export class ServerGroupDetailsComponent extends React.Component<
+  IServerGroupDetailsProps & IRouterInjectedProps,
+  IServerGroupDetailsState
+> {
   private destroy$ = new Subject();
+  private detailsRequest$ = new Subject();
+  private detailsRequestGeneration = 0;
   private serverGroupsRefreshUnsubscribe: () => void;
 
-  constructor(props: IServerGroupDetailsProps) {
+  constructor(props: IServerGroupDetailsProps & IRouterInjectedProps) {
     super(props);
 
     this.state = {
@@ -28,38 +34,57 @@ export class ServerGroupDetails extends React.Component<IServerGroupDetailsProps
     };
   }
 
-  private autoClose(): void {
-    AngularServices.$state.params.allowModalToStayOpen = true;
-    AngularServices.$state.go('^', null, { location: 'replace' });
+  private loadServerGroup(
+    props: IServerGroupDetailsProps & IRouterInjectedProps,
+    clearCurrentServerGroup = false,
+  ): void {
+    const requestGeneration = ++this.detailsRequestGeneration;
+    this.detailsRequest$.next();
+    if (clearCurrentServerGroup) {
+      this.setState({ loading: true, serverGroup: undefined });
+    }
+    props
+      .detailsGetter(props, () => {
+        if (requestGeneration === this.detailsRequestGeneration) {
+          props.stateService.params.allowModalToStayOpen = true;
+          props.stateService.go('^', null, { location: 'replace' });
+        }
+      })
+      .pipe(takeUntil(this.detailsRequest$), takeUntil(this.destroy$))
+      .subscribe((serverGroup: IServerGroup) => {
+        if (requestGeneration === this.detailsRequestGeneration) {
+          this.setState({ serverGroup, loading: false });
+        }
+      });
   }
 
-  private updateServerGroup = (serverGroup: IServerGroup): void => {
-    this.setState({ serverGroup, loading: false });
-  };
+  private serverGroupIdentityChanged(nextProps: IServerGroupDetailsProps): boolean {
+    const current = this.props.serverGroup;
+    const next = nextProps.serverGroup;
+    return (
+      current.name !== next.name ||
+      current.accountId !== next.accountId ||
+      current.provider !== next.provider ||
+      current.region !== next.region
+    );
+  }
 
   public componentDidMount(): void {
-    this.props
-      .detailsGetter(this.props, this.autoClose)
-      .pipe(takeUntil(this.destroy$))
-      .subscribe(this.updateServerGroup);
+    this.loadServerGroup(this.props);
     this.serverGroupsRefreshUnsubscribe = this.props.app.serverGroups.onRefresh(null, () => {
-      this.props
-        .detailsGetter(this.props, this.autoClose)
-        .pipe(takeUntil(this.destroy$))
-        .subscribe(this.updateServerGroup);
+      this.loadServerGroup(this.props);
     });
   }
 
-  public componentWillReceiveProps(nextProps: IServerGroupDetailsProps): void {
-    if (nextProps.serverGroup !== this.props.serverGroup) {
-      this.props
-        .detailsGetter(nextProps, this.autoClose)
-        .pipe(takeUntil(this.destroy$))
-        .subscribe(this.updateServerGroup);
+  public componentWillReceiveProps(nextProps: IServerGroupDetailsProps & IRouterInjectedProps): void {
+    if (nextProps.detailsGetter !== this.props.detailsGetter || this.serverGroupIdentityChanged(nextProps)) {
+      this.loadServerGroup(nextProps, true);
     }
   }
 
   public componentWillUnmount(): void {
+    this.detailsRequestGeneration++;
+    this.detailsRequest$.next();
     this.destroy$.next();
     this.serverGroupsRefreshUnsubscribe();
   }
@@ -137,3 +162,6 @@ export class ServerGroupDetails extends React.Component<IServerGroupDetailsProps
     );
   }
 }
+
+export const ServerGroupDetails = withRouter(ServerGroupDetailsComponent);
+ServerGroupDetails.displayName = 'ServerGroupDetails';

--- a/deck/packages/core/src/serverGroup/details/ServerGroupDetailsWrapper.spec.tsx
+++ b/deck/packages/core/src/serverGroup/details/ServerGroupDetailsWrapper.spec.tsx
@@ -1,8 +1,10 @@
 import { shallow } from 'enzyme';
 import React from 'react';
+import { Subject } from 'rxjs';
 
 import type { Application } from '../../application';
-import { ServerGroupDetails } from './ServerGroupDetails';
+import { CloudProviderRegistry } from '../../cloudProvider';
+import { ServerGroupDetails, ServerGroupDetailsComponent } from './ServerGroupDetails';
 import { ServerGroupDetailsWrapper } from './ServerGroupDetailsWrapper';
 
 describe('ServerGroupDetailsWrapper', () => {
@@ -10,6 +12,7 @@ describe('ServerGroupDetailsWrapper', () => {
   const serverGroup = {
     accountId: 'test',
     name: 'deck-v001',
+    provider: 'aws',
     region: 'us-east-1',
   };
 
@@ -48,5 +51,139 @@ describe('ServerGroupDetailsWrapper', () => {
     component.setState({ Actions: undefined, detailsGetter: undefined, legacyDetailsConfigured: false, sections: [] });
 
     expect(component.isEmptyRender()).toBe(true);
+  });
+
+  it('switches provider configuration before rendering the next server group', async () => {
+    const AwsActions = () => <button className="aws-actions" />;
+    const AwsSection = () => <div className="aws-section" />;
+    const awsGetter = jasmine.createSpy('awsGetter');
+    const KubernetesActions = () => <button className="kubernetes-actions" />;
+    const KubernetesSection = () => <div className="kubernetes-section" />;
+    const kubernetesGetter = jasmine.createSpy('kubernetesGetter');
+    const values: Record<string, Record<string, any>> = {
+      aws: {
+        'serverGroup.detailsActions': AwsActions,
+        'serverGroup.detailsGetter': awsGetter,
+        'serverGroup.detailsSections': [AwsSection],
+      },
+      kubernetes: {
+        'serverGroup.detailsActions': KubernetesActions,
+        'serverGroup.detailsGetter': kubernetesGetter,
+        'serverGroup.detailsSections': [KubernetesSection],
+      },
+    };
+    const getValue = spyOn(CloudProviderRegistry, 'getValue').and.callFake(
+      (provider: string, key: string) => values[provider]?.[key],
+    );
+    const component = shallow(<ServerGroupDetailsWrapper app={app} serverGroup={serverGroup} />);
+    await Promise.resolve();
+    await Promise.resolve();
+    component.update();
+
+    expect(component.find(ServerGroupDetails).prop('Actions')).toBe(AwsActions);
+
+    const nextServerGroup = { ...serverGroup, name: 'deck-v002', provider: 'kubernetes' };
+    component.setProps({ serverGroup: nextServerGroup });
+
+    expect(component.find(ServerGroupDetails)).toHaveSize(0);
+    await Promise.resolve();
+    await Promise.resolve();
+    component.update();
+    expect(getValue.calls.allArgs().filter(([provider]) => provider === 'kubernetes')).toHaveSize(5);
+    expect(component.find(ServerGroupDetails).prop('serverGroup')).toBe(nextServerGroup);
+    expect(component.find(ServerGroupDetails).prop('Actions')).toBe(KubernetesActions);
+    expect(component.find(ServerGroupDetails).prop('detailsGetter')).toBe(kubernetesGetter);
+    expect(component.find(ServerGroupDetails).prop('sections')).toEqual([KubernetesSection]);
+  });
+
+  it('cancels old provider details when the server group and getter change', () => {
+    const oldUpdates = new Subject<any>();
+    const newUpdates = new Subject<any>();
+    const oldGetter = jasmine.createSpy('oldGetter').and.returnValue(oldUpdates);
+    const newGetter = jasmine.createSpy('newGetter').and.returnValue(newUpdates);
+    const OldActions = () => <button className="old-actions" />;
+    const NewActions = () => <button className="new-actions" />;
+    const go = jasmine.createSpy('go');
+    const stateService = { go, params: {} };
+    const oldProps = {
+      Actions: OldActions,
+      app: {
+        serverGroups: { onRefresh: jasmine.createSpy('onRefresh').and.returnValue(() => undefined) },
+      } as any,
+      detailsGetter: oldGetter,
+      router: {},
+      sections: [],
+      serverGroup,
+      stateParams: {},
+      stateService,
+    } as any;
+    const component = shallow(<ServerGroupDetailsComponent {...oldProps} />, { disableLifecycleMethods: true });
+    const instance = component.instance() as ServerGroupDetailsComponent;
+    instance.componentDidMount();
+    oldUpdates.next({ name: 'old-details', type: 'aws' });
+    const oldAutoClose = oldGetter.calls.mostRecent().args[1];
+
+    const nextProps = {
+      ...oldProps,
+      Actions: NewActions,
+      detailsGetter: newGetter,
+      serverGroup: { ...serverGroup, name: 'deck-v002', provider: 'kubernetes' },
+    };
+    instance.componentWillReceiveProps(nextProps);
+    component.setProps(nextProps);
+
+    expect(newGetter).toHaveBeenCalledWith(nextProps, jasmine.any(Function));
+    expect(component.state()).toEqual({ loading: true, serverGroup: undefined });
+
+    oldUpdates.next({ name: 'stale-details', type: 'aws' });
+    expect(component.state('serverGroup')).toBeUndefined();
+
+    const newDetails = { name: 'new-details', type: 'kubernetes' };
+    newUpdates.next(newDetails);
+    expect(component.find(NewActions).prop('serverGroup')).toBe(newDetails);
+    expect(component.find(OldActions)).toHaveSize(0);
+
+    oldAutoClose();
+    expect(go).not.toHaveBeenCalled();
+
+    const newAutoClose = newGetter.calls.mostRecent().args[1];
+    newAutoClose();
+    expect(stateService.params).toEqual({ allowModalToStayOpen: true });
+    expect(go).toHaveBeenCalledWith('^', null, { location: 'replace' });
+
+    go.calls.reset();
+    instance.componentWillUnmount();
+    newAutoClose();
+    expect(go).not.toHaveBeenCalled();
+  });
+
+  it('keeps the current actions mounted while refreshing the same server group', () => {
+    const updates = new Subject<any>();
+    const detailsGetter = jasmine.createSpy('detailsGetter').and.returnValue(updates);
+    const Actions = () => <button className="actions" />;
+    const onRefresh = jasmine.createSpy('onRefresh').and.returnValue(() => undefined);
+    const props = {
+      Actions,
+      app: { serverGroups: { onRefresh } } as any,
+      detailsGetter,
+      router: {},
+      sections: [],
+      serverGroup,
+      stateParams: {},
+      stateService: { go: jasmine.createSpy('go'), params: {} },
+    } as any;
+    const component = shallow(<ServerGroupDetailsComponent {...props} />, { disableLifecycleMethods: true });
+    const instance = component.instance() as ServerGroupDetailsComponent;
+    instance.componentDidMount();
+    const details = { ...serverGroup, type: 'aws' };
+    updates.next(details);
+
+    expect(component.find(Actions)).toHaveSize(1);
+
+    onRefresh.calls.mostRecent().args[1]();
+
+    expect(component.state()).toEqual({ loading: false, serverGroup: details });
+    expect(component.find(Actions)).toHaveSize(1);
+    instance.componentWillUnmount();
   });
 });

--- a/deck/packages/core/src/serverGroup/details/ServerGroupDetailsWrapper.tsx
+++ b/deck/packages/core/src/serverGroup/details/ServerGroupDetailsWrapper.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import type { Observable } from 'rxjs';
 
 import { ServerGroupDetails } from './ServerGroupDetails';
-import { AngularServices } from '../../angular/services';
 import type { Application } from '../../application';
 import { CloudProviderRegistry } from '../../cloudProvider';
 import type { IServerGroup } from '../../domain';
@@ -12,6 +11,7 @@ export interface IServerGroupDetailsWrapperProps {
   serverGroup: {
     name: string;
     accountId: string;
+    provider: string;
     region: string;
   };
 }
@@ -50,6 +50,8 @@ export class ServerGroupDetailsWrapper extends React.Component<
   IServerGroupDetailsWrapperProps,
   IServerGroupDetailsWrapperState
 > {
+  private configurationRequestId = 0;
+
   constructor(props: IServerGroupDetailsWrapperProps) {
     super(props);
 
@@ -61,8 +63,9 @@ export class ServerGroupDetailsWrapper extends React.Component<
     };
   }
 
-  private getServerGroupDetailsTemplate(): void {
-    const { provider } = AngularServices.$stateParams;
+  private getServerGroupDetailsTemplate(serverGroup: IServerGroupDetailsWrapperProps['serverGroup']): void {
+    const requestId = ++this.configurationRequestId;
+    const { provider } = serverGroup;
     Promise.all([
       CloudProviderRegistry.getValue(provider, 'serverGroup.detailsActions'),
       CloudProviderRegistry.getValue(provider, 'serverGroup.detailsGetter'),
@@ -80,17 +83,22 @@ export class ServerGroupDetailsWrapper extends React.Component<
         ],
       ) => {
         const [Actions, detailsGetter, sections, templateUrl, controller] = values;
-        this.setState({ Actions, detailsGetter, legacyDetailsConfigured: !!(templateUrl && controller), sections });
+        if (requestId === this.configurationRequestId) {
+          this.setState({ Actions, detailsGetter, legacyDetailsConfigured: !!(templateUrl && controller), sections });
+        }
       },
     );
   }
 
   public componentDidMount(): void {
-    this.getServerGroupDetailsTemplate();
+    this.getServerGroupDetailsTemplate(this.props.serverGroup);
   }
 
-  public componentWillReceiveProps(): void {
-    this.getServerGroupDetailsTemplate();
+  public componentWillReceiveProps(nextProps: IServerGroupDetailsWrapperProps): void {
+    if (nextProps.serverGroup.provider !== this.props.serverGroup.provider) {
+      this.setState({ Actions: undefined, detailsGetter: undefined, legacyDetailsConfigured: false, sections: [] });
+      this.getServerGroupDetailsTemplate(nextProps.serverGroup);
+    }
   }
 
   public render() {

--- a/deck/packages/core/src/serverGroup/serverGroup.states.spec.ts
+++ b/deck/packages/core/src/serverGroup/serverGroup.states.spec.ts
@@ -68,6 +68,7 @@ describe('server group states', () => {
     expect(transition.injector().get('serverGroup')).toEqual({
       accountId: 'prod',
       name: 'payments-v001',
+      provider: 'aws',
       region: 'eu-west-1',
     });
   });

--- a/deck/packages/core/src/serverGroup/serverGroup.states.ts
+++ b/deck/packages/core/src/serverGroup/serverGroup.states.ts
@@ -44,6 +44,7 @@ export function getServerGroupDetailsState(): INestedState {
           return {
             name: $stateParams.serverGroup,
             accountId: $stateParams.accountId,
+            provider: $stateParams.provider,
             region: $stateParams.region,
           };
         },

--- a/deck/packages/core/src/serverGroupManager/ServerGroupManager.spec.tsx
+++ b/deck/packages/core/src/serverGroupManager/ServerGroupManager.spec.tsx
@@ -1,9 +1,8 @@
 import { shallow } from 'enzyme';
 import React from 'react';
 
-import { ServerGroupManager } from './ServerGroupManager';
+import { ServerGroupManagerComponent } from './ServerGroupManager';
 import { ServerGroupManagerHeading } from './ServerGroupManagerHeading';
-import { AngularServices } from '../angular/services';
 
 describe('<ServerGroupManager />', () => {
   const serverGroup = {
@@ -26,18 +25,20 @@ describe('<ServerGroupManager />', () => {
   } as any;
 
   it('links grouped server group managers to manager details', () => {
-    spyOnProperty(AngularServices, '$state', 'get').and.returnValue({ includes: () => false } as any);
     const originalUrl = window.location.href;
     window.history.replaceState(null, '', '#/applications/kubernetesapp/clusters');
 
     try {
       const component = shallow(
-        <ServerGroupManager
+        <ServerGroupManagerComponent
           application={{ name: 'kubernetesapp' } as any}
           grouping={{} as any}
           manager="deployment backend"
           serverGroups={[serverGroup]}
           sortFilter={{} as any}
+          router={{} as any}
+          stateParams={{}}
+          stateService={{ includes: () => false } as any}
         />,
       );
 

--- a/deck/packages/core/src/serverGroupManager/ServerGroupManager.tsx
+++ b/deck/packages/core/src/serverGroupManager/ServerGroupManager.tsx
@@ -2,11 +2,12 @@ import classNames from 'classnames';
 import React from 'react';
 
 import { ServerGroupManagerHeading } from './ServerGroupManagerHeading';
-import { AngularServices } from '../angular/services';
 import type { Application } from '../application';
 import type { IClusterSubgroup } from '../cluster';
 import type { IInstanceCounts, IServerGroup } from '../domain';
 import type { ISortFilter } from '../filterModel';
+import type { IRouterInjectedProps } from '../navigation/routerContext';
+import { withRouter } from '../navigation/routerContext';
 import { ServerGroup } from '../serverGroup';
 
 interface IServerGroupManagerProps {
@@ -17,7 +18,7 @@ interface IServerGroupManagerProps {
   serverGroups: IServerGroup[];
 }
 
-export class ServerGroupManager extends React.Component<IServerGroupManagerProps> {
+export class ServerGroupManagerComponent extends React.Component<IServerGroupManagerProps & IRouterInjectedProps> {
   private getDetailsHref(): string {
     const { application, manager, serverGroups } = this.props;
     const currentHash = window.location.hash || `#/applications/${application.name}`;
@@ -39,7 +40,7 @@ export class ServerGroupManager extends React.Component<IServerGroupManagerProps
       serverGroupManager: manager,
       name: manager,
     };
-    return AngularServices.$state.includes('**.serverGroupManager', params);
+    return this.props.stateService.includes('**.serverGroupManager', params);
   };
 
   private handleClick = (e: React.MouseEvent<HTMLElement>): void => {
@@ -103,3 +104,6 @@ export class ServerGroupManager extends React.Component<IServerGroupManagerProps
     );
   }
 }
+
+export const ServerGroupManager = withRouter(ServerGroupManagerComponent);
+ServerGroupManager.displayName = 'ServerGroupManager';

--- a/deck/packages/core/src/serverGroupManager/ServerGroupManagerTag.tsx
+++ b/deck/packages/core/src/serverGroupManager/ServerGroupManagerTag.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import { AngularServices } from '../angular/services';
 
 import type { Application } from '../application';
 import type { IServerGroup, IServerGroupManager } from '../domain';
+import type { IRouterInjectedProps } from '../navigation/routerContext';
+import { withRouter } from '../navigation/routerContext';
 import { Tooltip } from '../presentation/Tooltip';
 
 import type { IServerGroupManagerStateParams } from './serverGroupManager.states';
@@ -12,7 +13,7 @@ export interface IServerGroupManagerTagProps {
   serverGroup: IServerGroup;
 }
 
-export class ServerGroupManagerTag extends React.Component<IServerGroupManagerTagProps> {
+class ServerGroupManagerTagComponent extends React.Component<IServerGroupManagerTagProps & IRouterInjectedProps> {
   public render() {
     const serverGroupManager = this.extractServerGroupManager();
     if (!serverGroupManager) {
@@ -48,9 +49,9 @@ export class ServerGroupManagerTag extends React.Component<IServerGroupManagerTa
 
   private openDetails = (event: React.MouseEvent<HTMLElement>): void => {
     event.preventDefault();
-    const { $state } = AngularServices;
-    const nextState = $state.current.name.endsWith('.clusters') ? '.serverGroupManager' : '^.serverGroupManager';
-    $state.go(nextState, this.buildStateParams());
+    const { stateService } = this.props;
+    const nextState = stateService.current.name.endsWith('.clusters') ? '.serverGroupManager' : '^.serverGroupManager';
+    stateService.go(nextState, this.buildStateParams());
   };
 
   private buildStateParams(): IServerGroupManagerStateParams {
@@ -63,3 +64,6 @@ export class ServerGroupManagerTag extends React.Component<IServerGroupManagerTa
     };
   }
 }
+
+export const ServerGroupManagerTag = withRouter(ServerGroupManagerTagComponent);
+ServerGroupManagerTag.displayName = 'ServerGroupManagerTag';

--- a/deck/packages/core/src/task/TaskNotFound.tsx
+++ b/deck/packages/core/src/task/TaskNotFound.tsx
@@ -1,9 +1,9 @@
+import { useCurrentStateAndParams } from '@uirouter/react';
 import React from 'react';
-import { AngularServices } from '../angular/services';
 
 import { NotFound } from '../notfound/NotFound';
 
 export function TaskNotFound() {
-  const { params } = AngularServices.$state;
+  const { params } = useCurrentStateAndParams();
   return <NotFound type="Task" entityId={params.taskId} />;
 }

--- a/deck/packages/core/src/task/TrafficGuardHelperLink.tsx
+++ b/deck/packages/core/src/task/TrafficGuardHelperLink.tsx
@@ -1,25 +1,23 @@
+import { useCurrentStateAndParams, useRouter } from '@uirouter/react';
 import React from 'react';
-import { AngularServices } from '../angular/services';
 
 export interface ITrafficGuardHelperLinkProps {
   errorMessage: string;
 }
 
-export class TrafficGuardHelperLink extends React.Component<ITrafficGuardHelperLinkProps> {
-  public render() {
-    const { errorMessage } = this.props;
-    if (!errorMessage.includes('has traffic guards enabled')) {
-      return null;
-    }
-    const { $state, $stateParams } = AngularServices;
-    const { project, application } = $stateParams;
-    const nextState = `home.${project ? 'project' : 'applications'}.application.config`;
-    const params = { project, application, section: 'traffic-guards' };
-    const href = $state.href(nextState, params);
-    return (
-      <p>
-        <a href={href}>Configure Traffic Guards for this application</a>
-      </p>
-    );
+export function TrafficGuardHelperLink({ errorMessage }: ITrafficGuardHelperLinkProps) {
+  const { stateService } = useRouter();
+  const { params: stateParams } = useCurrentStateAndParams();
+  if (!errorMessage.includes('has traffic guards enabled')) {
+    return null;
   }
+  const { project, application } = stateParams;
+  const nextState = `home.${project ? 'project' : 'applications'}.application.config`;
+  const params = { project, application, section: 'traffic-guards' };
+  const href = stateService.href(nextState, params);
+  return (
+    <p>
+      <a href={href}>Configure Traffic Guards for this application</a>
+    </p>
+  );
 }

--- a/deck/packages/core/src/task/monitor/TaskMonitorError.tsx
+++ b/deck/packages/core/src/task/monitor/TaskMonitorError.tsx
@@ -2,8 +2,9 @@ import type { RawParams } from '@uirouter/core';
 import React from 'react';
 
 import { TrafficGuardHelperLink } from '../TrafficGuardHelperLink';
-import { AngularServices } from '../../angular/services';
 import type { ITask } from '../../domain';
+import type { IRouterInjectedProps } from '../../navigation/routerContext';
+import { withRouter } from '../../navigation/routerContext';
 import { Markdown } from '../../presentation';
 
 export interface ITaskMonitorErrorProps {
@@ -11,25 +12,23 @@ export interface ITaskMonitorErrorProps {
   task?: ITask;
 }
 
-export class TaskMonitorError extends React.Component<ITaskMonitorErrorProps> {
+class TaskMonitorErrorComponent extends React.Component<ITaskMonitorErrorProps & IRouterInjectedProps> {
   private getBaseState() {
-    const { $stateParams } = AngularServices;
-    return `home.${$stateParams.project ? 'project' : 'applications'}.application`;
+    return `home.${this.props.stateParams.project ? 'project' : 'applications'}.application`;
   }
 
   private getParams(extras: RawParams): RawParams {
-    const { project, application } = AngularServices.$stateParams;
+    const { project, application } = this.props.stateParams;
     return { project, application, ...extras };
   }
 
   public render() {
     const { errorMessage, task } = this.props;
-    const { $state } = AngularServices;
     if (!errorMessage) {
       return null;
     }
     const taskLink = task.id
-      ? $state.href(this.getBaseState() + '.tasks.taskDetails', this.getParams({ taskId: task.id }))
+      ? this.props.stateService.href(this.getBaseState() + '.tasks.taskDetails', this.getParams({ taskId: task.id }))
       : null;
     return (
       <div className="col-md-12 overlay-modal-error">
@@ -51,3 +50,6 @@ export class TaskMonitorError extends React.Component<ITaskMonitorErrorProps> {
     );
   }
 }
+
+export const TaskMonitorError = withRouter(TaskMonitorErrorComponent);
+TaskMonitorError.displayName = 'TaskMonitorError';

--- a/deck/packages/core/src/task/monitor/TaskMonitorStatus.tsx
+++ b/deck/packages/core/src/task/monitor/TaskMonitorStatus.tsx
@@ -1,14 +1,15 @@
+import { useRouter } from '@uirouter/react';
 import React from 'react';
 
 import { StatusGlyph } from '../StatusGlyph';
 import type { TaskMonitor } from './TaskMonitor';
-import { AngularServices } from '../../angular/services';
 import { displayableTasks } from '../displayableTasks.filter';
 import { robotToHuman, useForceUpdate, useObservable } from '../../presentation';
 import { duration } from '../../utils';
 import { Spinner } from '../../widgets/spinners/Spinner';
 
 export const TaskMonitorStatus = ({ monitor }: { monitor: TaskMonitor }) => {
+  const { stateService } = useRouter();
   const forceUpdate = useForceUpdate();
   useObservable(monitor.statusUpdatedStream, () => forceUpdate());
 
@@ -43,7 +44,7 @@ export const TaskMonitorStatus = ({ monitor }: { monitor: TaskMonitor }) => {
         <p>
           You can{' '}
           <a
-            href={AngularServices.$state.href('home.applications.application.tasks.taskDetails', {
+            href={stateService.href('home.applications.application.tasks.taskDetails', {
               application: monitor.application.name,
               taskId: monitor.task.id,
             })}

--- a/deck/packages/ecs/src/ecs.module.spec.ts
+++ b/deck/packages/ecs/src/ecs.module.spec.ts
@@ -11,7 +11,9 @@ describe('ECS package registration', () => {
   it('registers ECS through React components', () => {
     expect(CloudProviderRegistry.getValue('ecs', 'serverGroup.transformer')).toBe(EcsServerGroupTransformer);
     expect(CloudProviderRegistry.getValue('ecs', 'serverGroup.commandBuilder')).toBe(EcsServerGroupCommandBuilder);
-    expect(CloudProviderRegistry.getValue('ecs', 'serverGroup.detailsActions')).toBe(EcsServerGroupActions);
+    expect(CloudProviderRegistry.getValue('ecs', 'serverGroup.detailsActions').displayName).toBe(
+      EcsServerGroupActions.displayName,
+    );
     expect(CloudProviderRegistry.getValue('ecs', 'adHocInfrastructureWritesEnabled')).toBeTrue();
     const detailsSections = CloudProviderRegistry.getValue('ecs', 'serverGroup.detailsSections');
     expect(detailsSections.length).toBe(9);

--- a/deck/packages/ecs/src/instance/details/EcsInstanceDetails.spec.tsx
+++ b/deck/packages/ecs/src/instance/details/EcsInstanceDetails.spec.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 
 import { InstanceInformation, InstanceStatus, VpcTag } from '@spinnaker/amazon';
 import {
-  AngularServices,
   CollapsibleSection,
   ConsoleOutputLink,
   InstanceDetailsHeader,
@@ -13,14 +12,13 @@ import {
   RecentHistoryService,
 } from '@spinnaker/core';
 
-import { EcsInstanceDetails } from './EcsInstanceDetails';
+import { EcsInstanceDetailsComponent as EcsInstanceDetails } from './EcsInstanceDetails';
 
 describe('EcsInstanceDetails', () => {
-  let $state: { go: jasmine.Spy };
+  let stateService: { go: jasmine.Spy };
 
   beforeEach(() => {
-    $state = { go: jasmine.createSpy('go') };
-    spyOnProperty(AngularServices, '$state', 'get').and.returnValue($state as any);
+    stateService = { go: jasmine.createSpy('go') };
     spyOn(RecentHistoryService, 'addExtraDataToLatest');
     spyOn(RecentHistoryService, 'removeLastItem');
   });
@@ -250,7 +248,7 @@ describe('EcsInstanceDetails', () => {
     expect(wrapper.text()).toContain('Instance not found.');
     expect(wrapper.text()).toContain('missing-task');
     expect(RecentHistoryService.removeLastItem).toHaveBeenCalledWith('instances');
-    expect($state.go).not.toHaveBeenCalled();
+    expect(stateService.go).not.toHaveBeenCalled();
   });
 
   it('closes routed details when loading fails', async () => {
@@ -260,13 +258,16 @@ describe('EcsInstanceDetails', () => {
         app={application()}
         environment="test"
         moniker={{ app: 'fnord' }}
+        router={{} as any}
+        stateParams={{}}
+        stateService={stateService as any}
         $stateParams={{ provider: 'ecs', instanceId: 'task-1' }}
       />,
     );
 
     await settle();
 
-    expect($state.go).toHaveBeenCalledWith('^', { allowModalToStayOpen: true }, { location: 'replace' });
+    expect(stateService.go).toHaveBeenCalledWith('^', { allowModalToStayOpen: true }, { location: 'replace' });
   });
 
   it('keeps newer instance details when an older request resolves last', async () => {

--- a/deck/packages/ecs/src/instance/details/EcsInstanceDetails.tsx
+++ b/deck/packages/ecs/src/instance/details/EcsInstanceDetails.tsx
@@ -2,9 +2,8 @@ import React from 'react';
 
 import type { IAmazonHealth } from '@spinnaker/amazon';
 import { InstanceInformation, InstanceStatus, VpcTag } from '@spinnaker/amazon';
-import type { Application, IInstanceDetailsProps, IMoniker } from '@spinnaker/core';
+import type { Application, IInstanceDetailsProps, IMoniker, IRouterInjectedProps } from '@spinnaker/core';
 import {
-  AngularServices,
   CollapsibleSection,
   ConsoleOutputLink,
   CopyToClipboard,
@@ -14,6 +13,7 @@ import {
   LabeledValue,
   RecentHistoryService,
   SubnetTag,
+  withRouter,
 } from '@spinnaker/core';
 
 interface IEcsInstanceParams {
@@ -291,7 +291,10 @@ function NetworkAddress({ address, label }: { address?: string; label: string })
   );
 }
 
-export class EcsInstanceDetails extends React.Component<IEcsInstanceDetailsProps, IEcsInstanceDetailsState> {
+export class EcsInstanceDetailsComponent extends React.Component<
+  IEcsInstanceDetailsProps & IRouterInjectedProps,
+  IEcsInstanceDetailsState
+> {
   public state: IEcsInstanceDetailsState = {
     instance: undefined,
     instanceIdNotFound: undefined,
@@ -347,8 +350,10 @@ export class EcsInstanceDetails extends React.Component<IEcsInstanceDetailsProps
     this.unsubscribeFromRefresh?.();
   }
 
-  private getInstanceParams(props: IEcsInstanceDetailsProps = this.props): IEcsInstanceParams {
-    const params = props.instance || props.$stateParams || ({} as IEcsInstanceParams);
+  private getInstanceParams(
+    props: IEcsInstanceDetailsProps & Partial<IRouterInjectedProps> = this.props,
+  ): IEcsInstanceParams {
+    const params = props.instance || props.$stateParams || props.stateParams || ({} as IEcsInstanceParams);
     return {
       ...params,
       account: params.account || params.accountId || props.accountId,
@@ -357,7 +362,7 @@ export class EcsInstanceDetails extends React.Component<IEcsInstanceDetailsProps
   }
 
   private closeDetails(): void {
-    AngularServices.$state.go('^', { allowModalToStayOpen: true }, { location: 'replace' });
+    this.props.stateService.go('^', { allowModalToStayOpen: true }, { location: 'replace' });
   }
 
   private retrieveInstance(clearInstance = false): void {
@@ -465,3 +470,5 @@ export class EcsInstanceDetails extends React.Component<IEcsInstanceDetailsProps
     );
   }
 }
+
+export const EcsInstanceDetails = withRouter(EcsInstanceDetailsComponent);

--- a/deck/packages/ecs/src/securityGroup/details/EcsSecurityGroupDetails.spec.tsx
+++ b/deck/packages/ecs/src/securityGroup/details/EcsSecurityGroupDetails.spec.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { IPRangeRules } from '@spinnaker/amazon';
 import { CollapsibleSection } from '@spinnaker/core';
 
-import { EcsSecurityGroupDetails } from './EcsSecurityGroupDetails';
+import { EcsSecurityGroupDetailsComponent as EcsSecurityGroupDetails } from './EcsSecurityGroupDetails';
 
 const tick = () => new Promise((resolve) => setTimeout(resolve));
 
@@ -26,6 +26,21 @@ describe('EcsSecurityGroupDetails', () => {
       }),
     } as any;
   }
+
+  it('replaces missing details through the injected state service', () => {
+    const stateService = { go: jasmine.createSpy('go') };
+    const component = new EcsSecurityGroupDetails({
+      app: app(),
+      resolvedSecurityGroup,
+      router: {},
+      stateParams: {},
+      stateService,
+    } as any);
+
+    (component as any).showNotFound();
+
+    expect(stateService.go).toHaveBeenCalledWith('^', { allowModalToStayOpen: true }, { location: 'replace' });
+  });
 
   function securityGroup(name = 'web-sg') {
     return {

--- a/deck/packages/ecs/src/securityGroup/details/EcsSecurityGroupDetails.tsx
+++ b/deck/packages/ecs/src/securityGroup/details/EcsSecurityGroupDetails.tsx
@@ -3,7 +3,13 @@ import { isEmpty } from 'lodash';
 import React from 'react';
 
 import { buildIpRulesModel, buildSecurityGroupRulesModel, IPRangeRules, VpcReader } from '@spinnaker/amazon';
-import type { Application, ISecurityGroup, ISecurityGroupDetail, SecurityGroupReader } from '@spinnaker/core';
+import type {
+  Application,
+  IRouterInjectedProps,
+  ISecurityGroup,
+  ISecurityGroupDetail,
+  SecurityGroupReader,
+} from '@spinnaker/core';
 import {
   AccountTag,
   AngularServices,
@@ -12,6 +18,7 @@ import {
   FirewallLabels,
   RecentHistoryService,
   Spinner,
+  withRouter,
 } from '@spinnaker/core';
 
 interface IEcsResolvedSecurityGroup {
@@ -36,8 +43,8 @@ interface IEcsSecurityGroupDetailsState {
   securityGroup?: ISecurityGroupDetail & ISecurityGroup & Record<string, any>;
 }
 
-export class EcsSecurityGroupDetails extends React.Component<
-  IEcsSecurityGroupDetailsProps,
+export class EcsSecurityGroupDetailsComponent extends React.Component<
+  IEcsSecurityGroupDetailsProps & IRouterInjectedProps,
   IEcsSecurityGroupDetailsState
 > {
   public state: IEcsSecurityGroupDetailsState = { loading: true };
@@ -99,7 +106,7 @@ export class EcsSecurityGroupDetails extends React.Component<
       this.setState({ loading: false, notFound: true, securityGroup: undefined });
       return;
     }
-    AngularServices.$state.go('^', { allowModalToStayOpen: true }, { location: 'replace' });
+    this.props.stateService.go('^', { allowModalToStayOpen: true }, { location: 'replace' });
   };
 
   private loadSecurityGroup = (): void => {
@@ -164,7 +171,7 @@ export class EcsSecurityGroupDetails extends React.Component<
   };
 
   private closeDetails = (): void => {
-    AngularServices.$state.go('^');
+    this.props.stateService.go('^');
   };
 
   public render(): JSX.Element {
@@ -271,3 +278,5 @@ export class EcsSecurityGroupDetails extends React.Component<
     );
   }
 }
+
+export const EcsSecurityGroupDetails = withRouter(EcsSecurityGroupDetailsComponent);

--- a/deck/packages/ecs/src/serverGroup/configure/wizard/EcsCloneServerGroupModal.spec.tsx
+++ b/deck/packages/ecs/src/serverGroup/configure/wizard/EcsCloneServerGroupModal.spec.tsx
@@ -18,7 +18,7 @@ import {
 
 import type { IEcsServerGroupCommand } from '../serverGroupConfiguration.service';
 import { ServiceDiscoveryReader } from '../../../serviceDiscovery/serviceDiscovery.read.service';
-import { EcsCloneServerGroupModal } from './EcsCloneServerGroupModal';
+import { EcsCloneServerGroupModalComponent as EcsCloneServerGroupModal } from './EcsCloneServerGroupModal';
 import { BasicSettings } from './pages/BasicSettings';
 import { NetworkingSettings } from './pages/NetworkingSettings';
 import { EcsNetworking } from './networking/Networking';
@@ -769,7 +769,7 @@ describe('EcsCloneServerGroupModal', () => {
       go: jasmine.createSpy('go'),
       includes: jasmine.createSpy('includes').and.callFake((name: string) => name === '**.clusters'),
     };
-    spyOnProperty(AngularServices, '$state', 'get').and.returnValue(state as any);
+    props.stateService = state;
 
     modal.onTaskComplete();
 

--- a/deck/packages/ecs/src/serverGroup/configure/wizard/EcsCloneServerGroupModal.tsx
+++ b/deck/packages/ecs/src/serverGroup/configure/wizard/EcsCloneServerGroupModal.tsx
@@ -1,7 +1,13 @@
 import { get, uniq, uniqBy } from 'lodash';
 import React from 'react';
 
-import type { Application, IModalComponentProps, ISubnet, IWizardPageInjectedProps } from '@spinnaker/core';
+import type {
+  Application,
+  IModalComponentProps,
+  IRouterInjectedProps,
+  ISubnet,
+  IWizardPageInjectedProps,
+} from '@spinnaker/core';
 import {
   AccountService,
   AngularServices,
@@ -11,6 +17,7 @@ import {
   ReactModal,
   REST,
   TaskMonitor,
+  withRouter,
   WizardModal,
   WizardPage,
 } from '@spinnaker/core';
@@ -60,8 +67,8 @@ interface IEcsCloneServerGroupModalState {
   taskMonitor: TaskMonitor;
 }
 
-export class EcsCloneServerGroupModal extends React.Component<
-  IEcsCloneServerGroupModalProps,
+export class EcsCloneServerGroupModalComponent extends React.Component<
+  IEcsCloneServerGroupModalProps & IRouterInjectedProps,
   IEcsCloneServerGroupModalState
 > {
   private command: IEcsServerGroupCommand;
@@ -85,7 +92,7 @@ export class EcsCloneServerGroupModal extends React.Component<
     return ReactModal.show(EcsCloneServerGroupModal, props, modalProps);
   }
 
-  constructor(props: IEcsCloneServerGroupModalProps) {
+  constructor(props: IEcsCloneServerGroupModalProps & IRouterInjectedProps) {
     super(props);
     this.ensureCommandShape(props.command);
     this.command = props.command;
@@ -132,16 +139,16 @@ export class EcsCloneServerGroupModal extends React.Component<
     }
 
     let transitionTo = '^.^.^.clusters.serverGroup';
-    if (AngularServices.$state.includes('**.clusters.serverGroup')) {
+    if (this.props.stateService.includes('**.clusters.serverGroup')) {
       transitionTo = '^.serverGroup';
     }
-    if (AngularServices.$state.includes('**.clusters.cluster.serverGroup')) {
+    if (this.props.stateService.includes('**.clusters.cluster.serverGroup')) {
       transitionTo = '^.^.serverGroup';
     }
-    if (AngularServices.$state.includes('**.clusters')) {
+    if (this.props.stateService.includes('**.clusters')) {
       transitionTo = '.serverGroup';
     }
-    AngularServices.$state.go(transitionTo, {
+    this.props.stateService.go(transitionTo, {
       accountId: command.credentials,
       provider: 'ecs',
       region: command.region,
@@ -710,3 +717,8 @@ export class EcsCloneServerGroupModal extends React.Component<
     );
   }
 }
+
+export const EcsCloneServerGroupModal = Object.assign(
+  withRouter<IEcsCloneServerGroupModalProps & IRouterInjectedProps>(EcsCloneServerGroupModalComponent),
+  { show: EcsCloneServerGroupModalComponent.show },
+);

--- a/deck/packages/ecs/src/serverGroup/details/EcsServerGroupActions.spec.tsx
+++ b/deck/packages/ecs/src/serverGroup/details/EcsServerGroupActions.spec.tsx
@@ -12,7 +12,7 @@ import {
   ServerGroupWarningMessageService,
 } from '@spinnaker/core';
 
-import { EcsServerGroupActions } from './EcsServerGroupActions';
+import { EcsServerGroupActionsComponent as EcsServerGroupActions } from './EcsServerGroupActions';
 import { EcsResizeServerGroupModal } from './resize/EcsResizeServerGroupModal';
 import { EcsRollbackServerGroupModal } from './rollback/EcsRollbackServerGroupModal';
 
@@ -152,9 +152,21 @@ describe('<EcsServerGroupActions />', () => {
       const writer = AngularServices.serverGroupWriter as any;
       const write = spyOn(writer, writerMethod).and.returnValue(Promise.resolve());
       const confirm = spyOn(ConfirmationModalService, 'confirm').and.returnValue(Promise.resolve());
+      const stateService = {
+        go: jasmine.createSpy('go'),
+        includes: jasmine.createSpy('includes').and.returnValue(true),
+      };
       spyOn(ServerGroupWarningMessageService, 'addDisableWarningMessage');
       spyOn(ServerGroupWarningMessageService, 'addDestroyWarningMessage');
-      const wrapper = shallow(<EcsServerGroupActions app={app} serverGroup={serverGroup} />);
+      const wrapper = shallow(
+        <EcsServerGroupActions
+          app={app}
+          router={{} as any}
+          serverGroup={serverGroup}
+          stateParams={{}}
+          stateService={stateService as any}
+        />,
+      );
 
       action(wrapper, label).prop('onClick')();
 
@@ -164,6 +176,10 @@ describe('<EcsServerGroupActions />', () => {
       const command = { interestingHealthProviderNames: ['Ecs'], reason: 'because it is safe' };
       params.submitMethod(command);
       expect(write).toHaveBeenCalledOnceWith(serverGroup, label === 'Disable' ? app.name : app, command);
+      if (label === 'Destroy') {
+        params.taskMonitorConfig.onTaskComplete();
+        expect(stateService.go).toHaveBeenCalledWith('^');
+      }
     });
   });
 

--- a/deck/packages/ecs/src/serverGroup/details/EcsServerGroupActions.tsx
+++ b/deck/packages/ecs/src/serverGroup/details/EcsServerGroupActions.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Dropdown, Tooltip } from 'react-bootstrap';
 
 import { AWSProviderSettings } from '@spinnaker/amazon';
-import type { IOwnerOption, IServerGroupActionsProps, IServerGroupJob } from '@spinnaker/core';
+import type { IOwnerOption, IRouterInjectedProps, IServerGroupActionsProps, IServerGroupJob } from '@spinnaker/core';
 import {
   AddEntityTagLinks,
   AngularServices,
@@ -11,6 +11,7 @@ import {
   ManagedMenuItem,
   ServerGroupWarningMessageService,
   SETTINGS,
+  withRouter,
 } from '@spinnaker/core';
 
 import { EcsResizeServerGroupModal } from './resize/EcsResizeServerGroupModal';
@@ -24,7 +25,11 @@ const actionLabels: Record<ConfirmedAction, { present: string; progressive: stri
   enable: { present: 'Enable', progressive: 'Enabling' },
 };
 
-export function EcsServerGroupActions({ app, serverGroup }: IServerGroupActionsProps) {
+export function EcsServerGroupActionsComponent({
+  app,
+  serverGroup,
+  stateService,
+}: IServerGroupActionsProps & IRouterInjectedProps) {
   if (!AWSProviderSettings.adHocInfraWritesEnabled) {
     return null;
   }
@@ -50,8 +55,8 @@ export function EcsServerGroupActions({ app, serverGroup }: IServerGroupActionsP
         ...(action === 'destroy'
           ? {
               onTaskComplete: () => {
-                if (AngularServices.$state.includes('**.serverGroup', stateParams)) {
-                  AngularServices.$state.go('^');
+                if (stateService.includes('**.serverGroup', stateParams)) {
+                  stateService.go('^');
                 }
               },
             }
@@ -141,3 +146,5 @@ export function EcsServerGroupActions({ app, serverGroup }: IServerGroupActionsP
     </Dropdown>
   );
 }
+
+export const EcsServerGroupActions = withRouter(EcsServerGroupActionsComponent);

--- a/deck/packages/google/src/gce.module.spec.ts
+++ b/deck/packages/google/src/gce.module.spec.ts
@@ -27,7 +27,7 @@ import { GceLoadBalancerTransformer } from './loadBalancer/loadBalancer.transfor
 import { GceLoadBalancerChoiceModal } from './loadBalancer/configure/choice/GceLoadBalancerChoiceModal';
 import { GceLoadBalancerActions, loadGceLoadBalancerDetails } from './loadBalancer/details/gceLoadBalancerDetails';
 import { interpolatedBakeDetailUrl } from './pipeline/stages/bake/gceBakeStage';
-import { GceSecurityGroupModal } from './securityGroup/configure/GceSecurityGroupModal';
+import { GceSecurityGroupModalComponent as GceSecurityGroupModal } from './securityGroup/configure/GceSecurityGroupModal';
 import { GceSecurityGroupReader } from './securityGroup/securityGroup.reader';
 import { GceSecurityGroupTransformer } from './securityGroup/securityGroup.transformer';
 import { GceServerGroupCommandBuilder } from './serverGroup/configure/serverGroupCommandBuilder.service';

--- a/deck/packages/google/src/instance/details/GceInstanceDetails.spec.tsx
+++ b/deck/packages/google/src/instance/details/GceInstanceDetails.spec.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import type { Action } from '@spinnaker/core';
 import {
-  AngularServices,
+  AccountService,
   ConfirmationModalService,
   Details,
   InstanceActions,
@@ -12,7 +12,7 @@ import {
   RecentHistoryService,
 } from '@spinnaker/core';
 
-import { GceInstanceDetails } from './GceInstanceDetails';
+import { GceInstanceDetailsComponent as GceInstanceDetails } from './GceInstanceDetails';
 
 describe('GceInstanceDetails', () => {
   function application(loadBalancers: any[] = []) {
@@ -57,8 +57,20 @@ describe('GceInstanceDetails', () => {
     };
   }
 
-  function actionsFor(loadedInstance: any, app = application([networkLoadBalancer()])): Action[] {
-    const wrapper = shallow(<GceInstanceDetails app={app} initialInstance={loadedInstance} $stateParams={{}} />);
+  function actionsFor(
+    loadedInstance: any,
+    app = application([networkLoadBalancer()]),
+    stateService = { go: jasmine.createSpy('go'), includes: () => false },
+  ): Action[] {
+    const wrapper = shallow(
+      <GceInstanceDetails
+        app={app}
+        initialInstance={loadedInstance}
+        router={{} as any}
+        stateParams={{}}
+        stateService={stateService as any}
+      />,
+    );
     const renderedActions = shallow(wrapper.find(Details.Header).prop('actions') as React.ReactElement);
     const actionMenu = renderedActions.is(InstanceActions) ? renderedActions : renderedActions.find(InstanceActions);
     const actions = actionMenu.exists() ? actionMenu.prop('actions') : [];
@@ -100,7 +112,9 @@ describe('GceInstanceDetails', () => {
       <GceInstanceDetails
         app={app}
         instance={{ account: 'route-account', instanceId: 'instance-1', region: 'route-region' }}
-        $stateParams={{}}
+        router={{} as any}
+        stateParams={{}}
+        stateService={{} as any}
       />,
     );
 
@@ -109,6 +123,7 @@ describe('GceInstanceDetails', () => {
   });
 
   it('clears actions on instance identity changes and ignores stale responses', async () => {
+    spyOn(AccountService, 'challengeDestructiveActions').and.returnValue(Promise.resolve(false));
     const oldRequest = deferred<any>();
     const newRequest = deferred<any>();
     spyOn(RecentHistoryService, 'addExtraDataToLatest');
@@ -128,7 +143,14 @@ describe('GceInstanceDetails', () => {
     );
     const app = application();
     const RoutedDetails = ({ routedInstance }: { routedInstance: any }) => (
-      <GceInstanceDetails app={app} initialInstance={instance()} instance={routedInstance} $stateParams={{}} />
+      <GceInstanceDetails
+        app={app}
+        initialInstance={instance()}
+        instance={routedInstance}
+        router={{} as any}
+        stateParams={{}}
+        stateService={{} as any}
+      />
     );
     const wrapper = mount(
       <RoutedDetails routedInstance={{ account: 'test-account', instanceId: 'instance-1', region: 'us-central1' }} />,
@@ -258,7 +280,6 @@ describe('GceInstanceDetails', () => {
     spyOn(InstanceWriter, 'enableInstanceInDiscovery').and.returnValue(Promise.resolve({} as any));
     spyOn(InstanceWriter, 'disableInstanceInDiscovery').and.returnValue(Promise.resolve({} as any));
     const $state = { go: jasmine.createSpy('go'), includes: jasmine.createSpy('includes').and.returnValue(true) };
-    spyOnProperty(AngularServices, '$state', 'get').and.returnValue($state as any);
     const app = application([networkLoadBalancer()]);
     const loadedInstance = instance({
       health: [
@@ -268,7 +289,7 @@ describe('GceInstanceDetails', () => {
       ],
     });
 
-    const actions = actionsFor(loadedInstance, app);
+    const actions = actionsFor(loadedInstance, app, $state);
     expect(actions.length).toBe(7);
     if (!actions.length) {
       return;

--- a/deck/packages/google/src/instance/details/GceInstanceDetails.tsx
+++ b/deck/packages/google/src/instance/details/GceInstanceDetails.tsx
@@ -1,8 +1,8 @@
 import React, { useLayoutEffect, useState } from 'react';
 
+import type { IRouterInjectedProps } from '@spinnaker/core';
 import {
   AccountTag,
-  AngularServices,
   CollapsibleSection,
   ConfirmationModalService,
   Details,
@@ -10,11 +10,12 @@ import {
   InstanceReader,
   InstanceWriter,
   RecentHistoryService,
+  withRouter,
 } from '@spinnaker/core';
 
 import { GceXpnNamingService } from '../../common/xpnNaming.gce.service';
 
-interface IGceInstanceDetailsProps {
+interface IGceInstanceDetailsProps extends IRouterInjectedProps {
   app: any;
   instance?: any;
   initialInstance?: any;
@@ -22,7 +23,7 @@ interface IGceInstanceDetailsProps {
 }
 
 function getInstanceParams(props: IGceInstanceDetailsProps): any {
-  const stateParams = props.$stateParams || AngularServices.$stateParams || {};
+  const stateParams = props.$stateParams || props.stateParams || {};
   const instance = props.instance || props.initialInstance || {};
   return {
     account: instance.account || stateParams.account || stateParams.accountId,
@@ -150,10 +151,17 @@ function canRegisterWithDiscovery(instance: any): boolean {
   return discoveryHealth[0]?.state === 'OutOfService';
 }
 
-export function GceInstanceActions({ app, instance }: { app: any; instance: any }): JSX.Element {
+export function GceInstanceActionsComponent({
+  app,
+  instance,
+  stateService,
+}: {
+  app: any;
+  instance: any;
+} & IRouterInjectedProps): JSX.Element {
   const closeIfCurrentInstance = () => {
-    if (AngularServices.$state.includes('**.instanceDetails', { instanceId: instance.instanceId })) {
-      AngularServices.$state.go('^');
+    if (stateService.includes('**.instanceDetails', { instanceId: instance.instanceId })) {
+      stateService.go('^');
     }
   };
   const confirm = (
@@ -287,7 +295,7 @@ export function GceInstanceActions({ app, instance }: { app: any; instance: any 
   return <InstanceActions actions={actions} />;
 }
 
-export function GceInstanceDetails(props: IGceInstanceDetailsProps): JSX.Element {
+export function GceInstanceDetailsComponent(props: IGceInstanceDetailsProps): JSX.Element {
   const [instance, setInstance] = useState<any>(props.initialInstance || null);
   const [loading, setLoading] = useState<boolean>(true);
   const [notFound, setNotFound] = useState<boolean>(false);
@@ -331,7 +339,7 @@ export function GceInstanceDetails(props: IGceInstanceDetailsProps): JSX.Element
     return () => {
       cancelled = true;
     };
-  }, [props.app, props.instance, props.initialInstance, props.$stateParams]);
+  }, [props.app, props.instance, props.initialInstance, props.$stateParams, props.stateParams]);
 
   if (notFound) {
     return <div className="alert alert-warning">Instance not found.</div>;
@@ -344,7 +352,15 @@ export function GceInstanceDetails(props: IGceInstanceDetailsProps): JSX.Element
           <Details.Header
             icon={<span className="icon-gce" />}
             name={instance.name || instance.instanceId}
-            actions={<GceInstanceActions app={props.app} instance={instance} />}
+            actions={
+              <GceInstanceActionsComponent
+                app={props.app}
+                instance={instance}
+                router={props.router}
+                stateParams={props.stateParams}
+                stateService={props.stateService}
+              />
+            }
           />
           <Details.Content loading={loading}>
             <CollapsibleSection heading="Instance Information" defaultExpanded={true}>
@@ -398,3 +414,6 @@ export function GceInstanceDetails(props: IGceInstanceDetailsProps): JSX.Element
     </Details>
   );
 }
+
+export const GceInstanceActions = withRouter(GceInstanceActionsComponent);
+export const GceInstanceDetails = withRouter(GceInstanceDetailsComponent);

--- a/deck/packages/google/src/securityGroup/configure/GceSecurityGroupModal.spec.tsx
+++ b/deck/packages/google/src/securityGroup/configure/GceSecurityGroupModal.spec.tsx
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme';
 
 import { AngularServices, SecurityGroupWriter, SubmitButton } from '@spinnaker/core';
 
-import { GceSecurityGroupModal } from './GceSecurityGroupModal';
+import { GceSecurityGroupModalComponent as GceSecurityGroupModal } from './GceSecurityGroupModal';
 
 describe('GceSecurityGroupModal', () => {
   const application = {
@@ -141,13 +141,15 @@ describe('GceSecurityGroupModal', () => {
         go: jasmine.createSpy('go'),
         includes: jasmine.createSpy('includes').and.returnValue(mode === 'clone'),
       };
-      spyOnProperty(AngularServices, '$state', 'get').and.returnValue(state as any);
       const modal = new GceSecurityGroupModal({
         application: { name: 'my-app', securityGroups: { onNextRefresh, refresh } },
         closeModal,
         credentials: 'my-account',
         mode,
+        router: {},
         securityGroup: mode === 'clone' ? validSecurityGroup({ name: 'source-firewall' }) : undefined,
+        stateParams: {},
+        stateService: state,
       } as any);
       (modal.state as any).securityGroup = validSecurityGroup({ name: ' new-firewall ', network: ' default ' });
 

--- a/deck/packages/google/src/securityGroup/configure/GceSecurityGroupModal.tsx
+++ b/deck/packages/google/src/securityGroup/configure/GceSecurityGroupModal.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import type { ISecurityGroupsByAccountSourceData } from '@spinnaker/core';
+import type { IRouterInjectedProps, ISecurityGroupsByAccountSourceData } from '@spinnaker/core';
 import {
   AngularServices,
   FirewallLabels,
@@ -10,6 +10,7 @@ import {
   SubmitButton,
   TaskMonitor,
   TaskMonitorWrapper,
+  withRouter,
 } from '@spinnaker/core';
 
 export type GceSecurityGroupModalMode = 'create' | 'edit' | 'clone';
@@ -181,14 +182,17 @@ export function initializeGceSecurityGroupForModal(props: IGceSecurityGroupModal
   return securityGroup;
 }
 
-export class GceSecurityGroupModal extends React.Component<IGceSecurityGroupModalProps, IGceSecurityGroupModalState> {
+export class GceSecurityGroupModalComponent extends React.Component<
+  IGceSecurityGroupModalProps & IRouterInjectedProps,
+  IGceSecurityGroupModalState
+> {
   private mounted = false;
 
   public static show(props: IGceSecurityGroupModalProps): Promise<any> {
     return ReactModal.show(GceSecurityGroupModal, props, { dialogClassName: 'modal-lg' });
   }
 
-  public constructor(props: IGceSecurityGroupModalProps) {
+  public constructor(props: IGceSecurityGroupModalProps & IRouterInjectedProps) {
     super(props);
     const application = this.getApplication(props);
     const mode = props.mode || 'create';
@@ -250,8 +254,8 @@ export class GceSecurityGroupModal extends React.Component<IGceSecurityGroupModa
     const showNewSecurityGroup = (): void => {
       const { securityGroup } = this.state;
       this.props.closeModal?.();
-      AngularServices.$state.go(
-        AngularServices.$state.includes('**.firewallDetails') ? '^.firewallDetails' : '.firewallDetails',
+      this.props.stateService.go(
+        this.props.stateService.includes('**.firewallDetails') ? '^.firewallDetails' : '.firewallDetails',
         {
           accountId: accountFor(securityGroup),
           name: securityGroup.name.trim(),
@@ -521,3 +525,7 @@ export class GceSecurityGroupModal extends React.Component<IGceSecurityGroupModa
     );
   }
 }
+
+export const GceSecurityGroupModal = Object.assign(withRouter(GceSecurityGroupModalComponent), {
+  show: GceSecurityGroupModalComponent.show,
+});

--- a/deck/packages/google/src/serverGroup/configure/wizard/GceCloneServerGroupModal.spec.tsx
+++ b/deck/packages/google/src/serverGroup/configure/wizard/GceCloneServerGroupModal.spec.tsx
@@ -4,7 +4,11 @@ import { mount, shallow } from 'enzyme';
 
 import { AngularServices, ReactModal, TaskMonitor, WizardModal, WizardPage } from '@spinnaker/core';
 
-import { GceCloneServerGroupModal, transformGceServerGroupCommand } from './GceCloneServerGroupModal';
+import {
+  GceCloneServerGroupModal as RoutedGceCloneServerGroupModal,
+  GceCloneServerGroupModalComponent as GceCloneServerGroupModal,
+  transformGceServerGroupCommand,
+} from './GceCloneServerGroupModal';
 import type { IGceServerGroupCommand, IGceServerGroupWizardAdapter } from './GceServerGroupWizard.types';
 
 const application = {
@@ -34,7 +38,7 @@ describe('GceCloneServerGroupModal', () => {
 
     GceCloneServerGroupModal.show(props);
 
-    expect(ReactModal.show).toHaveBeenCalledWith(GceCloneServerGroupModal, props, {
+    expect(ReactModal.show).toHaveBeenCalledWith(RoutedGceCloneServerGroupModal, props, {
       dialogClassName: 'wizard-modal modal-lg',
     });
   });
@@ -991,7 +995,7 @@ describe('GceCloneServerGroupModal', () => {
       go: jasmine.createSpy('go'),
       includes: jasmine.createSpy('includes').and.callFake((name: string) => name === '**.clusters'),
     };
-    spyOnProperty(AngularServices, '$state', 'get').and.returnValue(state as any);
+    props.stateService = state;
 
     modal.onTaskComplete();
 
@@ -1080,6 +1084,9 @@ function buildProps(command: IGceServerGroupCommand, adapter?: IGceServerGroupWi
     closeModal: jasmine.createSpy('closeModal'),
     command,
     dismissModal: jasmine.createSpy('dismissModal'),
+    router: {},
+    stateParams: {},
+    stateService: { go: jasmine.createSpy('go'), includes: () => false },
     title: 'Configure GCE server group',
   };
 }

--- a/deck/packages/google/src/serverGroup/configure/wizard/GceCloneServerGroupModal.tsx
+++ b/deck/packages/google/src/serverGroup/configure/wizard/GceCloneServerGroupModal.tsx
@@ -1,8 +1,14 @@
 import { cloneDeep } from 'lodash';
 import React from 'react';
 
-import type { Application, IModalComponentProps, IStage, IWizardPageInjectedProps } from '@spinnaker/core';
-import { AngularServices, noop, ReactModal, TaskMonitor, WizardModal, WizardPage } from '@spinnaker/core';
+import type {
+  Application,
+  IModalComponentProps,
+  IRouterInjectedProps,
+  IStage,
+  IWizardPageInjectedProps,
+} from '@spinnaker/core';
+import { AngularServices, noop, ReactModal, TaskMonitor, withRouter, WizardModal, WizardPage } from '@spinnaker/core';
 
 import { validateGceServerGroupCommand } from './GceServerGroupWizard.helpers';
 import type {
@@ -197,11 +203,11 @@ export function transformGceServerGroupCommand(command: IGceServerGroupCommand):
   return transformed;
 }
 
-export class GceCloneServerGroupModal extends React.Component<
-  IGceCloneServerGroupModalProps,
+export class GceCloneServerGroupModalComponent extends React.Component<
+  IGceCloneServerGroupModalProps & IRouterInjectedProps,
   IGceCloneServerGroupModalState
 > {
-  public static defaultProps: Partial<IGceCloneServerGroupModalProps> = {
+  public static defaultProps: Partial<IGceCloneServerGroupModalProps & IRouterInjectedProps> = {
     closeModal: noop,
     dismissModal: noop,
   };
@@ -218,7 +224,7 @@ export class GceCloneServerGroupModal extends React.Component<
     return ReactModal.show(GceCloneServerGroupModal, props, { dialogClassName: 'wizard-modal modal-lg' });
   }
 
-  public constructor(props: IGceCloneServerGroupModalProps) {
+  public constructor(props: IGceCloneServerGroupModalProps & IRouterInjectedProps) {
     super(props);
     this.adapter = props.adapter || new GceServerGroupWizardAdapter();
     this.command = cloneDeep(props.command);
@@ -322,16 +328,16 @@ export class GceCloneServerGroupModal extends React.Component<
     }
 
     let transitionTo = '^.^.^.clusters.serverGroup';
-    if (AngularServices.$state.includes('**.clusters.serverGroup')) {
+    if (this.props.stateService.includes('**.clusters.serverGroup')) {
       transitionTo = '^.serverGroup';
     }
-    if (AngularServices.$state.includes('**.clusters.cluster.serverGroup')) {
+    if (this.props.stateService.includes('**.clusters.cluster.serverGroup')) {
       transitionTo = '^.^.serverGroup';
     }
-    if (AngularServices.$state.includes('**.clusters')) {
+    if (this.props.stateService.includes('**.clusters')) {
       transitionTo = '.serverGroup';
     }
-    AngularServices.$state.go(transitionTo, {
+    this.props.stateService.go(transitionTo, {
       accountId: command.credentials,
       provider: 'gce',
       region: command.region,
@@ -466,6 +472,10 @@ export class GceCloneServerGroupModal extends React.Component<
     );
   }
 }
+
+export const GceCloneServerGroupModal = Object.assign(withRouter(GceCloneServerGroupModalComponent), {
+  show: GceCloneServerGroupModalComponent.show,
+});
 
 function initializeCommand(command: IGceServerGroupCommand, snapshot: IPersistedSelectionSnapshot): void {
   const accountAvailable =

--- a/deck/packages/kubernetes/src/instance/details/KubernetesInstanceDetails.spec.tsx
+++ b/deck/packages/kubernetes/src/instance/details/KubernetesInstanceDetails.spec.tsx
@@ -13,7 +13,10 @@ import {
 } from '@spinnaker/core';
 
 import type { IKubernetesInstanceDetailsProps } from './KubernetesInstanceDetails';
-import { KubernetesInstanceActions, KubernetesInstanceDetails } from './KubernetesInstanceDetails';
+import {
+  KubernetesInstanceActions,
+  KubernetesInstanceDetailsComponent as KubernetesInstanceDetails,
+} from './KubernetesInstanceDetails';
 import { findKubernetesInstanceIdentifier } from './kubernetesInstanceDetails.utils';
 import { AnnotationCustomSections } from '../../manifest/AnnotationCustomSections';
 import { ManifestLabels } from '../../manifest/ManifestLabels';
@@ -221,6 +224,21 @@ describe('<KubernetesInstanceDetails />', () => {
     expect(autoClose).toHaveBeenCalled();
     expect(InstanceReader.getInstanceDetails).not.toHaveBeenCalled();
     expect(ManifestReader.getManifest).not.toHaveBeenCalled();
+  });
+
+  it('replaces missing instance details through the injected state service', () => {
+    const stateService = { go: jasmine.createSpy('go'), params: {} };
+    const component = new KubernetesInstanceDetails({
+      ...props,
+      router: {},
+      stateParams: {},
+      stateService,
+    } as any);
+
+    (component as any).autoClose();
+
+    expect(stateService.params.allowModalToStayOpen).toBe(true);
+    expect(stateService.go).toHaveBeenCalledWith('^', null, { location: 'replace' });
   });
 
   it('waits for application data before loading changed instance props', async () => {

--- a/deck/packages/kubernetes/src/instance/details/KubernetesInstanceDetails.tsx
+++ b/deck/packages/kubernetes/src/instance/details/KubernetesInstanceDetails.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
 import { Dropdown, MenuItem } from 'react-bootstrap';
 
-import type { Application, IManifest, IMoniker } from '@spinnaker/core';
+import type { Application, IManifest, IMoniker, IRouterInjectedProps } from '@spinnaker/core';
 import {
   AccountTag,
-  AngularServices,
   CollapsibleSection,
   ConsoleOutputLink,
   InstanceDetailsHeader,
@@ -16,6 +15,7 @@ import {
   SETTINGS,
   timestamp,
   useModal,
+  withRouter,
 } from '@spinnaker/core';
 
 import type { IKubernetesInstance } from '../../interfaces';
@@ -68,8 +68,8 @@ export interface IKubernetesInstanceActionsProps {
   manifest: IManifest;
 }
 
-export class KubernetesInstanceDetails extends React.Component<
-  IKubernetesInstanceDetailsProps,
+export class KubernetesInstanceDetailsComponent extends React.Component<
+  IKubernetesInstanceDetailsProps & IRouterInjectedProps,
   IKubernetesInstanceDetailsState
 > {
   protected readonly renderActions: boolean = true;
@@ -169,8 +169,8 @@ export class KubernetesInstanceDetails extends React.Component<
       return;
     }
 
-    AngularServices.$state.params.allowModalToStayOpen = true;
-    AngularServices.$state.go('^', null, { location: 'replace' });
+    this.props.stateService.params.allowModalToStayOpen = true;
+    this.props.stateService.go('^', null, { location: 'replace' });
   };
 
   private buildConsoleOutputInstance(instance: IKubernetesInstance): IConsoleOutputInstance {
@@ -298,6 +298,8 @@ export class KubernetesInstanceDetails extends React.Component<
     );
   }
 }
+
+export const KubernetesInstanceDetails = withRouter(KubernetesInstanceDetailsComponent);
 
 export function KubernetesInstanceActions({ app, instance, manifest }: IKubernetesInstanceActionsProps) {
   const deleteModal = useModal();

--- a/deck/packages/kubernetes/src/kubernetes.module.spec.ts
+++ b/deck/packages/kubernetes/src/kubernetes.module.spec.ts
@@ -9,9 +9,13 @@ describe('Kubernetes provider registration', () => {
   it('registers the provider configuration', () => {
     registerKubernetesProvider();
 
-    expect(CloudProviderRegistry.getValue('kubernetes', 'instance.details')).toBe(KubernetesInstanceDetails);
+    expect(CloudProviderRegistry.getValue('kubernetes', 'instance.details').displayName).toBe(
+      KubernetesInstanceDetails.displayName,
+    );
     expect(CloudProviderRegistry.getValue('kubernetes', 'securityGroup.CreateSecurityGroupModal')).toBe(ManifestWizard);
-    expect(CloudProviderRegistry.getValue('kubernetes', 'securityGroup.details')).toBe(KubernetesSecurityGroupDetails);
+    expect(CloudProviderRegistry.getValue('kubernetes', 'securityGroup.details').displayName).toBe(
+      KubernetesSecurityGroupDetails.displayName,
+    );
     expect(CloudProviderRegistry.getValue('kubernetes', 'securityGroup.transformer')).toBe(
       KubernetesV2SecurityGroupTransformer,
     );

--- a/deck/packages/kubernetes/src/pipelines/stages/deployManifest/manifestStatus/ManifestDetailsLink.spec.tsx
+++ b/deck/packages/kubernetes/src/pipelines/stages/deployManifest/manifestStatus/ManifestDetailsLink.spec.tsx
@@ -1,0 +1,35 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import { AccountService } from '@spinnaker/core';
+
+import { ManifestDetailsLinkComponent } from './ManifestDetailsLink';
+
+describe('Kubernetes ManifestDetailsLink', () => {
+  it('builds its link through the injected state service', async () => {
+    spyOn(AccountService, 'getAccountDetails').and.returnValue(
+      Promise.resolve({ spinnakerKindMap: { Deployment: 'serverGroups' } } as any) as any,
+    );
+    const href = jasmine.createSpy('href').and.returnValue('#/manifest');
+    const component = shallow(
+      <ManifestDetailsLinkComponent
+        {...({ router: {}, stateParams: {}, stateService: { href } } as any)}
+        accountId="test-account"
+        linkName="Manifest"
+        manifest={{ manifest: { kind: 'Deployment', metadata: { annotations: {}, name: 'test-v001' } } } as any}
+      />,
+    );
+
+    await Promise.resolve();
+    component.update();
+
+    expect(href).toHaveBeenCalledWith('home.applications.application.insight.clusters.serverGroup', {
+      accountId: 'test-account',
+      provider: 'kubernetes',
+      reg: '',
+      region: '_',
+      serverGroup: 'deployment test-v001',
+    });
+    expect(component.find('a').prop('href')).toBe('#/manifest');
+  });
+});

--- a/deck/packages/kubernetes/src/pipelines/stages/deployManifest/manifestStatus/ManifestDetailsLink.tsx
+++ b/deck/packages/kubernetes/src/pipelines/stages/deployManifest/manifestStatus/ManifestDetailsLink.tsx
@@ -1,8 +1,8 @@
 import { get, trim } from 'lodash';
 import React from 'react';
 
-import type { IManifest } from '@spinnaker/core';
-import { AccountService, AngularServices } from '@spinnaker/core';
+import type { IManifest, IRouterInjectedProps } from '@spinnaker/core';
+import { AccountService, withRouter } from '@spinnaker/core';
 
 const UNMAPPED_K8S_RESOURCE_STATE_KEY = 'kubernetesResource';
 
@@ -16,14 +16,17 @@ export interface IManifestDetailsState {
   url: string;
 }
 
-export class ManifestDetailsLink extends React.Component<IManifestDetailsProps, IManifestDetailsState> {
+export class ManifestDetailsLinkComponent extends React.Component<
+  IManifestDetailsProps & IRouterInjectedProps,
+  IManifestDetailsState
+> {
   private spinnakerKindStateMap: { [k: string]: string } = {
     // keys from clouddriver's KubernetesSpinnakerKindMap
     serverGroupManagers: 'serverGroupManager',
     serverGroups: 'serverGroup',
   };
 
-  constructor(props: IManifestDetailsProps) {
+  constructor(props: IManifestDetailsProps & IRouterInjectedProps) {
     super(props);
     this.state = {
       url: '',
@@ -73,7 +76,7 @@ export class ManifestDetailsLink extends React.Component<IManifestDetailsProps, 
       const spinnakerKind = this.spinnakerKindFromKubernetesKind(kind, account.spinnakerKindMap);
       const stateKey = this.spinnakerKindStateMap[spinnakerKind] || UNMAPPED_K8S_RESOURCE_STATE_KEY;
       const params = this.getStateParams(stateKey);
-      const url = AngularServices.$state.href(`home.applications.application.insight.clusters.${stateKey}`, params);
+      const url = this.props.stateService.href(`home.applications.application.insight.clusters.${stateKey}`, params);
       this.setState({ url });
     });
   }
@@ -90,3 +93,5 @@ export class ManifestDetailsLink extends React.Component<IManifestDetailsProps, 
     }
   }
 }
+
+export const ManifestDetailsLink = withRouter(ManifestDetailsLinkComponent);

--- a/deck/packages/kubernetes/src/securityGroup/details/KubernetesSecurityGroupDetails.spec.tsx
+++ b/deck/packages/kubernetes/src/securityGroup/details/KubernetesSecurityGroupDetails.spec.tsx
@@ -12,7 +12,10 @@ import {
   SETTINGS,
 } from '@spinnaker/core';
 
-import { KubernetesSecurityGroupActions, KubernetesSecurityGroupDetails } from './KubernetesSecurityGroupDetails';
+import {
+  KubernetesSecurityGroupActions,
+  KubernetesSecurityGroupDetailsComponent as KubernetesSecurityGroupDetails,
+} from './KubernetesSecurityGroupDetails';
 import type { IKubernetesSecurityGroupDetailsProps } from './KubernetesSecurityGroupDetails';
 import { KubernetesV2SecurityGroupTransformer } from '../transformer';
 import { AnnotationCustomSections } from '../../manifest/AnnotationCustomSections';
@@ -49,6 +52,21 @@ describe('<KubernetesSecurityGroupDetails />', () => {
     } as IKubernetesSecurityGroupDetailsProps;
 
     spyOn(ManifestReader, 'getManifest').and.returnValue(Promise.resolve(manifestDetails()) as any);
+  });
+
+  it('replaces missing details through the injected state service', () => {
+    const stateService = { go: jasmine.createSpy('go'), params: {} };
+    const component = new KubernetesSecurityGroupDetails({
+      ...props,
+      router: {},
+      stateParams: {},
+      stateService,
+    } as any);
+
+    (component as any).autoClose();
+
+    expect(stateService.params.allowModalToStayOpen).toBe(true);
+    expect(stateService.go).toHaveBeenCalledWith('^', null, { location: 'replace' });
   });
 
   afterEach(() => {

--- a/deck/packages/kubernetes/src/securityGroup/details/KubernetesSecurityGroupDetails.tsx
+++ b/deck/packages/kubernetes/src/securityGroup/details/KubernetesSecurityGroupDetails.tsx
@@ -5,6 +5,7 @@ import type {
   Application,
   IManifest,
   IOverridableProps,
+  IRouterInjectedProps,
   ISecurityGroupDetail,
   SecurityGroupReader,
 } from '@spinnaker/core';
@@ -21,6 +22,7 @@ import {
   SETTINGS,
   timestamp,
   useModal,
+  withRouter,
 } from '@spinnaker/core';
 
 import type { IKubernetesSecurityGroup } from '../../interfaces';
@@ -55,8 +57,8 @@ export interface IKubernetesSecurityGroupActionsProps {
   securityGroup: IKubernetesSecurityGroup;
 }
 
-export class KubernetesSecurityGroupDetails extends React.Component<
-  IKubernetesSecurityGroupDetailsProps,
+export class KubernetesSecurityGroupDetailsComponent extends React.Component<
+  IKubernetesSecurityGroupDetailsProps & IRouterInjectedProps,
   IKubernetesSecurityGroupDetailsState
 > {
   public state: IKubernetesSecurityGroupDetailsState = {
@@ -161,12 +163,12 @@ export class KubernetesSecurityGroupDetails extends React.Component<
       return;
     }
 
-    AngularServices.$state.params.allowModalToStayOpen = true;
-    AngularServices.$state.go('^', null, { location: 'replace' });
+    this.props.stateService.params.allowModalToStayOpen = true;
+    this.props.stateService.go('^', null, { location: 'replace' });
   };
 
   private closeDetails = (): void => {
-    AngularServices.$state.go('^');
+    this.props.stateService.go('^');
   };
 
   public render(): JSX.Element {
@@ -246,6 +248,8 @@ export class KubernetesSecurityGroupDetails extends React.Component<
     );
   }
 }
+
+export const KubernetesSecurityGroupDetails = withRouter(KubernetesSecurityGroupDetailsComponent);
 
 export function KubernetesSecurityGroupActions({ app, manifest, securityGroup }: IKubernetesSecurityGroupActionsProps) {
   const deleteModal = useModal();

--- a/deck/packages/kubernetes/src/serverGroupManager/details/ServerGroupManagerDetails.spec.ts
+++ b/deck/packages/kubernetes/src/serverGroupManager/details/ServerGroupManagerDetails.spec.ts
@@ -1,0 +1,12 @@
+import { closeServerGroupManagerDetails } from './ServerGroupManagerDetails';
+
+describe('closeServerGroupManagerDetails', () => {
+  it('replaces details through the injected state service', () => {
+    const stateService = { go: jasmine.createSpy('go'), params: {} };
+
+    closeServerGroupManagerDetails(stateService as any);
+
+    expect(stateService.params.allowModalToStayOpen).toBe(true);
+    expect(stateService.go).toHaveBeenCalledWith('^', null, { location: 'replace' });
+  });
+});

--- a/deck/packages/kubernetes/src/serverGroupManager/details/ServerGroupManagerDetails.tsx
+++ b/deck/packages/kubernetes/src/serverGroupManager/details/ServerGroupManagerDetails.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
 
-import type { Application, IServerGroupManagerDetailsProps, IServerGroupManagerStateParams } from '@spinnaker/core';
-import { AngularServices, CloudProviderLogo, Details, EntityNotifications, IfFeatureEnabled } from '@spinnaker/core';
+import type {
+  Application,
+  IRouterInjectedProps,
+  IServerGroupManagerDetailsProps,
+  IServerGroupManagerStateParams,
+} from '@spinnaker/core';
+import { CloudProviderLogo, Details, EntityNotifications, IfFeatureEnabled, withRouter } from '@spinnaker/core';
 
 import { ServerGroupManagerActions } from './ServerGroupManagerActions';
 import {
@@ -20,11 +25,15 @@ export interface IKubernetesServerGroupManagerDetailsProps extends IServerGroupM
   serverGroupManager: IServerGroupManagerStateParams;
 }
 
-export function ServerGroupManagerDetails(props: IKubernetesServerGroupManagerDetailsProps) {
-  const autoClose = () => {
-    AngularServices.$state.params.allowModalToStayOpen = true;
-    AngularServices.$state.go('^', null, { location: 'replace' });
-  };
+export function closeServerGroupManagerDetails(stateService: IRouterInjectedProps['stateService']): void {
+  stateService.params.allowModalToStayOpen = true;
+  stateService.go('^', null, { location: 'replace' });
+}
+
+export function ServerGroupManagerDetailsComponent(
+  props: IKubernetesServerGroupManagerDetailsProps & IRouterInjectedProps,
+) {
+  const autoClose = () => closeServerGroupManagerDetails(props.stateService);
   const [serverGroupManager, manifest, loading] = useKubernetesServerGroupManagerDetails(props, autoClose);
 
   if (loading || !serverGroupManager || !manifest) return <Details loading={true} />;
@@ -70,3 +79,5 @@ export function ServerGroupManagerDetails(props: IKubernetesServerGroupManagerDe
     </Details>
   );
 }
+
+export const ServerGroupManagerDetails = withRouter(ServerGroupManagerDetailsComponent);

--- a/deck/packages/titus/src/instance/details/titusInstanceDetailsUtils.spec.ts
+++ b/deck/packages/titus/src/instance/details/titusInstanceDetailsUtils.spec.ts
@@ -5,6 +5,7 @@ import type {
   ITargetGroup,
 } from '@spinnaker/amazon';
 import type { Application } from '@spinnaker/core';
+import { ConfirmationModalService, setDirectRouter } from '@spinnaker/core';
 import { mockHealth, mockInstance, mockLoadBalancer, mockLoadBalancerHealth } from '@spinnaker/mocks';
 import {
   applyTargetGroupInfoToHealthMetric,
@@ -100,6 +101,8 @@ describe('extractHealthMetrics', () => {
 });
 
 describe('buildTaskActions', () => {
+  afterEach(() => setDirectRouter(null));
+
   it('should render required actions', () => {
     // Instance has Discovery health
     const actions1 = buildTaskActions(mockInstance, {} as Application);
@@ -120,5 +123,16 @@ describe('buildTaskActions', () => {
     // Instance has no health
     const actions4 = buildTaskActions({ ...mockInstance, health: [] }, {} as Application);
     expect(actions4.length).toEqual(2);
+  });
+
+  it('closes instance details through the direct router after termination', () => {
+    const directGo = jasmine.createSpy('directGo');
+    setDirectRouter({ stateService: { go: directGo, includes: () => true } } as any);
+    const confirm = spyOn(ConfirmationModalService, 'confirm');
+
+    buildTaskActions(mockInstance, {} as Application)[0].triggerAction();
+    confirm.calls.mostRecent().args[0].taskMonitorConfig.onTaskComplete();
+
+    expect(directGo).toHaveBeenCalledWith('^');
   });
 });

--- a/deck/packages/titus/src/instance/details/titusInstanceDetailsUtils.ts
+++ b/deck/packages/titus/src/instance/details/titusInstanceDetailsUtils.ts
@@ -7,7 +7,7 @@ import type {
 } from '@spinnaker/amazon';
 import { getAllTargetGroups } from '@spinnaker/amazon';
 import type { Action, Application, IInstance, IJob } from '@spinnaker/core';
-import { AngularServices, ConfirmationModalService, InstanceWriter } from '@spinnaker/core';
+import { ConfirmationModalService, getDirectRouter, InstanceWriter } from '@spinnaker/core';
 
 export const applyTargetGroupInfoToHealthMetric = (
   metricGroups: IAmazonTargetGroupHealth[],
@@ -54,8 +54,9 @@ const terminateInstance = (instance: IInstance, app: Application) => {
       application: app,
       title: `Terminating ${instance.id}`,
       onTaskComplete: () => {
-        if (AngularServices.$state.includes('**.instanceDetails', { id: instance.id })) {
-          AngularServices.$state.go('^');
+        const stateService = getDirectRouter()?.stateService;
+        if (stateService?.includes('**.instanceDetails', { id: instance.id })) {
+          stateService.go('^');
         }
       },
     };
@@ -84,8 +85,9 @@ const terminateInstanceAndShrinkServerGroup = (instance: IInstance, app: Applica
       application: app,
       title: `Terminating ${instance.id} and shrinking server group`,
       onTaskComplete: () => {
-        if (AngularServices.$state.includes('**.instanceDetails', { instanceId: instance.id })) {
-          AngularServices.$state.go('^');
+        const stateService = getDirectRouter()?.stateService;
+        if (stateService?.includes('**.instanceDetails', { instanceId: instance.id })) {
+          stateService.go('^');
         }
       },
     };

--- a/deck/packages/titus/src/serverGroup/configure/wizard/TitusCloneServerGroupModal.spec.tsx
+++ b/deck/packages/titus/src/serverGroup/configure/wizard/TitusCloneServerGroupModal.spec.tsx
@@ -1,0 +1,49 @@
+import { TaskMonitor } from '@spinnaker/core';
+
+import { TitusCloneServerGroupModalComponent } from './TitusCloneServerGroupModal';
+
+describe('TitusCloneServerGroupModal', () => {
+  it('navigates to the created server group through its injected state service', () => {
+    spyOn(TaskMonitor, 'modalInstanceEmulation').and.returnValue({
+      dismiss: jasmine.createSpy('dismiss'),
+      result: Promise.resolve(),
+    } as any);
+    const stateService = {
+      go: jasmine.createSpy('go'),
+      includes: jasmine.createSpy('includes').and.callFake((state: string) => state === '**.clusters.serverGroup'),
+    };
+    const modal = new TitusCloneServerGroupModalComponent({
+      application: { name: 'fnord' },
+      command: {
+        credentials: 'test-account',
+        region: 'us-east-1',
+        viewState: { requiresTemplateSelection: true },
+      },
+      dismissModal: jasmine.createSpy('dismissModal'),
+      stateService,
+    } as any) as any;
+    modal.state = {
+      taskMonitor: {
+        task: {
+          execution: {
+            stages: [
+              {
+                context: { 'deploy.server.groups': { 'us-east-1': 'fnord-main-v042' } },
+                type: 'cloneServerGroup',
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    modal.onApplicationRefresh();
+
+    expect(stateService.go).toHaveBeenCalledWith('^.serverGroup', {
+      accountId: 'test-account',
+      provider: 'titus',
+      region: 'us-east-1',
+      serverGroup: 'fnord-main-v042',
+    });
+  });
+});

--- a/deck/packages/titus/src/serverGroup/configure/wizard/TitusCloneServerGroupModal.tsx
+++ b/deck/packages/titus/src/serverGroup/configure/wizard/TitusCloneServerGroupModal.tsx
@@ -2,7 +2,7 @@ import { get, isEqual } from 'lodash';
 import React from 'react';
 
 import { ServerGroupCapacity, ServerGroupLoadBalancers, ServerGroupSecurityGroups } from '@spinnaker/amazon';
-import type { Application, IModalComponentProps, IStage } from '@spinnaker/core';
+import type { Application, IModalComponentProps, IRouterInjectedProps, IStage } from '@spinnaker/core';
 import {
   AccountTag,
   AngularServices,
@@ -11,6 +11,7 @@ import {
   noop,
   ReactModal,
   TaskMonitor,
+  withRouter,
   WizardModal,
   WizardPage,
 } from '@spinnaker/core';
@@ -36,8 +37,8 @@ export interface ITitusCloneServerGroupModalState {
   taskMonitor: TaskMonitor;
 }
 
-export class TitusCloneServerGroupModal extends React.Component<
-  ITitusCloneServerGroupModalProps,
+export class TitusCloneServerGroupModalComponent extends React.Component<
+  ITitusCloneServerGroupModalProps & IRouterInjectedProps,
   ITitusCloneServerGroupModalState
 > {
   public static defaultProps: Partial<ITitusCloneServerGroupModalProps> = {
@@ -53,7 +54,7 @@ export class TitusCloneServerGroupModal extends React.Component<
     return ReactModal.show(TitusCloneServerGroupModal, props, modalProps);
   }
 
-  constructor(props: ITitusCloneServerGroupModalProps) {
+  constructor(props: ITitusCloneServerGroupModalProps & IRouterInjectedProps) {
     super(props);
 
     const requiresTemplateSelection = get(props, 'command.viewState.requiresTemplateSelection', false);
@@ -102,19 +103,19 @@ export class TitusCloneServerGroupModal extends React.Component<
           provider: 'titus',
         };
         let transitionTo = '^.^.^.clusters.serverGroup';
-        if (AngularServices.$state.includes('**.clusters.serverGroup')) {
+        if (this.props.stateService.includes('**.clusters.serverGroup')) {
           // clone via details, all view
           transitionTo = '^.serverGroup';
         }
-        if (AngularServices.$state.includes('**.clusters.cluster.serverGroup')) {
+        if (this.props.stateService.includes('**.clusters.cluster.serverGroup')) {
           // clone or create with details open
           transitionTo = '^.^.serverGroup';
         }
-        if (AngularServices.$state.includes('**.clusters')) {
+        if (this.props.stateService.includes('**.clusters')) {
           // create new, no details open
           transitionTo = '.serverGroup';
         }
-        AngularServices.$state.go(transitionTo, newStateParams);
+        this.props.stateService.go(transitionTo, newStateParams);
       }
     }
   };
@@ -294,3 +295,8 @@ export class TitusCloneServerGroupModal extends React.Component<
     );
   }
 }
+
+export const TitusCloneServerGroupModal = Object.assign(
+  withRouter<ITitusCloneServerGroupModalProps & IRouterInjectedProps>(TitusCloneServerGroupModalComponent),
+  { show: TitusCloneServerGroupModalComponent.show },
+);

--- a/deck/packages/titus/src/serverGroup/configure/wizard/pages/ServerGroupBasicSettings.spec.tsx
+++ b/deck/packages/titus/src/serverGroup/configure/wizard/pages/ServerGroupBasicSettings.spec.tsx
@@ -1,0 +1,38 @@
+import { ServerGroupBasicSettingsComponent } from './ServerGroupBasicSettings';
+
+describe('Titus ServerGroupBasicSettings', () => {
+  it('opens the latest server group through the injected state service', () => {
+    const stateService = { go: jasmine.createSpy('go'), is: () => true };
+    const component = new ServerGroupBasicSettingsComponent({
+      app: {
+        clusters: [],
+        name: 'app',
+        serverGroups: {
+          data: [{ account: 'test', cluster: 'app-main', createdTime: 1, name: 'app-main-v001', region: 'us-east-1' }],
+        },
+      },
+      formik: {
+        setFieldValue: () => undefined,
+        values: {
+          credentials: 'test',
+          freeFormDetails: '',
+          region: 'us-east-1',
+          selectedProvider: 'titus',
+          stack: 'main',
+        },
+      },
+      router: {},
+      stateParams: {},
+      stateService,
+    } as any);
+
+    (component as any).navigateToLatestServerGroup();
+
+    expect(stateService.go).toHaveBeenCalledWith('.serverGroup', {
+      accountId: 'test',
+      provider: 'titus',
+      region: 'us-east-1',
+      serverGroup: 'app-main-v001',
+    });
+  });
+});

--- a/deck/packages/titus/src/serverGroup/configure/wizard/pages/ServerGroupBasicSettings.tsx
+++ b/deck/packages/titus/src/serverGroup/configure/wizard/pages/ServerGroupBasicSettings.tsx
@@ -3,11 +3,10 @@ import { Field } from 'formik';
 import React from 'react';
 
 import { AWSProviderSettings, SubnetSelectField } from '@spinnaker/amazon';
-import type { Application, IServerGroup, IWizardPageComponent } from '@spinnaker/core';
+import type { Application, IRouterInjectedProps, IServerGroup, IWizardPageComponent } from '@spinnaker/core';
 import {
   AccountSelectInput,
   AccountTag,
-  AngularServices,
   DeployingIntoManagedClusterWarning,
   DeploymentStrategySelector,
   HelpField,
@@ -15,6 +14,7 @@ import {
   RegionSelectField,
   ServerGroupDetailsField,
   ServerGroupNamePreview,
+  withRouter,
 } from '@spinnaker/core';
 import { DockerImageAndTagSelector, DockerImageUtils } from '@spinnaker/docker';
 
@@ -41,10 +41,10 @@ export interface IServerGroupBasicSettingsState {
   latestServerGroup: IServerGroup;
 }
 
-export class ServerGroupBasicSettings
-  extends React.Component<IServerGroupBasicSettingsProps, IServerGroupBasicSettingsState>
+export class ServerGroupBasicSettingsComponent
+  extends React.Component<IServerGroupBasicSettingsProps & IRouterInjectedProps, IServerGroupBasicSettingsState>
   implements IWizardPageComponent<ITitusServerGroupCommand> {
-  constructor(props: IServerGroupBasicSettingsProps) {
+  constructor(props: IServerGroupBasicSettingsProps & IRouterInjectedProps) {
     super(props);
 
     const { values, setFieldValue } = this.props.formik;
@@ -142,11 +142,10 @@ export class ServerGroupBasicSettings
       serverGroup: latestServerGroup.name,
     };
 
-    const { $state } = AngularServices;
-    if ($state.is('home.applications.application.insight.clusters')) {
-      $state.go('.serverGroup', params);
+    if (this.props.stateService.is('home.applications.application.insight.clusters')) {
+      this.props.stateService.go('.serverGroup', params);
     } else {
-      $state.go('^.serverGroup', params);
+      this.props.stateService.go('^.serverGroup', params);
     }
   };
 
@@ -337,3 +336,5 @@ export class ServerGroupBasicSettings
     );
   }
 }
+
+export const ServerGroupBasicSettings = withRouter(ServerGroupBasicSettingsComponent);

--- a/deck/packages/titus/src/serverGroup/details/TitusServerGroupActions.spec.tsx
+++ b/deck/packages/titus/src/serverGroup/details/TitusServerGroupActions.spec.tsx
@@ -5,7 +5,7 @@ import type { IRootScopeService } from 'angular';
 import { mock } from 'angular';
 import * as core from '@spinnaker/core';
 
-import { TitusServerGroupActions } from './TitusServerGroupActions';
+import { TitusServerGroupActionsComponent as TitusServerGroupActions } from './TitusServerGroupActions';
 import { TitusRollbackServerGroupModal } from './rollback/TitusRollbackServerGroupModal';
 
 describe('<TitusServerGroupActions />', () => {
@@ -84,6 +84,32 @@ describe('<TitusServerGroupActions />', () => {
 
     expect(() => (wrapper.instance() as any).rollbackServerGroup()).not.toThrow();
     expect(show).not.toHaveBeenCalled();
+  });
+
+  it('closes destroyed server group details through the injected state service', async () => {
+    const serverGroup = buildServerGroup();
+    const stateService = { go: jasmine.createSpy('go'), includes: jasmine.createSpy('includes').and.returnValue(true) };
+    const confirm = spyOn(core.ConfirmationModalService, 'confirm');
+    spyOn(core.ServerGroupWarningMessageService, 'addDestroyWarningMessage');
+    const wrapper = shallow(
+      <TitusServerGroupActions
+        app={buildApp([serverGroup])}
+        router={{} as any}
+        serverGroup={serverGroup}
+        stateParams={{}}
+        stateService={stateService as any}
+      />,
+    );
+
+    wrapper
+      .find('a')
+      .filterWhere((link: any) => link.text() === 'Destroy')
+      .simulate('click');
+    $rootScope.$digest();
+    await settle();
+    confirm.calls.mostRecent().args[0].taskMonitorConfig.onTaskComplete();
+
+    expect(stateService.go).toHaveBeenCalledWith('^');
   });
 });
 

--- a/deck/packages/titus/src/serverGroup/details/TitusServerGroupActions.tsx
+++ b/deck/packages/titus/src/serverGroup/details/TitusServerGroupActions.tsx
@@ -2,7 +2,7 @@ import { orderBy } from 'lodash';
 import React from 'react';
 import { Dropdown } from 'react-bootstrap';
 
-import type { IServerGroupActionsProps } from '@spinnaker/core';
+import type { IRouterInjectedProps, IServerGroupActionsProps } from '@spinnaker/core';
 import {
   AddEntityTagLinks,
   AngularServices,
@@ -11,6 +11,7 @@ import {
   ReactModal,
   ServerGroupWarningMessageService,
   SETTINGS,
+  withRouter,
 } from '@spinnaker/core';
 
 import { TitusServerGroupCommandBuilder } from '../configure/ServerGroupCommandBuilder';
@@ -18,7 +19,7 @@ import { TitusCloneServerGroupModal } from '../configure/wizard/TitusCloneServer
 import { TitusResizeServerGroupModal } from './resize/TitusResizeServerGroupModal';
 import { TitusRollbackServerGroupModal } from './rollback/TitusRollbackServerGroupModal';
 
-export class TitusServerGroupActions extends React.Component<IServerGroupActionsProps> {
+export class TitusServerGroupActionsComponent extends React.Component<IServerGroupActionsProps & IRouterInjectedProps> {
   private destroyServerGroup = (): void => {
     const { app, serverGroup } = this.props;
     const taskMonitorConfig = {
@@ -26,8 +27,8 @@ export class TitusServerGroupActions extends React.Component<IServerGroupActions
       title: 'Destroying ' + serverGroup.name,
       onTaskComplete: () => {
         const stateParams = { name: serverGroup.name, accountId: serverGroup.account, region: serverGroup.region };
-        if (AngularServices.$state.includes('**.serverGroup', stateParams)) {
-          AngularServices.$state.go('^');
+        if (this.props.stateService.includes('**.serverGroup', stateParams)) {
+          this.props.stateService.go('^');
         }
       },
     };
@@ -255,3 +256,5 @@ export class TitusServerGroupActions extends React.Component<IServerGroupActions
     );
   }
 }
+
+export const TitusServerGroupActions = withRouter(TitusServerGroupActionsComponent);

--- a/deck/test/functional/cypress/integration/google/clone.spec.js
+++ b/deck/test/functional/cypress/integration/google/clone.spec.js
@@ -573,13 +573,14 @@ function installGceTestHarness() {
 
     const CloneServerGroupModal = core.CloudProviderRegistry.getValue('gce', 'serverGroup.CloneServerGroupModal');
     const showModal = CloneServerGroupModal.show.bind(CloneServerGroupModal);
-    CloneServerGroupModal.show = (props) => showModal({ ...props, adapter });
-    win.__gceFunctionalHarness = { adapter, commandBuilder, core, lifecycle, showModal: CloneServerGroupModal.show };
+    const showModalWithAdapter = (props) => showModal({ ...props, adapter });
+    core.CloudProviderRegistry.overrideValue('gce', 'serverGroup.CloneServerGroupModal.show', showModalWithAdapter);
+    win.__gceFunctionalHarness = { adapter, commandBuilder, core, lifecycle, showModal: showModalWithAdapter };
   });
 }
 
 function resolvedApplication(harness) {
-  const globals = harness.core.AngularServices.$uiRouter.globals;
+  const globals = harness.core.getDirectRouter().globals;
   const transition = globals.transition || globals.successfulTransitions?.peekTail();
   return transition.injector().get('app');
 }


### PR DESCRIPTION
Replace usage of `AngularService` for routing with direct usage of `@uirouter/react`.