### PR TITLE
refactor(deck): remove Angular service facade consumers

### DIFF
--- a/deck-kayenta/src/kayenta/stages/kayentaStage/KayentaCanaryStageConfig.tsx
+++ b/deck-kayenta/src/kayenta/stages/kayentaStage/KayentaCanaryStageConfig.tsx
@@ -16,6 +16,7 @@ import {
   MapEditor,
   ProviderSelectionService,
   StageConfigField,
+  useDeckRuntimeServices,
 } from '@spinnaker/core';
 
 import { AnalysisType } from './AnalysisType';
@@ -43,6 +44,7 @@ import {
 import './kayentaStage.less';
 
 export function KayentaCanaryStageConfig({ application, stage, updateStage }: IStageConfigProps) {
+  const { serverGroupCommandBuilder, serverGroupTransformer } = useDeckRuntimeServices();
   const kayentaStage = (stage as unknown) as IKayentaStage;
   const [model, setModel] = useState<IKayentaStageConfigModel>(() => {
     const initialModel = createInitialKayentaStageConfigModel();
@@ -837,8 +839,8 @@ export function KayentaCanaryStageConfig({ application, stage, updateStage }: IS
       application,
       cloudProviderRegistry: CloudProviderRegistry,
       providerSelectionService: ProviderSelectionService,
-      serverGroupCommandBuilder: AngularServices.serverGroupCommandBuilder,
-      serverGroupTransformer: AngularServices.serverGroupTransformer,
+      serverGroupCommandBuilder,
+      serverGroupTransformer,
       $uibModal: AngularServices.$uibModal,
     };
   }

--- a/deck/packages/amazon/src/aws.module.spec.ts
+++ b/deck/packages/amazon/src/aws.module.spec.ts
@@ -1,5 +1,5 @@
 import type { IStageTypeConfig } from '@spinnaker/core';
-import { CloudProviderRegistry, AngularServices, Registry } from '@spinnaker/core';
+import { CloudProviderRegistry, Registry } from '@spinnaker/core';
 
 import * as amazonPackage from './index';
 import { AwsFunctionTransformer } from './function/function.transformer';
@@ -17,7 +17,10 @@ import { registerAmazonPipelineStages } from './aws.module';
 import { AwsSecurityGroupReader } from './securityGroup/securityGroup.reader';
 import { AwsSecurityGroupTransformer } from './securityGroup/securityGroup.transformer';
 import { AwsServerGroupCommandBuilder } from './serverGroup/configure/serverGroupCommandBuilder.service';
-import { AwsServerGroupConfigurationService } from './serverGroup/configure/serverGroupConfiguration.service';
+import {
+  AwsServerGroupConfigurationService,
+  AwsServerGroupConfigurationServiceDelegate,
+} from './serverGroup/configure/serverGroupConfiguration.service';
 import { AwsServerGroupTransformer } from './serverGroup/serverGroup.transformer';
 
 describe('Amazon package registration', () => {
@@ -60,7 +63,7 @@ describe('Amazon package registration', () => {
     expect(CloudProviderRegistry.getValue('aws', 'serverGroup.transformer')).toBe(AwsServerGroupTransformer);
     expect(CloudProviderRegistry.getValue('aws', 'serverGroup.commandBuilder')).toBe(AwsServerGroupCommandBuilder);
     expect(CloudProviderRegistry.getValue('aws', 'serverGroup.configurationService')).toBe(
-      AwsServerGroupConfigurationService,
+      AwsServerGroupConfigurationServiceDelegate,
     );
     expect(CloudProviderRegistry.getValue('aws', 'instance.instanceTypeService')).toBe(AwsInstanceTypeService);
     expect(CloudProviderRegistry.getValue('aws', 'loadBalancer.transformer')).toBe(AwsLoadBalancerTransformer);
@@ -124,14 +127,17 @@ describe('Amazon package registration', () => {
     });
   });
 
-  it('constructs the server group configuration delegate with usable defaults when Core passes the deferred compatibility argument', () => {
+  it('constructs the server group configuration service with explicit dependencies', () => {
     const securityGroupReader = { getAllSecurityGroups: jasmine.createSpy('getAllSecurityGroups') };
-    spyOnProperty(AngularServices, 'securityGroupReader', 'get').and.returnValue(securityGroupReader as any);
-    spyOnProperty(AngularServices, 'cacheInitializer', 'get').and.returnValue({
+    const cacheInitializer = {
       refreshCache: jasmine.createSpy('refreshCache'),
-    } as any);
+    };
 
-    const service = new AwsServerGroupConfigurationService({ when: jasmine.createSpy('when') } as any);
+    const service = new AwsServerGroupConfigurationService(
+      securityGroupReader as any,
+      new AwsInstanceTypeService(),
+      cacheInitializer as any,
+    );
 
     expect((service as any).securityGroupReader).toBe(securityGroupReader);
     expect(() => service.applyOverrides('beforeConfiguration', {} as any)).not.toThrow();

--- a/deck/packages/amazon/src/aws.module.ts
+++ b/deck/packages/amazon/src/aws.module.ts
@@ -45,7 +45,7 @@ import { AmazonSecurityGroupDetails } from './securityGroup/details/AmazonSecuri
 import { AwsSecurityGroupReader } from './securityGroup/securityGroup.reader';
 import { AwsSecurityGroupTransformer } from './securityGroup/securityGroup.transformer';
 import { AwsServerGroupCommandBuilder } from './serverGroup/configure/serverGroupCommandBuilder.service';
-import { AwsServerGroupConfigurationService } from './serverGroup/configure/serverGroupConfiguration.service';
+import { AwsServerGroupConfigurationServiceDelegate } from './serverGroup/configure/serverGroupConfiguration.service';
 import { AmazonCloneServerGroupModal } from './serverGroup/configure/wizard/AmazonCloneServerGroupModal';
 import { AmazonServerGroupActions } from './serverGroup/details/AmazonServerGroupActions';
 import { amazonServerGroupDetailsGetter } from './serverGroup/details/amazonServerGroupDetailsGetter';
@@ -114,7 +114,7 @@ export function registerAmazonProvider(): void {
       ],
       CloneServerGroupModal: AmazonCloneServerGroupModal,
       commandBuilder: AwsServerGroupCommandBuilder,
-      configurationService: AwsServerGroupConfigurationService,
+      configurationService: AwsServerGroupConfigurationServiceDelegate,
       instanceTypeService: AwsInstanceTypeService,
       scalingActivitiesEnabled: true,
       TargetTrackingChart,

--- a/deck/packages/amazon/src/aws.services.ts
+++ b/deck/packages/amazon/src/aws.services.ts
@@ -1,49 +1,21 @@
-import { AngularServices, FunctionReader } from '@spinnaker/core';
+import { FunctionReader } from '@spinnaker/core';
 
 import { AwsFunctionTransformer } from './function';
 import { AwsInstanceTypeService } from './instance/awsInstanceType.service';
-import { EvaluateCloudFormationChangeSetExecutionService } from './pipeline/stages/deployCloudFormation/evaluateCloudFormationChangeSetExecution.service';
-import { createAwsServerGroupCommandBuilder } from './serverGroup/configure/serverGroupCommandBuilder.service';
-import { AwsServerGroupConfigurationService } from './serverGroup/configure/serverGroupConfiguration.service';
 import { AwsServerGroupTransformer } from './serverGroup/serverGroup.transformer';
 
 let awsInstanceTypeService: AwsInstanceTypeService;
-let awsServerGroupCommandBuilder: ReturnType<typeof createAwsServerGroupCommandBuilder>;
-let awsServerGroupConfigurationService: AwsServerGroupConfigurationService;
 let awsServerGroupTransformer: AwsServerGroupTransformer;
 let functionReader: FunctionReader;
-let evaluateCloudFormationChangeSetExecutionService: EvaluateCloudFormationChangeSetExecutionService;
 
 export const AwsServices = {
   get awsInstanceTypeService() {
     return (awsInstanceTypeService = awsInstanceTypeService || new AwsInstanceTypeService());
-  },
-  get awsServerGroupCommandBuilder() {
-    return (awsServerGroupCommandBuilder =
-      awsServerGroupCommandBuilder ||
-      createAwsServerGroupCommandBuilder(
-        AngularServices.instanceTypeService,
-        AwsServices.awsServerGroupConfigurationService,
-      ));
-  },
-  get awsServerGroupConfigurationService() {
-    return (
-      awsServerGroupConfigurationService ||
-      (awsServerGroupConfigurationService = new AwsServerGroupConfigurationService())
-    );
   },
   get awsServerGroupTransformer() {
     return (awsServerGroupTransformer = awsServerGroupTransformer || new AwsServerGroupTransformer());
   },
   get functionReader() {
     return (functionReader = functionReader || new FunctionReader(new AwsFunctionTransformer()));
-  },
-  get evaluateCloudFormationChangeSetExecutionService() {
-    return (
-      evaluateCloudFormationChangeSetExecutionService ||
-      (evaluateCloudFormationChangeSetExecutionService = new EvaluateCloudFormationChangeSetExecutionService(
-        AngularServices.executionService,
-      ))
-    );
   },
 };

--- a/deck/packages/amazon/src/function/CreateLambdaFunction.tsx
+++ b/deck/packages/amazon/src/function/CreateLambdaFunction.tsx
@@ -1,7 +1,7 @@
 import { cloneDeep } from 'lodash';
 import React from 'react';
 
-import type { IFunctionModalProps, IRouterInjectedProps } from '@spinnaker/core';
+import type { DeckRuntimeServices, IFunctionModalProps, IRouterInjectedProps } from '@spinnaker/core';
 import { FunctionWriter, noop, ReactModal, TaskMonitor, withRouter, WizardModal, WizardPage } from '@spinnaker/core';
 
 import { ExecutionRole } from './configure/ExecutionRole';
@@ -48,9 +48,12 @@ export class CreateLambdaFunctionComponent extends React.Component<
   private _isUnmounted = false;
   private refreshUnsubscribe: () => void;
 
-  public static show(props: IAmazonCreateFunctionProps): Promise<IAmazonFunctionUpsertCommand> {
+  public static show(
+    props: IAmazonCreateFunctionProps,
+    runtimeServices: DeckRuntimeServices,
+  ): Promise<IAmazonFunctionUpsertCommand> {
     const modalProps = { dialogClassName: 'wizard-modal modal-lg' };
-    return ReactModal.show(CreateLambdaFunction, props, modalProps);
+    return ReactModal.show(CreateLambdaFunction, props, modalProps, runtimeServices);
   }
 
   public componentWillUnmount(): void {

--- a/deck/packages/amazon/src/function/configure/Network.tsx
+++ b/deck/packages/amazon/src/function/configure/Network.tsx
@@ -15,7 +15,7 @@ import type {
   IWizardPageComponent,
 } from '@spinnaker/core';
 import {
-  AngularServices,
+  DeckRuntimeContext,
   FormikFormField,
   HelpField,
   ReactSelectInput,
@@ -49,6 +49,9 @@ export interface INetworkState {
 export class Network
   extends React.Component<INetworkProps, INetworkState>
   implements IWizardPageComponent<IAmazonFunctionUpsertCommand> {
+  public static contextType = DeckRuntimeContext;
+  public declare context: React.ContextType<typeof DeckRuntimeContext>;
+
   constructor(props: INetworkProps) {
     super(props);
     this.getAllVpcs();
@@ -82,7 +85,7 @@ export class Network
   }
 
   private getAvailableSecurityGroups(): PromiseLike<ISecurityGroupsByAccountSourceData> {
-    return AngularServices.securityGroupReader.getAllSecurityGroups();
+    return this.context.services.securityGroupReader.getAllSecurityGroups();
   }
   private makeSubnetOptions(availableSubnets: ISubnet[]): ISubnetOption[] {
     const subOptions: ISubnetOption[] = availableSubnets.map((s) => ({ subnetId: s.id, vpcId: s.vpcId }));

--- a/deck/packages/amazon/src/function/details/FunctionActions.tsx
+++ b/deck/packages/amazon/src/function/details/FunctionActions.tsx
@@ -6,6 +6,7 @@ import {
   AddEntityTagLinks,
   ApplicationReader,
   ConfirmationModalService,
+  DeckRuntimeContext,
   FunctionWriter,
   SETTINGS,
 } from '@spinnaker/core';
@@ -26,6 +27,9 @@ export interface IFunctionActionsState {
 }
 
 export class FunctionActions extends React.Component<IFunctionActionsProps, IFunctionActionsState> {
+  public static contextType = DeckRuntimeContext;
+  public declare context: React.ContextType<typeof DeckRuntimeContext>;
+
   constructor(props: IFunctionActionsProps) {
     super(props);
     this.state = { application: props.app };
@@ -60,7 +64,7 @@ export class FunctionActions extends React.Component<IFunctionActionsProps, IFun
     const { functionDef } = this.props;
     const { application } = this.state;
     const FunctionModal = CreateLambdaFunction;
-    FunctionModal.show({ app: application, functionDef });
+    FunctionModal.show({ app: application, functionDef }, this.context.services);
   };
 
   public deleteFunction = (): void => {

--- a/deck/packages/amazon/src/instance/amazon.instance.write.service.ts
+++ b/deck/packages/amazon/src/instance/amazon.instance.write.service.ts
@@ -1,4 +1,10 @@
-import type { Application, IMultiInstanceGroup, IMultiInstanceJob, ITask } from '@spinnaker/core';
+import type {
+  Application,
+  DirectProviderServiceDelegate,
+  IMultiInstanceGroup,
+  IMultiInstanceJob,
+  ITask,
+} from '@spinnaker/core';
 import { InstanceWriter, TaskExecutor } from '@spinnaker/core';
 import type { IAmazonInstance } from '../domain';
 
@@ -15,9 +21,11 @@ export class AmazonInstanceWriter extends InstanceWriter {
     instanceGroups: IMultiInstanceGroup[],
     application: Application,
     targetGroupNames: string[],
+    providerServiceDelegate: DirectProviderServiceDelegate,
   ): PromiseLike<ITask> {
     const jobs = super.buildMultiInstanceJob(
       instanceGroups,
+      providerServiceDelegate,
       'deregisterInstancesFromLoadBalancer',
     ) as IAmazonMultiInstanceJob[];
     jobs.forEach((job) => (job.targetGroupNames = targetGroupNames));
@@ -51,9 +59,11 @@ export class AmazonInstanceWriter extends InstanceWriter {
     instanceGroups: IMultiInstanceGroup[],
     application: Application,
     targetGroupNames: string[],
+    providerServiceDelegate: DirectProviderServiceDelegate,
   ) {
     const jobs = super.buildMultiInstanceJob(
       instanceGroups,
+      providerServiceDelegate,
       'registerInstancesWithLoadBalancer',
     ) as IAmazonMultiInstanceJob[];
     jobs.forEach((job) => (job.targetGroupNames = targetGroupNames));

--- a/deck/packages/amazon/src/loadBalancer/configure/AmazonLoadBalancerChoiceModal.tsx
+++ b/deck/packages/amazon/src/loadBalancer/configure/AmazonLoadBalancerChoiceModal.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { Button, Modal } from 'react-bootstrap';
 
-import type { ILoadBalancerIncompatibility, ILoadBalancerModalProps } from '@spinnaker/core';
-import { CloudProviderRegistry, Markdown, ModalClose, noop, ReactModal } from '@spinnaker/core';
+import type { DeckRuntimeServices, ILoadBalancerIncompatibility, ILoadBalancerModalProps } from '@spinnaker/core';
+import { CloudProviderRegistry, DeckRuntimeContext, Markdown, ModalClose, noop, ReactModal } from '@spinnaker/core';
 
 import type { IAmazonLoadBalancerConfig } from './LoadBalancerTypes';
 import { LoadBalancerTypes } from './LoadBalancerTypes';
@@ -17,6 +17,9 @@ export class AmazonLoadBalancerChoiceModal extends React.Component<
   ILoadBalancerModalProps,
   IAmazonLoadBalancerChoiceModalState
 > {
+  public static contextType = DeckRuntimeContext;
+  public declare context: React.ContextType<typeof DeckRuntimeContext>;
+
   public static supportsPipelineConfig = true;
 
   public static defaultProps: Partial<ILoadBalancerModalProps> = {
@@ -24,11 +27,11 @@ export class AmazonLoadBalancerChoiceModal extends React.Component<
     dismissModal: noop,
   };
 
-  public static show(props: ILoadBalancerModalProps): Promise<any> {
+  public static show(props: ILoadBalancerModalProps, runtimeServices: DeckRuntimeServices): Promise<any> {
     if ((props as any).isNew === false && props.loadBalancer?.loadBalancerType) {
       const loadBalancerType = LoadBalancerTypes.find((type) => type.type === props.loadBalancer.loadBalancerType);
       if (loadBalancerType) {
-        return loadBalancerType.component.show(props);
+        return loadBalancerType.component.show(props, runtimeServices);
       }
     }
 
@@ -39,6 +42,7 @@ export class AmazonLoadBalancerChoiceModal extends React.Component<
         className: 'create-pipeline-modal-overflow-visible modal-lg',
       },
       { bsSize: 'lg' },
+      runtimeServices,
     );
   }
 
@@ -58,7 +62,7 @@ export class AmazonLoadBalancerChoiceModal extends React.Component<
     const { children, ...loadBalancerProps } = this.props;
     this.close();
     this.state.selectedChoice.component
-      .show(loadBalancerProps)
+      .show(loadBalancerProps, this.context.services)
       .then((loadBalancer) => {
         this.props.closeModal(loadBalancer);
       })

--- a/deck/packages/amazon/src/loadBalancer/configure/LoadBalancerTypes.ts
+++ b/deck/packages/amazon/src/loadBalancer/configure/LoadBalancerTypes.ts
@@ -1,4 +1,4 @@
-import type { ILoadBalancerModalProps } from '@spinnaker/core';
+import type { DeckRuntimeServices, ILoadBalancerModalProps } from '@spinnaker/core';
 
 import { CreateApplicationLoadBalancer } from './application/CreateApplicationLoadBalancer';
 import { CreateClassicLoadBalancer } from './classic/CreateClassicLoadBalancer';
@@ -6,7 +6,10 @@ import type { IAmazonLoadBalancerUpsertCommand } from '../../domain';
 import { CreateNetworkLoadBalancer } from './network/CreateNetworkLoadBalancer';
 
 export type ICloseableLoadBalancerModal = React.ComponentType<ILoadBalancerModalProps> & {
-  show: (props: ILoadBalancerModalProps) => Promise<IAmazonLoadBalancerUpsertCommand>;
+  show: (
+    props: ILoadBalancerModalProps,
+    runtimeServices: DeckRuntimeServices,
+  ) => Promise<IAmazonLoadBalancerUpsertCommand>;
 };
 
 export interface IAmazonLoadBalancerConfig {

--- a/deck/packages/amazon/src/loadBalancer/configure/application/CreateApplicationLoadBalancer.tsx
+++ b/deck/packages/amazon/src/loadBalancer/configure/application/CreateApplicationLoadBalancer.tsx
@@ -1,7 +1,7 @@
 import { cloneDeep, get } from 'lodash';
 import React from 'react';
 
-import type { ILoadBalancerModalProps, IRouterInjectedProps } from '@spinnaker/core';
+import type { DeckRuntimeServices, ILoadBalancerModalProps, IRouterInjectedProps } from '@spinnaker/core';
 import {
   AccountService,
   FirewallLabels,
@@ -49,9 +49,12 @@ export class CreateApplicationLoadBalancerComponent extends React.Component<
   private refreshUnsubscribe: () => void;
   private certificateTypes = get(AWSProviderSettings, 'loadBalancers.certificateTypes', ['iam', 'acm']);
 
-  public static show(props: ICreateApplicationLoadBalancerProps): Promise<IAmazonApplicationLoadBalancerUpsertCommand> {
+  public static show(
+    props: ICreateApplicationLoadBalancerProps,
+    runtimeServices: DeckRuntimeServices,
+  ): Promise<IAmazonApplicationLoadBalancerUpsertCommand> {
     const modalProps = { dialogClassName: 'wizard-modal modal-lg' };
-    return ReactModal.show(CreateApplicationLoadBalancer, props, modalProps);
+    return ReactModal.show(CreateApplicationLoadBalancer, props, modalProps, runtimeServices);
   }
 
   constructor(props: ICreateApplicationLoadBalancerProps & IRouterInjectedProps) {

--- a/deck/packages/amazon/src/loadBalancer/configure/classic/CreateClassicLoadBalancer.tsx
+++ b/deck/packages/amazon/src/loadBalancer/configure/classic/CreateClassicLoadBalancer.tsx
@@ -2,7 +2,7 @@ import type { FormikErrors, FormikValues } from 'formik';
 import { cloneDeep, get } from 'lodash';
 import React from 'react';
 
-import type { ILoadBalancerModalProps, IRouterInjectedProps } from '@spinnaker/core';
+import type { DeckRuntimeServices, ILoadBalancerModalProps, IRouterInjectedProps } from '@spinnaker/core';
 import {
   AccountService,
   FirewallLabels,
@@ -49,9 +49,12 @@ export class CreateClassicLoadBalancerComponent extends React.Component<
   private refreshUnsubscribe: () => void;
   private certificateTypes = get(AWSProviderSettings, 'loadBalancers.certificateTypes', ['iam', 'acm']);
 
-  public static show(props: ICreateClassicLoadBalancerProps): Promise<IAmazonClassicLoadBalancerUpsertCommand> {
+  public static show(
+    props: ICreateClassicLoadBalancerProps,
+    runtimeServices: DeckRuntimeServices,
+  ): Promise<IAmazonClassicLoadBalancerUpsertCommand> {
     const modalProps = { dialogClassName: 'wizard-modal modal-lg' };
-    return ReactModal.show(CreateClassicLoadBalancer, props, modalProps);
+    return ReactModal.show(CreateClassicLoadBalancer, props, modalProps, runtimeServices);
   }
 
   constructor(props: ICreateClassicLoadBalancerProps & IRouterInjectedProps) {

--- a/deck/packages/amazon/src/loadBalancer/configure/common/SecurityGroups.tsx
+++ b/deck/packages/amazon/src/loadBalancer/configure/common/SecurityGroups.tsx
@@ -6,7 +6,7 @@ import { combineLatest as observableCombineLatest, Subject } from 'rxjs';
 import { distinctUntilChanged, map, mergeMap, switchMap, takeUntil, tap, withLatestFrom } from 'rxjs/operators';
 
 import type { ISecurityGroup, IWizardPageComponent } from '@spinnaker/core';
-import { AngularServices, FirewallLabels, InfrastructureCaches, Spinner, timestamp } from '@spinnaker/core';
+import { DeckRuntimeContext, FirewallLabels, InfrastructureCaches, Spinner, timestamp } from '@spinnaker/core';
 
 import { AWSProviderSettings } from '../../../aws.settings';
 import type { IAmazonLoadBalancerUpsertCommand } from '../../../domain';
@@ -29,6 +29,9 @@ export interface ISecurityGroupsState {
 export class SecurityGroups
   extends React.Component<ISecurityGroupsProps, ISecurityGroupsState>
   implements IWizardPageComponent<IAmazonLoadBalancerUpsertCommand> {
+  public static contextType = DeckRuntimeContext;
+  public declare context: React.ContextType<typeof DeckRuntimeContext>;
+
   private destroy$ = new Subject<void>();
   private props$ = new Subject<ISecurityGroupsProps>();
   private refresh$ = new Subject<void>();
@@ -107,8 +110,8 @@ export class SecurityGroups
   public componentDidMount(): void {
     const allSecurityGroups$ = this.refresh$.pipe(
       tap(() => this.onRefreshStart()),
-      switchMap(() => AngularServices.cacheInitializer.refreshCache('securityGroups')),
-      mergeMap(() => AngularServices.securityGroupReader.getAllSecurityGroups()),
+      switchMap(() => this.context.services.cacheInitializer.refreshCache('securityGroups')),
+      mergeMap(() => this.context.services.securityGroupReader.getAllSecurityGroups()),
       tap(() => this.onRefreshComplete()),
     );
 

--- a/deck/packages/amazon/src/loadBalancer/configure/network/CreateNetworkLoadBalancer.tsx
+++ b/deck/packages/amazon/src/loadBalancer/configure/network/CreateNetworkLoadBalancer.tsx
@@ -2,7 +2,7 @@ import type { FormikErrors } from 'formik';
 import { cloneDeep, every, get } from 'lodash';
 import React from 'react';
 
-import type { ILoadBalancerModalProps, IRouterInjectedProps } from '@spinnaker/core';
+import type { DeckRuntimeServices, ILoadBalancerModalProps, IRouterInjectedProps } from '@spinnaker/core';
 import {
   AccountService,
   LoadBalancerWriter,
@@ -47,9 +47,12 @@ export class CreateNetworkLoadBalancerComponent extends React.Component<
   private refreshUnsubscribe: () => void;
   private certificateTypes = get(AWSProviderSettings, 'loadBalancers.certificateTypes', ['iam', 'acm']);
 
-  public static show(props: ICreateNetworkLoadBalancerProps): Promise<IAmazonNetworkLoadBalancerUpsertCommand> {
+  public static show(
+    props: ICreateNetworkLoadBalancerProps,
+    runtimeServices: DeckRuntimeServices,
+  ): Promise<IAmazonNetworkLoadBalancerUpsertCommand> {
     const modalProps = { dialogClassName: 'wizard-modal modal-lg' };
-    return ReactModal.show(CreateNetworkLoadBalancer, props, modalProps);
+    return ReactModal.show(CreateNetworkLoadBalancer, props, modalProps, runtimeServices);
   }
 
   constructor(props: ICreateNetworkLoadBalancerProps & IRouterInjectedProps) {

--- a/deck/packages/amazon/src/loadBalancer/details/LoadBalancerActions.tsx
+++ b/deck/packages/amazon/src/loadBalancer/details/LoadBalancerActions.tsx
@@ -7,6 +7,7 @@ import {
   AddEntityTagLinks,
   ApplicationReader,
   ConfirmationModalService,
+  DeckRuntimeContext,
   HelpField,
   LoadBalancerWriter,
   ManagedMenuItem,
@@ -34,6 +35,9 @@ export interface ILoadBalancerActionsState {
 }
 
 export class LoadBalancerActions extends React.Component<ILoadBalancerActionsProps, ILoadBalancerActionsState> {
+  public static contextType = DeckRuntimeContext;
+  public declare context: React.ContextType<typeof DeckRuntimeContext>;
+
   constructor(props: ILoadBalancerActionsProps) {
     super(props);
 
@@ -68,7 +72,7 @@ export class LoadBalancerActions extends React.Component<ILoadBalancerActionsPro
     const { loadBalancer } = this.props;
     const { application } = this.state;
     const LoadBalancerModal = LoadBalancerTypes.find((t) => t.type === loadBalancer.loadBalancerType).component;
-    LoadBalancerModal.show({ app: application, loadBalancer });
+    LoadBalancerModal.show({ app: application, loadBalancer }, this.context.services);
   };
 
   public deleteLoadBalancer = (): void => {

--- a/deck/packages/amazon/src/loadBalancer/details/amazonLoadBalancerDetails.spec.tsx
+++ b/deck/packages/amazon/src/loadBalancer/details/amazonLoadBalancerDetails.spec.tsx
@@ -1,9 +1,9 @@
-import { mount, ReactWrapper } from 'enzyme';
+import { mount as enzymeMount, ReactWrapper } from 'enzyme';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { BehaviorSubject } from 'rxjs';
 
-import { AngularServices } from '@spinnaker/core';
+import { DeckRuntimeContext } from '@spinnaker/core';
 
 import { useAmazonLoadBalancerDetails } from './amazonLoadBalancerDetails';
 import { RequestBuilder } from '../../../../core/src/api/ApiService';
@@ -12,6 +12,15 @@ describe('useAmazonLoadBalancerDetails', () => {
   const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
   const defaultHttpClient = RequestBuilder.defaultHttpClient;
   let wrapper: ReactWrapper | undefined;
+  let runtimeServices: any;
+  const RuntimeWrapper = ({ children }: React.PropsWithChildren<{}>) => (
+    <DeckRuntimeContext.Provider value={{ services: runtimeServices } as any}>{children}</DeckRuntimeContext.Provider>
+  );
+  const mount = (component: React.ReactElement) => enzymeMount(component, { wrappingComponent: RuntimeWrapper });
+
+  beforeEach(() => {
+    runtimeServices = {};
+  });
 
   afterEach(() => {
     if (wrapper) {
@@ -44,9 +53,9 @@ describe('useAmazonLoadBalancerDetails', () => {
     } as any;
     const get = jasmine.createSpy('get').and.returnValue(new Promise(() => undefined));
     RequestBuilder.defaultHttpClient = { get } as any;
-    spyOnProperty(AngularServices, 'securityGroupReader', 'get').and.returnValue({
+    runtimeServices.securityGroupReader = {
       getApplicationSecurityGroup: jasmine.createSpy('getApplicationSecurityGroup'),
-    } as any);
+    };
 
     function TestComponent() {
       useAmazonLoadBalancerDetails({
@@ -99,9 +108,9 @@ describe('useAmazonLoadBalancerDetails', () => {
     const get = jasmine.createSpy('get').and.returnValue(detailsRequest);
     const consoleError = spyOn(console, 'error');
     RequestBuilder.defaultHttpClient = { get } as any;
-    spyOnProperty(AngularServices, 'securityGroupReader', 'get').and.returnValue({
+    runtimeServices.securityGroupReader = {
       getApplicationSecurityGroup: jasmine.createSpy('getApplicationSecurityGroup'),
-    } as any);
+    };
 
     function TestComponent() {
       useAmazonLoadBalancerDetails({

--- a/deck/packages/amazon/src/loadBalancer/details/amazonLoadBalancerDetails.tsx
+++ b/deck/packages/amazon/src/loadBalancer/details/amazonLoadBalancerDetails.tsx
@@ -15,7 +15,6 @@ import type {
 } from '@spinnaker/core';
 import {
   AccountTag,
-  AngularServices,
   CollapsibleSection,
   CopyToClipboard,
   FirewallLabels,
@@ -25,6 +24,7 @@ import {
   SubnetReader,
   timestamp,
   useDataSource,
+  useDeckRuntimeServices,
 } from '@spinnaker/core';
 
 import { LoadBalancerActions } from './LoadBalancerActions';
@@ -192,6 +192,7 @@ export function useAmazonLoadBalancerDetails({
   loadBalancerParams,
   autoClose,
 }: IUseDetailsHookProps): UseDetailsResult<ILoadBalancer> {
+  const { securityGroupReader } = useDeckRuntimeServices();
   const dataSource = app.getDataSource('loadBalancers');
   const { data: loadBalancers, loaded, refresh, error } = useDataSource<ILoadBalancer[]>(dataSource);
   const [data, setData] = React.useState<IAmazonLoadBalancer>();
@@ -224,7 +225,7 @@ export function useAmazonLoadBalancerDetails({
         autoClose: () => autoCloseRef.current(),
         loadBalancerParams: { accountId, name, provider, region, vpcId },
         loadBalancers,
-        securityGroupReader: AngularServices.securityGroupReader,
+        securityGroupReader,
       });
       if (isMountedRef.current) {
         setData(loadBalancer);
@@ -238,7 +239,7 @@ export function useAmazonLoadBalancerDetails({
         setLoadingDetails(false);
       }
     }
-  }, [accountId, app, error, loadBalancers, loaded, name, provider, region, vpcId]);
+  }, [accountId, app, error, loadBalancers, loaded, name, provider, region, securityGroupReader, vpcId]);
 
   React.useEffect(() => {
     loadDetails();

--- a/deck/packages/amazon/src/pipeline/stages/deployCloudFormation/evaluateCloudFormationChangeSetExecutionApproval.tsx
+++ b/deck/packages/amazon/src/pipeline/stages/deployCloudFormation/evaluateCloudFormationChangeSetExecutionApproval.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
 
 import type { Application, IExecution, IExecutionStage } from '@spinnaker/core';
-import { Spinner } from '@spinnaker/core';
-import { AwsServices } from '../../../aws.services';
+import { Spinner, useDeckRuntimeServices } from '@spinnaker/core';
+import { EvaluateCloudFormationChangeSetExecutionService } from './evaluateCloudFormationChangeSetExecution.service';
 
 export interface IEvaluateCloudFormationChangeSetExecutionApprovalProps {
   execution: IExecution;
@@ -20,6 +20,7 @@ export const EvaluateCloudFormationChangeSetExecutionApproval = (
   props: IEvaluateCloudFormationChangeSetExecutionApprovalProps,
 ) => {
   const { execution, stage, application } = props;
+  const { executionService } = useDeckRuntimeServices();
   const [submitting, setSubmitting] = useState(false);
   const [judgmentDecision, setJudgmentDecision] = useState('');
   const [error, setError] = useState(false);
@@ -28,7 +29,7 @@ export const EvaluateCloudFormationChangeSetExecutionApproval = (
     setSubmitting(true);
     setJudgmentDecision(judgmentDecision);
     setError(false);
-    AwsServices.evaluateCloudFormationChangeSetExecutionService.evaluateExecution(
+    new EvaluateCloudFormationChangeSetExecutionService(executionService).evaluateExecution(
       application,
       execution,
       stage,

--- a/deck/packages/amazon/src/pipeline/stages/deployLambda/components/NetworkForm.tsx
+++ b/deck/packages/amazon/src/pipeline/stages/deployLambda/components/NetworkForm.tsx
@@ -7,13 +7,13 @@ import type { Option } from 'react-select';
 
 import type { IFormikStageConfigInjectedProps, IFormInputProps, ISecurityGroup, ISubnet, IVpc } from '@spinnaker/core';
 import {
-  AngularServices,
   FormikFormField,
   NetworkReader,
   ReactSelectInput,
   SubnetReader,
   TetheredSelect,
   useData,
+  useDeckRuntimeServices,
 } from '@spinnaker/core';
 
 const toSubnetOption = (value: ISubnet): Option<string> => {
@@ -21,6 +21,7 @@ const toSubnetOption = (value: ISubnet): Option<string> => {
 };
 
 export function NetworkForm(props: IFormikStageConfigInjectedProps) {
+  const { securityGroupReader } = useDeckRuntimeServices();
   const { values } = props.formik;
 
   const onChangeVpc = (vpcs: any) => {
@@ -47,11 +48,7 @@ export function NetworkForm(props: IFormikStageConfigInjectedProps) {
 
   const { result: fetchSubnetsResult } = useData(() => SubnetReader.listSubnetsByProvider('aws'), [], []);
 
-  const { result: fetchSGsResult } = useData(
-    () => AngularServices.securityGroupReader.getAllSecurityGroups(),
-    undefined,
-    [],
-  );
+  const { result: fetchSGsResult } = useData(() => securityGroupReader.getAllSecurityGroups(), undefined, []);
 
   const availableVpcs =
     values.account && values.region && fetchVpcsStatus !== 'PENDING'

--- a/deck/packages/amazon/src/securityGroup/details/AmazonSecurityGroupDetails.tsx
+++ b/deck/packages/amazon/src/securityGroup/details/AmazonSecurityGroupDetails.tsx
@@ -13,10 +13,10 @@ import type {
 import {
   AccountTag,
   AddEntityTagLinks,
-  AngularServices,
   CollapsibleSection,
   ConfirmationModalService,
   confirmNotManaged,
+  DeckRuntimeContext,
   FirewallLabels,
   ManagedResourceDetailsIndicator,
   RecentHistoryService,
@@ -209,6 +209,9 @@ export class AmazonSecurityGroupDetailsComponent extends React.Component<
   IAmazonSecurityGroupDetailsProps & IRouterInjectedProps,
   IAmazonSecurityGroupDetailsState
 > {
+  public static contextType = DeckRuntimeContext;
+  public declare context: React.ContextType<typeof DeckRuntimeContext>;
+
   public state: IAmazonSecurityGroupDetailsState = { loading: true };
 
   private isUnmounted = false;
@@ -250,7 +253,7 @@ export class AmazonSecurityGroupDetailsComponent extends React.Component<
   }
 
   private getSecurityGroupReader(): SecurityGroupReader {
-    return this.props.securityGroupReader || AngularServices.securityGroupReader;
+    return this.props.securityGroupReader || this.context.services.securityGroupReader;
   }
 
   private autoClose = (): void => {

--- a/deck/packages/amazon/src/serverGroup/configure/serverGroupCommandBuilder.service.ts
+++ b/deck/packages/amazon/src/serverGroup/configure/serverGroupCommandBuilder.service.ts
@@ -1,12 +1,12 @@
 import _ from 'lodash';
 
-import type { Application, InstanceTypeService } from '@spinnaker/core';
-import { AccountService, AngularServices, DeploymentStrategyRegistry, NameUtils, SubnetReader } from '@spinnaker/core';
+import type { Application, DeckRuntimeServices, InstanceTypeService } from '@spinnaker/core';
+import { AccountService, DeploymentStrategyRegistry, NameUtils, SubnetReader } from '@spinnaker/core';
 
 import { AWSProviderSettings } from '../../aws.settings';
 import type { IAmazonLaunchTemplateOverrides, ILaunchTemplateData } from '../../domain';
 import type { IAmazonServerGroup, IAmazonServerGroupView, INetworkInterface } from '../../domain';
-import { AwsServerGroupConfigurationService } from './serverGroupConfiguration.service';
+import type { AwsServerGroupConfigurationService } from './serverGroupConfiguration.service';
 import type {
   IAmazonInstanceTypeOverride,
   IAmazonServerGroupCommand,
@@ -41,8 +41,8 @@ export interface AwsServerGroupCommandBuilder {
 }
 
 export function createAwsServerGroupCommandBuilder(
-  instanceTypeService: InstanceTypeService = AngularServices.instanceTypeService,
-  awsServerGroupConfigurationService: AwsServerGroupConfigurationService = new AwsServerGroupConfigurationService(),
+  instanceTypeService: InstanceTypeService,
+  awsServerGroupConfigurationService: AwsServerGroupConfigurationService,
 ): AwsServerGroupCommandBuilder {
   function buildNewServerGroupCommand(
     application: Application,
@@ -498,7 +498,16 @@ export function createAwsServerGroupCommandBuilder(
 }
 
 export class AwsServerGroupCommandBuilderDelegate implements AwsServerGroupCommandBuilder {
-  private delegate = createAwsServerGroupCommandBuilder();
+  public static readonly requiresDeckRuntimeServices = true;
+
+  private delegate: AwsServerGroupCommandBuilder;
+
+  constructor(_promiseService: unknown, runtimeServices: DeckRuntimeServices) {
+    const configurationService = runtimeServices.providerServiceDelegate.getDelegate<
+      AwsServerGroupConfigurationService
+    >('aws', 'serverGroup.configurationService');
+    this.delegate = createAwsServerGroupCommandBuilder(runtimeServices.instanceTypeService, configurationService);
+  }
 
   public buildNewServerGroupCommand(
     application: Application,

--- a/deck/packages/amazon/src/serverGroup/configure/serverGroupConfiguration.service.ts
+++ b/deck/packages/amazon/src/serverGroup/configure/serverGroupConfiguration.service.ts
@@ -18,6 +18,7 @@ import {
 import type {
   Application,
   CacheInitializerService,
+  DeckRuntimeServices,
   IAccountDetails,
   IDeploymentStrategy,
   IRegion,
@@ -32,14 +33,7 @@ import type {
   SecurityGroupReader,
   ServerGroupCommandRegistry,
 } from '@spinnaker/core';
-import {
-  AccountService,
-  AngularServices,
-  NameUtils,
-  REST,
-  setMatchingResourceSummary,
-  SubnetReader,
-} from '@spinnaker/core';
+import { AccountService, NameUtils, REST, setMatchingResourceSummary, SubnetReader } from '@spinnaker/core';
 
 import { AWSProviderSettings } from '../../aws.settings';
 import { AutoScalingProcessService } from '../details/scalingProcesses/AutoScalingProcessService';
@@ -173,36 +167,29 @@ export class AwsServerGroupConfigurationService {
     'ClosestToNextInstanceHour',
     'Default',
   ];
-  private securityGroupReader?: SecurityGroupReader;
+  private securityGroupReader: SecurityGroupReader;
   private awsInstanceTypeService: AwsInstanceTypeService;
-  private cacheInitializer?: CacheInitializerService;
+  private cacheInitializer: CacheInitializerService;
 
   constructor(
-    securityGroupReader?: SecurityGroupReader,
-    awsInstanceTypeService: AwsInstanceTypeService = new AwsInstanceTypeService(),
-    cacheInitializer?: CacheInitializerService,
+    securityGroupReader: SecurityGroupReader,
+    awsInstanceTypeService: AwsInstanceTypeService,
+    cacheInitializer: CacheInitializerService,
     private serverGroupCommandRegistry: Pick<ServerGroupCommandRegistry, 'getCommandOverrides'> = {
       getCommandOverrides: () => [],
     },
   ) {
-    if (typeof securityGroupReader?.getAllSecurityGroups === 'function') {
-      this.securityGroupReader = securityGroupReader;
-    } else if (securityGroupReader) {
-      this.securityGroupReader = AngularServices.securityGroupReader;
-    }
-    this.awsInstanceTypeService =
-      typeof awsInstanceTypeService?.getAllTypesByRegion === 'function'
-        ? awsInstanceTypeService
-        : new AwsInstanceTypeService();
+    this.securityGroupReader = securityGroupReader;
+    this.awsInstanceTypeService = awsInstanceTypeService;
     this.cacheInitializer = cacheInitializer;
   }
 
   private getSecurityGroupReader(): SecurityGroupReader {
-    return (this.securityGroupReader = this.securityGroupReader || AngularServices.securityGroupReader);
+    return this.securityGroupReader;
   }
 
   private getCacheInitializer(): CacheInitializerService {
-    return (this.cacheInitializer = this.cacheInitializer || AngularServices.cacheInitializer);
+    return this.cacheInitializer;
   }
 
   public configureUpdateCommand(command: IAmazonServerGroupCommand): void {
@@ -751,5 +738,13 @@ export class AwsServerGroupConfigurationService {
     };
 
     this.applyOverrides('attachEventHandlers', cmd);
+  }
+}
+
+export class AwsServerGroupConfigurationServiceDelegate extends AwsServerGroupConfigurationService {
+  public static readonly requiresDeckRuntimeServices = true;
+
+  constructor(_promiseService: unknown, runtimeServices: DeckRuntimeServices) {
+    super(runtimeServices.securityGroupReader, new AwsInstanceTypeService(), runtimeServices.cacheInitializer);
   }
 }

--- a/deck/packages/amazon/src/serverGroup/configure/wizard/AmazonCloneServerGroupModal.tsx
+++ b/deck/packages/amazon/src/serverGroup/configure/wizard/AmazonCloneServerGroupModal.tsx
@@ -1,9 +1,15 @@
 import { get } from 'lodash';
 import React from 'react';
 
-import type { Application, IModalComponentProps, IRouterInjectedProps, IStage } from '@spinnaker/core';
+import type {
+  Application,
+  DeckRuntimeServices,
+  IModalComponentProps,
+  IRouterInjectedProps,
+  IStage,
+} from '@spinnaker/core';
 import {
-  AngularServices,
+  DeckRuntimeContext,
   FirewallLabels,
   noop,
   ReactModal,
@@ -14,7 +20,6 @@ import {
 } from '@spinnaker/core';
 
 import { ServerGroupTemplateSelection } from './ServerGroupTemplateSelection';
-import { AwsServices } from '../../../aws.services';
 import {
   ServerGroupAdvancedSettings,
   ServerGroupBasicSettings,
@@ -25,6 +30,7 @@ import {
   ServerGroupZones,
 } from './pages';
 import type { IAmazonServerGroupCommand } from '../serverGroupConfiguration.service';
+import type { AwsServerGroupConfigurationService } from '../serverGroupConfiguration.service';
 
 export interface IAmazonCloneServerGroupModalProps extends IModalComponentProps {
   title: string;
@@ -43,6 +49,9 @@ export class AmazonCloneServerGroupModalComponent extends React.Component<
   IAmazonCloneServerGroupModalProps & IRouterInjectedProps,
   IAmazonCloneServerGroupModalState
 > {
+  public static contextType = DeckRuntimeContext;
+  public declare context: React.ContextType<typeof DeckRuntimeContext>;
+
   public static defaultProps: Partial<IAmazonCloneServerGroupModalProps> = {
     closeModal: noop,
     dismissModal: noop,
@@ -51,19 +60,18 @@ export class AmazonCloneServerGroupModalComponent extends React.Component<
   private _isUnmounted = false;
   private refreshUnsubscribe: () => void;
 
-  public static show(props: IAmazonCloneServerGroupModalProps): Promise<IAmazonServerGroupCommand> {
+  public static show(
+    props: IAmazonCloneServerGroupModalProps,
+    runtimeServices: DeckRuntimeServices,
+  ): Promise<IAmazonServerGroupCommand> {
     const modalProps = { dialogClassName: 'wizard-modal modal-lg' };
-    return ReactModal.show(AmazonCloneServerGroupModal, props, modalProps);
+    return ReactModal.show(AmazonCloneServerGroupModal, props, modalProps, runtimeServices);
   }
 
   constructor(props: IAmazonCloneServerGroupModalProps & IRouterInjectedProps) {
     super(props);
 
     const requiresTemplateSelection = get(props, 'command.viewState.requiresTemplateSelection', false);
-    if (!requiresTemplateSelection) {
-      this.configureCommand();
-    }
-
     this.state = {
       firewallsLabel: FirewallLabels.get('Firewalls'),
       loaded: false,
@@ -75,6 +83,19 @@ export class AmazonCloneServerGroupModalComponent extends React.Component<
         onTaskComplete: this.onTaskComplete,
       }),
     };
+  }
+
+  public componentDidMount(): void {
+    if (!this.state.requiresTemplateSelection) {
+      this.configureCommand();
+    }
+  }
+
+  private get configurationService(): AwsServerGroupConfigurationService {
+    return this.context.services.providerServiceDelegate.getDelegate(
+      this.props.command.selectedProvider,
+      'serverGroup.configurationService',
+    );
   }
 
   private templateSelected = () => {
@@ -127,12 +148,12 @@ export class AmazonCloneServerGroupModalComponent extends React.Component<
 
     command.credentialsChanged(command);
     command.regionChanged(command);
-    AwsServices.awsServerGroupConfigurationService.configureSubnetPurposes(command);
+    this.configurationService.configureSubnetPurposes(command);
   };
 
   private configureCommand = () => {
     const { application, command } = this.props;
-    AwsServices.awsServerGroupConfigurationService.configureCommand(application, command).then(() => {
+    this.configurationService.configureCommand(application, command).then(() => {
       this.initializeCommand();
       this.setState({ loaded: true, requiresTemplateSelection: false });
     });
@@ -163,7 +184,7 @@ export class AmazonCloneServerGroupModalComponent extends React.Component<
       this.props.closeModal && this.props.closeModal(command);
     } else {
       this.state.taskMonitor.submit(() =>
-        AngularServices.serverGroupWriter.cloneServerGroup(command, this.props.application),
+        this.context.services.serverGroupWriter.cloneServerGroup(command, this.props.application),
       );
     }
   };

--- a/deck/packages/amazon/src/serverGroup/configure/wizard/instanceType/simpleMode/SimpleModeSelector.spec.tsx
+++ b/deck/packages/amazon/src/serverGroup/configure/wizard/instanceType/simpleMode/SimpleModeSelector.spec.tsx
@@ -1,13 +1,23 @@
-import { mount } from 'enzyme';
+import { mount as enzymeMount } from 'enzyme';
 import React from 'react';
 
-import { AngularServices } from '@spinnaker/core';
+import { DeckRuntimeContext } from '@spinnaker/core';
 
 import { SimpleModeSelector } from './SimpleModeSelector';
 
 describe('SimpleModeSelector', () => {
+  let runtimeServices: any;
+  const RuntimeWrapper = ({ children }: React.PropsWithChildren<{}>) => (
+    <DeckRuntimeContext.Provider value={{ services: runtimeServices } as any}>{children}</DeckRuntimeContext.Provider>
+  );
+  const mount = (component: React.ReactElement) => enzymeMount(component, { wrappingComponent: RuntimeWrapper });
+
+  beforeEach(() => {
+    runtimeServices = {};
+  });
+
   it('shows instance type rows when an instance profile tile is clicked', async () => {
-    spyOnProperty(AngularServices, 'instanceTypeService', 'get').and.returnValue(instanceTypeService() as any);
+    runtimeServices.instanceTypeService = instanceTypeService();
     const command = buildCommand();
     const component = mount(
       <SimpleModeSelector
@@ -28,7 +38,7 @@ describe('SimpleModeSelector', () => {
   });
 
   it('updates derived command fields from the selected instance type', async () => {
-    spyOnProperty(AngularServices, 'instanceTypeService', 'get').and.returnValue(instanceTypeService() as any);
+    runtimeServices.instanceTypeService = instanceTypeService();
     const command = buildCommand();
     const component = mount(
       <SimpleModeSelector

--- a/deck/packages/amazon/src/serverGroup/configure/wizard/pages/ServerGroupLoadBalancers.tsx
+++ b/deck/packages/amazon/src/serverGroup/configure/wizard/pages/ServerGroupLoadBalancers.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import type { Option } from 'react-select';
 
 import type { IWizardPageComponent } from '@spinnaker/core';
-import { AngularServices, HelpField, TetheredSelect } from '@spinnaker/core';
+import { DeckRuntimeContext, HelpField, TetheredSelect } from '@spinnaker/core';
 
 import type { IAmazonServerGroupCommand } from '../../serverGroupConfiguration.service';
 
@@ -27,6 +27,9 @@ const stringToOption = (value: string): Option<string> => {
 export class ServerGroupLoadBalancers
   extends React.Component<IServerGroupLoadBalancersProps, IServerGroupLoadBalancersState>
   implements IWizardPageComponent<IAmazonServerGroupCommand> {
+  public static contextType = DeckRuntimeContext;
+  public declare context: React.ContextType<typeof DeckRuntimeContext>;
+
   public state = {
     refreshing: false,
     refreshed: false,
@@ -49,7 +52,7 @@ export class ServerGroupLoadBalancers
   public refreshLoadBalancers = () => {
     const { values } = this.props.formik;
     this.setState({ refreshing: true });
-    const configurationService: any = AngularServices.providerServiceDelegate.getDelegate(
+    const configurationService: any = this.context.services.providerServiceDelegate.getDelegate(
       values.cloudProvider || values.selectedProvider,
       'serverGroup.configurationService',
     );

--- a/deck/packages/amazon/src/serverGroup/configure/wizard/securityGroups/SecurityGroupSelector.tsx
+++ b/deck/packages/amazon/src/serverGroup/configure/wizard/securityGroups/SecurityGroupSelector.tsx
@@ -3,7 +3,7 @@ import type { Option } from 'react-select';
 import VirtualizedSelect from 'react-virtualized-select';
 
 import type { ISecurityGroup } from '@spinnaker/core';
-import { AngularServices, FirewallLabels, HelpField, InfrastructureCaches, timestamp } from '@spinnaker/core';
+import { DeckRuntimeContext, FirewallLabels, HelpField, InfrastructureCaches, timestamp } from '@spinnaker/core';
 
 import type { IAmazonServerGroupCommand } from '../../serverGroupConfiguration.service';
 
@@ -23,6 +23,9 @@ export interface ISecurityGroupSelectorState {
 }
 
 export class SecurityGroupSelector extends React.Component<ISecurityGroupSelectorProps, ISecurityGroupSelectorState> {
+  public static contextType = DeckRuntimeContext;
+  public declare context: React.ContextType<typeof DeckRuntimeContext>;
+
   constructor(props: ISecurityGroupSelectorProps) {
     super(props);
     this.state = {
@@ -38,7 +41,7 @@ export class SecurityGroupSelector extends React.Component<ISecurityGroupSelecto
     if (this.props.refresh) {
       this.props.refresh().then(() => this.setState({ refreshing: false }));
     } else {
-      (AngularServices.providerServiceDelegate.getDelegate(
+      (this.context.services.providerServiceDelegate.getDelegate(
         this.props.command.selectedProvider,
         'serverGroup.configurationService',
       ) as any)

--- a/deck/packages/amazon/src/serverGroup/details/AmazonServerGroupActions.spec.tsx
+++ b/deck/packages/amazon/src/serverGroup/details/AmazonServerGroupActions.spec.tsx
@@ -2,12 +2,7 @@ import { shallow } from 'enzyme';
 import React from 'react';
 
 import type { Application } from '@spinnaker/core';
-import {
-  AngularServices,
-  ConfirmationModalService,
-  ManagedMenuItem,
-  ServerGroupWarningMessageService,
-} from '@spinnaker/core';
+import { ConfirmationModalService, ManagedMenuItem, ServerGroupWarningMessageService } from '@spinnaker/core';
 
 import type { IAmazonServerGroupView } from '../../domain';
 import { AWSProviderSettings } from '../../aws.settings';
@@ -16,6 +11,13 @@ import { AmazonRollbackServerGroupModal } from './rollback';
 
 describe('<AmazonServerGroupActions /> rollback integration', () => {
   const originalAdHocInfraWritesEnabled = AWSProviderSettings.adHocInfraWritesEnabled;
+  const runtimeServices = {} as any;
+
+  const shallowActions = (component: React.ReactElement) => {
+    const wrapper = shallow(component);
+    (wrapper.instance() as any).context = { services: runtimeServices };
+    return wrapper;
+  };
 
   const buildServerGroup = (overrides: Partial<IAmazonServerGroupView> = {}): IAmazonServerGroupView =>
     ({
@@ -59,7 +61,7 @@ describe('<AmazonServerGroupActions /> rollback integration', () => {
     const unrelated = buildServerGroup({ app: 'other-app', cluster: 'other-app-main', name: 'other-app-main-v001' });
     const application = buildApplication([selected, rollbackSource, unrelated]);
     const show = spyOn(AmazonRollbackServerGroupModal, 'show').and.returnValue(Promise.resolve({} as any));
-    const wrapper = shallow(<AmazonServerGroupActions app={application} serverGroup={selected} />);
+    const wrapper = shallowActions(<AmazonServerGroupActions app={application} serverGroup={selected} />);
 
     const rollback = action(wrapper, 'Rollback');
     expect(rollback.length).toBe(1);
@@ -69,12 +71,15 @@ describe('<AmazonServerGroupActions /> rollback integration', () => {
 
     rollback.prop('onClick')();
 
-    expect(show).toHaveBeenCalledOnceWith({
-      allServerGroups: [selected],
-      application,
-      previousServerGroup: selected,
-      serverGroup: rollbackSource,
-    });
+    expect(show).toHaveBeenCalledOnceWith(
+      {
+        allServerGroups: [selected],
+        application,
+        previousServerGroup: selected,
+        serverGroup: rollbackSource,
+      },
+      runtimeServices,
+    );
   });
 
   it('does not render Rollback when a disabled server group has no enabled rollback source', () => {
@@ -90,18 +95,21 @@ describe('<AmazonServerGroupActions /> rollback integration', () => {
     const application = buildApplication([selected, rollbackSource]);
     const confirm = spyOn(ConfirmationModalService, 'confirm').and.returnValue(Promise.resolve() as any);
     const show = spyOn(AmazonRollbackServerGroupModal, 'show').and.returnValue(Promise.resolve({} as any));
-    const wrapper = shallow(<AmazonServerGroupActions app={application} serverGroup={selected} />);
+    const wrapper = shallowActions(<AmazonServerGroupActions app={application} serverGroup={selected} />);
 
     action(wrapper, 'Enable').prop('onClick')();
     await settle();
 
     expect(confirm).toHaveBeenCalledTimes(1);
-    expect(show).toHaveBeenCalledOnceWith({
-      allServerGroups: [selected],
-      application,
-      previousServerGroup: selected,
-      serverGroup: rollbackSource,
-    });
+    expect(show).toHaveBeenCalledOnceWith(
+      {
+        allServerGroups: [selected],
+        application,
+        previousServerGroup: selected,
+        serverGroup: rollbackSource,
+      },
+      runtimeServices,
+    );
   });
 
   it('continues to the ordinary Enable confirmation when orchestrated rollback is declined', async () => {
@@ -135,8 +143,10 @@ describe('<AmazonServerGroupActions /> rollback integration', () => {
       Promise.reject({ source: 'header' }) as any,
     );
     const show = spyOn(AmazonRollbackServerGroupModal, 'show').and.returnValue(Promise.resolve({} as any));
-    const enable = spyOn(AngularServices.serverGroupWriter, 'enableServerGroup');
+    const writer = { enableServerGroup: jasmine.createSpy('enableServerGroup') };
+    const enable = writer.enableServerGroup;
     const wrapper = shallow(<AmazonServerGroupActions app={application} serverGroup={selected} />);
+    (wrapper.instance() as any).context = { services: { serverGroupWriter: writer } };
 
     action(wrapper, 'Enable').prop('onClick')();
     await settle();

--- a/deck/packages/amazon/src/serverGroup/details/AmazonServerGroupActions.tsx
+++ b/deck/packages/amazon/src/serverGroup/details/AmazonServerGroupActions.tsx
@@ -5,9 +5,9 @@ import { Dropdown, MenuItem, Tooltip } from 'react-bootstrap';
 import type { IOwnerOption, IRouterInjectedProps, IServerGroupActionsProps, IServerGroupJob } from '@spinnaker/core';
 import {
   AddEntityTagLinks,
-  AngularServices,
   ClusterTargetBuilder,
   ConfirmationModalService,
+  DeckRuntimeContext,
   ManagedMenuItem,
   Overridable,
   ServerGroupWarningMessageService,
@@ -15,7 +15,6 @@ import {
   withRouter,
 } from '@spinnaker/core';
 
-import { AwsServices } from '../../aws.services';
 import { AWSProviderSettings } from '../../aws.settings';
 import type { IAmazonServerGroupCommand } from '../configure';
 import { AmazonCloneServerGroupModal } from '../configure/wizard/AmazonCloneServerGroupModal';
@@ -34,8 +33,11 @@ export interface IAmazonServerGroupActionsProps extends IServerGroupActionsProps
 
 @Overridable('AmazonServerGroupActions.resize')
 export class AmazonServerGroupActionsResize extends React.Component<IAmazonResizeServerGroupModalProps> {
+  public static contextType = DeckRuntimeContext;
+  public declare context: React.ContextType<typeof DeckRuntimeContext>;
+
   private resizeServerGroup = (): void => {
-    AmazonResizeServerGroupModal.show(this.props);
+    AmazonResizeServerGroupModal.show(this.props, this.context.services);
   };
 
   public render(): JSX.Element {
@@ -46,6 +48,9 @@ export class AmazonServerGroupActionsResize extends React.Component<IAmazonResiz
 export class AmazonServerGroupActionsComponent extends React.Component<
   IAmazonServerGroupActionsProps & IRouterInjectedProps
 > {
+  public static contextType = DeckRuntimeContext;
+  public declare context: React.ContextType<typeof DeckRuntimeContext>;
+
   private isEnableLocked(): boolean {
     if (this.props.serverGroup.isDisabled) {
       const resizeTasks = (this.props.serverGroup.runningTasks || []).filter((task) =>
@@ -82,7 +87,7 @@ export class AmazonServerGroupActionsComponent extends React.Component<
     };
 
     const submitMethod = (params: IServerGroupJob) =>
-      AngularServices.serverGroupWriter.destroyServerGroup(serverGroup, app, params);
+      this.context.services.serverGroupWriter.destroyServerGroup(serverGroup, app, params);
 
     const stateParams = {
       name: serverGroup.name,
@@ -120,7 +125,7 @@ export class AmazonServerGroupActionsComponent extends React.Component<
     };
 
     const submitMethod = (params: IServerGroupJob) => {
-      return AngularServices.serverGroupWriter.disableServerGroup(serverGroup, app.name, params);
+      return this.context.services.serverGroupWriter.disableServerGroup(serverGroup, app.name, params);
     };
 
     const confirmationModalParams = {
@@ -177,7 +182,7 @@ export class AmazonServerGroupActionsComponent extends React.Component<
     };
 
     const submitMethod = (params: IServerGroupJob) => {
-      return AngularServices.serverGroupWriter.enableServerGroup(serverGroup, app, params);
+      return this.context.services.serverGroupWriter.enableServerGroup(serverGroup, app, params);
     };
 
     const confirmationModalParams = {
@@ -208,17 +213,17 @@ export class AmazonServerGroupActionsComponent extends React.Component<
     );
 
     if (selection) {
-      AmazonRollbackServerGroupModal.show({ application: app, ...selection });
+      AmazonRollbackServerGroupModal.show({ application: app, ...selection }, this.context.services);
     }
   };
 
   private cloneServerGroup = (): void => {
     const { app, serverGroup } = this.props;
-    AwsServices.awsServerGroupCommandBuilder
+    this.context.services.serverGroupCommandBuilder
       .buildServerGroupCommandFromExisting(app, serverGroup)
       .then((command: IAmazonServerGroupCommand) => {
         const title = `Clone ${serverGroup.name}`;
-        AmazonCloneServerGroupModal.show({ title, application: app, command });
+        AmazonCloneServerGroupModal.show({ title, application: app, command }, this.context.services);
       });
   };
 

--- a/deck/packages/amazon/src/serverGroup/details/advancedSettings/EditAsgAdvancedSettingsModal.spec.tsx
+++ b/deck/packages/amazon/src/serverGroup/details/advancedSettings/EditAsgAdvancedSettingsModal.spec.tsx
@@ -1,20 +1,47 @@
-import { shallow } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import React from 'react';
 
-import { FormikFormField, ReactModal, TaskMonitorModal } from '@spinnaker/core';
+import { DeckRuntimeContext, FormikFormField, ReactModal, TaskMonitorModal } from '@spinnaker/core';
 
 import { EditAsgAdvancedSettingsModal } from './EditAsgAdvancedSettingsModal';
-import { AwsServices } from '../../../aws.services';
 
 describe('EditAsgAdvancedSettingsModal', () => {
   const application = { name: 'deck', serverGroups: { refresh: jasmine.createSpy('refresh') } } as any;
   const serverGroup = { name: 'deck-main-v001', account: 'test', region: 'us-east-1' } as any;
+  let buildUpdateServerGroupCommand: jasmine.Spy;
   const modalProps = {
     application,
     serverGroup,
     closeModal: jasmine.createSpy('closeModal'),
     dismissModal: jasmine.createSpy('dismissModal'),
   };
+
+  function mountModal(command: any) {
+    buildUpdateServerGroupCommand = jasmine.createSpy().and.returnValue(command);
+    const commandBuilder = { buildUpdateServerGroupCommand };
+    const runtime = {
+      services: { providerServiceDelegate: { getDelegate: jasmine.createSpy().and.returnValue(commandBuilder) } },
+    } as any;
+    return mount(
+      <DeckRuntimeContext.Provider value={runtime}>
+        <EditAsgAdvancedSettingsModal {...modalProps} />
+      </DeckRuntimeContext.Provider>,
+    ).find(EditAsgAdvancedSettingsModal);
+  }
+
+  it('builds one update command and preserves it across rerenders', () => {
+    const command = {
+      backingData: { enabledMetrics: [], healthCheckTypes: [], terminationPolicies: [] },
+    } as any;
+    const wrapper = mountModal(command);
+    const initialValues = wrapper.find(TaskMonitorModal).prop('initialValues');
+
+    wrapper.instance().forceUpdate();
+    wrapper.update();
+
+    expect(buildUpdateServerGroupCommand).toHaveBeenCalledTimes(1);
+    expect(wrapper.find(TaskMonitorModal).prop('initialValues')).toBe(initialValues);
+  });
 
   it('uses the update command builder and exposes every advanced setting', () => {
     const command = {
@@ -30,9 +57,7 @@ describe('EditAsgAdvancedSettingsModal', () => {
         terminationPolicies: ['Default'],
       },
     } as any;
-    spyOn(AwsServices.awsServerGroupCommandBuilder, 'buildUpdateServerGroupCommand').and.returnValue(command);
-
-    const wrapper = shallow(<EditAsgAdvancedSettingsModal {...modalProps} />);
+    const wrapper = mountModal(command);
     const taskModal = wrapper.find(TaskMonitorModal);
 
     expect(taskModal.prop('initialValues')).toBe(command);
@@ -55,9 +80,7 @@ describe('EditAsgAdvancedSettingsModal', () => {
       healthCheckGracePeriod: 600,
       backingData: { enabledMetrics: [], healthCheckTypes: [], terminationPolicies: [] },
     } as any;
-    spyOn(AwsServices.awsServerGroupCommandBuilder, 'buildUpdateServerGroupCommand').and.returnValue(command);
-
-    const wrapper = shallow(<EditAsgAdvancedSettingsModal {...modalProps} />);
+    const wrapper = mountModal(command);
     const taskModal = wrapper.find(TaskMonitorModal);
     const fields = shallow(<div>{taskModal.prop('render')({ values: command } as any)}</div>).find(FormikFormField);
 
@@ -73,13 +96,15 @@ describe('EditAsgAdvancedSettingsModal', () => {
 
   it('opens only after managed-resource verification succeeds', async () => {
     const show = spyOn(ReactModal, 'show').and.returnValue(Promise.resolve() as any);
+    const runtimeServices = {} as any;
 
-    await EditAsgAdvancedSettingsModal.show({ application, serverGroup });
+    await EditAsgAdvancedSettingsModal.show({ application, serverGroup }, runtimeServices);
 
     expect(show).toHaveBeenCalledWith(
       EditAsgAdvancedSettingsModal,
       { application, serverGroup },
       { dialogClassName: 'modal-lg' },
+      runtimeServices,
     );
   });
 });

--- a/deck/packages/amazon/src/serverGroup/details/advancedSettings/EditAsgAdvancedSettingsModal.tsx
+++ b/deck/packages/amazon/src/serverGroup/details/advancedSettings/EditAsgAdvancedSettingsModal.tsx
@@ -1,10 +1,11 @@
 import type { FormikProps } from 'formik';
 import React from 'react';
 
-import type { Application, IModalComponentProps } from '@spinnaker/core';
+import type { Application, DeckRuntimeServices, IModalComponentProps } from '@spinnaker/core';
 import {
   CheckboxInput,
   confirmNotManaged,
+  DeckRuntimeContext,
   FormikFormField,
   HelpField,
   NumberInput,
@@ -13,7 +14,7 @@ import {
   TaskMonitorModal,
 } from '@spinnaker/core';
 
-import { AwsServices } from '../../../aws.services';
+import type { AwsServerGroupCommandBuilder } from '../../configure/serverGroupCommandBuilder.service';
 import type { IAmazonServerGroupCommand } from '../../configure/serverGroupConfiguration.service';
 import type { IAmazonServerGroup } from '../../../domain';
 
@@ -29,14 +30,24 @@ function validateRequiredNonNegativeNumber(value: unknown): string | undefined {
 }
 
 export class EditAsgAdvancedSettingsModal extends React.Component<IEditAsgAdvancedSettingsModalProps> {
-  public static show(props: IEditAsgAdvancedSettingsModalProps) {
+  public static contextType = DeckRuntimeContext;
+  public declare context: React.ContextType<typeof DeckRuntimeContext>;
+
+  private directCommand: Partial<IAmazonServerGroupCommand>;
+
+  public static show(props: IEditAsgAdvancedSettingsModalProps, runtimeServices: DeckRuntimeServices) {
     return confirmNotManaged(props.serverGroup, props.application).then(
       (notManaged) =>
-        notManaged && ReactModal.show(EditAsgAdvancedSettingsModal, props, { dialogClassName: 'modal-lg' }),
+        notManaged &&
+        ReactModal.show(EditAsgAdvancedSettingsModal, props, { dialogClassName: 'modal-lg' }, runtimeServices),
     );
   }
 
-  private command = AwsServices.awsServerGroupCommandBuilder.buildUpdateServerGroupCommand(this.props.serverGroup);
+  private get command(): Partial<IAmazonServerGroupCommand> {
+    return (this.directCommand ||= this.context.services.providerServiceDelegate
+      .getDelegate<AwsServerGroupCommandBuilder>('aws', 'serverGroup.commandBuilder')
+      .buildUpdateServerGroupCommand(this.props.serverGroup));
+  }
 
   private renderFields = (formik: FormikProps<IAmazonServerGroupCommand>) => {
     const { backingData } = formik.values;

--- a/deck/packages/amazon/src/serverGroup/details/resize/AmazonResizeServerGroupModal.tsx
+++ b/deck/packages/amazon/src/serverGroup/details/resize/AmazonResizeServerGroupModal.tsx
@@ -4,11 +4,17 @@ import { pickBy } from 'lodash';
 import React from 'react';
 import { Modal } from 'react-bootstrap';
 
-import type { Application, ICapacity, IModalComponentProps, IServerGroupJob } from '@spinnaker/core';
+import type {
+  Application,
+  DeckRuntimeServices,
+  ICapacity,
+  IModalComponentProps,
+  IServerGroupJob,
+} from '@spinnaker/core';
 import {
-  AngularServices,
   CheckboxInput,
   confirmNotManaged,
+  DeckRuntimeContext,
   FormikFormField,
   HelpField,
   MinMaxDesiredChanges,
@@ -58,6 +64,9 @@ export class AmazonResizeServerGroupModal extends React.Component<
   IAmazonResizeServerGroupModalProps,
   IAmazonResizeServerGroupModalState
 > {
+  public static contextType = DeckRuntimeContext;
+  public declare context: React.ContextType<typeof DeckRuntimeContext>;
+
   public static defaultProps: Partial<IAmazonResizeServerGroupModalProps> = {
     closeModal: noop,
     dismissModal: noop,
@@ -65,11 +74,11 @@ export class AmazonResizeServerGroupModal extends React.Component<
 
   private formikRef = React.createRef<Formik<IAmazonResizeServerGroupValues>>();
 
-  public static show(props: IAmazonResizeServerGroupModalProps) {
+  public static show(props: IAmazonResizeServerGroupModalProps, runtimeServices: DeckRuntimeServices) {
     const modalProps = {};
     const { serverGroup, application } = props;
     return confirmNotManaged(serverGroup, application).then((notManaged) => {
-      notManaged && ReactModal.show(AmazonResizeServerGroupModal, props, modalProps);
+      notManaged && ReactModal.show(AmazonResizeServerGroupModal, props, modalProps, runtimeServices);
     });
   }
 
@@ -200,7 +209,7 @@ export class AmazonResizeServerGroupModal extends React.Component<
       };
     }
     this.state.taskMonitor.submit(() => {
-      return AngularServices.serverGroupWriter.resizeServerGroup(serverGroup, application, command);
+      return this.context.services.serverGroupWriter.resizeServerGroup(serverGroup, application, command);
     });
   };
 

--- a/deck/packages/amazon/src/serverGroup/details/rollback/AmazonRollbackServerGroupModal.spec.tsx
+++ b/deck/packages/amazon/src/serverGroup/details/rollback/AmazonRollbackServerGroupModal.spec.tsx
@@ -2,7 +2,6 @@ import { shallow } from 'enzyme';
 import React from 'react';
 
 import {
-  AngularServices,
   PlatformHealthOverride,
   ReactModal,
   ServerGroupWriter,
@@ -231,8 +230,8 @@ describe('AmazonRollbackServerGroupModal', () => {
   it('submits only after verification and preserves the exact values', () => {
     const app = application({ platformHealthOnly: true, platformHealthOnlyShowOverride: true });
     const writer = { rollbackServerGroup: jasmine.createSpy('rollbackServerGroup').and.returnValue(Promise.resolve()) };
-    spyOnProperty(AngularServices, 'serverGroupWriter', 'get').and.returnValue(writer as any);
     const component = new AmazonRollbackServerGroupModal(props(app));
+    (component as any).context = { services: { serverGroupWriter: writer } };
     spyOn(component.state.taskMonitor, 'submit').and.callFake((submitMethod: any) => submitMethod());
     const values = {
       delayBeforeDisableSeconds: 30,
@@ -277,9 +276,10 @@ describe('AmazonRollbackServerGroupModal', () => {
   it('exposes a show primitive for later actions integration', () => {
     const show = spyOn(ReactModal, 'show').and.returnValue(Promise.resolve() as any);
     const modalProps = props();
+    const runtimeServices = {} as any;
 
-    AmazonRollbackServerGroupModal.show(modalProps);
+    AmazonRollbackServerGroupModal.show(modalProps, runtimeServices);
 
-    expect(show).toHaveBeenCalledOnceWith(AmazonRollbackServerGroupModal, modalProps);
+    expect(show).toHaveBeenCalledOnceWith(AmazonRollbackServerGroupModal, modalProps, undefined, runtimeServices);
   });
 });

--- a/deck/packages/amazon/src/serverGroup/details/rollback/AmazonRollbackServerGroupModal.tsx
+++ b/deck/packages/amazon/src/serverGroup/details/rollback/AmazonRollbackServerGroupModal.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { Modal } from 'react-bootstrap';
 
-import type { Application, IModalComponentProps, IServerGroupJob } from '@spinnaker/core';
+import type { Application, DeckRuntimeServices, IModalComponentProps, IServerGroupJob } from '@spinnaker/core';
 import {
-  AngularServices,
+  DeckRuntimeContext,
   ModalClose,
   noop,
   PlatformHealthOverride,
@@ -159,14 +159,20 @@ export class AmazonRollbackServerGroupModal extends React.Component<
   IAmazonRollbackServerGroupModalProps,
   IAmazonRollbackServerGroupModalState
 > {
+  public static contextType = DeckRuntimeContext;
+  public declare context: React.ContextType<typeof DeckRuntimeContext>;
+
   public static defaultProps: Partial<IAmazonRollbackServerGroupModalProps> = {
     allServerGroups: [],
     closeModal: noop,
     dismissModal: noop,
   };
 
-  public static show(props: IAmazonRollbackServerGroupModalProps): Promise<IAmazonRollbackJob> {
-    return ReactModal.show(AmazonRollbackServerGroupModal, props);
+  public static show(
+    props: IAmazonRollbackServerGroupModalProps,
+    runtimeServices: DeckRuntimeServices,
+  ): Promise<IAmazonRollbackJob> {
+    return ReactModal.show(AmazonRollbackServerGroupModal, props, undefined, runtimeServices);
   }
 
   public constructor(props: IAmazonRollbackServerGroupModalProps) {
@@ -221,7 +227,7 @@ export class AmazonRollbackServerGroupModal extends React.Component<
 
     const command = buildAmazonRollbackJob(application, serverGroup, this.rollbackType, values);
     this.state.taskMonitor.submit(() =>
-      AngularServices.serverGroupWriter.rollbackServerGroup(serverGroup, application, command),
+      this.context.services.serverGroupWriter.rollbackServerGroup(serverGroup, application, command),
     );
   };
 

--- a/deck/packages/amazon/src/serverGroup/details/sections/AdvancedSettingsDetailsSection.tsx
+++ b/deck/packages/amazon/src/serverGroup/details/sections/AdvancedSettingsDetailsSection.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { CollapsibleSection } from '@spinnaker/core';
+import { CollapsibleSection, DeckRuntimeContext } from '@spinnaker/core';
 import { HelpField } from '@spinnaker/core';
 
 import type { IAmazonServerGroupDetailsSectionProps } from './IAmazonServerGroupDetailsSectionProps';
@@ -8,9 +8,12 @@ import { EditAsgAdvancedSettingsModal } from '../advancedSettings';
 import { AWSProviderSettings } from '../../../aws.settings';
 
 export class AdvancedSettingsDetailsSection extends React.Component<IAmazonServerGroupDetailsSectionProps> {
+  public static contextType = DeckRuntimeContext;
+  public declare context: React.ContextType<typeof DeckRuntimeContext>;
+
   private editAdvancedSettings = (): void => {
     const { app: application, serverGroup } = this.props;
-    EditAsgAdvancedSettingsModal.show({ application, serverGroup });
+    EditAsgAdvancedSettingsModal.show({ application, serverGroup }, this.context.services);
   };
 
   public render(): JSX.Element {

--- a/deck/packages/amazon/src/serverGroup/details/sections/AmazonCapacityDetailsSection.tsx
+++ b/deck/packages/amazon/src/serverGroup/details/sections/AmazonCapacityDetailsSection.tsx
@@ -1,7 +1,13 @@
 import React from 'react';
 
 import type { ICapacity } from '@spinnaker/core';
-import { CapacityDetailsSection, CollapsibleSection, Overridable, ViewScalingActivitiesLink } from '@spinnaker/core';
+import {
+  CapacityDetailsSection,
+  CollapsibleSection,
+  DeckRuntimeContext,
+  Overridable,
+  ViewScalingActivitiesLink,
+} from '@spinnaker/core';
 
 import type { IAmazonServerGroupDetailsSectionProps } from './IAmazonServerGroupDetailsSectionProps';
 import { AWSProviderSettings } from '../../../aws.settings';
@@ -9,6 +15,9 @@ import { AmazonResizeServerGroupModal } from '../resize/AmazonResizeServerGroupM
 
 @Overridable('amazon.serverGroup.CapacityDetailsSection')
 export class AmazonCapacityDetailsSection extends React.Component<IAmazonServerGroupDetailsSectionProps> {
+  public static contextType = DeckRuntimeContext;
+  public declare context: React.ContextType<typeof DeckRuntimeContext>;
+
   public render(): JSX.Element {
     const { serverGroup, app: application } = this.props;
 
@@ -24,7 +33,10 @@ export class AmazonCapacityDetailsSection extends React.Component<IAmazonServerG
 
         <div>
           {AWSProviderSettings.adHocInfraWritesEnabled && (
-            <a className="clickable" onClick={() => AmazonResizeServerGroupModal.show({ application, serverGroup })}>
+            <a
+              className="clickable"
+              onClick={() => AmazonResizeServerGroupModal.show({ application, serverGroup }, this.context.services)}
+            >
               Resize Server Group
             </a>
           )}

--- a/deck/packages/amazon/src/serverGroup/details/sections/AmazonServerGroupMaintenanceActions.spec.tsx
+++ b/deck/packages/amazon/src/serverGroup/details/sections/AmazonServerGroupMaintenanceActions.spec.tsx
@@ -17,6 +17,7 @@ import { SecurityGroupsDetailsSection } from './SecurityGroupsDetailsSection';
 
 describe('Amazon server group maintenance action integration', () => {
   const originalAdHocInfraWritesEnabled = AWSProviderSettings.adHocInfraWritesEnabled;
+  const runtimeServices = {} as any;
   const editSecurityGroupsLabel = `Edit ${FirewallLabels.get('Firewalls')}`;
   const resolvedSecurityGroup = {
     accountName: 'test-account',
@@ -52,6 +53,11 @@ describe('Amazon server group maintenance action integration', () => {
   const editLink = (wrapper: ReturnType<typeof shallow>, label: string) =>
     wrapper.find('a.clickable').filterWhere((link) => link.text() === label);
 
+  const withRuntimeServices = <T extends React.Component>(wrapper: ReturnType<typeof shallow>) => {
+    (wrapper.instance() as T).context = { services: runtimeServices };
+    return wrapper;
+  };
+
   beforeEach(() => {
     AWSProviderSettings.adHocInfraWritesEnabled = true;
   });
@@ -62,11 +68,13 @@ describe('Amazon server group maintenance action integration', () => {
 
   it('opens Advanced Settings with the exact application and enriched server group', () => {
     const show = spyOn(EditAsgAdvancedSettingsModal, 'show');
-    const wrapper = shallow(<AdvancedSettingsDetailsSection app={application} serverGroup={serverGroup} />);
+    const wrapper = withRuntimeServices(
+      shallow(<AdvancedSettingsDetailsSection app={application} serverGroup={serverGroup} />),
+    );
 
     editLink(wrapper, 'Edit Advanced Settings').simulate('click');
 
-    expect(show).toHaveBeenCalledOnceWith({ application, serverGroup });
+    expect(show).toHaveBeenCalledOnceWith({ application, serverGroup }, runtimeServices);
   });
 
   it('opens Scaling Processes with the exact application and enriched server group', () => {
@@ -89,11 +97,16 @@ describe('Amazon server group maintenance action integration', () => {
 
   it('opens Security Groups with resolved groups and exact application and enriched server group', () => {
     const show = spyOn(EditSecurityGroupsModal, 'show');
-    const wrapper = shallow(<SecurityGroupsDetailsSection app={application} serverGroup={serverGroup} />);
+    const wrapper = withRuntimeServices(
+      shallow(<SecurityGroupsDetailsSection app={application} serverGroup={serverGroup} />),
+    );
 
     editLink(wrapper, editSecurityGroupsLabel).simulate('click');
 
-    expect(show).toHaveBeenCalledOnceWith({ application, securityGroups: [resolvedSecurityGroup], serverGroup });
+    expect(show).toHaveBeenCalledOnceWith(
+      { application, securityGroups: [resolvedSecurityGroup], serverGroup },
+      runtimeServices,
+    );
   });
 
   it('hides all maintenance links when ad-hoc infrastructure writes are disabled', () => {

--- a/deck/packages/amazon/src/serverGroup/details/sections/SecurityGroupsDetailsSection.tsx
+++ b/deck/packages/amazon/src/serverGroup/details/sections/SecurityGroupsDetailsSection.tsx
@@ -3,7 +3,7 @@ import { chain, find, sortBy } from 'lodash';
 import React from 'react';
 
 import type { ISecurityGroup, ISecurityGroupsByAccount } from '@spinnaker/core';
-import { CollapsibleSection, FirewallLabels } from '@spinnaker/core';
+import { CollapsibleSection, DeckRuntimeContext, FirewallLabels } from '@spinnaker/core';
 
 import type { IAmazonServerGroupDetailsSectionProps } from './IAmazonServerGroupDetailsSectionProps';
 import { AWSProviderSettings } from '../../../aws.settings';
@@ -18,6 +18,9 @@ export class SecurityGroupsDetailsSection extends React.Component<
   IAmazonServerGroupDetailsSectionProps,
   ISecurityGroupsDetailsSectionState
 > {
+  public static contextType = DeckRuntimeContext;
+  public declare context: React.ContextType<typeof DeckRuntimeContext>;
+
   constructor(props: IAmazonServerGroupDetailsSectionProps) {
     super(props);
 
@@ -68,7 +71,10 @@ export class SecurityGroupsDetailsSection extends React.Component<
 
   private editSecurityGroups = (): void => {
     const { app: application, serverGroup } = this.props;
-    EditSecurityGroupsModal.show({ application, securityGroups: this.state.securityGroups, serverGroup });
+    EditSecurityGroupsModal.show(
+      { application, securityGroups: this.state.securityGroups, serverGroup },
+      this.context.services,
+    );
   };
 
   public render(): JSX.Element {

--- a/deck/packages/amazon/src/serverGroup/details/securityGroups/EditSecurityGroupsModal.spec.tsx
+++ b/deck/packages/amazon/src/serverGroup/details/securityGroups/EditSecurityGroupsModal.spec.tsx
@@ -1,8 +1,9 @@
-import { shallow } from 'enzyme';
+import { mount as enzymeMount } from 'enzyme';
 import React from 'react';
 import Select from 'react-select';
+import { of } from 'rxjs';
 
-import { AngularServices, TaskMonitor } from '@spinnaker/core';
+import { AccountService, DeckRuntimeContext, TaskMonitor } from '@spinnaker/core';
 
 import { AwsModalFooter } from '../../../common/AwsModalFooter';
 
@@ -13,6 +14,24 @@ import {
 } from './EditSecurityGroupsModal';
 
 describe('EditSecurityGroupsModal', () => {
+  let originalAccounts: typeof AccountService.accounts$;
+  let runtimeServices: any;
+  const RuntimeWrapper = ({ children }: React.PropsWithChildren<{}>) => (
+    <DeckRuntimeContext.Provider value={{ services: runtimeServices } as any}>{children}</DeckRuntimeContext.Provider>
+  );
+  const shallowModal = (props: any) =>
+    enzymeMount(<EditSecurityGroupsModal {...props} />, { wrappingComponent: RuntimeWrapper });
+
+  beforeEach(() => {
+    originalAccounts = AccountService.accounts$;
+    AccountService.accounts$ = of([]);
+    runtimeServices = {};
+  });
+
+  afterEach(() => {
+    AccountService.accounts$ = originalAccounts;
+  });
+
   const serverGroup = {
     name: 'deck-main-v001',
     account: 'test',
@@ -73,10 +92,10 @@ describe('EditSecurityGroupsModal', () => {
     const getAllSecurityGroups = jasmine
       .createSpy('getAllSecurityGroups')
       .and.returnValues(Promise.reject(new Error('inventory unavailable')), Promise.resolve(allGroups));
-    spyOnProperty(AngularServices, 'securityGroupReader', 'get').and.returnValue({ getAllSecurityGroups } as any);
+    runtimeServices.securityGroupReader = { getAllSecurityGroups };
     spyOn(TaskMonitor, 'modalInstanceEmulation').and.returnValue({ result: Promise.resolve() } as any);
 
-    const wrapper = shallow(<EditSecurityGroupsModal {...modalProps} securityGroups={selected} />);
+    const wrapper = shallowModal({ ...modalProps, securityGroups: selected });
     await flush();
     wrapper.update();
 
@@ -107,9 +126,9 @@ describe('EditSecurityGroupsModal', () => {
         finishLoading = resolve;
       }),
     );
-    spyOnProperty(AngularServices, 'securityGroupReader', 'get').and.returnValue({ getAllSecurityGroups } as any);
+    runtimeServices.securityGroupReader = { getAllSecurityGroups };
     spyOn(TaskMonitor, 'modalInstanceEmulation').and.returnValue({ result: Promise.resolve() } as any);
-    const wrapper = shallow(<EditSecurityGroupsModal {...modalProps} />);
+    const wrapper = shallowModal(modalProps);
     const modal = wrapper.instance() as EditSecurityGroupsModal;
     const setState = spyOn(modal, 'setState').and.callThrough();
 
@@ -122,9 +141,7 @@ describe('EditSecurityGroupsModal', () => {
 
   it('submits selected groups through the writer with mixed-instance launch-template state', () => {
     spyOn(TaskMonitor, 'modalInstanceEmulation').and.returnValue({ result: Promise.resolve() } as any);
-    const update = spyOn(AngularServices.serverGroupWriter, 'updateSecurityGroups').and.returnValue(
-      Promise.resolve({} as any),
-    );
+    const update = jasmine.createSpy('updateSecurityGroups').and.returnValue(Promise.resolve({} as any));
     const selected = [{ id: 'sg-attached', name: 'attached' }] as any;
     const modal = new EditSecurityGroupsModal({
       application,
@@ -133,6 +150,7 @@ describe('EditSecurityGroupsModal', () => {
       closeModal: jasmine.createSpy('closeModal'),
       dismissModal: jasmine.createSpy('dismissModal'),
     } as any) as any;
+    modal.context = { services: { serverGroupWriter: { updateSecurityGroups: update } } };
     modal.state.taskMonitor = { submit: (method: () => any) => method() };
 
     modal.submit();

--- a/deck/packages/amazon/src/serverGroup/details/securityGroups/EditSecurityGroupsModal.tsx
+++ b/deck/packages/amazon/src/serverGroup/details/securityGroups/EditSecurityGroupsModal.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 import { Modal } from 'react-bootstrap';
 import Select from 'react-select';
 
-import type { Application, IModalComponentProps, ISecurityGroup } from '@spinnaker/core';
+import type { Application, DeckRuntimeServices, IModalComponentProps, ISecurityGroup } from '@spinnaker/core';
 import {
-  AngularServices,
   confirmNotManaged,
+  DeckRuntimeContext,
   FirewallLabels,
   ModalClose,
   ReactModal,
@@ -57,9 +57,12 @@ export class EditSecurityGroupsModal extends React.Component<
   IEditSecurityGroupsModalProps,
   IEditSecurityGroupsModalState
 > {
-  public static show(props: IEditSecurityGroupsModalProps) {
+  public static contextType = DeckRuntimeContext;
+  public declare context: React.ContextType<typeof DeckRuntimeContext>;
+
+  public static show(props: IEditSecurityGroupsModalProps, runtimeServices: DeckRuntimeServices) {
     return confirmNotManaged(props.serverGroup, props.application).then(
-      (notManaged) => notManaged && ReactModal.show(EditSecurityGroupsModal, props),
+      (notManaged) => notManaged && ReactModal.show(EditSecurityGroupsModal, props, undefined, runtimeServices),
     );
   }
 
@@ -91,7 +94,7 @@ export class EditSecurityGroupsModal extends React.Component<
 
   private loadSecurityGroups = () => {
     this.setState({ securityGroupsLoaded: false, securityGroupsLoadError: undefined });
-    return AngularServices.securityGroupReader
+    return this.context.services.securityGroupReader
       .getAllSecurityGroups()
       .then((allGroups) => {
         if (!this.isUnmounted) {
@@ -118,7 +121,7 @@ export class EditSecurityGroupsModal extends React.Component<
   private submit = () => {
     const { application, serverGroup } = this.props;
     this.state.taskMonitor.submit(() =>
-      AngularServices.serverGroupWriter.updateSecurityGroups(
+      this.context.services.serverGroupWriter.updateSecurityGroups(
         serverGroup,
         this.state.securityGroups,
         application,

--- a/deck/packages/app/scripts/angular-removal-guard.test.js
+++ b/deck/packages/app/scripts/angular-removal-guard.test.js
@@ -12,6 +12,21 @@ const bridgePath = path.join(coreSourceRoot, 'navigation/legacyStateConfig.bridg
 const legacyImportPackage = ['ng', 'import'].join('');
 const routeProvider = /['"](?:stateConfigProvider|applicationStateProvider)['"]/;
 const routerFacadeMembers = ['$' + 'state', '$' + 'stateParams', '$' + 'uiRouter', 'state' + 'Events', 'h' + 'as'];
+const runtimeServiceFacadeMembers = [
+  'cacheInitializer',
+  'clusterService',
+  'executionDetailsSectionService',
+  'executionService',
+  'infrastructureSearchService',
+  'instanceTypeService',
+  'loadBalancerReader',
+  'pageTitleService',
+  'providerServiceDelegate',
+  'securityGroupReader',
+  'serverGroupCommandBuilder',
+  'serverGroupTransformer',
+  'serverGroupWriter',
+];
 const angularServicesName = 'Angular' + 'Services';
 
 function productionSourceFiles(directory) {
@@ -45,7 +60,7 @@ function workspaceSourceFiles(directory) {
   });
 }
 
-function usesRouterFacadeMember(source, member) {
+function usesAngularServicesMember(source, member) {
   if (source.includes(`${angularServicesName}.${member}`)) {
     return true;
   }
@@ -53,7 +68,9 @@ function usesRouterFacadeMember(source, member) {
   const escapedMember = member.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   const indirectPropertyAccess = new RegExp(
     `${angularServicesName}\\s*\\[\\s*['"]${escapedMember}['"]\\s*\\]|` +
-      `spyOnProperty\\(\\s*${angularServicesName}\\s*,\\s*['"]${escapedMember}['"]`,
+      `spyOnProperty\\(\\s*${angularServicesName}\\s*,\\s*['"]${escapedMember}['"]|` +
+      `\\(\\s*${angularServicesName}\\s+as\\s+[^)]+\\)\\s*(?:\\.${escapedMember}|` +
+      `\\[\\s*['"]${escapedMember}['"]\\s*\\])`,
   );
   if (indirectPropertyAccess.test(source)) {
     return true;
@@ -120,7 +137,20 @@ test('Deck and Deck-Kayenta source and tests do not use AngularServices router f
     .flatMap((file) => {
       const source = readFileSync(file, 'utf8');
       return routerFacadeMembers
-        .filter((member) => usesRouterFacadeMember(source, member))
+        .filter((member) => usesAngularServicesMember(source, member))
+        .map((member) => `${path.relative(repositoryRoot, file)}: ${member}`);
+    });
+
+  assert.deepEqual(references, []);
+});
+
+test('Deck and Deck-Kayenta source and tests do not use AngularServices runtime service facade members', () => {
+  const references = routerConsumerRoots
+    .flatMap((root) => workspaceSourceFiles(root))
+    .flatMap((file) => {
+      const source = readFileSync(file, 'utf8');
+      return runtimeServiceFacadeMembers
+        .filter((member) => usesAngularServicesMember(source, member))
         .map((member) => `${path.relative(repositoryRoot, file)}: ${member}`);
     });
 

--- a/deck/packages/app/scripts/bootstrap-entry.test.js
+++ b/deck/packages/app/scripts/bootstrap-entry.test.js
@@ -39,6 +39,8 @@ test('app entry renders Deck directly without creating an AngularJS root module'
   assert.doesNotMatch(appEntry, /from 'angular'/);
   assert.doesNotMatch(appEntry, /module\('netflix\.spinnaker'/);
   assert.doesNotMatch(appEntry, /strictDi/);
+  assert.doesNotMatch(appEntry, /registerPreconfiguredJobStages/);
+  assert.doesNotMatch(appEntry, /registerPreconfiguredWebhookStages/);
 });
 
 test('app entry leaves settings ownership to the configured settings bundle', () => {

--- a/deck/packages/app/src/app.ts
+++ b/deck/packages/app/src/app.ts
@@ -15,10 +15,8 @@ import '@spinnaker/ecs';
 import '@spinnaker/cloudrun';
 import '@spinnaker/cloudfoundry';
 
-import { bootstrapDeck, registerPreconfiguredJobStages, registerPreconfiguredWebhookStages } from '@spinnaker/core';
+import { bootstrapDeck } from '@spinnaker/core';
 
-void registerPreconfiguredJobStages();
-void registerPreconfiguredWebhookStages();
 void bootstrapDeck(document.getElementById('spinnaker-root')).catch((error) => {
   console.error('Deck bootstrap failed', error);
 });

--- a/deck/packages/app/src/canary/canary/CanaryStageConfig.spec.tsx
+++ b/deck/packages/app/src/canary/canary/CanaryStageConfig.spec.tsx
@@ -1,28 +1,14 @@
-import { shallow } from 'enzyme';
-import React from 'react';
-
-import { CanaryStageConfig } from './CanaryStageConfig';
+import { initializeCanaryStage } from './CanaryStageConfig';
 
 describe('CanaryStageConfig', () => {
   it('initializes a missing canary config for an existing stage', () => {
-    const Component = CanaryStageConfig as React.ComponentType<any>;
     const stage = { baseline: {}, canary: {}, isNew: false, scaleUp: { enabled: false } } as any;
 
-    expect(() =>
-      shallow(
-        <Component
-          application={{ serverGroups: { ready: () => Promise.resolve() } }}
-          pipeline={{ name: 'Pipeline' }}
-          stage={stage}
-          stageFieldUpdated={() => undefined}
-        />,
-      ),
-    ).not.toThrow();
+    expect(() => initializeCanaryStage(stage, { name: 'Pipeline' }, { authenticated: false })).not.toThrow();
     expect(stage.canary.canaryConfig.canaryAnalysisConfig.notificationHours).toEqual([1, 2, 3]);
   });
 
   it('initializes a missing canary analysis config for an existing stage', () => {
-    const Component = CanaryStageConfig as React.ComponentType<any>;
     const stage = {
       baseline: {},
       canary: {
@@ -37,22 +23,12 @@ describe('CanaryStageConfig', () => {
       scaleUp: { enabled: false },
     } as any;
 
-    expect(() =>
-      shallow(
-        <Component
-          application={{ serverGroups: { ready: () => Promise.resolve() } }}
-          pipeline={{ name: 'Pipeline' }}
-          stage={stage}
-          stageFieldUpdated={() => undefined}
-        />,
-      ),
-    ).not.toThrow();
+    expect(() => initializeCanaryStage(stage, { name: 'Pipeline' }, { authenticated: false })).not.toThrow();
     expect(stage.canary.canaryConfig.name).toBe('Existing canary config');
     expect(stage.canary.canaryConfig.canaryAnalysisConfig.notificationHours).toEqual([1, 2, 3]);
   });
 
   it('initializes missing notification hours for an existing canary analysis config', () => {
-    const Component = CanaryStageConfig as React.ComponentType<any>;
     const stage = {
       baseline: {},
       canary: {
@@ -68,16 +44,7 @@ describe('CanaryStageConfig', () => {
       scaleUp: { enabled: false },
     } as any;
 
-    expect(() =>
-      shallow(
-        <Component
-          application={{ serverGroups: { ready: () => Promise.resolve() } }}
-          pipeline={{ name: 'Pipeline' }}
-          stage={stage}
-          stageFieldUpdated={() => undefined}
-        />,
-      ),
-    ).not.toThrow();
+    expect(() => initializeCanaryStage(stage, { name: 'Pipeline' }, { authenticated: false })).not.toThrow();
     expect(stage.canary.canaryConfig.canaryAnalysisConfig.name).toBe('Existing analysis config');
     expect(stage.canary.canaryConfig.canaryAnalysisConfig.notificationHours).toEqual([1, 2, 3]);
   });

--- a/deck/packages/app/src/canary/canary/CanaryStageConfig.tsx
+++ b/deck/packages/app/src/canary/canary/CanaryStageConfig.tsx
@@ -4,13 +4,13 @@ import React from 'react';
 import type { IStageConfigProps } from '@spinnaker/core';
 import {
   AccountService,
-  AngularServices,
   AppListExtractor,
   AuthenticationService,
   CloudProviderRegistry,
   HelpField,
   NameUtils,
   ProviderSelectionService,
+  useDeckRuntimeServices,
 } from '@spinnaker/core';
 
 import { CanaryAnalysisNameSelector } from './CanaryAnalysisNameSelector';
@@ -82,9 +82,7 @@ function getDefaultCanaryConfig(pipeline: any) {
   };
 }
 
-export function CanaryStageConfig(props: IStageConfigProps) {
-  const { application, pipeline, stage, stageFieldUpdated } = props;
-  const user = AuthenticationService.getAuthenticatedUser();
+export function initializeCanaryStage(stage: any, pipeline: any, user: any): { cc: any; cac: any } {
   stage.baseline = stage.baseline || {};
   stage.scaleUp = stage.scaleUp || { enabled: false };
   stage.canary = stage.canary || {};
@@ -99,8 +97,18 @@ export function CanaryStageConfig(props: IStageConfigProps) {
     stage.canary.canaryConfig.canaryAnalysisConfig.notificationHours ||
     defaultCanaryConfig.canaryAnalysisConfig.notificationHours;
 
-  const cc = stage.canary.canaryConfig;
-  const cac = cc.canaryAnalysisConfig;
+  return {
+    cc: stage.canary.canaryConfig,
+    cac: stage.canary.canaryConfig.canaryAnalysisConfig,
+  };
+}
+
+export function CanaryStageConfig(props: IStageConfigProps) {
+  const runtimeServices = useDeckRuntimeServices();
+  const { serverGroupCommandBuilder, serverGroupTransformer } = runtimeServices;
+  const { application, pipeline, stage, stageFieldUpdated } = props;
+  const user = AuthenticationService.getAuthenticatedUser();
+  const { cc, cac } = initializeCanaryStage(stage, pipeline, user);
   cc.lifetimeHours = !isExpression(cc.lifetimeHours) ? toInteger(cc.lifetimeHours) || undefined : cc.lifetimeHours;
   cac.lookbackMins = !isExpression(cac.lookbackMins) ? toInteger(cac.lookbackMins) || undefined : cac.lookbackMins;
   cac.canaryAnalysisIntervalMins = !isExpression(cac.canaryAnalysisIntervalMins)
@@ -184,7 +192,7 @@ export function CanaryStageConfig(props: IStageConfigProps) {
       (selectedProvider: string) => {
         const config = CloudProviderRegistry.getValue(selectedProvider, 'serverGroup');
         const title = 'Add Cluster Pair';
-        AngularServices.serverGroupCommandBuilder
+        serverGroupCommandBuilder
           .buildNewServerGroupCommandForPipeline(selectedProvider, stage, pipeline)
           .then((command: any) => {
             configureServerGroupCommandForEditing(command);
@@ -197,12 +205,10 @@ export function CanaryStageConfig(props: IStageConfigProps) {
                 new Error(`No React clone server group modal is registered for provider "${selectedProvider}".`),
               );
             }
-            return config.CloneServerGroupModal.show({ title, application, command });
+            return config.CloneServerGroupModal.show({ title, application, command }, runtimeServices);
           })
           .then((command: any) => {
-            const baselineCluster = AngularServices.serverGroupTransformer.convertServerGroupCommandToDeployConfiguration(
-              command,
-            );
+            const baselineCluster = serverGroupTransformer.convertServerGroupCommandToDeployConfiguration(command);
             const canaryCluster = cloneDeep(baselineCluster);
             cleanupClusterConfig(baselineCluster, 'baseline');
             cleanupClusterConfig(canaryCluster, 'canary');
@@ -219,7 +225,7 @@ export function CanaryStageConfig(props: IStageConfigProps) {
     cluster.provider = cluster.provider || getCloudProvider() || 'aws';
     const config = CloudProviderRegistry.getValue(cluster.provider, 'serverGroup');
     const title = `Configure ${type} Cluster`;
-    AngularServices.serverGroupCommandBuilder
+    serverGroupCommandBuilder
       .buildServerGroupCommandFromPipeline(application, cluster, stage, pipeline)
       .then((command: any) => {
         configureServerGroupCommandForEditing(command);
@@ -236,12 +242,10 @@ export function CanaryStageConfig(props: IStageConfigProps) {
             new Error(`No React clone server group modal is registered for provider "${cluster.provider}".`),
           );
         }
-        return config.CloneServerGroupModal.show({ title, application, command });
+        return config.CloneServerGroupModal.show({ title, application, command }, runtimeServices);
       })
       .then((command: any) => {
-        const stageCluster = AngularServices.serverGroupTransformer.convertServerGroupCommandToDeployConfiguration(
-          command,
-        );
+        const stageCluster = serverGroupTransformer.convertServerGroupCommandToDeployConfiguration(command);
         cleanupClusterConfig(stageCluster, type);
         stage.clusterPairs[index][type.toLowerCase()] = stageCluster;
         stageFieldUpdated();

--- a/deck/packages/app/src/providerRoutes.spec.ts
+++ b/deck/packages/app/src/providerRoutes.spec.ts
@@ -1,4 +1,4 @@
-import type { UIRouterReact } from '@uirouter/react';
+import { UIRouterReact } from '@uirouter/react';
 
 import '@spinnaker/ecs';
 import '@spinnaker/kubernetes';
@@ -12,6 +12,8 @@ import {
 } from '../../core/src/application/applicationState.registration';
 // eslint-disable-next-line @spinnaker/import-from-npm-not-relative
 import '../../core/src/navigation/coreRoutes';
+// eslint-disable-next-line @spinnaker/import-from-npm-not-relative
+import { createDeckRuntime } from '../../core/src/bootstrap/DeckRuntime';
 // eslint-disable-next-line @spinnaker/import-from-npm-not-relative
 import { setDirectRouter } from '../../core/src/navigation/directRouter';
 // eslint-disable-next-line @spinnaker/import-from-npm-not-relative
@@ -47,7 +49,10 @@ describe('direct provider route registration', () => {
   });
 
   it('loads Kubernetes and ECS states into both application trees', () => {
-    router = configureRouter();
+    router = new UIRouterReact();
+    const runtime = createDeckRuntime(router);
+    router.disposable(runtime);
+    configureRouter(router, runtime.services);
     const stateNames = router.stateRegistry.get().map((state) => state.name);
 
     [

--- a/deck/packages/azure/src/securityGroup/details/AzureSecurityGroupDetails.tsx
+++ b/deck/packages/azure/src/securityGroup/details/AzureSecurityGroupDetails.tsx
@@ -8,7 +8,13 @@ import type {
   ISecurityGroupDetail,
   SecurityGroupReader,
 } from '@spinnaker/core';
-import { AccountTag, AngularServices, CollapsibleSection, ConfirmationModalService, withRouter } from '@spinnaker/core';
+import {
+  AccountTag,
+  CollapsibleSection,
+  ConfirmationModalService,
+  DeckRuntimeContext,
+  withRouter,
+} from '@spinnaker/core';
 
 import { AzureSecurityGroupModal } from '../configure/AzureSecurityGroupModal';
 import { AzureSecurityGroupWriter } from '../securityGroup.write.service';
@@ -41,6 +47,9 @@ export class AzureSecurityGroupDetailsComponent extends React.Component<
   IAzureSecurityGroupDetailsProps & IRouterInjectedProps,
   IAzureSecurityGroupDetailsState
 > {
+  public static contextType = DeckRuntimeContext;
+  public declare context: React.ContextType<typeof DeckRuntimeContext>;
+
   public state: IAzureSecurityGroupDetailsState = { loading: true };
 
   private isUnmounted = false;
@@ -82,7 +91,7 @@ export class AzureSecurityGroupDetailsComponent extends React.Component<
   }
 
   private getSecurityGroupReader(): SecurityGroupReader {
-    return this.props.securityGroupReader || AngularServices.securityGroupReader;
+    return this.props.securityGroupReader || this.context.services.securityGroupReader;
   }
 
   private loadSecurityGroup = (): void => {

--- a/deck/packages/azure/src/serverGroup/configure/serverGroupConfiguration.service.js
+++ b/deck/packages/azure/src/serverGroup/configure/serverGroupConfiguration.service.js
@@ -1,17 +1,25 @@
 import _ from 'lodash';
 
-import { AccountService, AngularServices } from '@spinnaker/core';
+import { AccountService } from '@spinnaker/core';
 import { AzureInstanceTypeService } from '../../instance/azureInstanceType.service';
 
 export class AzureServerGroupConfigurationService {
-  constructor($q) {
+  static requiresDeckRuntimeServices = true;
+
+  constructor($q, runtimeServices) {
     this.$q = $q;
     this.azureInstanceTypeService = new AzureInstanceTypeService($q);
+    this.cacheInitializer = runtimeServices.cacheInitializer;
+    this.loadBalancerReader = runtimeServices.loadBalancerReader;
+    this.securityGroupReader = runtimeServices.securityGroupReader;
   }
 
   createDelegate() {
     const all = this.$q && this.$q.all ? this.$q.all.bind(this.$q) : Promise.all.bind(Promise);
     const azureInstanceTypeService = this.azureInstanceTypeService;
+    const cacheInitializer = this.cacheInitializer;
+    const loadBalancerReader = this.loadBalancerReader;
+    const securityGroupReader = this.securityGroupReader;
     const dataDiskTypes = ['Standard_LRS', 'StandardSSD_LRS', 'Premium_LRS'];
     const dataDiskCachingTypes = ['None', 'ReadOnly', 'ReadWrite'];
 
@@ -32,8 +40,6 @@ export class AzureServerGroupConfigurationService {
     }
 
     function configureCommand(application, command) {
-      const securityGroupReader = AngularServices.securityGroupReader;
-      const loadBalancerReader = AngularServices.loadBalancerReader;
       return all([
         AccountService.getCredentialsKeyedByAccount('azure'),
         securityGroupReader.loadSecurityGroups(),
@@ -200,8 +206,6 @@ export class AzureServerGroupConfigurationService {
     }
 
     function refreshSecurityGroups(command, skipCommandReconfiguration) {
-      const cacheInitializer = AngularServices.cacheInitializer;
-      const securityGroupReader = AngularServices.securityGroupReader;
       return cacheInitializer.refreshCache('securityGroups').then(function () {
         return securityGroupReader.getAllSecurityGroups().then(function (securityGroups) {
           command.backingData.securityGroups = securityGroups;
@@ -236,7 +240,6 @@ export class AzureServerGroupConfigurationService {
     }
 
     function refreshLoadBalancers(command, skipCommandReconfiguration) {
-      const loadBalancerReader = AngularServices.loadBalancerReader;
       return loadBalancerReader.listLoadBalancers('azure').then(function (loadBalancers) {
         command.backingData.loadBalancers = loadBalancers;
         if (!skipCommandReconfiguration) {
@@ -326,7 +329,6 @@ export class AzureServerGroupConfigurationService {
     }
 
     function refreshInstanceTypes(command) {
-      const cacheInitializer = AngularServices.cacheInitializer;
       return cacheInitializer.refreshCache('instanceTypes').then(function () {
         return azureInstanceTypeService.getAllTypesByRegion().then(function (instanceTypes) {
           command.backingData.instanceTypes = instanceTypes;

--- a/deck/packages/azure/src/serverGroup/configure/serverGroupConfiguration.service.spec.js
+++ b/deck/packages/azure/src/serverGroup/configure/serverGroupConfiguration.service.spec.js
@@ -6,7 +6,11 @@ describe('Service: azureServerGroupConfiguration', function () {
   var service;
 
   beforeEach(function () {
-    service = new AzureServerGroupConfigurationService(Promise);
+    service = new AzureServerGroupConfigurationService(Promise, {
+      cacheInitializer: {},
+      loadBalancerReader: {},
+      securityGroupReader: {},
+    });
 
     this.allLoadBalancers = [
       {

--- a/deck/packages/azure/src/serverGroup/configure/wizard/AzureCloneServerGroupModal.spec.tsx
+++ b/deck/packages/azure/src/serverGroup/configure/wizard/AzureCloneServerGroupModal.spec.tsx
@@ -4,7 +4,6 @@ import {
   DeploymentStrategySelector,
   MapEditor,
   NetworkReader,
-  AngularServices,
   ReactModal,
   TaskMonitor,
   WizardModal,
@@ -15,6 +14,7 @@ import React from 'react';
 
 import { registerAzureProvider } from '../../../azure.module';
 import { AzureServerGroupTransformer } from '../../serverGroup.transformer';
+import { AzureServerGroupConfigurationService } from '../serverGroupConfiguration.service';
 import {
   AzureCloneServerGroupModal as RoutedAzureCloneServerGroupModal,
   AzureCloneServerGroupModalComponent as AzureCloneServerGroupModal,
@@ -30,6 +30,7 @@ import {
 } from './pages';
 
 describe('AzureCloneServerGroupModal', () => {
+  let runtimeServices: any;
   const application = {
     name: 'fnord',
     serverGroups: {
@@ -73,7 +74,40 @@ describe('AzureCloneServerGroupModal', () => {
       dismiss: () => null,
       result: Promise.resolve(),
     } as any);
+    runtimeServices = {
+      cacheInitializer: {},
+      loadBalancerReader: { getLoadBalancerDetails: jasmine.createSpy('getLoadBalancerDetails') },
+      securityGroupReader: {},
+    };
+    const configurationService = new AzureServerGroupConfigurationService(Promise, runtimeServices);
+    runtimeServices.providerServiceDelegate = {
+      getDelegate: jasmine.createSpy('getDelegate').and.returnValue(configurationService),
+    };
   });
+
+  function shallowModal(serverGroupCommand: any): any {
+    const wrapper = shallow(
+      <AzureCloneServerGroupModal
+        title="Configure"
+        application={application}
+        command={serverGroupCommand}
+        closeModal={jasmine.createSpy('closeModal')}
+        dismissModal={jasmine.createSpy('dismissModal')}
+      />,
+      { disableLifecycleMethods: true },
+    );
+    const modal = wrapper.instance() as any;
+    modal.context = { services: runtimeServices };
+    modal.componentDidMount();
+    wrapper.update();
+    return wrapper;
+  }
+
+  function loadBalancerPage(serverGroupCommand: any): any {
+    const page = new ServerGroupLoadBalancers({ formik: formik(serverGroupCommand) } as any) as any;
+    page.context = { services: runtimeServices };
+    return page;
+  }
 
   function formik(values: any): any {
     return {
@@ -100,19 +134,24 @@ describe('AzureCloneServerGroupModal', () => {
 
   it('show opens the React wizard and resolves with the submitted pipeline command', async () => {
     const serverGroupCommand = command();
+    const runtimeServices = {} as any;
     spyOn(ReactModal, 'show').and.returnValue(Promise.resolve(serverGroupCommand));
 
-    const result = await RoutedAzureCloneServerGroupModal.show({
-      title: 'Configure',
-      application,
-      command: serverGroupCommand,
-    } as any);
+    const result = await RoutedAzureCloneServerGroupModal.show(
+      {
+        title: 'Configure',
+        application,
+        command: serverGroupCommand,
+      } as any,
+      runtimeServices,
+    );
 
     expect(result).toBe(serverGroupCommand);
     expect(ReactModal.show).toHaveBeenCalledWith(
       RoutedAzureCloneServerGroupModal,
       jasmine.objectContaining({ title: 'Configure', application, command: serverGroupCommand }),
       { dialogClassName: 'wizard-modal modal-lg' },
+      runtimeServices,
     );
   });
 
@@ -122,7 +161,10 @@ describe('AzureCloneServerGroupModal', () => {
     spyOn(ReactModal, 'show').and.returnValue(Promise.reject('cancelled'));
 
     await expectAsync(
-      RoutedAzureCloneServerGroupModal.show({ title: 'Clone', application, command: serverGroupCommand } as any),
+      RoutedAzureCloneServerGroupModal.show(
+        { title: 'Clone', application, command: serverGroupCommand } as any,
+        {} as any,
+      ),
     ).toBeRejectedWith('cancelled');
 
     expect(JSON.stringify(serverGroupCommand)).toBe(original);
@@ -157,15 +199,7 @@ describe('AzureCloneServerGroupModal', () => {
 
   it('renders the React wizard with Azure pages in parity order', () => {
     const serverGroupCommand = command();
-    const wrapper = shallow(
-      <AzureCloneServerGroupModal
-        title="Configure"
-        application={application}
-        command={serverGroupCommand}
-        closeModal={jasmine.createSpy('closeModal')}
-        dismissModal={jasmine.createSpy('dismissModal')}
-      />,
-    );
+    const wrapper = shallowModal(serverGroupCommand);
 
     wrapper.setState({ loaded: true });
     const wizard = wrapper.find(WizardModal);
@@ -215,15 +249,7 @@ describe('AzureCloneServerGroupModal', () => {
 
   it('renders template selection before configuring deploy-stage commands', () => {
     const serverGroupCommand = { viewState: { requiresTemplateSelection: true, disableStrategySelection: true } };
-    const wrapper = shallow(
-      <AzureCloneServerGroupModal
-        title="Configure"
-        application={application}
-        command={serverGroupCommand}
-        closeModal={jasmine.createSpy('closeModal')}
-        dismissModal={jasmine.createSpy('dismissModal')}
-      />,
-    );
+    const wrapper = shallowModal(serverGroupCommand);
 
     expect(wrapper.find(DeployInitializer).exists()).toBe(true);
     expect(wrapper.find(WizardModal).exists()).toBe(false);
@@ -237,15 +263,7 @@ describe('AzureCloneServerGroupModal', () => {
       ],
     });
 
-    const wrapper = shallow(
-      <AzureCloneServerGroupModal
-        title="Configure"
-        application={application}
-        command={serverGroupCommand}
-        closeModal={jasmine.createSpy('closeModal')}
-        dismissModal={jasmine.createSpy('dismissModal')}
-      />,
-    );
+    const wrapper = shallowModal(serverGroupCommand);
     const workingCommand = (wrapper.state() as any).command;
 
     expect(workingCommand.backingData.filtered.images).toEqual([{ imageName: 'ubuntu-west', ami: 'ami-west' }]);
@@ -261,15 +279,7 @@ describe('AzureCloneServerGroupModal', () => {
         { imageName: 'ubuntu-east', amis: { eastus: ['ami-east'] } },
       ],
     });
-    const wrapper = shallow(
-      <AzureCloneServerGroupModal
-        title="Configure"
-        application={application}
-        command={serverGroupCommand}
-        closeModal={jasmine.createSpy('closeModal')}
-        dismissModal={jasmine.createSpy('dismissModal')}
-      />,
-    );
+    const wrapper = shallowModal(serverGroupCommand);
     const workingCommand = (wrapper.state() as any).command;
 
     workingCommand.region = 'eastus';
@@ -329,9 +339,9 @@ describe('AzureCloneServerGroupModal', () => {
         filtered: { loadBalancers: ['lb-a'] },
       },
     });
-    spyOnProperty(AngularServices as any, 'loadBalancerReader', 'get').and.returnValue({
+    runtimeServices.loadBalancerReader = {
       getLoadBalancerDetails: () => Promise.resolve([{ vnet: 'vnet-a' }]),
-    });
+    };
     spyOn(NetworkReader, 'listNetworks').and.returnValue(
       Promise.resolve({
         azure: [
@@ -349,7 +359,7 @@ describe('AzureCloneServerGroupModal', () => {
       } as any),
     );
 
-    const page = new ServerGroupLoadBalancers({ formik: formik(serverGroupCommand) } as any) as any;
+    const page = loadBalancerPage(serverGroupCommand);
     await page.loadBalancerChanged('lb-a');
 
     expect(serverGroupCommand.loadBalancerType).toBe('Azure Application Gateway');
@@ -368,9 +378,9 @@ describe('AzureCloneServerGroupModal', () => {
         filtered: { loadBalancers: ['lb-a'] },
       },
     });
-    spyOnProperty(AngularServices as any, 'loadBalancerReader', 'get').and.returnValue({
+    runtimeServices.loadBalancerReader = {
       getLoadBalancerDetails: () => Promise.resolve([{ vnet: 'vnet-a' }]),
-    });
+    };
     spyOn(NetworkReader, 'listNetworks').and.returnValue(
       Promise.resolve({
         azure: [
@@ -385,7 +395,7 @@ describe('AzureCloneServerGroupModal', () => {
       } as any),
     );
 
-    const page = new ServerGroupLoadBalancers({ formik: formik(serverGroupCommand) } as any) as any;
+    const page = loadBalancerPage(serverGroupCommand);
     await page.loadBalancerChanged('lb-a');
 
     expect(serverGroupCommand.selectedVnet.name).toBe('vnet-a');
@@ -404,9 +414,9 @@ describe('AzureCloneServerGroupModal', () => {
       selectedVnetSubnets: ['old-subnet'],
       backingData: { loadBalancers: [], filtered: { loadBalancers: [] } },
     });
-    spyOnProperty(AngularServices as any, 'loadBalancerReader', 'get').and.returnValue({
+    runtimeServices.loadBalancerReader = {
       getLoadBalancerDetails: jasmine.createSpy('getLoadBalancerDetails'),
-    });
+    };
     spyOn(NetworkReader, 'listNetworks').and.returnValue(
       Promise.resolve({
         azure: [
@@ -421,7 +431,7 @@ describe('AzureCloneServerGroupModal', () => {
       } as any),
     );
 
-    const page = new ServerGroupLoadBalancers({ formik: formik(serverGroupCommand) } as any) as any;
+    const page = loadBalancerPage(serverGroupCommand);
     await page.loadVnetSubnets(null, null, 0);
 
     expect(serverGroupCommand.selectedVnet.subnets).toEqual([{ name: 'subnet-new', devices: [] }]);
@@ -438,9 +448,9 @@ describe('AzureCloneServerGroupModal', () => {
       selectedVnetSubnets: [],
       backingData: { loadBalancers: [], filtered: { loadBalancers: [] } },
     });
-    spyOnProperty(AngularServices as any, 'loadBalancerReader', 'get').and.returnValue({
+    runtimeServices.loadBalancerReader = {
       getLoadBalancerDetails: jasmine.createSpy('getLoadBalancerDetails'),
-    });
+    };
     spyOn(NetworkReader, 'listNetworks').and.returnValue(
       Promise.resolve({
         azure: [
@@ -455,7 +465,7 @@ describe('AzureCloneServerGroupModal', () => {
       } as any),
     );
 
-    const page = new ServerGroupLoadBalancers({ formik: formik(serverGroupCommand) } as any) as any;
+    const page = loadBalancerPage(serverGroupCommand);
     page.componentDidMount();
     await Promise.resolve();
     await Promise.resolve();
@@ -558,12 +568,12 @@ describe('AzureCloneServerGroupModal', () => {
       selectedVnetSubnets: [],
       backingData: { loadBalancers: [], filtered: { loadBalancers: [] } },
     });
-    spyOnProperty(AngularServices as any, 'loadBalancerReader', 'get').and.returnValue({
+    runtimeServices.loadBalancerReader = {
       getLoadBalancerDetails: jasmine.createSpy('getLoadBalancerDetails'),
-    });
+    };
     spyOn(NetworkReader, 'listNetworks').and.returnValue(Promise.reject(new Error('boom')));
 
-    const page = new ServerGroupLoadBalancers({ formik: formik(serverGroupCommand) } as any) as any;
+    const page = loadBalancerPage(serverGroupCommand);
 
     await expectAsync(page.loadVnetSubnets(null, null, 0)).toBeResolved();
 
@@ -583,12 +593,12 @@ describe('AzureCloneServerGroupModal', () => {
       vnet: 'old-vnet',
       vnetResourceGroup: 'old-rg',
     });
-    spyOnProperty(AngularServices as any, 'loadBalancerReader', 'get').and.returnValue({
+    runtimeServices.loadBalancerReader = {
       getLoadBalancerDetails: jasmine.createSpy('getLoadBalancerDetails'),
-    });
+    };
     spyOn(NetworkReader, 'listNetworks').and.returnValue(Promise.reject(new Error('boom')));
 
-    const page = new ServerGroupLoadBalancers({ formik: formik(serverGroupCommand) } as any) as any;
+    const page = loadBalancerPage(serverGroupCommand);
 
     await page.loadBalancerChanged('lb-b', true);
 
@@ -614,9 +624,9 @@ describe('AzureCloneServerGroupModal', () => {
         filtered: { loadBalancers: ['lb-a'] },
       },
     });
-    spyOnProperty(AngularServices as any, 'loadBalancerReader', 'get').and.returnValue({
+    runtimeServices.loadBalancerReader = {
       getLoadBalancerDetails: () => Promise.resolve([]),
-    });
+    };
     spyOn(NetworkReader, 'listNetworks').and.returnValue(
       Promise.resolve({
         azure: [
@@ -625,7 +635,7 @@ describe('AzureCloneServerGroupModal', () => {
       } as any),
     );
 
-    const page = new ServerGroupLoadBalancers({ formik: formik(serverGroupCommand) } as any) as any;
+    const page = loadBalancerPage(serverGroupCommand);
     await page.loadBalancerChanged('lb-a');
 
     expect(serverGroupCommand.loadBalancerType).toBe('Azure Load Balancer');
@@ -647,7 +657,7 @@ describe('AzureCloneServerGroupModal', () => {
       },
     });
     let resolveFirstRequest: (details: any[]) => void;
-    spyOnProperty(AngularServices as any, 'loadBalancerReader', 'get').and.returnValue({
+    runtimeServices.loadBalancerReader = {
       getLoadBalancerDetails: (_provider: string, _account: string, _region: string, loadBalancerName: string) => {
         if (loadBalancerName === 'lb-a') {
           return new Promise((resolve) => {
@@ -656,7 +666,7 @@ describe('AzureCloneServerGroupModal', () => {
         }
         return Promise.resolve([{ vnet: 'vnet-b' }]);
       },
-    });
+    };
     spyOn(NetworkReader, 'listNetworks').and.returnValue(
       Promise.resolve({
         azure: [
@@ -666,7 +676,7 @@ describe('AzureCloneServerGroupModal', () => {
       } as any),
     );
 
-    const page = new ServerGroupLoadBalancers({ formik: formik(serverGroupCommand) } as any) as any;
+    const page = loadBalancerPage(serverGroupCommand);
     const firstRequest = page.loadBalancerChanged('lb-a');
     const secondRequest = page.loadBalancerChanged('lb-b');
     await secondRequest;

--- a/deck/packages/azure/src/serverGroup/configure/wizard/AzureCloneServerGroupModal.tsx
+++ b/deck/packages/azure/src/serverGroup/configure/wizard/AzureCloneServerGroupModal.tsx
@@ -3,13 +3,14 @@ import React from 'react';
 
 import type {
   Application,
+  DeckRuntimeServices,
   IModalComponentProps,
   IRouterInjectedProps,
   IStage,
   ITemplateSelectionText,
 } from '@spinnaker/core';
 import {
-  AngularServices,
+  DeckRuntimeContext,
   DeployInitializer,
   FirewallLabels,
   noop,
@@ -32,7 +33,7 @@ import {
   ServerGroupSecurityGroups,
   ServerGroupTags,
 } from './pages';
-import { AzureServerGroupConfigurationService } from '../serverGroupConfiguration.service';
+import type { AzureServerGroupConfigurationService } from '../serverGroupConfiguration.service';
 
 export interface IAzureCloneServerGroupModalProps extends IModalComponentProps {
   application: Application;
@@ -52,16 +53,22 @@ export class AzureCloneServerGroupModalComponent extends React.Component<
   IAzureCloneServerGroupModalProps & IRouterInjectedProps,
   IAzureCloneServerGroupModalState
 > {
+  public static contextType = DeckRuntimeContext;
+  public declare context: React.ContextType<typeof DeckRuntimeContext>;
+
   public static defaultProps: Partial<IAzureCloneServerGroupModalProps> = {
     closeModal: noop,
     dismissModal: noop,
   };
 
   private _isUnmounted = false;
-  private configurationService = new AzureServerGroupConfigurationService(null);
-
-  public static show(props: IAzureCloneServerGroupModalProps): Promise<any> {
-    return ReactModal.show(AzureCloneServerGroupModal, props, { dialogClassName: 'wizard-modal modal-lg' });
+  public static show(props: IAzureCloneServerGroupModalProps, runtimeServices: DeckRuntimeServices): Promise<any> {
+    return ReactModal.show(
+      AzureCloneServerGroupModal,
+      props,
+      { dialogClassName: 'wizard-modal modal-lg' },
+      runtimeServices,
+    );
   }
 
   constructor(props: IAzureCloneServerGroupModalProps & IRouterInjectedProps) {
@@ -101,12 +108,18 @@ export class AzureCloneServerGroupModalComponent extends React.Component<
       }),
       templateSelectionText,
     };
+  }
 
-    if (alreadyConfigured) {
-      this.completeConfiguration(workingCommand);
-    } else if (!requiresTemplateSelection) {
+  public componentDidMount(): void {
+    if (this.state.loaded) {
+      this.completeConfiguration(this.state.command);
+    } else if (!this.state.requiresTemplateSelection) {
       this.prepareCommand();
     }
+  }
+
+  private get configurationService(): AzureServerGroupConfigurationService {
+    return this.context.services.providerServiceDelegate.getDelegate('azure', 'serverGroup.configurationService');
   }
 
   private templateSelected = (): void => {
@@ -223,7 +236,7 @@ export class AzureCloneServerGroupModalComponent extends React.Component<
       return this.props.closeModal(command);
     }
     return this.state.taskMonitor.submit(() =>
-      AngularServices.serverGroupWriter.cloneServerGroup(command, this.props.application),
+      this.context.services.serverGroupWriter.cloneServerGroup(command, this.props.application),
     );
   };
 

--- a/deck/packages/azure/src/serverGroup/configure/wizard/pages/ServerGroupLoadBalancers.tsx
+++ b/deck/packages/azure/src/serverGroup/configure/wizard/pages/ServerGroupLoadBalancers.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { AngularServices, InfrastructureCaches, NetworkReader } from '@spinnaker/core';
+import { DeckRuntimeContext, InfrastructureCaches, NetworkReader } from '@spinnaker/core';
 
 import { AzureWizardPage } from './common';
 import Utility from '../../../../utility';
@@ -34,11 +34,10 @@ function matchesSelectedVnet(candidate: any, selectedVnet: any): boolean {
   );
 }
 
-function getLoadBalancerReader(): any {
-  return (AngularServices as any).loadBalancerReader;
-}
-
 export class ServerGroupLoadBalancers extends AzureWizardPage {
+  public static contextType = DeckRuntimeContext;
+  public declare context: React.ContextType<typeof DeckRuntimeContext>;
+
   private loadVnetSubnetsRequestId = 0;
 
   private getCommandLoadBalancer(loadBalancerName: string | null): any {
@@ -119,7 +118,12 @@ export class ServerGroupLoadBalancers extends AzureWizardPage {
     try {
       [loadBalancerDetails, networks] = await Promise.all([
         loadBalancerName
-          ? getLoadBalancerReader().getLoadBalancerDetails('azure', credentials, region, loadBalancerName)
+          ? this.context.services.loadBalancerReader.getLoadBalancerDetails(
+              'azure',
+              credentials,
+              region,
+              loadBalancerName,
+            )
           : Promise.resolve([]),
         NetworkReader.listNetworks(),
       ]);

--- a/deck/packages/azure/src/serverGroup/details/azureServerGroupDetails.spec.tsx
+++ b/deck/packages/azure/src/serverGroup/details/azureServerGroupDetails.spec.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import {
   CloudProviderRegistry,
   ConfirmationModalService,
+  DeckRuntimeContext,
   ServerGroupReader,
   ServerGroupWarningMessageService,
 } from '@spinnaker/core';
@@ -20,6 +21,7 @@ import {
 } from './azureServerGroupDetails';
 
 describe('Azure server group details', () => {
+  let runtimeServices: any;
   const stateService = { go: jasmine.createSpy('go'), includes: jasmine.createSpy('includes').and.returnValue(true) };
   const routerProps = { router: {} as any, stateParams: {}, stateService: stateService as any };
   const serverGroupParams = {
@@ -47,6 +49,22 @@ describe('Azure server group details', () => {
         error: reject,
       });
     });
+  }
+
+  function mountActions(app: any, serverGroup: any) {
+    runtimeServices = {
+      serverGroupCommandBuilder: new AzureServerGroupCommandBuilder(Promise),
+      serverGroupWriter: {
+        destroyServerGroup: jasmine.createSpy('destroyServerGroup'),
+        disableServerGroup: jasmine.createSpy('disableServerGroup'),
+        enableServerGroup: jasmine.createSpy('enableServerGroup'),
+      },
+    };
+    return mount(
+      <DeckRuntimeContext.Provider value={{ services: runtimeServices }}>
+        <AzureServerGroupActions {...routerProps} app={app} serverGroup={serverGroup} />
+      </DeckRuntimeContext.Provider>,
+    );
   }
 
   beforeEach(() => {
@@ -155,7 +173,7 @@ describe('Azure server group details', () => {
     spyOn(ServerGroupWarningMessageService, 'addDestroyWarningMessage');
     spyOn(ServerGroupWarningMessageService, 'addDisableWarningMessage');
 
-    const wrapper = mount(<AzureServerGroupActions {...routerProps} app={app} serverGroup={serverGroup as any} />);
+    const wrapper = mountActions(app, serverGroup);
     wrapper
       .find('a')
       .filterWhere((node) => node.text() === 'Destroy')
@@ -188,7 +206,7 @@ describe('Azure server group details', () => {
     );
     spyOn(AzureCloneServerGroupModal, 'show').and.returnValue(Promise.resolve());
 
-    const wrapper = mount(<AzureServerGroupActions {...routerProps} app={app} serverGroup={serverGroup as any} />);
+    const wrapper = mountActions(app, serverGroup);
     wrapper
       .find('a')
       .filterWhere((node) => node.text() === 'Clone')
@@ -199,11 +217,14 @@ describe('Azure server group details', () => {
       app,
       serverGroup,
     );
-    expect(AzureCloneServerGroupModal.show).toHaveBeenCalledWith({
-      application: app,
-      command,
-      title: 'Clone azure-v001',
-    });
+    expect(AzureCloneServerGroupModal.show).toHaveBeenCalledWith(
+      {
+        application: app,
+        command,
+        title: 'Clone azure-v001',
+      },
+      runtimeServices,
+    );
   });
 
   it('opens the clone wizard with image data seeded on the built command', async () => {
@@ -227,7 +248,7 @@ describe('Azure server group details', () => {
     spyOn(AzureImageReader.prototype, 'findImages').and.returnValue(Promise.resolve(images));
     spyOn(AzureCloneServerGroupModal, 'show').and.returnValue(Promise.resolve());
 
-    const wrapper = mount(<AzureServerGroupActions {...routerProps} app={app} serverGroup={serverGroup as any} />);
+    const wrapper = mountActions(app, serverGroup);
     wrapper
       .find('a')
       .filterWhere((node) => node.text() === 'Clone')

--- a/deck/packages/azure/src/serverGroup/details/azureServerGroupDetails.tsx
+++ b/deck/packages/azure/src/serverGroup/details/azureServerGroupDetails.tsx
@@ -11,7 +11,6 @@ import type {
 } from '@spinnaker/core';
 import {
   AccountTag,
-  AngularServices,
   CloudProviderRegistry,
   CollapsibleSection,
   ConfirmationModalService,
@@ -20,10 +19,10 @@ import {
   ServerGroupReader,
   ServerGroupWarningMessageService,
   timestamp,
+  useDeckRuntimeServices,
   withRouter,
 } from '@spinnaker/core';
 
-import { AzureServerGroupCommandBuilder } from '../configure/serverGroupCommandBuilder.service';
 import { AzureRollbackServerGroupModal } from './rollback/RollbackServerGroupModal';
 
 function findServerGroupSummary(props: IServerGroupDetailsProps): PromiseLike<any> {
@@ -137,6 +136,8 @@ export function AzureServerGroupActionsComponent({
   serverGroup,
   stateService,
 }: IServerGroupActionsProps & IRouterInjectedProps) {
+  const runtimeServices = useDeckRuntimeServices();
+  const { serverGroupCommandBuilder, serverGroupWriter } = runtimeServices;
   const destroyServerGroup = (): void => {
     const stateParams = {
       name: serverGroup.name,
@@ -157,7 +158,7 @@ export function AzureServerGroupActionsComponent({
           }
         },
       },
-      submitMethod: (params: any) => AngularServices.serverGroupWriter.destroyServerGroup(serverGroup, app, params),
+      submitMethod: (params: any) => serverGroupWriter.destroyServerGroup(serverGroup, app, params),
     };
 
     ServerGroupWarningMessageService.addDestroyWarningMessage(app, serverGroup, confirmationModalParams);
@@ -173,8 +174,7 @@ export function AzureServerGroupActionsComponent({
         application: app,
         title: `Disabling ${serverGroup.name}`,
       },
-      submitMethod: (params: any) =>
-        AngularServices.serverGroupWriter.disableServerGroup(serverGroup, app.name, params),
+      submitMethod: (params: any) => serverGroupWriter.disableServerGroup(serverGroup, app.name, params),
     };
 
     ServerGroupWarningMessageService.addDisableWarningMessage(app, serverGroup, confirmationModalParams);
@@ -191,7 +191,7 @@ export function AzureServerGroupActionsComponent({
         title: `Enabling ${serverGroup.name}`,
       },
       submitMethod: (params: any) =>
-        AngularServices.serverGroupWriter.enableServerGroup(serverGroup, app, {
+        serverGroupWriter.enableServerGroup(serverGroup, app, {
           ...params,
           interestingHealthProviderNames: [],
         }),
@@ -205,17 +205,15 @@ export function AzureServerGroupActionsComponent({
     const disabledServerGroups = (cluster?.serverGroups || []).filter((candidate: any) => {
       return candidate.isDisabled && candidate.region === serverGroup.region;
     });
-    AzureRollbackServerGroupModal.show({ application: app, serverGroup, disabledServerGroups });
+    AzureRollbackServerGroupModal.show({ application: app, serverGroup, disabledServerGroups }, runtimeServices);
   };
 
   const cloneServerGroup = (): void => {
     const CloneServerGroupModal = CloudProviderRegistry.getValue('azure', 'serverGroup.CloneServerGroupModal');
     if (CloneServerGroupModal?.show) {
-      new AzureServerGroupCommandBuilder(null)
-        .buildServerGroupCommandFromExisting(app, serverGroup)
-        .then((command: any) => {
-          CloneServerGroupModal.show({ application: app, command, title: `Clone ${serverGroup.name}` });
-        });
+      serverGroupCommandBuilder.buildServerGroupCommandFromExisting(app, serverGroup).then((command: any) => {
+        CloneServerGroupModal.show({ application: app, command, title: `Clone ${serverGroup.name}` }, runtimeServices);
+      });
     }
   };
 

--- a/deck/packages/azure/src/serverGroup/details/rollback/RollbackServerGroupModal.tsx
+++ b/deck/packages/azure/src/serverGroup/details/rollback/RollbackServerGroupModal.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 import { Modal } from 'react-bootstrap';
 import Select from 'react-select';
 
-import type { IModalComponentProps } from '@spinnaker/core';
+import type { DeckRuntimeServices, IModalComponentProps } from '@spinnaker/core';
 import {
-  AngularServices,
+  DeckRuntimeContext,
   ModalClose,
   noop,
   ReactModal,
@@ -31,14 +31,17 @@ export class AzureRollbackServerGroupModal extends React.Component<
   IAzureRollbackServerGroupModalProps,
   IAzureRollbackServerGroupModalState
 > {
+  public static contextType = DeckRuntimeContext;
+  public declare context: React.ContextType<typeof DeckRuntimeContext>;
+
   public static defaultProps: Partial<IAzureRollbackServerGroupModalProps> = {
     closeModal: noop,
     dismissModal: noop,
   };
 
-  public static show(props: IAzureRollbackServerGroupModalProps) {
+  public static show(props: IAzureRollbackServerGroupModalProps, runtimeServices: DeckRuntimeServices) {
     const modalProps = {};
-    return ReactModal.show(AzureRollbackServerGroupModal, props, modalProps);
+    return ReactModal.show(AzureRollbackServerGroupModal, props, modalProps, runtimeServices);
   }
 
   constructor(props: IAzureRollbackServerGroupModalProps) {
@@ -72,7 +75,9 @@ export class AzureRollbackServerGroupModal extends React.Component<
     const { command, taskMonitor } = this.state;
     const { serverGroup, application } = this.props;
 
-    taskMonitor.submit(() => AngularServices.serverGroupWriter.rollbackServerGroup(serverGroup, application, command));
+    taskMonitor.submit(() =>
+      this.context.services.serverGroupWriter.rollbackServerGroup(serverGroup, application, command),
+    );
   };
 
   private filterServerGroups = (disabledServerGroups: any[]) => {

--- a/deck/packages/cloudfoundry/src/loadBalancer/configure/CloudFoundryMapLoadBalancerModal.tsx
+++ b/deck/packages/cloudfoundry/src/loadBalancer/configure/CloudFoundryMapLoadBalancerModal.tsx
@@ -7,6 +7,7 @@ import { takeUntil } from 'rxjs/operators';
 
 import type {
   Application,
+  DeckRuntimeServices,
   IAccount,
   ILoadBalancerModalProps,
   IModalComponentProps,
@@ -14,7 +15,7 @@ import type {
 } from '@spinnaker/core';
 import {
   AccountService,
-  AngularServices,
+  DeckRuntimeContext,
   ModalClose,
   noop,
   ReactModal,
@@ -49,6 +50,9 @@ export class CloudFoundryMapLoadBalancerModal extends React.Component<
   ICloudFoundryLoadBalancerModalProps,
   ICreateCloudFoundryMapLoadBalancerState
 > {
+  public static contextType = DeckRuntimeContext;
+  public declare context: React.ContextType<typeof DeckRuntimeContext>;
+
   public static defaultProps: Partial<ICloudFoundryLoadBalancerModalProps> = {
     closeModal: noop,
     dismissModal: noop,
@@ -82,7 +86,7 @@ export class CloudFoundryMapLoadBalancerModal extends React.Component<
       .subscribe((rawAccounts: IAccount[]) => this.setState({ accounts: rawAccounts }));
   }
 
-  public static show(props: ILoadBalancerModalProps): Promise<void> {
+  public static show(props: ILoadBalancerModalProps, runtimeServices: DeckRuntimeServices): Promise<void> {
     const modalProps = { dialogClassName: 'wizard-modal modal-lg' };
     return ReactModal.show(
       CloudFoundryMapLoadBalancerModal,
@@ -91,6 +95,7 @@ export class CloudFoundryMapLoadBalancerModal extends React.Component<
         // className: 'create-pipeline-modal-overflow-visible',
       },
       modalProps,
+      runtimeServices,
     );
   }
 
@@ -126,7 +131,7 @@ export class CloudFoundryMapLoadBalancerModal extends React.Component<
     };
 
     this.state.taskMonitor.submit(() => {
-      return AngularServices.serverGroupWriter.mapLoadBalancers(coreServerGroup, this.props.application, {
+      return this.context.services.serverGroupWriter.mapLoadBalancers(coreServerGroup, this.props.application, {
         serverGroupName: serverGroup.name,
       });
     });

--- a/deck/packages/cloudfoundry/src/pipeline/stages/cloneServerGroup/CloudFoundryCloneServerGroupStageConfig.tsx
+++ b/deck/packages/cloudfoundry/src/pipeline/stages/cloneServerGroup/CloudFoundryCloneServerGroupStageConfig.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import type { IStageConfigProps } from '@spinnaker/core';
-import { StageConstants } from '@spinnaker/core';
+import { DeckRuntimeContext, StageConstants } from '@spinnaker/core';
 import { CloudFoundryServerGroupCommandBuilder } from '../../../serverGroup/configure';
 import { CloudFoundryCreateServerGroupModal } from '../../../serverGroup/configure/wizard/CreateServerGroupModal';
 
@@ -13,6 +13,9 @@ export class CloudFoundryCloneServerGroupStageConfig extends React.Component<
   IStageConfigProps,
   ICloudFoundryCloneServerGroupStageConfigState
 > {
+  public static contextType = DeckRuntimeContext;
+  public declare context: React.ContextType<typeof DeckRuntimeContext>;
+
   constructor(props: IStageConfigProps) {
     super(props);
     this.props.updateStageField({
@@ -48,12 +51,15 @@ export class CloudFoundryCloneServerGroupStageConfig extends React.Component<
     const { application, stage, pipeline } = this.props;
     const title = 'Clone Cluster';
     const command = CloudFoundryServerGroupCommandBuilder.buildCloneServerGroupCommandFromPipeline(stage, pipeline);
-    CloudFoundryCreateServerGroupModal.show({
-      application,
-      command,
-      isSourceConstant: false,
-      title,
-    })
+    CloudFoundryCreateServerGroupModal.show(
+      {
+        application,
+        command,
+        isSourceConstant: false,
+        title,
+      },
+      this.context.services,
+    )
       .then(this.handleResult)
       .catch(() => {});
   };

--- a/deck/packages/cloudfoundry/src/serverGroup/configure/wizard/CreateServerGroupModal.tsx
+++ b/deck/packages/cloudfoundry/src/serverGroup/configure/wizard/CreateServerGroupModal.tsx
@@ -1,8 +1,8 @@
 import { get } from 'lodash';
 import React from 'react';
 
-import type { Application, IModalComponentProps, IPipeline, IStage } from '@spinnaker/core';
-import { AngularServices, noop, ReactModal, TaskMonitor, WizardModal, WizardPage } from '@spinnaker/core';
+import type { Application, DeckRuntimeServices, IModalComponentProps, IPipeline, IStage } from '@spinnaker/core';
+import { DeckRuntimeContext, noop, ReactModal, TaskMonitor, WizardModal, WizardPage } from '@spinnaker/core';
 
 import { ServerGroupTemplateSelection } from './ServerGroupTemplateSelection';
 import type { ICloudFoundryServerGroup } from '../../../domain';
@@ -36,14 +36,20 @@ export class CloudFoundryCreateServerGroupModal extends React.Component<
   ICloudFoundryCreateServerGroupProps,
   ICloudFoundryCreateServerGroupState
 > {
+  public static contextType = DeckRuntimeContext;
+  public declare context: React.ContextType<typeof DeckRuntimeContext>;
+
   public static defaultProps: Partial<ICloudFoundryCreateServerGroupProps> = {
     closeModal: noop,
     dismissModal: noop,
   };
 
-  public static show(props: ICloudFoundryCreateServerGroupProps): Promise<ICloudFoundryCreateServerGroupCommand> {
+  public static show(
+    props: ICloudFoundryCreateServerGroupProps,
+    runtimeServices: DeckRuntimeServices,
+  ): Promise<ICloudFoundryCreateServerGroupCommand> {
     const modalProps = { dialogClassName: 'wizard-modal modal-lg' };
-    return ReactModal.show(CloudFoundryCreateServerGroupModal, props, modalProps);
+    return ReactModal.show(CloudFoundryCreateServerGroupModal, props, modalProps, runtimeServices);
   }
 
   constructor(props: ICloudFoundryCreateServerGroupProps) {
@@ -89,11 +95,11 @@ export class CloudFoundryCreateServerGroupModal extends React.Component<
       this.props.closeModal && this.props.closeModal(command);
     } else if (command.viewState.mode === 'clone') {
       this.state.taskMonitor.submit(() =>
-        AngularServices.serverGroupWriter.cloneServerGroup(command, this.props.application),
+        this.context.services.serverGroupWriter.cloneServerGroup(command, this.props.application),
       );
     } else {
       this.state.taskMonitor.submit(() =>
-        AngularServices.serverGroupWriter.cloneServerGroup(command, this.props.application),
+        this.context.services.serverGroupWriter.cloneServerGroup(command, this.props.application),
       );
     }
   };

--- a/deck/packages/cloudfoundry/src/serverGroup/details/cloudFoundryServerGroupActions.tsx
+++ b/deck/packages/cloudfoundry/src/serverGroup/details/cloudFoundryServerGroupActions.tsx
@@ -5,9 +5,9 @@ import { Dropdown, Tooltip } from 'react-bootstrap';
 import type { IOwnerOption, IRouterInjectedProps, IServerGroupActionsProps, IServerGroupJob } from '@spinnaker/core';
 import {
   AddEntityTagLinks,
-  AngularServices,
   ClusterTargetBuilder,
   ConfirmationModalService,
+  DeckRuntimeContext,
   ServerGroupWarningMessageService,
   SETTINGS,
   withRouter,
@@ -32,6 +32,9 @@ export interface ICloudFoundryServerGroupJob extends IServerGroupJob {
 export class CloudFoundryServerGroupActionsComponent extends React.Component<
   ICloudFoundryServerGroupActionsProps & IRouterInjectedProps
 > {
+  public static contextType = DeckRuntimeContext;
+  public declare context: React.ContextType<typeof DeckRuntimeContext>;
+
   private isEnableLocked(): boolean {
     if (this.props.serverGroup.isDisabled) {
       const resizeTasks = (this.props.serverGroup.runningTasks || []).filter((task) =>
@@ -90,7 +93,7 @@ export class CloudFoundryServerGroupActionsComponent extends React.Component<
 
     const submitMethod = (params: ICloudFoundryServerGroupJob) => {
       params.serverGroupName = serverGroup.name;
-      return AngularServices.serverGroupWriter.destroyServerGroup(serverGroup, app, params);
+      return this.context.services.serverGroupWriter.destroyServerGroup(serverGroup, app, params);
     };
 
     const confirmationModalParams = {
@@ -123,7 +126,7 @@ export class CloudFoundryServerGroupActionsComponent extends React.Component<
 
     const submitMethod = (params: ICloudFoundryServerGroupJob) => {
       params.serverGroupName = serverGroup.name;
-      return AngularServices.serverGroupWriter.disableServerGroup(serverGroup, app.name, params);
+      return this.context.services.serverGroupWriter.disableServerGroup(serverGroup, app.name, params);
     };
 
     const confirmationModalParams = {
@@ -181,7 +184,7 @@ export class CloudFoundryServerGroupActionsComponent extends React.Component<
 
     const submitMethod = (params: ICloudFoundryServerGroupJob) => {
       params.serverGroupName = serverGroup.name;
-      return AngularServices.serverGroupWriter.enableServerGroup(serverGroup, app, params);
+      return this.context.services.serverGroupWriter.enableServerGroup(serverGroup, app, params);
     };
 
     const confirmationModalParams = {
@@ -245,41 +248,47 @@ export class CloudFoundryServerGroupActionsComponent extends React.Component<
       region: serverGroup.region,
     }) as ICloudFoundryServerGroup[];
 
-    CloudFoundryRollbackServerGroupModal.show({
-      serverGroup,
-      previousServerGroup,
-      disabledServerGroups: disabledServerGroups.sort((a, b) => b.name.localeCompare(a.name)),
-      allServerGroups: allServerGroups.sort((a, b) => b.name.localeCompare(a.name)),
-      application: app,
-    });
+    CloudFoundryRollbackServerGroupModal.show(
+      {
+        serverGroup,
+        previousServerGroup,
+        disabledServerGroups: disabledServerGroups.sort((a, b) => b.name.localeCompare(a.name)),
+        allServerGroups: allServerGroups.sort((a, b) => b.name.localeCompare(a.name)),
+        application: app,
+      },
+      this.context.services,
+    );
   };
 
   private resizeServerGroup = (): void => {
     const { app, serverGroup } = this.props;
-    CloudFoundryResizeServerGroupModal.show({ application: app, serverGroup });
+    CloudFoundryResizeServerGroupModal.show({ application: app, serverGroup }, this.context.services);
   };
 
   private mapServerGroupToLoadBalancers = (): void => {
     const { app, serverGroup } = this.props;
-    CloudFoundryMapLoadBalancersModal.show({ application: app, serverGroup });
+    CloudFoundryMapLoadBalancersModal.show({ application: app, serverGroup }, this.context.services);
   };
 
   private unmapServerGroupFromLoadBalancers = (): void => {
     const { app, serverGroup } = this.props;
-    CloudFoundryUnmapLoadBalancersModal.show({ application: app, serverGroup });
+    CloudFoundryUnmapLoadBalancersModal.show({ application: app, serverGroup }, this.context.services);
   };
 
   private cloneServerGroup = (): void => {
     const { app, serverGroup } = this.props;
     const command = CloudFoundryServerGroupCommandBuilder.buildServerGroupCommandFromExisting(app, serverGroup);
     const title = `Clone ${serverGroup.name}`;
-    CloudFoundryCreateServerGroupModal.show({
-      application: app,
-      command,
-      isSourceConstant: true,
-      serverGroup,
-      title,
-    });
+    CloudFoundryCreateServerGroupModal.show(
+      {
+        application: app,
+        command,
+        isSourceConstant: true,
+        serverGroup,
+        title,
+      },
+      this.context.services,
+    );
   };
 
   public render(): JSX.Element {

--- a/deck/packages/cloudfoundry/src/serverGroup/details/mapLoadBalancers/CloudFoundryMapLoadBalancersModal.tsx
+++ b/deck/packages/cloudfoundry/src/serverGroup/details/mapLoadBalancers/CloudFoundryMapLoadBalancersModal.tsx
@@ -3,9 +3,15 @@ import { Form } from 'formik';
 import React from 'react';
 import { Modal, ModalFooter } from 'react-bootstrap';
 
-import type { Application, IModalComponentProps, IServerGroup, IServerGroupJob } from '@spinnaker/core';
+import type {
+  Application,
+  DeckRuntimeServices,
+  IModalComponentProps,
+  IServerGroup,
+  IServerGroupJob,
+} from '@spinnaker/core';
 import {
-  AngularServices,
+  DeckRuntimeContext,
   ModalClose,
   noop,
   ReactModal,
@@ -40,6 +46,9 @@ export class CloudFoundryMapLoadBalancersModal extends React.Component<
   ICloudFoundryLoadBalancerLinksModalProps,
   ICloudFoundryLoadBalancerLinksModalState
 > {
+  public static contextType = DeckRuntimeContext;
+  public declare context: React.ContextType<typeof DeckRuntimeContext>;
+
   public static defaultProps: Partial<ICloudFoundryLoadBalancerLinksModalProps> = {
     closeModal: noop,
     dismissModal: noop,
@@ -47,8 +56,11 @@ export class CloudFoundryMapLoadBalancersModal extends React.Component<
 
   private formikRef = React.createRef<Formik<ICloudFoundryLoadBalancerLinksModalValues>>();
 
-  public static show(props: ICloudFoundryLoadBalancerLinksModalProps): Promise<ICloudFoundryLoadBalancerLinkJob> {
-    return ReactModal.show(CloudFoundryMapLoadBalancersModal, props, {});
+  public static show(
+    props: ICloudFoundryLoadBalancerLinksModalProps,
+    runtimeServices: DeckRuntimeServices,
+  ): Promise<ICloudFoundryLoadBalancerLinkJob> {
+    return ReactModal.show(CloudFoundryMapLoadBalancersModal, props, {}, runtimeServices);
   }
 
   constructor(props: ICloudFoundryLoadBalancerLinksModalProps) {
@@ -87,7 +99,7 @@ export class CloudFoundryMapLoadBalancersModal extends React.Component<
     };
 
     this.state.taskMonitor.submit(() => {
-      return AngularServices.serverGroupWriter.mapLoadBalancers(coreServerGroup, this.props.application, {
+      return this.context.services.serverGroupWriter.mapLoadBalancers(coreServerGroup, this.props.application, {
         serverGroupName: serverGroup.name,
       });
     });

--- a/deck/packages/cloudfoundry/src/serverGroup/details/mapLoadBalancers/CloudFoundryUnmapLoadBalancersModal.tsx
+++ b/deck/packages/cloudfoundry/src/serverGroup/details/mapLoadBalancers/CloudFoundryUnmapLoadBalancersModal.tsx
@@ -3,9 +3,15 @@ import { Form } from 'formik';
 import React from 'react';
 import { Modal, ModalFooter } from 'react-bootstrap';
 
-import type { Application, IModalComponentProps, IServerGroup, IServerGroupJob } from '@spinnaker/core';
+import type {
+  Application,
+  DeckRuntimeServices,
+  IModalComponentProps,
+  IServerGroup,
+  IServerGroupJob,
+} from '@spinnaker/core';
 import {
-  AngularServices,
+  DeckRuntimeContext,
   ModalClose,
   noop,
   ReactModal,
@@ -40,6 +46,9 @@ export class CloudFoundryUnmapLoadBalancersModal extends React.Component<
   ICloudFoundryLoadBalancerLinksModalProps,
   ICloudFoundryLoadBalancerLinksModalState
 > {
+  public static contextType = DeckRuntimeContext;
+  public declare context: React.ContextType<typeof DeckRuntimeContext>;
+
   public static defaultProps: Partial<ICloudFoundryLoadBalancerLinksModalProps> = {
     closeModal: noop,
     dismissModal: noop,
@@ -47,8 +56,11 @@ export class CloudFoundryUnmapLoadBalancersModal extends React.Component<
 
   private formikRef = React.createRef<Formik<ICloudFoundryLoadBalancerLinksModalValues>>();
 
-  public static show(props: ICloudFoundryLoadBalancerLinksModalProps): Promise<ICloudFoundryLoadBalancerLinkJob> {
-    return ReactModal.show(CloudFoundryUnmapLoadBalancersModal, props, {});
+  public static show(
+    props: ICloudFoundryLoadBalancerLinksModalProps,
+    runtimeServices: DeckRuntimeServices,
+  ): Promise<ICloudFoundryLoadBalancerLinkJob> {
+    return ReactModal.show(CloudFoundryUnmapLoadBalancersModal, props, {}, runtimeServices);
   }
 
   constructor(props: ICloudFoundryLoadBalancerLinksModalProps) {
@@ -87,7 +99,7 @@ export class CloudFoundryUnmapLoadBalancersModal extends React.Component<
     };
 
     this.state.taskMonitor.submit(() => {
-      return AngularServices.serverGroupWriter.unmapLoadBalancers(coreServerGroup, this.props.application, {
+      return this.context.services.serverGroupWriter.unmapLoadBalancers(coreServerGroup, this.props.application, {
         serverGroupName: serverGroup.name,
       });
     });

--- a/deck/packages/cloudfoundry/src/serverGroup/details/resize/CloudFoundryResizeServerGroupModal.tsx
+++ b/deck/packages/cloudfoundry/src/serverGroup/details/resize/CloudFoundryResizeServerGroupModal.tsx
@@ -3,9 +3,15 @@ import { Form } from 'formik';
 import React from 'react';
 import { Modal, ModalFooter } from 'react-bootstrap';
 
-import type { Application, ICapacity, IModalComponentProps, IServerGroupJob } from '@spinnaker/core';
+import type {
+  Application,
+  DeckRuntimeServices,
+  ICapacity,
+  IModalComponentProps,
+  IServerGroupJob,
+} from '@spinnaker/core';
 import {
-  AngularServices,
+  DeckRuntimeContext,
   FormikFormField,
   ModalClose,
   noop,
@@ -49,6 +55,9 @@ export class CloudFoundryResizeServerGroupModal extends React.Component<
   ICloudFoundryResizeServerGroupModalProps,
   ICloudFoundryResizeServerGroupModalState
 > {
+  public static contextType = DeckRuntimeContext;
+  public declare context: React.ContextType<typeof DeckRuntimeContext>;
+
   public static defaultProps: Partial<ICloudFoundryResizeServerGroupModalProps> = {
     closeModal: noop,
     dismissModal: noop,
@@ -56,9 +65,12 @@ export class CloudFoundryResizeServerGroupModal extends React.Component<
 
   private formikRef = React.createRef<Formik<ICloudFoundryResizeServerGroupValues>>();
 
-  public static show(props: ICloudFoundryResizeServerGroupModalProps): Promise<ICloudFoundryResizeJob> {
+  public static show(
+    props: ICloudFoundryResizeServerGroupModalProps,
+    runtimeServices: DeckRuntimeServices,
+  ): Promise<ICloudFoundryResizeJob> {
     const modalProps = {};
-    return ReactModal.show(CloudFoundryResizeServerGroupModal, props, modalProps);
+    return ReactModal.show(CloudFoundryResizeServerGroupModal, props, modalProps, runtimeServices);
   }
 
   constructor(props: ICloudFoundryResizeServerGroupModalProps) {
@@ -103,7 +115,7 @@ export class CloudFoundryResizeServerGroupModal extends React.Component<
     };
 
     this.state.taskMonitor.submit(() => {
-      return AngularServices.serverGroupWriter.resizeServerGroup(serverGroup, application, command);
+      return this.context.services.serverGroupWriter.resizeServerGroup(serverGroup, application, command);
     });
   };
 

--- a/deck/packages/cloudfoundry/src/serverGroup/details/rollback/CloudFoundryRollbackServerGroupModal.tsx
+++ b/deck/packages/cloudfoundry/src/serverGroup/details/rollback/CloudFoundryRollbackServerGroupModal.tsx
@@ -3,9 +3,9 @@ import { Form } from 'formik';
 import React from 'react';
 import { Modal, ModalFooter } from 'react-bootstrap';
 
-import type { Application, IModalComponentProps, IServerGroupJob } from '@spinnaker/core';
+import type { Application, DeckRuntimeServices, IModalComponentProps, IServerGroupJob } from '@spinnaker/core';
 import {
-  AngularServices,
+  DeckRuntimeContext,
   FormikFormField,
   ModalClose,
   noop,
@@ -50,6 +50,9 @@ export class CloudFoundryRollbackServerGroupModal extends React.Component<
   ICloudFoundryRollbackServerGroupModalProps,
   ICloudFoundryRollbackServerGroupModalState
 > {
+  public static contextType = DeckRuntimeContext;
+  public declare context: React.ContextType<typeof DeckRuntimeContext>;
+
   public static defaultProps: Partial<ICloudFoundryRollbackServerGroupModalProps> = {
     closeModal: noop,
     dismissModal: noop,
@@ -57,9 +60,12 @@ export class CloudFoundryRollbackServerGroupModal extends React.Component<
 
   private formikRef = React.createRef<Formik<ICloudFoundryRollbackServerGroupValues>>();
 
-  public static show(props: ICloudFoundryRollbackServerGroupModalProps): Promise<ICloudFoundryRollbackJob> {
+  public static show(
+    props: ICloudFoundryRollbackServerGroupModalProps,
+    runtimeServices: DeckRuntimeServices,
+  ): Promise<ICloudFoundryRollbackJob> {
     const modalProps = {};
-    return ReactModal.show(CloudFoundryRollbackServerGroupModal, props, modalProps);
+    return ReactModal.show(CloudFoundryRollbackServerGroupModal, props, modalProps, runtimeServices);
   }
 
   constructor(props: ICloudFoundryRollbackServerGroupModalProps) {
@@ -99,7 +105,7 @@ export class CloudFoundryRollbackServerGroupModal extends React.Component<
     };
 
     this.state.taskMonitor.submit(() => {
-      return AngularServices.serverGroupWriter.rollbackServerGroup(serverGroup, application, command);
+      return this.context.services.serverGroupWriter.rollbackServerGroup(serverGroup, application, command);
     });
   };
 

--- a/deck/packages/cloudrun/src/serverGroup/configure/wizard/serverGroupWizard.tsx
+++ b/deck/packages/cloudrun/src/serverGroup/configure/wizard/serverGroupWizard.tsx
@@ -1,7 +1,21 @@
 import React from 'react';
 
-import type { Application, IModalComponentProps, IRouterInjectedProps, IStage } from '@spinnaker/core';
-import { AngularServices, noop, ReactModal, TaskMonitor, withRouter, WizardModal, WizardPage } from '@spinnaker/core';
+import type {
+  Application,
+  DeckRuntimeServices,
+  IModalComponentProps,
+  IRouterInjectedProps,
+  IStage,
+} from '@spinnaker/core';
+import {
+  DeckRuntimeContext,
+  noop,
+  ReactModal,
+  TaskMonitor,
+  withRouter,
+  WizardModal,
+  WizardPage,
+} from '@spinnaker/core';
 
 import { WizardServerGroupBasicSettings } from './BasicSettings';
 import { WizardServerGroupConfigFilesSettings } from './ConfigFiles';
@@ -27,6 +41,9 @@ export class ServerGroupWizardComponent extends React.Component<
   ICloudrunServerGroupModalProps & IRouterInjectedProps,
   ICloudrunServerGroupModalState
 > {
+  public static contextType = DeckRuntimeContext;
+  public declare context: React.ContextType<typeof DeckRuntimeContext>;
+
   public static defaultProps: Partial<ICloudrunServerGroupModalProps & IRouterInjectedProps> = {
     closeModal: noop,
     dismissModal: noop,
@@ -35,9 +52,12 @@ export class ServerGroupWizardComponent extends React.Component<
   private _isUnmounted = false;
 
   /*     private serverGroupWriter: ServerGroupWriter; */
-  public static show(props: ICloudrunServerGroupModalProps): Promise<ICloudrunServerGroupCommandData> {
+  public static show(
+    props: ICloudrunServerGroupModalProps,
+    runtimeServices: DeckRuntimeServices,
+  ): Promise<ICloudrunServerGroupCommandData> {
     const modalProps = { dialogClassName: 'wizard-modal modal-lg' };
-    return ReactModal.show(ServerGroupWizard, props, modalProps);
+    return ReactModal.show(ServerGroupWizard, props, modalProps, runtimeServices);
   }
 
   constructor(props: ICloudrunServerGroupModalProps & IRouterInjectedProps) {
@@ -112,7 +132,8 @@ export class ServerGroupWizardComponent extends React.Component<
       this.props.closeModal && this.props.closeModal(command);
     } else {
       //command.viewState.mode = 'create';
-      const submitMethod = () => AngularServices.serverGroupWriter.cloneServerGroup(command, this.props.application);
+      const submitMethod = () =>
+        this.context.services.serverGroupWriter.cloneServerGroup(command, this.props.application);
       this.state.taskMonitor.submit(submitMethod);
       return null;
     }

--- a/deck/packages/cloudrun/src/serverGroup/details/CloudrunServerGroupActions.tsx
+++ b/deck/packages/cloudrun/src/serverGroup/details/CloudrunServerGroupActions.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Dropdown, MenuItem } from 'react-bootstrap';
 
 import type { IRouterInjectedProps, IServerGroupActionsProps } from '@spinnaker/core';
-import { AngularServices, ConfirmationModalService, withRouter } from '@spinnaker/core';
+import { ConfirmationModalService, useDeckRuntimeServices, withRouter } from '@spinnaker/core';
 
 import { CloudrunHealth } from '../../common/cloudrunHealth';
 import type { ICloudrunServerGroup } from '../../interfaces';
@@ -12,6 +12,7 @@ export function CloudrunServerGroupActionsComponent({
   serverGroup,
   stateService,
 }: IServerGroupActionsProps & IRouterInjectedProps) {
+  const { serverGroupWriter } = useDeckRuntimeServices();
   const cloudrunServerGroup = serverGroup as ICloudrunServerGroup;
   const canDestroyServerGroup = Boolean(
     cloudrunServerGroup && !cloudrunServerGroup.tags?.isLatest && cloudrunServerGroup.disabled,
@@ -36,8 +37,7 @@ export function CloudrunServerGroupActionsComponent({
       buttonText: `Destroy ${cloudrunServerGroup.name}`,
       account: cloudrunServerGroup.account,
       taskMonitorConfig: taskMonitor,
-      submitMethod: (params: any) =>
-        AngularServices.serverGroupWriter.destroyServerGroup(cloudrunServerGroup, app, params),
+      submitMethod: (params: any) => serverGroupWriter.destroyServerGroup(cloudrunServerGroup, app, params),
       askForReason: true,
       platformHealthOnlyShowOverride: app.attributes.platformHealthOnlyShowOverride,
       platformHealthType: CloudrunHealth.PLATFORM,

--- a/deck/packages/cloudrun/src/serverGroup/routerConsumers.spec.tsx
+++ b/deck/packages/cloudrun/src/serverGroup/routerConsumers.spec.tsx
@@ -1,8 +1,8 @@
-import { shallow } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import React from 'react';
 import { MenuItem } from 'react-bootstrap';
 
-import { ConfirmationModalService, ServerGroupNamePreview, TaskMonitor } from '@spinnaker/core';
+import { ConfirmationModalService, DeckRuntimeContext, ServerGroupNamePreview, TaskMonitor } from '@spinnaker/core';
 
 import { ServerGroupBasicSettingsComponent } from './configure/wizard/BasicSettings';
 import { ServerGroupWizardComponent } from './configure/wizard/serverGroupWizard';
@@ -57,23 +57,25 @@ describe('Cloud Run server group router consumers', () => {
   it('closes destroyed server group details through the injected state service', () => {
     const go = jasmine.createSpy('go');
     const confirm = spyOn(ConfirmationModalService, 'confirm');
-    const component = shallow(
-      <CloudrunServerGroupActionsComponent
-        {...({ router: {}, stateParams: {}, stateService: { go, includes: () => true } } as any)}
-        app={{ attributes: {} } as any}
-        serverGroup={
-          {
-            account: 'test',
-            disabled: true,
-            name: 'app-v001',
-            region: 'us',
-            tags: { isLatest: false },
-          } as any
-        }
-      />,
+    const component = mount(
+      <DeckRuntimeContext.Provider value={{ services: { serverGroupWriter: {} } } as any}>
+        <CloudrunServerGroupActionsComponent
+          {...({ router: {}, stateParams: {}, stateService: { go, includes: () => true } } as any)}
+          app={{ attributes: {} } as any}
+          serverGroup={
+            {
+              account: 'test',
+              disabled: true,
+              name: 'app-v001',
+              region: 'us',
+              tags: { isLatest: false },
+            } as any
+          }
+        />
+      </DeckRuntimeContext.Provider>,
     );
 
-    component.find(MenuItem).first().simulate('click');
+    component.find(MenuItem).first().prop('onClick')();
     confirm.calls.mostRecent().args[0].taskMonitorConfig.onTaskComplete();
 
     expect(go).toHaveBeenCalledWith('^');

--- a/deck/packages/core/src/angular/services.spec.ts
+++ b/deck/packages/core/src/angular/services.spec.ts
@@ -3,35 +3,36 @@ import { UIRouterReact } from '@uirouter/react';
 import { AccountService } from '../account';
 import { mockHttpClient } from '../api/mock/jasmine';
 import { ApplicationDataSourceRegistry } from '../application/service/ApplicationDataSourceRegistry';
+import type { DeckRuntime } from '../bootstrap/DeckRuntime';
+import { createDeckRuntime } from '../bootstrap/DeckRuntime';
 import { InfrastructureCaches } from '../cache';
 import { CloudProviderRegistry } from '../cloudProvider';
 import { SETTINGS } from '../config';
 import { registerLoadBalancerDataSource } from '../loadBalancer/loadBalancer.dataSource';
 import { createLoadBalancerTransformer } from '../loadBalancer/loadBalancer.transformer';
-import { setDirectRouter } from '../navigation/directRouter';
 import { AngularServices } from './services';
 
-describe('AngularServices direct services', () => {
+describe('Deck runtime services', () => {
   const provider = 'serverGroupCommandBuilderTest';
+  let runtime: DeckRuntime;
+
+  beforeEach(() => {
+    runtime = createDeckRuntime(new UIRouterReact());
+  });
 
   afterEach(() => {
-    setDirectRouter(null);
-    (AngularServices as any).directCacheInitializer = null;
-    (AngularServices as any).directExecutionDetailsSectionService = null;
-    (AngularServices as any).directLoadBalancerReader = null;
-    (AngularServices as any).directSecurityGroupReader = null;
-    (AngularServices as any).directServerGroupWriter = null;
+    runtime.dispose();
     InfrastructureCaches.destroyCaches();
     delete SETTINGS.providers[provider];
     (CloudProviderRegistry as any).providers.delete(provider);
   });
 
   it('returns a direct infrastructure search service when Angular is not bootstrapped', () => {
-    expect(AngularServices.infrastructureSearchService.getSearcher()).toBeDefined();
+    expect(runtime.services.infrastructureSearchService.getSearcher()).toBeDefined();
   });
 
   it('returns a direct page title service when Angular is not bootstrapped', () => {
-    AngularServices.pageTitleService.handleRoutingSuccess({ pageTitleMain: { label: 'Search' } });
+    runtime.services.pageTitleService.handleRoutingSuccess({ pageTitleMain: { label: 'Search' } });
 
     expect(document.title).toBe('Search');
   });
@@ -39,11 +40,11 @@ describe('AngularServices direct services', () => {
   it('returns direct modal and cache fallbacks when Angular is not bootstrapped', async () => {
     spyOn(InfrastructureCaches, 'createCache').and.returnValue({} as any);
     spyOn(InfrastructureCaches, 'clearCache');
-    spyOn(AngularServices.securityGroupReader, 'getAllSecurityGroups').and.returnValue(Promise.resolve([]));
+    spyOn(runtime.services.securityGroupReader, 'getAllSecurityGroups').and.returnValue(Promise.resolve([]));
 
     expect(AngularServices.modalService.open).toBeDefined();
     expect(() => AngularServices.modalStackService.dismissAll()).not.toThrow();
-    await expectAsync(AngularServices.cacheInitializer.refreshCaches()).toBeResolved();
+    await expectAsync(runtime.services.cacheInitializer.refreshCaches()).toBeResolved();
   });
 
   it('returns direct root scope and timeout fallbacks when Angular is not bootstrapped', async () => {
@@ -61,10 +62,7 @@ describe('AngularServices direct services', () => {
   });
 
   it('returns a direct execution details section service when Angular is not bootstrapped', () => {
-    const router = new UIRouterReact();
-    setDirectRouter(router);
-
-    expect(() => AngularServices.executionDetailsSectionService.synchronizeSection(['stage'])).not.toThrow();
+    expect(() => runtime.services.executionDetailsSectionService.synchronizeSection(['stage'])).not.toThrow();
   });
 
   it('returns a direct $q fallback with Angular-style promise helpers', async () => {
@@ -118,7 +116,7 @@ describe('AngularServices direct services', () => {
         commandBuilder: TestServerGroupCommandBuilder,
       },
     });
-    const command = await AngularServices.serverGroupCommandBuilder.buildNewServerGroupCommandForPipeline(
+    const command = await runtime.services.serverGroupCommandBuilder.buildNewServerGroupCommandForPipeline(
       provider,
       stage,
       pipeline,
@@ -143,56 +141,50 @@ describe('AngularServices direct services', () => {
         transformer: TestServerGroupTransformer,
       },
     });
-    expect(AngularServices.serverGroupTransformer.convertServerGroupCommandToDeployConfiguration(command)).toEqual({
+    expect(runtime.services.serverGroupTransformer.convertServerGroupCommandToDeployConfiguration(command)).toEqual({
       converted: true,
       base: command,
     });
   });
 
   it('returns a direct security group reader when Angular is not bootstrapped', () => {
-    expect(AngularServices.securityGroupReader.getAllSecurityGroups).toEqual(jasmine.any(Function));
+    expect(runtime.services.securityGroupReader.getAllSecurityGroups).toEqual(jasmine.any(Function));
   });
 
   it('returns a direct instance type service when Angular is not bootstrapped', () => {
-    expect(AngularServices.instanceTypeService.getCategoryForMultipleInstanceTypes).toEqual(jasmine.any(Function));
+    expect(runtime.services.instanceTypeService.getCategoryForMultipleInstanceTypes).toEqual(jasmine.any(Function));
   });
 });
 
-describe('AngularServices direct|load balancer data source service accessors', () => {
+describe('Deck runtime service accessors', () => {
   const provider = 'directServiceAccessorTest';
-
-  const resetDirectServices = () => {
-    (AngularServices as any).directCacheInitializer = null;
-    (AngularServices as any).directLoadBalancerReader = null;
-    (AngularServices as any).directSecurityGroupReader = null;
-    (AngularServices as any).directServerGroupWriter = null;
-  };
+  let runtime: DeckRuntime;
 
   beforeEach(() => {
-    resetDirectServices();
+    runtime = createDeckRuntime(new UIRouterReact());
   });
 
   afterEach(() => {
-    resetDirectServices();
+    runtime.dispose();
     InfrastructureCaches.destroyCaches();
     delete SETTINGS.providers[provider];
     (CloudProviderRegistry as any).providers.delete(provider);
   });
 
-  it('AngularServices direct accessors lazily cache service instances', () => {
-    expect(AngularServices.serverGroupWriter).toBe(AngularServices.serverGroupWriter);
-    expect(AngularServices.cacheInitializer).toBe(AngularServices.cacheInitializer);
-    expect(AngularServices.loadBalancerReader).toBe(AngularServices.loadBalancerReader);
+  it('lazily caches service instances', () => {
+    expect(runtime.services.serverGroupWriter).toBe(runtime.services.serverGroupWriter);
+    expect(runtime.services.cacheInitializer).toBe(runtime.services.cacheInitializer);
+    expect(runtime.services.loadBalancerReader).toBe(runtime.services.loadBalancerReader);
   });
 
-  it('AngularServices direct cache initializer exposes working methods', async () => {
+  it('exposes working cache initializer methods', async () => {
     spyOn(InfrastructureCaches, 'createCache').and.returnValue({} as any);
     spyOn(InfrastructureCaches, 'clearCache');
     spyOn(AccountService, 'listProviders').and.returnValue(Promise.resolve([]));
-    const getAllSecurityGroups = spyOn(AngularServices.securityGroupReader, 'getAllSecurityGroups').and.returnValue(
+    const getAllSecurityGroups = spyOn(runtime.services.securityGroupReader, 'getAllSecurityGroups').and.returnValue(
       Promise.resolve([]),
     );
-    const cacheInitializer = AngularServices.cacheInitializer;
+    const cacheInitializer = runtime.services.cacheInitializer;
 
     expect(cacheInitializer.initialize).toEqual(jasmine.any(Function));
     expect(cacheInitializer.refreshCache).toEqual(jasmine.any(Function));
@@ -206,8 +198,8 @@ describe('AngularServices direct|load balancer data source service accessors', (
     expect(getAllSecurityGroups).toHaveBeenCalledTimes(3);
   });
 
-  it('AngularServices direct server group writer submits destroy jobs', async () => {
-    const serverGroupWriter = AngularServices.serverGroupWriter;
+  it('submits destroy jobs through the server group writer', async () => {
+    const serverGroupWriter = runtime.services.serverGroupWriter;
     const http = mockHttpClient();
     let submitted: any;
     http
@@ -239,7 +231,7 @@ describe('AngularServices direct|load balancer data source service accessors', (
     );
   });
 
-  it('AngularServices direct load balancer reader uses a registered provider transformer', async () => {
+  it('uses a registered provider transformer in the load balancer reader', async () => {
     class TestLoadBalancerTransformer {
       public normalizeLoadBalancer(loadBalancer: any) {
         return Promise.resolve({ ...loadBalancer, transformed: true });
@@ -251,7 +243,7 @@ describe('AngularServices direct|load balancer data source service accessors', (
       name: 'Direct Service Accessor Test',
       loadBalancer: { transformer: TestLoadBalancerTransformer },
     });
-    const loadBalancerReader = AngularServices.loadBalancerReader;
+    const loadBalancerReader = runtime.services.loadBalancerReader;
     const http = mockHttpClient();
     http.expectGET('/applications/app/loadBalancers').respond(200, [
       {
@@ -276,7 +268,7 @@ describe('AngularServices direct|load balancer data source service accessors', (
     ]);
   });
 
-  it('AngularServices direct load balancer transformer factory preserves provider and set normalization', async () => {
+  it('preserves provider and set normalization in the load balancer transformer factory', async () => {
     const normalizeLoadBalancerSet = jasmine
       .createSpy('normalizeLoadBalancerSet')
       .and.callFake((loadBalancers: any[]) => loadBalancers.slice().reverse());
@@ -313,7 +305,7 @@ describe('AngularServices direct|load balancer data source service accessors', (
     expect(providerServiceDelegate.getDelegate).toHaveBeenCalledWith(provider, 'loadBalancer.setTransformer');
   });
 
-  it('AngularServices direct load balancer transformer resolves each provider set transformer once', () => {
+  it('resolves each provider set transformer once in the load balancer transformer', () => {
     const secondProvider = `${provider}Second`;
     const resolvedProviders: string[] = [];
     const createdDelegates: any[] = [];
@@ -350,7 +342,7 @@ describe('AngularServices direct|load balancer data source service accessors', (
     expect(invokedDelegates).toEqual(createdDelegates);
   });
 
-  it('AngularServices direct load balancer transformer leaves unregistered providers unchanged', async () => {
+  it('leaves unregistered providers unchanged in the load balancer transformer', async () => {
     const providerServiceDelegate = {
       hasDelegate: jasmine.createSpy('hasDelegate').and.returnValue(false),
       getDelegate: jasmine.createSpy('getDelegate'),
@@ -362,29 +354,25 @@ describe('AngularServices direct|load balancer data source service accessors', (
     expect(providerServiceDelegate.getDelegate).not.toHaveBeenCalled();
   });
 
-  it('AngularServices direct server group conversion throws the contextual missing transformer error', () => {
+  it('throws the contextual missing server group transformer error', () => {
     expect(() =>
-      AngularServices.serverGroupTransformer.convertServerGroupCommandToDeployConfiguration({
+      runtime.services.serverGroupTransformer.convertServerGroupCommandToDeployConfiguration({
         selectedProvider: provider,
       }),
     ).toThrowError(`No "serverGroup.transformer" service found for provider "${provider}"`);
   });
 });
 
-describe('AngularServices direct|load balancer data source registration', () => {
+describe('Deck runtime load balancer data source registration', () => {
+  let runtime: DeckRuntime;
+
   beforeEach(() => {
-    (AngularServices as any).directCacheInitializer = null;
-    (AngularServices as any).directLoadBalancerReader = null;
-    (AngularServices as any).directSecurityGroupReader = null;
-    (AngularServices as any).directServerGroupWriter = null;
+    runtime = createDeckRuntime(new UIRouterReact());
     ApplicationDataSourceRegistry.clearDataSources();
   });
 
   afterEach(() => {
-    (AngularServices as any).directCacheInitializer = null;
-    (AngularServices as any).directLoadBalancerReader = null;
-    (AngularServices as any).directSecurityGroupReader = null;
-    (AngularServices as any).directServerGroupWriter = null;
+    runtime.dispose();
     ApplicationDataSourceRegistry.clearDataSources();
   });
 
@@ -393,18 +381,13 @@ describe('AngularServices direct|load balancer data source registration', () => 
     const loadBalancerReader = {
       loadLoadBalancers: jasmine.createSpy('loadLoadBalancers').and.returnValue(Promise.resolve(loadBalancers)),
     };
-    const readerAccessor = spyOnProperty(AngularServices, 'loadBalancerReader', 'get').and.returnValue(
-      loadBalancerReader as any,
-    );
-
-    registerLoadBalancerDataSource();
+    registerLoadBalancerDataSource(runtime.promiseService, loadBalancerReader as any);
     const dataSource = ApplicationDataSourceRegistry.getDataSources()[0];
 
     await expectAsync(Promise.resolve(dataSource.loader({ name: 'app' } as any))).toBeResolvedTo(loadBalancers);
     await expectAsync(Promise.resolve(dataSource.onLoad({ name: 'app' } as any, loadBalancers))).toBeResolvedTo(
       loadBalancers,
     );
-    expect(readerAccessor).toHaveBeenCalled();
     expect(loadBalancerReader.loadLoadBalancers).toHaveBeenCalledWith('app');
   });
 });

--- a/deck/packages/core/src/angular/services.ts
+++ b/deck/packages/core/src/angular/services.ts
@@ -1,78 +1,10 @@
-import type { IDeferred, IQService, IRootScopeService, ITimeoutService } from 'angular';
+import type { IRootScopeService, ITimeoutService } from 'angular';
 import type { IModalService, IModalStackService } from 'angular-ui-bootstrap';
-import { of as observableOf, Subject } from 'rxjs';
-import { switchMap, toArray } from 'rxjs/operators';
 
-import type { Application } from '../application';
 import type { DeckRuntime } from '../bootstrap/DeckRuntime';
 import { createDeckRuntime } from '../bootstrap/DeckRuntime';
-import { CacheInitializerService } from '../cache/cacheInitializer.service';
-import type { ProviderServiceDelegate } from '../cloudProvider/providerService.delegate';
-import { ClusterService } from '../cluster/cluster.service';
 import { InsightFilterStateModel } from '../insight/insightFilterState.model';
-import { InstanceTypeService } from '../instance';
-import { LoadBalancerReader } from '../loadBalancer/loadBalancer.read.service';
-import { createLoadBalancerTransformer } from '../loadBalancer/loadBalancer.transformer';
-import { getDirectRouter } from '../navigation/directRouter';
 import { overrideRegistry } from '../overrideRegistry/override.registry';
-import type { PageTitleService } from '../pageTitle';
-import { ExecutionDetailsSectionService } from '../pipeline/details/executionDetailsSection.service';
-import { ExecutionService } from '../pipeline/service/execution.service';
-import type {
-  IProviderResultFormatter,
-  ISearchResultFormatter,
-  ISearchResultSet,
-} from '../search/infrastructure/infrastructureSearch.service';
-import { InfrastructureSearchServiceV2 } from '../search/infrastructure/infrastructureSearchV2.service';
-import type { ISearchResult } from '../search/search.service';
-import { SearchStatus } from '../search/searchResult/SearchStatus';
-import type { SearchResultType } from '../search/searchResult/searchResultType';
-import { searchResultTypeRegistry } from '../search/searchResult/searchResultType.registry';
-import { SecurityGroupReader } from '../securityGroup/securityGroupReader.service';
-import { SecurityGroupTransformerService } from '../securityGroup/securityGroupTransformer.service';
-import type { ServerGroupCommandBuilderService } from '../serverGroup/configure/common/serverGroupCommandBuilder.service';
-import { ServerGroupWriter } from '../serverGroup/serverGroupWriter.service';
-
-const directServerGroupTransformer = {
-  normalizeServerGroup: (serverGroup: any, application: Application) => {
-    const provider = serverGroup.provider || serverGroup.type;
-    if (!AngularServices.providerServiceDelegate.hasDelegate(provider, 'serverGroup.transformer')) {
-      return Promise.resolve(serverGroup);
-    }
-
-    return AngularServices.providerServiceDelegate
-      .getDelegate<any>(provider, 'serverGroup.transformer')
-      .normalizeServerGroup(serverGroup, application);
-  },
-  convertServerGroupCommandToDeployConfiguration: (base: any) => {
-    return AngularServices.providerServiceDelegate
-      .getDelegate<any>(base.selectedProvider, 'serverGroup.transformer')
-      .convertServerGroupCommandToDeployConfiguration(base);
-  },
-};
-
-const directServerGroupCommandBuilder = ({
-  buildNewServerGroupCommand: (application: Application, provider: string, options: any) => {
-    return AngularServices.providerServiceDelegate
-      .getDelegate<any>(provider, 'serverGroup.commandBuilder')
-      .buildNewServerGroupCommand(application, options);
-  },
-  buildServerGroupCommandFromExisting: (application: Application, serverGroup: any, mode?: string) => {
-    return AngularServices.providerServiceDelegate
-      .getDelegate<any>(serverGroup.type, 'serverGroup.commandBuilder')
-      .buildServerGroupCommandFromExisting(application, serverGroup, mode);
-  },
-  buildNewServerGroupCommandForPipeline: (provider: string, currentStage: any, pipeline: any) => {
-    return AngularServices.providerServiceDelegate
-      .getDelegate<any>(provider, 'serverGroup.commandBuilder')
-      .buildNewServerGroupCommandForPipeline(currentStage, pipeline);
-  },
-  buildServerGroupCommandFromPipeline: (application: Application, cluster: any, currentStage: any, pipeline: any) => {
-    return AngularServices.providerServiceDelegate
-      .getDelegate<any>(cluster.provider, 'serverGroup.commandBuilder')
-      .buildServerGroupCommandFromPipeline(application, cluster, currentStage, pipeline);
-  },
-} as unknown) as ServerGroupCommandBuilderService;
 
 const directRootScope = ({
   routing: false,
@@ -92,89 +24,9 @@ const directModalStackService = ({
   dismissAll: (): void => undefined,
 } as unknown) as IModalStackService;
 
-class DirectInfrastructureSearcher {
-  private deferred: IDeferred<ISearchResultSet[]>;
-  private querySubject: Subject<string> = new Subject<string>();
-
-  constructor(private $q: IQService, private providerServiceDelegate: ProviderServiceDelegate) {
-    this.querySubject
-      .pipe(
-        switchMap((query: string) => {
-          if (!query || query.trim() === '') {
-            const fallbackResults = searchResultTypeRegistry
-              .getAll()
-              .map((type) => ({ type, results: [], status: SearchStatus.INITIAL } as ISearchResultSet));
-            return observableOf(fallbackResults);
-          }
-
-          return InfrastructureSearchServiceV2.search({ key: query }).pipe(toArray());
-        }),
-      )
-      .subscribe((result: ISearchResultSet[]) => {
-        this.deferred.resolve(result);
-      });
-  }
-
-  public query(q: string): PromiseLike<ISearchResultSet[]> {
-    this.deferred = this.$q.defer();
-    this.querySubject.next(q);
-    return this.deferred.promise;
-  }
-
-  public getCategoryConfig(category: string): SearchResultType {
-    return searchResultTypeRegistry.get(category);
-  }
-
-  public formatRouteResult(category: string, entry: ISearchResult): PromiseLike<string> {
-    return this.formatResult(category, entry, true);
-  }
-
-  private formatResult(category: string, entry: ISearchResult, fromRoute = false): PromiseLike<string> {
-    const type = searchResultTypeRegistry.get(category);
-    if (!type) {
-      return this.$q.when('') as PromiseLike<string>;
-    }
-
-    let formatter: ISearchResultFormatter = type.displayFormatter;
-    if (this.providerServiceDelegate.hasDelegate(entry.provider, 'search.resultFormatter')) {
-      const providerFormatter: IProviderResultFormatter = this.providerServiceDelegate.getDelegate<
-        IProviderResultFormatter
-      >(entry.provider, 'search.resultFormatter');
-      if (providerFormatter[category]) {
-        formatter = providerFormatter[category];
-      }
-    }
-    return this.$q.when(formatter(entry, fromRoute)) as PromiseLike<string>;
-  }
-}
-
-class DirectInfrastructureSearchService {
-  constructor(private $q: IQService, private providerServiceDelegate: ProviderServiceDelegate) {}
-
-  public getSearcher(): DirectInfrastructureSearcher {
-    return new DirectInfrastructureSearcher(this.$q, this.providerServiceDelegate);
-  }
-}
-
-class DirectPageTitleService {
-  public handleRoutingSuccess(config: { pageTitleMain?: { field?: string; label?: string } } = {}): void {
-    document.title = config.pageTitleMain?.label || 'Spinnaker';
-  }
-}
-
 class AngularServiceAccessors {
   private runtime = createDeckRuntime();
-  private directCacheInitializer: CacheInitializerService;
-  private directClusterService: ClusterService;
-  private directExecutionDetailsSectionService: ExecutionDetailsSectionService;
-  private directExecutionService: ExecutionService;
-  private directInfrastructureSearchService: DirectInfrastructureSearchService;
   private directInsightFilterStateModel: InsightFilterStateModel;
-  private directInstanceTypeService: InstanceTypeService;
-  private directLoadBalancerReader: LoadBalancerReader;
-  private directPageTitleService = new DirectPageTitleService();
-  private directSecurityGroupReader: SecurityGroupReader;
-  private directServerGroupWriter: ServerGroupWriter;
 
   public bindRuntime(runtime: DeckRuntime): void {
     if (this.runtime === runtime) {
@@ -213,29 +65,8 @@ class AngularServiceAccessors {
   public get $uibModal() {
     return directModalService;
   }
-  public get cacheInitializer() {
-    return this.getDirectCacheInitializer();
-  }
-  public get clusterService() {
-    return this.getDirectClusterService();
-  }
-  public get executionDetailsSectionService() {
-    return this.getDirectExecutionDetailsSectionService();
-  }
-  public get executionService() {
-    return this.getDirectExecutionService();
-  }
-  public get infrastructureSearchService(): DirectInfrastructureSearchService {
-    return this.getDirectInfrastructureSearchService();
-  }
   public get insightFilterStateModel() {
     return this.getDirectInsightFilterStateModel();
-  }
-  public get instanceTypeService() {
-    return this.getDirectInstanceTypeService();
-  }
-  public get loadBalancerReader() {
-    return this.getDirectLoadBalancerReader();
   }
   public get modalService() {
     return this.$uibModal;
@@ -246,127 +77,6 @@ class AngularServiceAccessors {
   public get overrideRegistry() {
     return overrideRegistry;
   }
-  public get pageTitleService() {
-    return this.directPageTitleService as PageTitleService;
-  }
-  public get providerServiceDelegate() {
-    return (this.runtime.providerServiceDelegate as unknown) as ProviderServiceDelegate;
-  }
-  public get securityGroupReader() {
-    return this.getDirectSecurityGroupReader();
-  }
-  public get serverGroupCommandBuilder() {
-    return directServerGroupCommandBuilder;
-  }
-  public get serverGroupTransformer() {
-    return directServerGroupTransformer;
-  }
-  public get serverGroupWriter() {
-    return this.getDirectServerGroupWriter();
-  }
-  private getDirectCacheInitializer(): CacheInitializerService {
-    if (!this.directCacheInitializer) {
-      this.directCacheInitializer = new CacheInitializerService(
-        this.$q,
-        this.getDirectSecurityGroupReader(),
-        this.providerServiceDelegate,
-      );
-    }
-
-    return this.directCacheInitializer;
-  }
-
-  private getDirectInfrastructureSearchService(): DirectInfrastructureSearchService {
-    if (!this.directInfrastructureSearchService) {
-      this.directInfrastructureSearchService = new DirectInfrastructureSearchService(
-        this.$q,
-        this.providerServiceDelegate,
-      );
-    }
-
-    return this.directInfrastructureSearchService;
-  }
-
-  private getDirectLoadBalancerReader(): LoadBalancerReader {
-    if (!this.directLoadBalancerReader) {
-      this.directLoadBalancerReader = new LoadBalancerReader(
-        this.$q,
-        createLoadBalancerTransformer(this.providerServiceDelegate),
-      );
-    }
-
-    return this.directLoadBalancerReader;
-  }
-
-  private getDirectClusterService(): ClusterService {
-    if (!this.directClusterService) {
-      this.directClusterService = new ClusterService(
-        this.$q,
-        directServerGroupTransformer,
-        this.providerServiceDelegate,
-      );
-    }
-
-    return this.directClusterService;
-  }
-
-  private getDirectExecutionService(): ExecutionService {
-    if (!this.directExecutionService) {
-      const router = getDirectRouter();
-      if (!router) {
-        throw new Error('Cannot create ExecutionService before the direct UI Router is initialized');
-      }
-      this.directExecutionService = new ExecutionService(this.$q, router.stateService, this.$timeout);
-    }
-
-    return this.directExecutionService;
-  }
-
-  private getDirectExecutionDetailsSectionService(): ExecutionDetailsSectionService {
-    if (!this.directExecutionDetailsSectionService) {
-      const router = getDirectRouter();
-      if (!router) {
-        throw new Error('Cannot create ExecutionDetailsSectionService before the direct UI Router is initialized');
-      }
-      this.directExecutionDetailsSectionService = new ExecutionDetailsSectionService(
-        router.globals.params,
-        router.stateService as any,
-        this.$timeout,
-      );
-    }
-
-    return this.directExecutionDetailsSectionService;
-  }
-
-  private getDirectSecurityGroupReader(): SecurityGroupReader {
-    if (!this.directSecurityGroupReader) {
-      this.directSecurityGroupReader = new SecurityGroupReader(
-        this.$log,
-        this.$q,
-        new SecurityGroupTransformerService(this.providerServiceDelegate),
-        this.providerServiceDelegate,
-      );
-    }
-
-    return this.directSecurityGroupReader;
-  }
-
-  private getDirectServerGroupWriter(): ServerGroupWriter {
-    if (!this.directServerGroupWriter) {
-      this.directServerGroupWriter = new ServerGroupWriter(directServerGroupTransformer);
-    }
-
-    return this.directServerGroupWriter;
-  }
-
-  private getDirectInstanceTypeService(): InstanceTypeService {
-    if (!this.directInstanceTypeService) {
-      this.directInstanceTypeService = new InstanceTypeService(this.providerServiceDelegate);
-    }
-
-    return this.directInstanceTypeService;
-  }
-
   private getDirectInsightFilterStateModel(): InsightFilterStateModel {
     if (!this.directInsightFilterStateModel) {
       this.directInsightFilterStateModel = new InsightFilterStateModel();
@@ -376,15 +86,7 @@ class AngularServiceAccessors {
   }
 
   private resetRuntimeServices(): void {
-    this.directCacheInitializer = null;
-    this.directClusterService = null;
-    this.directExecutionDetailsSectionService = null;
-    this.directExecutionService = null;
-    this.directInfrastructureSearchService = null;
-    this.directInstanceTypeService = null;
-    this.directLoadBalancerReader = null;
-    this.directSecurityGroupReader = null;
-    this.directServerGroupWriter = null;
+    this.directInsightFilterStateModel = null;
   }
 }
 

--- a/deck/packages/core/src/application/service/directDataSources.spec.ts
+++ b/deck/packages/core/src/application/service/directDataSources.spec.ts
@@ -1,26 +1,71 @@
 import type { IRootScopeService } from 'angular';
 import { mock } from 'angular';
+import { UIRouterReact } from '@uirouter/react';
 
 import { ApplicationDataSourceRegistry } from './ApplicationDataSourceRegistry';
 import { ApplicationDataSource } from './applicationDataSource';
-import { AngularServices } from '../../angular/services';
 import { mockHttpClient } from '../../api/mock/jasmine';
 import { registerApplicationConfigDataSource } from '../config/appConfig.dataSource';
 import { navigationCategoryRegistry } from '../nav/navigationCategory.registry';
 import { SETTINGS } from '../../config/settings';
 import { registerCiDataSources } from '../../ci/ci.dataSource';
 import { registerEntityTagsDataSource } from '../../entityTag/entityTags.dataSource';
-import { registerFunctionDataSource } from '../../function/function.dataSource';
+import {
+  createDirectFunctionReader,
+  registerFunctionDataSource as registerFunctionDataSourceImpl,
+} from '../../function/function.dataSource';
 import { registerManagedResourcesDataSources } from '../../managed/managed.dataSource';
-import * as loadBalancerDataSource from '../../loadBalancer/loadBalancer.dataSource';
-import * as securityGroupDataSource from '../../securityGroup/securityGroup.dataSource';
-import * as serverGroupDataSource from '../../serverGroup/serverGroup.dataSource';
+import * as loadBalancerDataSourceImpl from '../../loadBalancer/loadBalancer.dataSource';
+import * as securityGroupDataSourceImpl from '../../securityGroup/securityGroup.dataSource';
+import * as serverGroupDataSourceImpl from '../../serverGroup/serverGroup.dataSource';
 import { registerServerGroupManagerDataSource } from '../../serverGroupManager/serverGroupManager.dataSource';
-import { registerTaskDataSources } from '../../task/task.dataSource';
-import { registerPipelineDataSources } from '../../pipeline/pipeline.dataSource';
+import { registerTaskDataSources as registerTaskDataSourcesImpl } from '../../task/task.dataSource';
+import { registerPipelineDataSources as registerPipelineDataSourcesImpl } from '../../pipeline/pipeline.dataSource';
 import { ExecutionService } from '../../pipeline/service/execution.service';
 import { getDirectRouter, setDirectRouter } from '../../navigation/directRouter';
 import { Application } from '../application.model';
+import { createDeckRuntime } from '../../bootstrap/DeckRuntime';
+
+const testRuntime = createDeckRuntime(new UIRouterReact());
+const loadBalancerDataSource = {
+  ...loadBalancerDataSourceImpl,
+  registerLoadBalancerDataSource: ($q = testRuntime.promiseService, reader = testRuntime.services.loadBalancerReader) =>
+    loadBalancerDataSourceImpl.registerLoadBalancerDataSource($q, reader),
+};
+const securityGroupDataSource = {
+  ...securityGroupDataSourceImpl,
+  registerSecurityGroupDataSource: (
+    $q = testRuntime.promiseService,
+    reader = testRuntime.services.securityGroupReader,
+  ) => securityGroupDataSourceImpl.registerSecurityGroupDataSource($q, reader),
+};
+const serverGroupDataSource = {
+  ...serverGroupDataSourceImpl,
+  registerServerGroupDataSource: ($q = testRuntime.promiseService, service = testRuntime.services.clusterService) =>
+    serverGroupDataSourceImpl.registerServerGroupDataSource($q, service),
+};
+
+function registerFunctionDataSource(): void {
+  registerFunctionDataSourceImpl(
+    createDirectFunctionReader(testRuntime.services.providerServiceDelegate),
+    <T>(value: T | PromiseLike<T>) => testRuntime.promiseService.when(value),
+  );
+}
+
+function registerTaskDataSources(
+  $q = testRuntime.promiseService,
+  clusterService = testRuntime.services.clusterService,
+) {
+  return registerTaskDataSourcesImpl($q, clusterService);
+}
+
+function registerPipelineDataSources(
+  $q = testRuntime.promiseService,
+  executionService = testRuntime.services.executionService,
+  clusterService = testRuntime.services.clusterService,
+) {
+  return registerPipelineDataSourcesImpl($q, executionService, clusterService);
+}
 
 function getDataSourcesByKey(key: string): any[] {
   return ApplicationDataSourceRegistry.getDataSources().filter((dataSource) => dataSource.key === key);
@@ -138,10 +183,8 @@ describe('direct application data source registration', () => {
       }
       return transformer;
     });
-    spyOnProperty(AngularServices, 'providerServiceDelegate', 'get').and.returnValue({
-      hasDelegate: () => true,
-      getDelegate,
-    } as any);
+    spyOn(testRuntime.services.providerServiceDelegate, 'hasDelegate').and.returnValue(true);
+    spyOn(testRuntime.services.providerServiceDelegate, 'getDelegate').and.callFake(getDelegate);
     SETTINGS.feature = { ...SETTINGS.feature, functions: true };
     http.expectGET('/applications/app/functions').respond(200, [{ name: 'function-with-default-provider' }]);
 
@@ -180,10 +223,8 @@ describe('direct application data source registration', () => {
       }
       return transformer;
     });
-    spyOnProperty(AngularServices, 'providerServiceDelegate', 'get').and.returnValue({
-      hasDelegate: () => true,
-      getDelegate,
-    } as any);
+    spyOn(testRuntime.services.providerServiceDelegate, 'hasDelegate').and.returnValue(true);
+    spyOn(testRuntime.services.providerServiceDelegate, 'getDelegate').and.callFake(getDelegate);
     SETTINGS.feature = { ...SETTINGS.feature, functions: true };
     http.expectGET('/applications/app/functions').respond(200, [
       { name: 'function-one', provider: 'aws' },
@@ -465,21 +506,14 @@ describe('load balancer Angular-compatible registration', () => {
     };
     const whenResult = {} as PromiseLike<any>;
     const directQ = { when: jasmine.createSpy('directWhen').and.returnValue(whenResult) } as any;
-    const readerAccessor = spyOnProperty(AngularServices, 'loadBalancerReader', 'get').and.returnValue(
-      directReader as any,
-    );
-    const qAccessor = spyOnProperty(AngularServices, '$q', 'get').and.returnValue(directQ);
-
-    loadBalancerDataSource.registerLoadBalancerDataSource();
-    loadBalancerDataSource.registerLoadBalancerDataSource();
+    loadBalancerDataSource.registerLoadBalancerDataSource(directQ, directReader as any);
+    loadBalancerDataSource.registerLoadBalancerDataSource(directQ, directReader as any);
 
     const dataSources = getDataSourcesByKey('loadBalancers');
     expect(dataSources.length).toBe(1);
     expect(dataSources[0].loader({ name: 'app' } as Application)).toBe(directLoadResult);
     expect(dataSources[0].onLoad({ name: 'app' } as Application, [])).toBe(whenResult);
     expect(directReader.loadLoadBalancers).toHaveBeenCalledWith('app');
-    expect(readerAccessor).toHaveBeenCalledTimes(1);
-    expect(qAccessor).toHaveBeenCalledTimes(1);
   });
 
   describe('when direct registration precedes Angular activation', () => {
@@ -496,9 +530,7 @@ describe('load balancer Angular-compatible registration', () => {
       directQ = { when: jasmine.createSpy('directWhen').and.returnValue({ source: 'direct' }) };
       angularQ = { when: jasmine.createSpy('angularWhen').and.returnValue({ source: 'angular' }) };
       selectedQ = directQ;
-      spyOnProperty(AngularServices, 'loadBalancerReader', 'get').and.returnValue(directReader);
-      spyOnProperty(AngularServices, '$q', 'get').and.callFake(() => selectedQ);
-      loadBalancerDataSource.registerLoadBalancerDataSource();
+      loadBalancerDataSource.registerLoadBalancerDataSource(selectedQ, directReader);
       directDataSource = getDataSourcesByKey('loadBalancers')[0];
     });
 
@@ -563,7 +595,7 @@ describe('load balancer Angular-compatible registration', () => {
       const whenResult = {} as PromiseLike<any>;
       const when = spyOn($q, 'when').and.returnValue(whenResult as any);
 
-      loadBalancerDataSource.registerLoadBalancerDataSource();
+      loadBalancerDataSource.registerLoadBalancerDataSource($q, angularReader);
       expect(angularDataSource.loader({ name: 'app' } as Application)).toBe(loadResult);
       expect(angularDataSource.onLoad({ name: 'app' } as Application, [])).toBe(whenResult);
 
@@ -590,14 +622,13 @@ describe('security group Angular-compatible registration', () => {
 
   it('registers one data source across repeated direct calls using direct defaults', () => {
     const directQ = {} as ng.IQService;
-    const providerServiceDelegate = {} as any;
-    const qAccessor = spyOnProperty(AngularServices, '$q', 'get').and.returnValue(directQ);
-    const delegateAccessor = spyOnProperty(AngularServices, 'providerServiceDelegate', 'get').and.returnValue(
-      providerServiceDelegate,
-    );
+    const directReader = {
+      loadSecurityGroupsByApplicationName: jasmine.createSpy('directLoadSecurityGroups'),
+      getApplicationSecurityGroups: jasmine.createSpy('directGetApplicationSecurityGroups'),
+    } as any;
 
-    securityGroupDataSource.registerSecurityGroupDataSource();
-    securityGroupDataSource.registerSecurityGroupDataSource();
+    securityGroupDataSource.registerSecurityGroupDataSource(directQ, directReader);
+    securityGroupDataSource.registerSecurityGroupDataSource(directQ, directReader);
 
     expect(getDataSourcesByKey('securityGroups')).toEqual([
       jasmine.objectContaining({
@@ -609,15 +640,16 @@ describe('security group Angular-compatible registration', () => {
         regionField: 'region',
       }),
     ]);
-    expect(qAccessor).toHaveBeenCalledTimes(1);
-    expect(delegateAccessor).toHaveBeenCalledTimes(2);
   });
 
   describe('when direct registration precedes Angular activation', () => {
     let directDataSource: any;
 
     beforeEach(() => {
-      securityGroupDataSource.registerSecurityGroupDataSource();
+      securityGroupDataSource.registerSecurityGroupDataSource(
+        testRuntime.promiseService,
+        testRuntime.services.securityGroupReader,
+      );
       directDataSource = getDataSourcesByKey('securityGroups')[0];
     });
     beforeEach(
@@ -665,7 +697,7 @@ describe('security group Angular-compatible registration', () => {
 
       expect(angularDataSource.loader(application)).toBe(loadResult);
       expect(angularDataSource.onLoad(application, securityGroups)).toBe(onLoadResult);
-      securityGroupDataSource.registerSecurityGroupDataSource();
+      securityGroupDataSource.registerSecurityGroupDataSource(testRuntime.promiseService, angularReader);
 
       expect(getDataSourcesByKey('securityGroups')).toEqual([angularDataSource]);
       expect(angularReader.loadSecurityGroupsByApplicationName).toHaveBeenCalledWith('app');

--- a/deck/packages/core/src/bootstrap/DeckRuntime.spec.ts
+++ b/deck/packages/core/src/bootstrap/DeckRuntime.spec.ts
@@ -1,6 +1,7 @@
 import { UIRouterReact } from '@uirouter/react';
 
-import { DeckRuntimeContext, createDeckRuntime } from './DeckRuntime';
+import { createDeckRuntime } from './DeckRuntime';
+import { DeckRuntimeContext } from './DeckRuntimeContext';
 
 describe('createDeckRuntime', () => {
   beforeEach(() => jasmine.clock().install());
@@ -15,7 +16,7 @@ describe('createDeckRuntime', () => {
     expect(runtime.timeoutService).toEqual(jasmine.any(Function));
     expect(runtime.logger.error).toEqual(jasmine.any(Function));
     expect(runtime.interpolate).toEqual(jasmine.any(Function));
-    expect(runtime.providerServiceDelegate).toBeDefined();
+    expect(runtime.services.providerServiceDelegate).toBeDefined();
     expect(DeckRuntimeContext._currentValue).toBeNull();
     router.dispose();
   });
@@ -29,5 +30,35 @@ describe('createDeckRuntime', () => {
     jasmine.clock().tick(100);
 
     expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('creates services lazily and preserves their identity within a runtime', () => {
+    const runtime = createDeckRuntime();
+
+    expect(() => runtime.services.executionService).toThrowError(
+      'Cannot create ExecutionService before the direct UI Router is initialized',
+    );
+
+    expect(runtime.services.cacheInitializer).toBe(runtime.services.cacheInitializer);
+    expect(runtime.services.serverGroupWriter).toBe(runtime.services.serverGroupWriter);
+  });
+
+  it('isolates service instances between runtimes', () => {
+    const firstRuntime = createDeckRuntime();
+    const secondRuntime = createDeckRuntime();
+
+    expect(firstRuntime.services.cacheInitializer).not.toBe(secondRuntime.services.cacheInitializer);
+    expect(firstRuntime.services.serverGroupTransformer).not.toBe(secondRuntime.services.serverGroupTransformer);
+  });
+
+  it('releases service instances when disposed', () => {
+    const runtime = createDeckRuntime();
+    const cacheInitializer = runtime.services.cacheInitializer;
+    const serverGroupWriter = runtime.services.serverGroupWriter;
+
+    runtime.dispose();
+
+    expect(runtime.services.cacheInitializer).not.toBe(cacheInitializer);
+    expect(runtime.services.serverGroupWriter).not.toBe(serverGroupWriter);
   });
 });

--- a/deck/packages/core/src/bootstrap/DeckRuntime.ts
+++ b/deck/packages/core/src/bootstrap/DeckRuntime.ts
@@ -1,7 +1,7 @@
 import type { UIRouterReact } from '@uirouter/react';
 import type { ILogService, IQService } from 'angular';
-import * as React from 'react';
 
+import { DeckRuntimeServices } from './DeckRuntimeServices';
 import { DirectProviderServiceDelegate } from '../cloudProvider/providerService.delegate';
 import type { CancellableTimeout } from '../utils/cancellableTimeout';
 import { createCancellableTimeout } from '../utils/cancellableTimeout';
@@ -15,23 +15,27 @@ export interface DeckRuntime {
   timeoutService: CancellableTimeout;
   logger: ILogService;
   interpolate: typeof interpolate;
-  providerServiceDelegate: DirectProviderServiceDelegate;
+  services: DeckRuntimeServices;
   dispose: () => void;
 }
-
-export const DeckRuntimeContext = React.createContext<DeckRuntime | null>(null);
 
 export function createDeckRuntime(router: UIRouterReact | null = null): DeckRuntime {
   const promiseService = createNativePromiseService();
   const timeoutService = createCancellableTimeout();
+  const logger = createDiagnosticLogger();
+  const providerServiceDelegate = new DirectProviderServiceDelegate(promiseService);
+  const services = new DeckRuntimeServices(router, promiseService, timeoutService, logger, providerServiceDelegate);
 
   return {
     router,
     promiseService,
     timeoutService,
-    logger: createDiagnosticLogger(),
+    logger,
     interpolate,
-    providerServiceDelegate: new DirectProviderServiceDelegate(promiseService),
-    dispose: timeoutService.dispose,
+    services,
+    dispose: () => {
+      services.dispose();
+      timeoutService.dispose();
+    },
   };
 }

--- a/deck/packages/core/src/bootstrap/DeckRuntimeContext.spec.tsx
+++ b/deck/packages/core/src/bootstrap/DeckRuntimeContext.spec.tsx
@@ -1,0 +1,66 @@
+import { mount } from 'enzyme';
+import React from 'react';
+
+import { createDeckRuntime } from './DeckRuntime';
+import { DeckRuntimeContext } from './DeckRuntimeContext';
+import {
+  IDeckRuntimeServicesInjectedProps,
+  useDeckRuntimeServices,
+  withDeckRuntimeServices,
+} from './DeckRuntimeContext';
+
+describe('DeckRuntimeContext service access', () => {
+  it('returns the services owned by the nearest runtime', () => {
+    const runtime = createDeckRuntime();
+    let services: ReturnType<typeof useDeckRuntimeServices>;
+    const Consumer = () => {
+      services = useDeckRuntimeServices();
+      return null;
+    };
+
+    mount(
+      <DeckRuntimeContext.Provider value={runtime}>
+        <Consumer />
+      </DeckRuntimeContext.Provider>,
+    );
+
+    expect(services).toBe(runtime.services);
+    runtime.dispose();
+  });
+
+  it('throws a clear error outside a runtime provider', () => {
+    spyOn(React, 'useContext').and.returnValue(null);
+
+    expect(() => useDeckRuntimeServices()).toThrowError(
+      'Deck runtime services are unavailable outside DeckRuntimeContext',
+    );
+  });
+
+  it('injects runtime services into class components and forwards refs', () => {
+    const runtime = createDeckRuntime();
+    const ref = React.createRef<ServiceConsumer>();
+
+    interface IProps extends IDeckRuntimeServicesInjectedProps {
+      label: string;
+    }
+
+    class ServiceConsumer extends React.Component<IProps> {
+      public render() {
+        return <span>{this.props.label}</span>;
+      }
+    }
+
+    const WrappedConsumer = withDeckRuntimeServices(ServiceConsumer);
+    const wrapper = mount(
+      <DeckRuntimeContext.Provider value={runtime}>
+        <WrappedConsumer ref={ref} label="runtime services" />
+      </DeckRuntimeContext.Provider>,
+    );
+
+    expect(wrapper.find(ServiceConsumer).props()).toEqual(
+      jasmine.objectContaining({ label: 'runtime services', deckRuntimeServices: runtime.services }),
+    );
+    expect(ref.current).toEqual(jasmine.any(ServiceConsumer));
+    runtime.dispose();
+  });
+});

--- a/deck/packages/core/src/bootstrap/DeckRuntimeContext.tsx
+++ b/deck/packages/core/src/bootstrap/DeckRuntimeContext.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+
+import type { DeckRuntime } from './DeckRuntime';
+import type { DeckRuntimeServices } from './DeckRuntimeServices';
+
+export type DeckRuntimeContextValue = Pick<DeckRuntime, 'services'>;
+
+export const DeckRuntimeContext = React.createContext<DeckRuntimeContextValue | null>(null);
+
+export interface IDeckRuntimeServicesInjectedProps {
+  deckRuntimeServices: DeckRuntimeServices;
+}
+
+export function useDeckRuntimeServices(): DeckRuntimeServices {
+  const runtime = React.useContext(DeckRuntimeContext);
+  if (!runtime) {
+    throw new Error('Deck runtime services are unavailable outside DeckRuntimeContext');
+  }
+
+  return runtime.services;
+}
+
+export function withDeckRuntimeServices<P extends IDeckRuntimeServicesInjectedProps>(
+  Component: React.ComponentType<P>,
+): React.ForwardRefExoticComponent<
+  React.PropsWithoutRef<React.PropsWithChildren<Omit<P, keyof IDeckRuntimeServicesInjectedProps>>> &
+    React.RefAttributes<any>
+> {
+  type OuterProps = React.PropsWithChildren<Omit<P, keyof IDeckRuntimeServicesInjectedProps>>;
+  const DeckRuntimeServicesWrapper = React.forwardRef<any, OuterProps>((props, ref) => {
+    const deckRuntimeServices = useDeckRuntimeServices();
+    const ServiceComponent = Component as any;
+    return <ServiceComponent {...props} ref={ref} deckRuntimeServices={deckRuntimeServices} />;
+  });
+  DeckRuntimeServicesWrapper.displayName = `withDeckRuntimeServices(${
+    Component.displayName || Component.name || 'Component'
+  })`;
+  return DeckRuntimeServicesWrapper;
+}

--- a/deck/packages/core/src/bootstrap/DeckRuntimeServices.ts
+++ b/deck/packages/core/src/bootstrap/DeckRuntimeServices.ts
@@ -1,0 +1,190 @@
+import type { UIRouterReact } from '@uirouter/react';
+import type { ILogService, IQService, ITimeoutService } from 'angular';
+
+import type { Application } from '../application';
+import { CacheInitializerService } from '../cache/cacheInitializer.service';
+import type { DirectProviderServiceDelegate, ProviderServiceDelegate } from '../cloudProvider/providerService.delegate';
+import { ClusterService } from '../cluster/cluster.service';
+import { InstanceTypeService } from '../instance';
+import { LoadBalancerReader } from '../loadBalancer/loadBalancer.read.service';
+import { createLoadBalancerTransformer } from '../loadBalancer/loadBalancer.transformer';
+import { ExecutionDetailsSectionService } from '../pipeline/details/executionDetailsSection.service';
+import { ExecutionService } from '../pipeline/service/execution.service';
+import { InfrastructureSearchService } from '../search/infrastructure/infrastructureSearch.service';
+import { SecurityGroupReader } from '../securityGroup/securityGroupReader.service';
+import { SecurityGroupTransformerService } from '../securityGroup/securityGroupTransformer.service';
+import { ServerGroupCommandBuilderService } from '../serverGroup/configure/common/serverGroupCommandBuilder.service';
+import { ServerGroupWriter } from '../serverGroup/serverGroupWriter.service';
+import type { CancellableTimeout } from '../utils/cancellableTimeout';
+
+export interface ServerGroupTransformer {
+  normalizeServerGroup(serverGroup: any, application: Application): PromiseLike<any>;
+  convertServerGroupCommandToDeployConfiguration(base: any): any;
+}
+
+export interface RuntimePageTitleService {
+  handleRoutingSuccess(config?: { pageTitleMain?: { field?: string; label?: string } }): void;
+}
+
+class DirectPageTitleService implements RuntimePageTitleService {
+  public handleRoutingSuccess(config: { pageTitleMain?: { field?: string; label?: string } } = {}): void {
+    document.title = config.pageTitleMain?.label || 'Spinnaker';
+  }
+}
+
+export class DeckRuntimeServices {
+  private directCacheInitializer: CacheInitializerService;
+  private directClusterService: ClusterService;
+  private directExecutionDetailsSectionService: ExecutionDetailsSectionService;
+  private directExecutionService: ExecutionService;
+  private directInfrastructureSearchService: InfrastructureSearchService;
+  private directInstanceTypeService: InstanceTypeService;
+  private directLoadBalancerReader: LoadBalancerReader;
+  private directPageTitleService: RuntimePageTitleService;
+  private directSecurityGroupReader: SecurityGroupReader;
+  private directServerGroupCommandBuilder: ServerGroupCommandBuilderService;
+  private directServerGroupTransformer: ServerGroupTransformer;
+  private directServerGroupWriter: ServerGroupWriter;
+
+  constructor(
+    private router: UIRouterReact | null,
+    private promiseService: IQService,
+    private timeoutService: CancellableTimeout,
+    private logger: ILogService,
+    public readonly providerServiceDelegate: DirectProviderServiceDelegate,
+  ) {
+    providerServiceDelegate.bindRuntimeServices(this);
+  }
+
+  public get cacheInitializer(): CacheInitializerService {
+    return (this.directCacheInitializer ||= new CacheInitializerService(
+      this.promiseService,
+      this.securityGroupReader,
+      this.providerServiceDelegate,
+    ));
+  }
+
+  public get clusterService(): ClusterService {
+    return (this.directClusterService ||= new ClusterService(
+      this.promiseService,
+      this.serverGroupTransformer,
+      (this.providerServiceDelegate as unknown) as ProviderServiceDelegate,
+    ));
+  }
+
+  public get executionDetailsSectionService(): ExecutionDetailsSectionService {
+    if (!this.router) {
+      throw new Error('Cannot create ExecutionDetailsSectionService before the direct UI Router is initialized');
+    }
+
+    return (this.directExecutionDetailsSectionService ||= new ExecutionDetailsSectionService(
+      this.router.globals.params,
+      this.router.stateService as any,
+      (this.timeoutService as unknown) as ITimeoutService,
+    ));
+  }
+
+  public get executionService(): ExecutionService {
+    if (!this.router) {
+      throw new Error('Cannot create ExecutionService before the direct UI Router is initialized');
+    }
+
+    return (this.directExecutionService ||= new ExecutionService(
+      this.promiseService,
+      this.router.stateService,
+      (this.timeoutService as unknown) as ITimeoutService,
+    ));
+  }
+
+  public get infrastructureSearchService(): InfrastructureSearchService {
+    return (this.directInfrastructureSearchService ||= new InfrastructureSearchService(
+      this.promiseService,
+      this.providerServiceDelegate,
+    ));
+  }
+
+  public get instanceTypeService(): InstanceTypeService {
+    return (this.directInstanceTypeService ||= new InstanceTypeService(
+      (this.providerServiceDelegate as unknown) as ProviderServiceDelegate,
+    ));
+  }
+
+  public get loadBalancerReader(): LoadBalancerReader {
+    return (this.directLoadBalancerReader ||= new LoadBalancerReader(
+      this.promiseService,
+      createLoadBalancerTransformer(this.providerServiceDelegate),
+    ));
+  }
+
+  public get pageTitleService(): RuntimePageTitleService {
+    return (this.directPageTitleService ||= new DirectPageTitleService());
+  }
+
+  public get securityGroupReader(): SecurityGroupReader {
+    const providerServiceDelegate = (this.providerServiceDelegate as unknown) as ProviderServiceDelegate;
+    const securityGroupTransformer = new SecurityGroupTransformerService(providerServiceDelegate);
+    const optionalSecurityGroupTransformer = {
+      normalizeSecurityGroup: (securityGroup: any) => {
+        const provider = securityGroup.provider || securityGroup.type;
+        return provider && this.providerServiceDelegate.hasDelegate(provider, 'securityGroup.transformer')
+          ? securityGroupTransformer.normalizeSecurityGroup(securityGroup)
+          : Promise.resolve(securityGroup);
+      },
+    } as SecurityGroupTransformerService;
+    return (this.directSecurityGroupReader ||= new SecurityGroupReader(
+      this.logger,
+      this.promiseService,
+      optionalSecurityGroupTransformer,
+      providerServiceDelegate,
+    ));
+  }
+
+  public get serverGroupCommandBuilder(): ServerGroupCommandBuilderService {
+    return (this.directServerGroupCommandBuilder ||= new ServerGroupCommandBuilderService(
+      (this.providerServiceDelegate as unknown) as ProviderServiceDelegate,
+    ));
+  }
+
+  public get serverGroupTransformer(): ServerGroupTransformer {
+    if (!this.directServerGroupTransformer) {
+      this.directServerGroupTransformer = {
+        normalizeServerGroup: (serverGroup: any, application: Application) => {
+          const provider = serverGroup.provider || serverGroup.type;
+          if (!this.providerServiceDelegate.hasDelegate(provider, 'serverGroup.transformer')) {
+            return Promise.resolve(serverGroup);
+          }
+
+          return this.providerServiceDelegate
+            .getDelegate<any>(provider, 'serverGroup.transformer')
+            .normalizeServerGroup(serverGroup, application);
+        },
+        convertServerGroupCommandToDeployConfiguration: (base: any) =>
+          this.providerServiceDelegate
+            .getDelegate<any>(base.selectedProvider, 'serverGroup.transformer')
+            .convertServerGroupCommandToDeployConfiguration(base),
+      };
+    }
+
+    return this.directServerGroupTransformer;
+  }
+
+  public get serverGroupWriter(): ServerGroupWriter {
+    return (this.directServerGroupWriter ||= new ServerGroupWriter(this.serverGroupTransformer));
+  }
+
+  public dispose(): void {
+    this.directCacheInitializer = null;
+    this.directClusterService = null;
+    this.directExecutionDetailsSectionService = null;
+    this.directExecutionService = null;
+    this.directInfrastructureSearchService = null;
+    this.directInstanceTypeService = null;
+    this.directLoadBalancerReader = null;
+    this.directPageTitleService = null;
+    this.directSecurityGroupReader = null;
+    this.directServerGroupCommandBuilder = null;
+    this.directServerGroupTransformer = null;
+    this.directServerGroupWriter = null;
+    this.providerServiceDelegate.dispose();
+  }
+}

--- a/deck/packages/core/src/bootstrap/bootstrapDeck.spec.tsx
+++ b/deck/packages/core/src/bootstrap/bootstrapDeck.spec.tsx
@@ -8,8 +8,10 @@ import { bootstrapDeck, createDeckRoot, resetBootstrapDeckForTests } from './boo
 import { AngularServices } from '../angular/services';
 import { ApplicationDataSourceRegistry } from '../application/service/ApplicationDataSourceRegistry';
 import { ApplicationReader } from '../application/service/ApplicationReader';
-import { AuthenticationInitializer } from '../authentication/AuthenticationInitializer';
+import type { IHttpClientImplementation } from '../api';
+import { RequestBuilder } from '../api';
 import { AuthenticationService } from '../authentication';
+import { AuthenticationInitializer } from '../authentication/AuthenticationInitializer';
 import { resetAuthenticationRuntime } from '../authentication/authentication.module';
 import { GlobalBannerService } from '../banner/global/GlobalBannerService';
 import { CacheInitializerService } from '../cache/cacheInitializer.service';
@@ -21,7 +23,8 @@ import { PluginRegistry } from '../plugins/plugin.registry';
 import { resetPluginInitializationForTests } from '../plugins/plugin.module';
 import { SchedulerFactory } from '../scheduler/SchedulerFactory';
 import type { DeckRuntime } from './DeckRuntime';
-import { DeckRuntimeContext, createDeckRuntime } from './DeckRuntime';
+import { createDeckRuntime } from './DeckRuntime';
+import { DeckRuntimeContext } from './DeckRuntimeContext';
 import { SpinnakerContainer } from './SpinnakerContainer';
 import * as State from '../state';
 
@@ -58,11 +61,13 @@ describe('bootstrapDeck', () => {
   let cacheInitializeSpy: jasmine.Spy;
   let deckManifestSpy: jasmine.Spy;
   let listenSpy: jasmine.Spy;
+  let metadataGet: jasmine.Spy;
   let notificationMetadataSpy: jasmine.Spy;
   let originalAuthEnabled: boolean;
   let originalCheckForUpdates: boolean;
   let originalDataSources: ReturnType<typeof ApplicationDataSourceRegistry.getDataSources>;
   let originalHash: string;
+  let originalHttpClient: IHttpClientImplementation;
   let pluginLoadsSpy: jasmine.Spy;
   let renderSpy: jasmine.Spy;
   let routerPluginSpy: jasmine.Spy;
@@ -82,7 +87,10 @@ describe('bootstrapDeck', () => {
   }
 
   function createConfiguredRouter(): UIRouterReact {
-    const router = configureRouter();
+    const router = new UIRouterReact();
+    const runtime = createDeckRuntime(router);
+    router.disposable(runtime);
+    configureRouter(router, runtime.services);
     configuredRouters.push(router);
     return router;
   }
@@ -97,10 +105,13 @@ describe('bootstrapDeck', () => {
     originalCheckForUpdates = SETTINGS.checkForUpdates;
     originalDataSources = ApplicationDataSourceRegistry.getDataSources();
     originalHash = window.location.hash;
+    originalHttpClient = RequestBuilder.defaultHttpClient;
     stateSnapshots = stateSingletons.map((state) => ({ state, descriptors: Object.getOwnPropertyDescriptors(state) }));
     ApplicationDataSourceRegistry.clearDataSources();
     SETTINGS.authEnabled = true;
     SETTINGS.checkForUpdates = true;
+    metadataGet = jasmine.createSpy('metadataGet').and.returnValue(Promise.resolve([]));
+    RequestBuilder.defaultHttpClient = { get: metadataGet } as IHttpClientImplementation;
     authenticationSpy = spyOn(AuthenticationInitializer, 'authenticateUser').and.returnValue(Promise.resolve(true));
     spyOn(GlobalBannerService, 'getActiveBanners').and.returnValue(Promise.resolve([]));
     notificationMetadataSpy = spyOn(NotificationService, 'getNotificationTypeMetadata').and.returnValue(
@@ -144,6 +155,7 @@ describe('bootstrapDeck', () => {
     resetPluginInitializationForTests();
     SETTINGS.authEnabled = originalAuthEnabled;
     SETTINGS.checkForUpdates = originalCheckForUpdates;
+    RequestBuilder.defaultHttpClient = originalHttpClient;
     window.location.hash = originalHash;
   });
 
@@ -378,9 +390,9 @@ describe('bootstrapDeck', () => {
     await bootstrapDeck(root);
 
     expect(order.filter((step) => step !== 'state initialized')).toEqual([
-      'runtime metadata',
       'authentication',
       'plugins',
+      'runtime metadata',
       'router constructed',
       'cache started',
       'render',
@@ -388,9 +400,9 @@ describe('bootstrapDeck', () => {
       'sync',
     ]);
     expect(order).toEqual([
-      'runtime metadata',
       'authentication',
       'plugins',
+      'runtime metadata',
       'router constructed',
       'state initialized',
       'cache started',
@@ -408,8 +420,9 @@ describe('bootstrapDeck', () => {
 
     await bootstrapDeck(root);
 
-    expect(runtimeDataSourceSpy).toHaveBeenCalled();
+    expect(runtimeDataSourceSpy).not.toHaveBeenCalled();
     expect(notificationMetadataSpy).not.toHaveBeenCalled();
+    expect(metadataGet).not.toHaveBeenCalled();
     expect(deckManifestSpy).not.toHaveBeenCalled();
     expect(routerPluginSpy).not.toHaveBeenCalled();
     expect(State.ExecutionState.filterModel).toBe(originalFilterModel);
@@ -427,9 +440,16 @@ describe('bootstrapDeck', () => {
     const bootstrap = bootstrapDeck(root);
 
     expect(notificationMetadataSpy).not.toHaveBeenCalled();
+    expect(metadataGet).not.toHaveBeenCalled();
     authentication.resolve(true);
     await bootstrap;
     expect(notificationMetadataSpy).toHaveBeenCalledTimes(1);
+    expect(metadataGet.calls.allArgs().map(([config]) => config.url)).toEqual(
+      jasmine.arrayWithExactContents([
+        jasmine.stringMatching(/jobs\/preconfigured$/),
+        jasmine.stringMatching(/webhooks\/preconfigured$/),
+      ]),
+    );
   });
 
   it('does not wait for dynamic metadata before plugins and router startup', async () => {
@@ -663,7 +683,7 @@ describe('bootstrapDeck', () => {
     await expectAsync(bootstrapDeck(root)).toBeResolved();
     expect(renderSpy).toHaveBeenCalledTimes(2);
     expect(syncSpy).toHaveBeenCalledTimes(1);
-    expect(cacheInitializeSpy).toHaveBeenCalledTimes(1);
+    expect(cacheInitializeSpy).toHaveBeenCalledTimes(2);
     expect(versionSchedulerCount()).toBe(1);
   });
 
@@ -688,9 +708,12 @@ describe('bootstrapDeck', () => {
     await expectAsync(bootstrapDeck(retryRoot)).toBeResolved();
     expect(renderSpy).toHaveBeenCalledTimes(2);
     expect(syncSpy).toHaveBeenCalledTimes(1);
-    expect(cacheInitializeSpy).toHaveBeenCalledTimes(1);
+    expect(cacheInitializeSpy).toHaveBeenCalledTimes(2);
     expect(versionSchedulerCount()).toBe(1);
-    expect(consoleError).toHaveBeenCalledOnceWith('Failed to initialize infrastructure caches', cacheFailure);
+    expect(consoleError.calls.allArgs()).toEqual([
+      ['Failed to initialize infrastructure caches', cacheFailure],
+      ['Failed to initialize infrastructure caches', cacheFailure],
+    ]);
   });
 
   it('preserves the bootstrap error and permits retry when failure cleanup cannot unmount', async () => {
@@ -743,7 +766,7 @@ describe('bootstrapDeck', () => {
     expect(dispose).toHaveBeenCalledTimes(1);
   });
 
-  it('binds public runtime services and clears their scheduled and router-bound work on rebootstrap', async () => {
+  it('clears scheduled and router-bound work on rebootstrap', async () => {
     jasmine.clock().install();
     try {
       const firstRoot = createRoot();
@@ -760,7 +783,6 @@ describe('bootstrapDeck', () => {
       AngularServices.$timeout(scheduled, 100);
 
       expect(AngularServices.$timeout as any).toBe(firstRuntime.timeoutService as any);
-      expect(AngularServices.providerServiceDelegate).toBe(firstRuntime.providerServiceDelegate as any);
 
       resetBootstrapDeckForTests();
       jasmine.clock().tick(100);

--- a/deck/packages/core/src/bootstrap/bootstrapDeck.tsx
+++ b/deck/packages/core/src/bootstrap/bootstrapDeck.tsx
@@ -3,7 +3,8 @@ import * as React from 'react';
 import { render, unmountComponentAtNode } from 'react-dom';
 
 import type { DeckRuntime } from './DeckRuntime';
-import { createDeckRuntime, DeckRuntimeContext } from './DeckRuntime';
+import { createDeckRuntime } from './DeckRuntime';
+import { DeckRuntimeContext } from './DeckRuntimeContext';
 import { SpinnakerContainer } from './SpinnakerContainer';
 import { AngularServices } from '../angular/services';
 import { initializeAuthentication } from '../authentication/authentication.module';
@@ -12,7 +13,12 @@ import '../navigation/coreRoutes';
 import { getDirectRouter, setDirectRouter } from '../navigation/directRouter';
 import { configureRouter, startRouter } from '../navigation/router';
 import { initializePlugins } from '../plugins/plugin.module';
-import { initializeDynamicRuntimeMetadata, initializeRuntimeMetadata } from './runtimeInitializers';
+import {
+  disposeRuntimeMetadata,
+  initializeDynamicRuntimeMetadata,
+  initializeRuntimeMetadata,
+  resetDynamicRuntimeMetadataForTests,
+} from './runtimeInitializers';
 import { initialize as initializeState } from '../state';
 
 import '../presentation/details.less';
@@ -45,6 +51,7 @@ function cleanupRuntime(): void {
   activeRuntime = null;
   activeRouter = null;
   renderedRoot = null;
+  cacheInitializationAttempt = null;
 
   if (router && getDirectRouter() === router) {
     setDirectRouter(null);
@@ -62,47 +69,53 @@ function cleanupRuntime(): void {
       console.error('Failed to dispose Deck router', error);
     } finally {
       try {
-        runtime?.dispose();
+        disposeRuntimeMetadata(runtime);
       } catch (error) {
-        console.error('Failed to dispose Deck runtime', error);
+        console.error('Failed to dispose Deck runtime metadata', error);
       } finally {
-        if (runtime) {
-          AngularServices.releaseRuntime(runtime);
+        try {
+          runtime?.dispose();
+        } catch (error) {
+          console.error('Failed to dispose Deck runtime', error);
+        } finally {
+          if (runtime) {
+            AngularServices.releaseRuntime(runtime);
+          }
         }
       }
     }
   }
 }
 
-function initializeInfrastructureCaches(): void {
+function initializeInfrastructureCaches(runtime: DeckRuntime): void {
   if (cacheInitializationAttempt) {
     return;
   }
 
   cacheInitializationAttempt = Promise.resolve()
-    .then(() => AngularServices.cacheInitializer.initialize())
+    .then(() => runtime.services.cacheInitializer.initialize())
     .then(() => undefined)
     .catch((error) => console.error('Failed to initialize infrastructure caches', error));
 }
 
 async function runBootstrap(root: HTMLElement): Promise<void> {
-  initializeRuntimeMetadata();
   const authenticated = await initializeAuthentication();
   if (!authenticated) {
     cleanupRuntime();
     return;
   }
 
-  void initializeDynamicRuntimeMetadata();
   await initializePlugins();
   const router = new UIRouterReact();
   const runtime = createDeckRuntime(router);
-  AngularServices.bindRuntime(runtime);
   activeRuntime = runtime;
-  configureRouter(router);
   activeRouter = router;
+  AngularServices.bindRuntime(runtime);
+  initializeRuntimeMetadata(runtime);
+  void initializeDynamicRuntimeMetadata();
+  configureRouter(router, runtime.services);
   initializeState();
-  initializeInfrastructureCaches();
+  initializeInfrastructureCaches(runtime);
   await Promise.resolve();
 
   renderedRoot = root;
@@ -145,6 +158,7 @@ export function resetBootstrapDeckForTests(): void {
     bootstrapRoot = null;
     bootstrapAttempt = null;
     cacheInitializationAttempt = null;
+    resetDynamicRuntimeMetadataForTests();
     VersionChecker.resetForTests();
   }
 }

--- a/deck/packages/core/src/bootstrap/index.ts
+++ b/deck/packages/core/src/bootstrap/index.ts
@@ -1,3 +1,4 @@
 export * from './bootstrapDeck';
 export * from './DeckRuntime';
+export * from './DeckRuntimeContext';
 export * from './paramChangedHelper';

--- a/deck/packages/core/src/bootstrap/runtimeInitializers.spec.ts
+++ b/deck/packages/core/src/bootstrap/runtimeInitializers.spec.ts
@@ -1,3 +1,7 @@
+import { UIRouterReact } from '@uirouter/react';
+
+import type { IHttpClientImplementation } from '../api';
+import { RequestBuilder } from '../api';
 import { ApplicationDataSourceRegistry } from '../application/service/ApplicationDataSourceRegistry';
 import type { INotificationSettings } from '../config';
 import { SETTINGS } from '../config/settings';
@@ -8,10 +12,14 @@ import type { IFilterType } from '../search/widgets/SearchFilterTypeRegistry';
 import { SearchFilterTypeRegistry } from '../search/widgets/SearchFilterTypeRegistry';
 
 import {
+  disposeRuntimeMetadata,
   initializeDynamicRuntimeMetadata,
   initializeRuntimeMetadata,
   registerRuntimeDataSources,
+  resetDynamicRuntimeMetadataForTests,
 } from './runtimeInitializers';
+import type { DeckRuntime } from './DeckRuntime';
+import { createDeckRuntime } from './DeckRuntime';
 
 function replaceSearchFilterTypes(filterTypes: IFilterType[]): void {
   (SearchFilterTypeRegistry as any).registry.clear();
@@ -23,9 +31,12 @@ describe('runtime initializers', () => {
   const originalHiddenStages = SETTINGS.hiddenStages;
   const originalNotifications = SETTINGS.notifications;
   let originalDataSources: ReturnType<typeof ApplicationDataSourceRegistry.getDataSources>;
+  let originalHttpClient: IHttpClientImplementation;
   let originalPipeline: typeof Registry.pipeline;
   let originalSearchFilterTypes: IFilterType[];
   let originalUrlBuilder: typeof Registry.urlBuilder;
+  let metadataGet: jasmine.Spy;
+  let runtime: DeckRuntime;
   const enabledKeys = [
     'serverGroups',
     'loadBalancers',
@@ -40,7 +51,9 @@ describe('runtime initializers', () => {
   ];
 
   beforeEach(() => {
+    resetDynamicRuntimeMetadataForTests();
     originalDataSources = ApplicationDataSourceRegistry.getDataSources();
+    originalHttpClient = RequestBuilder.defaultHttpClient;
     originalPipeline = Registry.pipeline;
     originalUrlBuilder = Registry.urlBuilder;
     originalSearchFilterTypes = SearchFilterTypeRegistry.getRegisteredFilterKeys().map((key) =>
@@ -57,9 +70,15 @@ describe('runtime initializers', () => {
     };
     SETTINGS.hiddenStages = [];
     (SETTINGS as any).notifications = undefined;
+    metadataGet = jasmine.createSpy('metadataGet').and.returnValue(Promise.resolve([]));
+    RequestBuilder.defaultHttpClient = { get: metadataGet } as IHttpClientImplementation;
+    runtime = createDeckRuntime(new UIRouterReact());
   });
 
   afterEach(() => {
+    resetDynamicRuntimeMetadataForTests();
+    disposeRuntimeMetadata();
+    runtime.dispose();
     ApplicationDataSourceRegistry.clearDataSources();
     originalDataSources.forEach((dataSource) => ApplicationDataSourceRegistry.registerDataSource(dataSource));
     Registry.pipeline = originalPipeline;
@@ -68,13 +87,14 @@ describe('runtime initializers', () => {
     SETTINGS.feature = originalFeatureSettings;
     SETTINGS.hiddenStages = originalHiddenStages;
     SETTINGS.notifications = originalNotifications;
+    RequestBuilder.defaultHttpClient = originalHttpClient;
   });
 
   it('registers each enabled data source once in stable registration order', () => {
     const registerDataSource = spyOn(ApplicationDataSourceRegistry, 'registerDataSource').and.callThrough();
 
-    registerRuntimeDataSources();
-    registerRuntimeDataSources();
+    registerRuntimeDataSources(runtime);
+    registerRuntimeDataSources(runtime);
 
     const keys = ApplicationDataSourceRegistry.getDataSources().map(({ key }) => key);
     enabledKeys.forEach((key) => expect(keys.filter((registeredKey) => registeredKey === key).length).toBe(1));
@@ -84,7 +104,7 @@ describe('runtime initializers', () => {
   it('omits gated data sources while retaining standard data sources', () => {
     SETTINGS.feature = { ...SETTINGS.feature, entityTags: false, functions: false };
 
-    registerRuntimeDataSources();
+    registerRuntimeDataSources(runtime);
 
     const keys = ApplicationDataSourceRegistry.getDataSources().map(({ key }) => key);
     expect(keys).not.toContain('functions');
@@ -95,8 +115,8 @@ describe('runtime initializers', () => {
   it('registers synchronous runtime metadata exactly once without loading dynamic metadata', () => {
     const getNotificationTypeMetadata = spyOn(NotificationService, 'getNotificationTypeMetadata');
 
-    initializeRuntimeMetadata();
-    initializeRuntimeMetadata();
+    initializeRuntimeMetadata(runtime);
+    initializeRuntimeMetadata(runtime);
 
     const dataSourceKeys = ApplicationDataSourceRegistry.getDataSources().map(({ key }) => key);
     enabledKeys.forEach((key) =>
@@ -134,13 +154,41 @@ describe('runtime initializers', () => {
     expect(getNotificationTypeMetadata).not.toHaveBeenCalled();
   });
 
-  it('registers supported dynamic notification metadata exactly once', async () => {
+  it('replaces runtime-bound metadata when a new runtime takes ownership', () => {
+    initializeRuntimeMetadata(runtime);
+    const firstServerGroups = ApplicationDataSourceRegistry.getDataSources().find(({ key }) => key === 'serverGroups');
+    const firstDeployStage = Registry.pipeline.getStageTypes().find(({ key }) => key === 'deploy');
+    const replacementRuntime = createDeckRuntime(new UIRouterReact());
+
+    initializeRuntimeMetadata(replacementRuntime);
+
+    const secondServerGroups = ApplicationDataSourceRegistry.getDataSources().find(({ key }) => key === 'serverGroups');
+    const deployStages = Registry.pipeline.getStageTypes().filter(({ key }) => key === 'deploy');
+    expect(secondServerGroups).not.toBe(firstServerGroups);
+    expect(deployStages.length).toBe(1);
+    expect(deployStages[0]).not.toBe(firstDeployStage);
+    disposeRuntimeMetadata(replacementRuntime);
+    replacementRuntime.dispose();
+  });
+
+  it('registers supported dynamic metadata exactly once', async () => {
     spyOn(NotificationService, 'getNotificationTypeMetadata').and.returnValue(
       Promise.resolve([
         { notificationType: 'runtime-basic', uiType: 'BASIC', parameters: [] },
         { notificationType: 'runtime-custom', uiType: 'CUSTOM', parameters: [] },
       ]),
     );
+    metadataGet.and.callFake(({ url }) => {
+      if (url.endsWith('/jobs/preconfigured')) {
+        return Promise.resolve([
+          { type: 'runtime-job', uiType: 'BASIC', label: 'Runtime job', producesArtifacts: false },
+        ]);
+      }
+      if (url.endsWith('/webhooks/preconfigured')) {
+        return Promise.resolve([{ type: 'runtime-webhook', label: 'Runtime webhook' }]);
+      }
+      return Promise.resolve([]);
+    });
 
     await initializeDynamicRuntimeMetadata();
     await initializeDynamicRuntimeMetadata();
@@ -148,6 +196,9 @@ describe('runtime initializers', () => {
     const notificationTypes = Registry.pipeline.getNotificationTypes();
     expect(notificationTypes.filter(({ key }) => key === 'runtime-basic').length).toBe(1);
     expect(notificationTypes.find(({ key }) => key === 'runtime-custom')).toBeUndefined();
+    const stageTypes = Registry.pipeline.getStageTypes();
+    expect(stageTypes.filter(({ key }) => key === 'runtime-job').length).toBe(1);
+    expect(stageTypes.filter(({ key }) => key === 'runtime-webhook').length).toBe(1);
   });
 
   it('does not restore a disabled built-in notification from dynamic metadata', async () => {
@@ -161,7 +212,7 @@ describe('runtime initializers', () => {
       sms: { enabled: false },
       cdevents: { enabled: false },
     } as INotificationSettings;
-    initializeRuntimeMetadata();
+    initializeRuntimeMetadata(runtime);
     spyOn(NotificationService, 'getNotificationTypeMetadata').and.returnValue(
       Promise.resolve([
         { notificationType: 'SLACK', uiType: 'BASIC', parameters: [] },
@@ -186,5 +237,24 @@ describe('runtime initializers', () => {
 
     expect(consoleError).toHaveBeenCalledTimes(1);
     expect(consoleError).toHaveBeenCalledWith('Failed to load notification type metadata', failure);
+  });
+
+  it('logs preconfigured metadata failures independently and resolves', async () => {
+    spyOn(NotificationService, 'getNotificationTypeMetadata').and.returnValue(Promise.resolve([]));
+    metadataGet.and.callFake(({ url }) =>
+      url.endsWith('/jobs/preconfigured') || url.endsWith('/webhooks/preconfigured')
+        ? Promise.reject(new Error(url))
+        : Promise.resolve([]),
+    );
+    const consoleError = spyOn(console, 'error').and.stub();
+
+    await initializeDynamicRuntimeMetadata();
+
+    expect(consoleError).toHaveBeenCalledTimes(2);
+    expect(consoleError).toHaveBeenCalledWith('Failed to load preconfigured job stage metadata', jasmine.any(Error));
+    expect(consoleError).toHaveBeenCalledWith(
+      'Failed to load preconfigured webhook stage metadata',
+      jasmine.any(Error),
+    );
   });
 });

--- a/deck/packages/core/src/bootstrap/runtimeInitializers.ts
+++ b/deck/packages/core/src/bootstrap/runtimeInitializers.ts
@@ -1,32 +1,95 @@
+import type { DeckRuntime } from './DeckRuntime';
+import { ApplicationDataSourceRegistry } from '../application/service/ApplicationDataSourceRegistry';
+import type { IStageTypeConfig } from '../domain';
 import { registerEntityTagsDataSource } from '../entityTag/entityTags.dataSource';
-import { registerFunctionDataSource } from '../function/function.dataSource';
+import { createDirectFunctionReader, registerFunctionDataSource } from '../function/function.dataSource';
 import { registerLoadBalancerDataSource } from '../loadBalancer/loadBalancer.dataSource';
 import { registerBuiltinNotificationTypes } from '../notification/notification.types';
 import { initializeDynamicNotificationTypes } from '../notification/notifications.module';
+import { registerDeployStage } from '../pipeline/config/stages/deploy/deployStage';
+import { registerPreconfiguredJobStages } from '../pipeline/config/stages/preconfiguredJob/preconfiguredJobStage';
 import { registerScriptStage } from '../pipeline/config/stages/script/scriptStage';
+import { registerPreconfiguredWebhookStages } from '../pipeline/config/stages/webhook/webhookStage';
 import { registerPipelineDataSources } from '../pipeline/pipeline.dataSource';
+import { Registry } from '../registry';
 import { registerSearchFilterTypes } from '../search/widgets/search.component';
 import { registerSecurityGroupDataSource } from '../securityGroup/securityGroup.dataSource';
 import { registerServerGroupDataSource } from '../serverGroup/serverGroup.dataSource';
 import { registerTaskDataSources } from '../task/task.dataSource';
 
-export function registerRuntimeDataSources(): void {
-  registerServerGroupDataSource();
-  registerLoadBalancerDataSource();
-  registerSecurityGroupDataSource();
-  registerFunctionDataSource();
-  registerEntityTagsDataSource();
-  registerPipelineDataSources();
-  registerTaskDataSources();
+interface RuntimeMetadataRegistration {
+  runtime: DeckRuntime;
+  dataSourceKeys: string[];
+  deployStage: IStageTypeConfig;
 }
 
-export function initializeRuntimeMetadata(): void {
-  registerRuntimeDataSources();
+let activeRuntimeMetadata: RuntimeMetadataRegistration | null = null;
+let dynamicRuntimeMetadataAttempt: Promise<void> | null = null;
+
+export function registerRuntimeDataSources(runtime: DeckRuntime): string[] {
+  const existingKeys = new Set(ApplicationDataSourceRegistry.getDataSources().map(({ key }) => key));
+  const { promiseService, services } = runtime;
+  registerServerGroupDataSource(promiseService, services.clusterService);
+  registerLoadBalancerDataSource(promiseService, services.loadBalancerReader);
+  registerSecurityGroupDataSource(promiseService, services.securityGroupReader);
+  registerFunctionDataSource(
+    createDirectFunctionReader(services.providerServiceDelegate),
+    <T>(value: T | PromiseLike<T>) => promiseService.when(value),
+  );
+  registerEntityTagsDataSource();
+  registerPipelineDataSources(promiseService, services.executionService, services.clusterService);
+  registerTaskDataSources(promiseService, services.clusterService);
+  return ApplicationDataSourceRegistry.getDataSources()
+    .map(({ key }) => key)
+    .filter((key) => !existingKeys.has(key));
+}
+
+export function initializeRuntimeMetadata(runtime: DeckRuntime): void {
+  if (activeRuntimeMetadata?.runtime === runtime) {
+    return;
+  }
+  disposeRuntimeMetadata();
+
+  const dataSourceKeys = registerRuntimeDataSources(runtime);
+  const deployStage = registerDeployStage(runtime.services.clusterService);
   registerScriptStage();
   registerBuiltinNotificationTypes();
   registerSearchFilterTypes();
+  activeRuntimeMetadata = { runtime, dataSourceKeys, deployStage };
+}
+
+export function disposeRuntimeMetadata(runtime?: DeckRuntime): void {
+  if (!activeRuntimeMetadata || (runtime && activeRuntimeMetadata.runtime !== runtime)) {
+    return;
+  }
+
+  activeRuntimeMetadata.dataSourceKeys.forEach((key) => ApplicationDataSourceRegistry.removeDataSource(key));
+  Registry.pipeline.unregisterStage(activeRuntimeMetadata.deployStage);
+  activeRuntimeMetadata = null;
+}
+
+async function initializeOptionalMetadata(message: string, initializer: () => PromiseLike<unknown>): Promise<void> {
+  try {
+    await initializer();
+  } catch (error) {
+    console.error(message, error);
+  }
 }
 
 export function initializeDynamicRuntimeMetadata(): Promise<void> {
-  return initializeDynamicNotificationTypes();
+  if (!dynamicRuntimeMetadataAttempt) {
+    dynamicRuntimeMetadataAttempt = Promise.all([
+      initializeDynamicNotificationTypes(),
+      initializeOptionalMetadata('Failed to load preconfigured job stage metadata', registerPreconfiguredJobStages),
+      initializeOptionalMetadata(
+        'Failed to load preconfigured webhook stage metadata',
+        registerPreconfiguredWebhookStages,
+      ),
+    ]).then(() => undefined);
+  }
+  return dynamicRuntimeMetadataAttempt;
+}
+
+export function resetDynamicRuntimeMetadataForTests(): void {
+  dynamicRuntimeMetadataAttempt = null;
 }

--- a/deck/packages/core/src/cloudProvider/providerService.delegate.spec.ts
+++ b/deck/packages/core/src/cloudProvider/providerService.delegate.spec.ts
@@ -6,15 +6,20 @@ import { DirectProviderServiceDelegate } from './providerService.delegate';
 
 describe('DirectProviderServiceDelegate', () => {
   const provider = 'directProviderServiceDelegateTest';
+  const otherProvider = 'otherDirectProviderServiceDelegateTest';
   const serviceKey = 'test.service';
+  const otherServiceKey = 'test.otherService';
 
   beforeEach(() => {
     SETTINGS.providers[provider] = {};
+    SETTINGS.providers[otherProvider] = {};
   });
 
   afterEach(() => {
     delete SETTINGS.providers[provider];
+    delete SETTINGS.providers[otherProvider];
     (CloudProviderRegistry as any).providers.delete(provider);
+    (CloudProviderRegistry as any).providers.delete(otherProvider);
   });
 
   it('checks for a delegate without constructing it', () => {
@@ -44,6 +49,74 @@ describe('DirectProviderServiceDelegate', () => {
 
     expect(service).toEqual(jasmine.any(TestService));
     expect(service.injectedPromiseService).toBe(promiseService);
+  });
+
+  it('only injects runtime services into delegates that opt in', () => {
+    const runtimeServices = {} as any;
+    class ExistingService {
+      constructor(_promiseService: IQService, public readonly existingSecondDependency = 'existing') {}
+    }
+    class RuntimeAwareService {
+      public static readonly requiresDeckRuntimeServices = true;
+      constructor(_promiseService: IQService, public readonly injectedRuntimeServices?: any) {}
+    }
+    CloudProviderRegistry.registerProvider(provider, {
+      name: provider,
+      test: { service: ExistingService, otherService: RuntimeAwareService },
+    });
+    const delegate = new DirectProviderServiceDelegate({} as IQService);
+    delegate.bindRuntimeServices(runtimeServices);
+
+    expect(delegate.getDelegate<ExistingService>(provider, serviceKey).existingSecondDependency).toBe('existing');
+    expect(delegate.getDelegate<RuntimeAwareService>(provider, otherServiceKey).injectedRuntimeServices).toBe(
+      runtimeServices,
+    );
+  });
+
+  it('caches each service instance by provider and service key', () => {
+    class TestService {}
+    CloudProviderRegistry.registerProvider(provider, {
+      name: provider,
+      test: { service: TestService, otherService: TestService },
+    });
+    CloudProviderRegistry.registerProvider(otherProvider, {
+      name: otherProvider,
+      test: { service: TestService },
+    });
+    const delegate = new DirectProviderServiceDelegate({} as IQService);
+    const service = delegate.getDelegate(provider, serviceKey);
+
+    expect(delegate.getDelegate(provider, serviceKey)).toBe(service);
+    expect(delegate.getDelegate(provider, otherServiceKey)).not.toBe(service);
+    expect(delegate.getDelegate(otherProvider, serviceKey)).not.toBe(service);
+  });
+
+  it('resolves registrations made after the delegate is created', () => {
+    class TestService {}
+    const delegate = new DirectProviderServiceDelegate({} as IQService);
+
+    expect(delegate.hasDelegate(provider, serviceKey)).toBe(false);
+
+    CloudProviderRegistry.registerProvider(provider, {
+      name: provider,
+      test: { service: TestService },
+    });
+
+    expect(delegate.getDelegate(provider, serviceKey)).toEqual(jasmine.any(TestService));
+  });
+
+  it('clears cached instances when disposed', () => {
+    class TestService {}
+    CloudProviderRegistry.registerProvider(provider, {
+      name: provider,
+      test: { service: TestService },
+    });
+    const delegate = new DirectProviderServiceDelegate({} as IQService);
+    const firstService = delegate.getDelegate(provider, serviceKey);
+
+    delegate.dispose();
+
+    expect(delegate.getDelegate(provider, serviceKey)).not.toBe(firstService);
   });
 
   it('throws the established error when no delegate is registered', () => {

--- a/deck/packages/core/src/cloudProvider/providerService.delegate.ts
+++ b/deck/packages/core/src/cloudProvider/providerService.delegate.ts
@@ -3,25 +3,52 @@ import { module } from 'angular';
 import { isFunction, isString } from 'lodash';
 
 import { CloudProviderRegistry } from './CloudProviderRegistry';
+import type { DeckRuntimeServices } from '../bootstrap/DeckRuntimeServices';
 
 import IInjectorService = angular.auto.IInjectorService;
 
-type DirectServiceConstructor<T> = new (promiseService: IQService) => T;
+interface DirectServiceConstructor<T> {
+  new (promiseService: IQService, runtimeServices?: DeckRuntimeServices): T;
+  requiresDeckRuntimeServices?: boolean;
+}
 
 export class DirectProviderServiceDelegate {
+  private instances = new Map<string, Map<string, unknown>>();
+  private runtimeServices: DeckRuntimeServices;
+
   constructor(private promiseService: IQService) {}
+
+  public bindRuntimeServices(runtimeServices: DeckRuntimeServices): void {
+    this.runtimeServices = runtimeServices;
+  }
 
   public hasDelegate(provider: string, serviceKey: string): boolean {
     return isFunction(CloudProviderRegistry.getValue(provider, serviceKey));
   }
 
   public getDelegate<T>(provider: string, serviceKey: string): T {
+    const cached = this.instances.get(provider)?.get(serviceKey);
+    if (cached) {
+      return cached as T;
+    }
+
     const ServiceClass = CloudProviderRegistry.getValue(provider, serviceKey) as DirectServiceConstructor<T>;
     if (isFunction(ServiceClass)) {
-      return new ServiceClass(this.promiseService);
+      const instance = ServiceClass.requiresDeckRuntimeServices
+        ? new ServiceClass(this.promiseService, this.runtimeServices)
+        : new ServiceClass(this.promiseService);
+      const providerInstances = this.instances.get(provider) || new Map<string, unknown>();
+      providerInstances.set(serviceKey, instance);
+      this.instances.set(provider, providerInstances);
+      return instance;
     }
 
     throw new Error('No "' + serviceKey + '" service found for provider "' + provider + '"');
+  }
+
+  public dispose(): void {
+    this.instances.clear();
+    this.runtimeServices = null;
   }
 }
 

--- a/deck/packages/core/src/cluster/AllClusters.tsx
+++ b/deck/packages/core/src/cluster/AllClusters.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 
 import { AllClustersGroupings } from './AllClustersGroupings';
 import type { IAccountDetails } from '../account';
-import { AngularServices } from '../angular/services';
 import type { Application } from '../application';
 import { BannerContainer } from '../banner';
+import { useDeckRuntimeServices } from '../bootstrap/DeckRuntimeContext';
 import type { ICloudProviderConfig } from '../cloudProvider';
 import { CloudProviderRegistry, ProviderSelectionService } from '../cloudProvider';
 import type { IFilterTag, ISortFilter } from '../filterModel';
@@ -126,6 +126,8 @@ export function ClusterControls({ showInstancesToggle, sortFilter, updateCluster
 }
 
 export function CreateServerGroupButton({ app }: { app: Application }) {
+  const runtimeServices = useDeckRuntimeServices();
+  const { serverGroupCommandBuilder } = runtimeServices;
   const [disabled, setDisabled] = React.useState(true);
   const [createServerGroupError, setCreateServerGroupError] = React.useState<string | null>(null);
 
@@ -142,23 +144,24 @@ export function CreateServerGroupButton({ app }: { app: Application }) {
     setCreateServerGroupError(null);
     ProviderSelectionService.selectProvider(app, 'serverGroup', hasReactCloneServerGroupModal)
       .then((provider) => {
-        return AngularServices.serverGroupCommandBuilder
-          .buildNewServerGroupCommand(app, provider, null)
-          .then((command: any) => {
-            const providerConfig = CloudProviderRegistry.getValue(provider, 'serverGroup');
-            if (!providerConfig.CloneServerGroupModal) {
-              throw new Error(`No React clone server group modal is registered for provider "${provider}".`);
-            }
+        return serverGroupCommandBuilder.buildNewServerGroupCommand(app, provider, null).then((command: any) => {
+          const providerConfig = CloudProviderRegistry.getValue(provider, 'serverGroup');
+          if (!providerConfig.CloneServerGroupModal) {
+            throw new Error(`No React clone server group modal is registered for provider "${provider}".`);
+          }
 
-            providerConfig.CloneServerGroupModal.show({
+          providerConfig.CloneServerGroupModal.show(
+            {
               title: 'Create New Server Group',
               application: app,
               serverGroup: null,
               command,
               provider,
               isNew: true,
-            });
-          });
+            },
+            runtimeServices,
+          );
+        });
       })
       .catch((error) => {
         if (error instanceof Error) {

--- a/deck/packages/core/src/diffs/ViewChangesLink.tsx
+++ b/deck/packages/core/src/diffs/ViewChangesLink.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { ChangesModal } from './ChangesModal';
 import type { ICommit } from './CommitHistory';
 import type { IJarDiff } from './JarDiffs';
-import { AngularServices } from '../angular/services';
+import { useDeckRuntimeServices } from '../bootstrap/DeckRuntimeContext';
 import type { IBuildDiffInfo, ICreationMetadata, ICreationMetadataTag, IExecution, IExecutionStage } from '../domain';
 import { LabeledValue, showModal, useData } from '../presentation';
 
@@ -22,12 +22,13 @@ export interface IViewChangesLinkProps {
 }
 
 export const ViewChangesLink = ({ changeConfig, linkText, nameItem, viewType }: IViewChangesLinkProps) => {
+  const { executionService } = useDeckRuntimeServices();
   const changeConfigValue = changeConfig?.metadata?.value || ({} as ICreationMetadata);
 
   const fetchExecution = () => {
     const isExecution = changeConfigValue.executionType === 'pipeline';
     if (isExecution) {
-      return AngularServices.executionService.getExecution(changeConfigValue.executionId);
+      return executionService.getExecution(changeConfigValue.executionId);
     }
     /** A noop promise so `useData` can be utilized */
     return (Promise.resolve({}) as unknown) as PromiseLike<IExecution>;

--- a/deck/packages/core/src/entityTag/EntitySource.tsx
+++ b/deck/packages/core/src/entityTag/EntitySource.tsx
@@ -2,7 +2,7 @@ import { UISref } from '@uirouter/react';
 import * as React from 'react';
 
 import { EntitySourcePopover } from './EntitySourcePopover';
-import { AngularServices } from '../angular/services';
+import { useDeckRuntimeServices } from '../bootstrap/DeckRuntimeContext';
 import type { ICreationMetadataTag, IExecution } from '../domain';
 import { HoverablePopover, useData } from '../presentation';
 
@@ -12,12 +12,13 @@ export interface IEntitySourceProps {
 }
 
 export const EntitySource = ({ metadata, relativePath = '^.^.^' }: IEntitySourceProps) => {
+  const { executionService } = useDeckRuntimeServices();
   const executionType = metadata?.value?.executionType === 'pipeline' ? 'pipeline' : 'task';
   const { application, comments, executionId, stageId } = metadata?.value || {};
 
   const fetchExecution = () => {
     if (executionType === 'pipeline') {
-      return AngularServices.executionService.getExecution(metadata?.value?.executionId);
+      return executionService.getExecution(metadata?.value?.executionId);
     }
 
     return new Promise(() => {});

--- a/deck/packages/core/src/function/CreateFunctionButton.tsx
+++ b/deck/packages/core/src/function/CreateFunctionButton.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import type { Application } from '../application';
+import { DeckRuntimeContext } from '../bootstrap/DeckRuntimeContext';
 import { CloudProviderRegistry, ProviderSelectionService } from '../cloudProvider';
 import type { IFunction } from '../domain';
 import type { IFunctionUpsertCommand } from './function.write.service';
@@ -27,6 +28,9 @@ export interface ICreateFunctionButtonState {
 }
 
 export class CreateFunctionButton extends React.Component<ICreateFunctionButtonProps, ICreateFunctionButtonState> {
+  public static contextType = DeckRuntimeContext;
+  public declare context: React.ContextType<typeof DeckRuntimeContext>;
+
   constructor(props: ICreateFunctionButtonProps) {
     super(props);
 
@@ -44,13 +48,16 @@ export class CreateFunctionButton extends React.Component<ICreateFunctionButtonP
 
     ProviderSelectionService.selectProvider(app, 'function').then((selectedProvider) => {
       const provider = CloudProviderRegistry.getValue(selectedProvider, 'function');
-      provider.CreateFunctionModal.show({
-        app: app,
-        application: app,
-        forPipelineConfig: false,
-        function: null,
-        isNew: true,
-      });
+      provider.CreateFunctionModal.show(
+        {
+          app: app,
+          application: app,
+          forPipelineConfig: false,
+          function: null,
+          isNew: true,
+        },
+        this.context.services,
+      );
     });
   };
 

--- a/deck/packages/core/src/function/function.dataSource.ts
+++ b/deck/packages/core/src/function/function.dataSource.ts
@@ -1,21 +1,20 @@
 import type { IQService } from 'angular';
 import { module } from 'angular';
-import { AngularServices } from '../angular/services';
+
 import type { Application } from '../application/application.model';
 import { INFRASTRUCTURE_KEY } from '../application/nav/defaultCategories';
 import { ApplicationDataSourceRegistry } from '../application/service/ApplicationDataSourceRegistry';
+import type { DirectProviderServiceDelegate } from '../cloudProvider/providerService.delegate';
 import { SETTINGS } from '../config/settings';
 import type { IFunction, IFunctionSourceData } from '../domain';
 import { EntityTagsReader } from '../entityTag/EntityTagsReader';
-
 import { FunctionReader } from './function.read.service';
 import { FUNCTION_READ_SERVICE } from './function.read.service';
 import type { IFunctionTransformer } from './function.transformer';
 
 export const FUNCTION_DATA_SOURCE = 'spinnaker.core.functions.dataSource';
 
-function createDirectFunctionReader(): FunctionReader {
-  const providerServiceDelegate = AngularServices.providerServiceDelegate;
+export function createDirectFunctionReader(providerServiceDelegate: DirectProviderServiceDelegate): FunctionReader {
   const functionTransformer: IFunctionTransformer = {
     normalizeFunction: (functionDef: IFunctionSourceData) =>
       providerServiceDelegate
@@ -50,9 +49,8 @@ function createDirectFunctionReader(): FunctionReader {
 }
 
 export function registerFunctionDataSource(
-  functionReader?: FunctionReader,
-  when: <T>(value: T | PromiseLike<T>) => PromiseLike<T> = <T>(value: T | PromiseLike<T>) =>
-    AngularServices.$q.when(value),
+  functionReader: FunctionReader,
+  when: <T>(value: T | PromiseLike<T>) => PromiseLike<T>,
 ): void {
   if (
     !SETTINGS.feature.functions ||
@@ -60,9 +58,8 @@ export function registerFunctionDataSource(
   ) {
     return;
   }
-  const reader = functionReader || createDirectFunctionReader();
   const functions = (application: Application) => {
-    return reader.loadFunctions(application.name);
+    return functionReader.loadFunctions(application.name);
   };
 
   const addFunctions = (_application: Application, functionList: IFunction[]) => {

--- a/deck/packages/core/src/header/SpinnakerHeader.spec.tsx
+++ b/deck/packages/core/src/header/SpinnakerHeader.spec.tsx
@@ -1,10 +1,12 @@
-import { UIRouter } from '@uirouter/react';
+import { UIRouter, UIRouterReact } from '@uirouter/react';
 import { mount } from 'enzyme';
 import React from 'react';
 import { RecoilRoot } from 'recoil';
 
 import { AuthenticationService } from '../authentication/AuthenticationService';
 import { GlobalBannerService } from '../banner/global/GlobalBannerService';
+import { createDeckRuntime } from '../bootstrap/DeckRuntime';
+import { DeckRuntimeContext } from '../bootstrap/DeckRuntimeContext';
 import { configureRouter } from '../navigation/router';
 import { SpinnakerHeaderContent } from './SpinnakerHeader';
 
@@ -15,16 +17,24 @@ describe('SpinnakerHeader', () => {
   });
 
   it('renders primary navigation with the legacy navbar class contract', () => {
+    const router = new UIRouterReact();
+    const runtime = createDeckRuntime(router);
+    router.disposable(runtime);
+    configureRouter(router, runtime.services);
     const wrapper = mount(
-      <UIRouter router={configureRouter()}>
-        <RecoilRoot>
-          <SpinnakerHeaderContent />
-        </RecoilRoot>
+      <UIRouter router={router}>
+        <DeckRuntimeContext.Provider value={runtime}>
+          <RecoilRoot>
+            <SpinnakerHeaderContent />
+          </RecoilRoot>
+        </DeckRuntimeContext.Provider>
       </UIRouter>,
     );
 
     const primaryNav = wrapper.find('ul.page-nav');
 
     expect(primaryNav.hasClass('navbar-nav')).toBe(true);
+    wrapper.unmount();
+    router.dispose();
   });
 });

--- a/deck/packages/core/src/index.ts
+++ b/deck/packages/core/src/index.ts
@@ -98,5 +98,7 @@ export * from './yamlEditor';
 
 export * from './bootstrap/bootstrapDeck';
 export * from './bootstrap/DeckRuntime';
+export * from './bootstrap/DeckRuntimeContext';
+export * from './bootstrap/DeckRuntimeServices';
 export * from './core.module';
 export * from './angular/services';

--- a/deck/packages/core/src/insight/InsightMenu.spec.tsx
+++ b/deck/packages/core/src/insight/InsightMenu.spec.tsx
@@ -34,6 +34,7 @@ describe('<InsightMenu />', () => {
         createApp={mergedParams.createApp}
         createProject={mergedParams.createProject}
         refreshCaches={mergedParams.refreshCaches}
+        deckRuntimeServices={{ cacheInitializer: {} as CacheInitializerService } as any}
         router={{} as any}
         stateParams={{}}
         stateService={{ go } as any}

--- a/deck/packages/core/src/insight/InsightMenu.tsx
+++ b/deck/packages/core/src/insight/InsightMenu.tsx
@@ -1,9 +1,10 @@
 import type { StateService } from '@uirouter/core';
 import React from 'react';
 import { Button } from 'react-bootstrap';
-import { AngularServices } from '../angular/services';
 
 import { CreateApplicationModal } from '../application/modal/CreateApplicationModal';
+import type { IDeckRuntimeServicesInjectedProps } from '../bootstrap/DeckRuntimeContext';
+import { withDeckRuntimeServices } from '../bootstrap/DeckRuntimeContext';
 import type { CacheInitializerService } from '../cache';
 import type { IRouterInjectedProps } from '../navigation/routerContext';
 import { withRouter } from '../navigation/routerContext';
@@ -20,17 +21,20 @@ export interface IInsightMenuState {
   refreshingCache: boolean;
 }
 
-export class InsightMenuComponent extends React.Component<IInsightMenuProps & IRouterInjectedProps, IInsightMenuState> {
+export class InsightMenuComponent extends React.Component<
+  IInsightMenuProps & IRouterInjectedProps & IDeckRuntimeServicesInjectedProps,
+  IInsightMenuState
+> {
   public static defaultProps: IInsightMenuProps = { createApp: true, createProject: true, refreshCaches: true };
 
   private $state: StateService;
   private cacheInitializer: CacheInitializerService;
 
-  constructor(props: IInsightMenuProps & IRouterInjectedProps) {
+  constructor(props: IInsightMenuProps & IRouterInjectedProps & IDeckRuntimeServicesInjectedProps) {
     super(props);
     this.state = {} as IInsightMenuState;
     this.$state = props.stateService;
-    this.cacheInitializer = AngularServices.cacheInitializer;
+    this.cacheInitializer = props.deckRuntimeServices.cacheInitializer;
   }
 
   private createProject = () =>
@@ -105,5 +109,5 @@ export class InsightMenuComponent extends React.Component<IInsightMenuProps & IR
 }
 
 const OverridableInsightMenu = Overridable('createInsightMenu')(InsightMenuComponent);
-export const InsightMenu = withRouter(OverridableInsightMenu);
+export const InsightMenu = withDeckRuntimeServices(withRouter(OverridableInsightMenu));
 InsightMenu.displayName = 'InsightMenu';

--- a/deck/packages/core/src/instance/details/MultipleInstancesDetails.spec.tsx
+++ b/deck/packages/core/src/instance/details/MultipleInstancesDetails.spec.tsx
@@ -5,6 +5,7 @@ import { mount } from 'enzyme';
 import React from 'react';
 
 import { AccountService } from '../../account';
+import { DeckRuntimeContext } from '../../bootstrap/DeckRuntimeContext';
 import { ProviderSelectionService } from '../../cloudProvider/providerSelection/ProviderSelectionService';
 import { ConfirmationModalService } from '../../confirmationModal';
 import { CollapsibleSection } from '../../presentation';
@@ -14,6 +15,7 @@ import { InstanceWriter } from '../instance.write.service';
 import { MultipleInstancesDetails } from './MultipleInstancesDetails';
 
 describe('<MultipleInstancesDetails />', () => {
+  const providerServiceDelegate = {} as any;
   let previousMultiselectModel: any;
   let $uiRouter: UIRouterReact;
 
@@ -49,7 +51,9 @@ describe('<MultipleInstancesDetails />', () => {
             context: $uiRouter.stateRegistry.get('application.insight.multipleInstances') as any,
           }}
         >
-          <MultipleInstancesDetails app={app} />
+          <DeckRuntimeContext.Provider value={{ services: { providerServiceDelegate } } as any}>
+            <MultipleInstancesDetails app={app} />
+          </DeckRuntimeContext.Provider>
         </UIViewContext.Provider>
       </UIRouterContext.Provider>,
     );
@@ -160,6 +164,7 @@ describe('<MultipleInstancesDetails />', () => {
         }),
       ],
       app,
+      providerServiceDelegate,
     );
 
     wrapper.unmount();

--- a/deck/packages/core/src/instance/details/MultipleInstancesDetails.tsx
+++ b/deck/packages/core/src/instance/details/MultipleInstancesDetails.tsx
@@ -4,6 +4,7 @@ import { Dropdown, MenuItem } from 'react-bootstrap';
 
 import { AccountTag } from '../../account';
 import type { Application } from '../../application';
+import { useDeckRuntimeServices } from '../../bootstrap/DeckRuntimeContext';
 import { CloudProviderLogo } from '../../cloudProvider';
 import { ProviderSelectionService } from '../../cloudProvider/providerSelection/ProviderSelectionService';
 import { ConfirmationModalService } from '../../confirmationModal';
@@ -70,6 +71,7 @@ function getDiscoveryState(instance: IInstance): string {
 }
 
 export function MultipleInstancesDetails({ app }: IMultipleInstancesDetailsProps): JSX.Element {
+  const { providerServiceDelegate } = useDeckRuntimeServices();
   const [isDisabled, setIsDisabled] = React.useState(false);
   const [selectedGroups, setSelectedGroups] = React.useState<IMultiInstanceGroup[]>(() => getSelectedGroups(app));
 
@@ -164,14 +166,14 @@ export function MultipleInstancesDetails({ app }: IMultipleInstancesDetailsProps
   };
 
   const registerWithDiscovery = () =>
-    confirm(() => InstanceWriter.enableInstancesInDiscovery(selectedGroups, app), {
+    confirm(() => InstanceWriter.enableInstancesInDiscovery(selectedGroups, app, providerServiceDelegate), {
       futurePerfect: 'Registered',
       presentContinuous: 'Registering',
       simplePresent: 'Register',
     });
 
   const deregisterWithDiscovery = () =>
-    confirm(() => InstanceWriter.disableInstancesInDiscovery(selectedGroups, app), {
+    confirm(() => InstanceWriter.disableInstancesInDiscovery(selectedGroups, app, providerServiceDelegate), {
       futurePerfect: 'Deregistered',
       presentContinuous: 'Deregistering',
       simplePresent: 'Deregister',
@@ -181,7 +183,13 @@ export function MultipleInstancesDetails({ app }: IMultipleInstancesDetailsProps
     const allLoadBalancers = getAllLoadBalancers().slice().sort();
 
     confirmLoadBalancerAction(
-      () => InstanceWriter.registerInstancesWithLoadBalancer(selectedGroups, app, allLoadBalancers),
+      () =>
+        InstanceWriter.registerInstancesWithLoadBalancer(
+          selectedGroups,
+          app,
+          allLoadBalancers,
+          providerServiceDelegate,
+        ),
       {
         futurePerfect: 'Registered',
         presentContinuous: 'Registering',
@@ -195,7 +203,13 @@ export function MultipleInstancesDetails({ app }: IMultipleInstancesDetailsProps
     const allLoadBalancers = getAllLoadBalancers().slice().sort();
 
     confirmLoadBalancerAction(
-      () => InstanceWriter.deregisterInstancesFromLoadBalancer(selectedGroups, app, allLoadBalancers),
+      () =>
+        InstanceWriter.deregisterInstancesFromLoadBalancer(
+          selectedGroups,
+          app,
+          allLoadBalancers,
+          providerServiceDelegate,
+        ),
       {
         futurePerfect: 'Deregistered',
         presentContinuous: 'Deregistering',
@@ -206,25 +220,28 @@ export function MultipleInstancesDetails({ app }: IMultipleInstancesDetailsProps
   };
 
   const rebootInstances = () =>
-    confirm(() => InstanceWriter.rebootInstances(selectedGroups, app), {
+    confirm(() => InstanceWriter.rebootInstances(selectedGroups, app, providerServiceDelegate), {
       futurePerfect: 'Rebooted',
       presentContinuous: 'Rebooting',
       simplePresent: 'Reboot',
     });
 
   const terminateInstances = () =>
-    confirm(() => InstanceWriter.terminateInstances(selectedGroups, app), {
+    confirm(() => InstanceWriter.terminateInstances(selectedGroups, app, providerServiceDelegate), {
       futurePerfect: 'Terminated',
       presentContinuous: 'Terminating',
       simplePresent: 'Terminate',
     });
 
   const terminateInstancesAndShrinkServerGroups = () =>
-    confirm(() => InstanceWriter.terminateInstancesAndShrinkServerGroups(selectedGroups, app), {
-      futurePerfect: 'Terminated',
-      presentContinuous: 'Terminating',
-      simplePresent: 'Terminate',
-    });
+    confirm(
+      () => InstanceWriter.terminateInstancesAndShrinkServerGroups(selectedGroups, app, providerServiceDelegate),
+      {
+        futurePerfect: 'Terminated',
+        presentContinuous: 'Terminating',
+        simplePresent: 'Terminate',
+      },
+    );
 
   const actionLink = (label: string, action: () => void) => (
     <MenuItem key={label} onClick={action}>

--- a/deck/packages/core/src/instance/instance.states.spec.ts
+++ b/deck/packages/core/src/instance/instance.states.spec.ts
@@ -1,5 +1,6 @@
 import { UIRouterReact } from '@uirouter/react';
 
+import { createDeckRuntime } from '../bootstrap/DeckRuntime';
 import { MultipleInstancesDetails } from './details/MultipleInstancesDetails';
 import { StandaloneInstanceDetails } from './details/StandaloneInstanceDetails';
 import { getMultipleInstancesState, getStandaloneInstanceState } from './instance.states';
@@ -59,7 +60,10 @@ describe('instance states', () => {
   });
 
   it('resolves a standalone instance during a direct transition', async () => {
-    const router = configureRouter();
+    const router = new UIRouterReact();
+    const runtime = createDeckRuntime(router);
+    router.disposable(runtime);
+    configureRouter(router, runtime.services);
     routers.push(router);
 
     await router.stateService.go('home.instanceDetails', {

--- a/deck/packages/core/src/instance/instance.write.service.spec.ts
+++ b/deck/packages/core/src/instance/instance.write.service.spec.ts
@@ -127,6 +127,7 @@ describe('Service: instance writer', function () {
 
   describe('multi-instance operations', () => {
     let task: ITaskCommand, serverGroupA: IServerGroup, serverGroupB: IServerGroup;
+    const providerServiceDelegate = { hasDelegate: () => false } as any;
 
     function getInstanceGroup(serverGroup: IServerGroup): IMultiInstanceGroup {
       return State.ClusterState.multiselectModel.getOrCreateInstanceGroup(serverGroup);
@@ -185,7 +186,11 @@ describe('Service: instance writer', function () {
         zone: 'a',
         launchTime: 2,
       });
-      InstanceWriter.terminateInstances([getInstanceGroup(serverGroupA), getInstanceGroup(serverGroupB)], application);
+      InstanceWriter.terminateInstances(
+        [getInstanceGroup(serverGroupA), getInstanceGroup(serverGroupB)],
+        application,
+        providerServiceDelegate,
+      );
 
       expect(task.job.length).toBe(1);
 
@@ -217,7 +222,11 @@ describe('Service: instance writer', function () {
         zone: 'a',
         launchTime: 2,
       });
-      InstanceWriter.terminateInstancesAndShrinkServerGroups([getInstanceGroup(serverGroupA)], application);
+      InstanceWriter.terminateInstancesAndShrinkServerGroups(
+        [getInstanceGroup(serverGroupA)],
+        application,
+        providerServiceDelegate,
+      );
 
       expect(task.job.length).toBe(1);
 
@@ -244,7 +253,7 @@ describe('Service: instance writer', function () {
         launchTime: 2,
       });
 
-      InstanceWriter.terminateInstances([getInstanceGroup(serverGroupA)], application);
+      InstanceWriter.terminateInstances([getInstanceGroup(serverGroupA)], application, providerServiceDelegate);
       expect(task.description).toBe('Terminate 1 instance');
 
       addInstance(serverGroupA, {
@@ -255,7 +264,7 @@ describe('Service: instance writer', function () {
         zone: 'a',
         launchTime: 1,
       });
-      InstanceWriter.terminateInstances([getInstanceGroup(serverGroupA)], application);
+      InstanceWriter.terminateInstances([getInstanceGroup(serverGroupA)], application, providerServiceDelegate);
       expect(task.description).toBe('Terminate 2 instances');
     });
 
@@ -270,7 +279,7 @@ describe('Service: instance writer', function () {
         launchTime: 2,
       });
 
-      InstanceWriter.rebootInstances([getInstanceGroup(serverGroupA)], application);
+      InstanceWriter.rebootInstances([getInstanceGroup(serverGroupA)], application, providerServiceDelegate);
       expect(task.description).toBe('Reboot 1 instance');
 
       addInstance(serverGroupA, {
@@ -281,7 +290,7 @@ describe('Service: instance writer', function () {
         zone: 'a',
         launchTime: 1,
       });
-      InstanceWriter.rebootInstances([getInstanceGroup(serverGroupA)], application);
+      InstanceWriter.rebootInstances([getInstanceGroup(serverGroupA)], application, providerServiceDelegate);
       expect(task.description).toBe('Reboot 2 instances');
     });
 
@@ -296,7 +305,11 @@ describe('Service: instance writer', function () {
         launchTime: 2,
       });
 
-      InstanceWriter.disableInstancesInDiscovery([getInstanceGroup(serverGroupA)], application);
+      InstanceWriter.disableInstancesInDiscovery(
+        [getInstanceGroup(serverGroupA)],
+        application,
+        providerServiceDelegate,
+      );
       expect(task.description).toBe('Disable 1 instance in discovery');
 
       addInstance(serverGroupA, {
@@ -307,7 +320,11 @@ describe('Service: instance writer', function () {
         zone: 'a',
         launchTime: 1,
       });
-      InstanceWriter.disableInstancesInDiscovery([getInstanceGroup(serverGroupA)], application);
+      InstanceWriter.disableInstancesInDiscovery(
+        [getInstanceGroup(serverGroupA)],
+        application,
+        providerServiceDelegate,
+      );
       expect(task.description).toBe('Disable 2 instances in discovery');
     });
 
@@ -322,7 +339,7 @@ describe('Service: instance writer', function () {
         launchTime: 2,
       });
 
-      InstanceWriter.enableInstancesInDiscovery([getInstanceGroup(serverGroupA)], application);
+      InstanceWriter.enableInstancesInDiscovery([getInstanceGroup(serverGroupA)], application, providerServiceDelegate);
       expect(task.description).toBe('Enable 1 instance in discovery');
 
       addInstance(serverGroupA, {
@@ -333,7 +350,7 @@ describe('Service: instance writer', function () {
         zone: 'a',
         launchTime: 1,
       });
-      InstanceWriter.enableInstancesInDiscovery([getInstanceGroup(serverGroupA)], application);
+      InstanceWriter.enableInstancesInDiscovery([getInstanceGroup(serverGroupA)], application, providerServiceDelegate);
       expect(task.description).toBe('Enable 2 instances in discovery');
     });
   });

--- a/deck/packages/core/src/instance/instance.write.service.ts
+++ b/deck/packages/core/src/instance/instance.write.service.ts
@@ -1,5 +1,5 @@
-import { AngularServices } from '../angular/services';
 import type { Application } from '../application/application.model';
+import type { DirectProviderServiceDelegate } from '../cloudProvider/providerService.delegate';
 import type { IInstance, IServerGroup, ITask } from '../domain';
 import { ServerGroupReader } from '../serverGroup/serverGroupReader.service';
 import type { IJob } from '../task/taskExecutor';
@@ -49,19 +49,32 @@ export class InstanceWriter {
   public static terminateInstances(
     instanceGroups: IMultiInstanceGroup[],
     application: Application,
+    providerServiceDelegate: DirectProviderServiceDelegate,
   ): PromiseLike<ITask> {
-    return InstanceWriter.executeMultiInstanceTask(instanceGroups, application, 'terminateInstances', 'Terminate');
+    return InstanceWriter.executeMultiInstanceTask(
+      instanceGroups,
+      application,
+      providerServiceDelegate,
+      'terminateInstances',
+      'Terminate',
+    );
   }
 
   private static executeMultiInstanceTask(
     instanceGroups: IMultiInstanceGroup[],
     application: Application,
+    providerServiceDelegate: DirectProviderServiceDelegate,
     type: string,
     baseDescriptor: string,
     descriptorSuffix?: string,
     additionalJobProperties: any = {},
   ): PromiseLike<ITask> {
-    const jobs = InstanceWriter.buildMultiInstanceJob(instanceGroups, type, additionalJobProperties);
+    const jobs = InstanceWriter.buildMultiInstanceJob(
+      instanceGroups,
+      providerServiceDelegate,
+      type,
+      additionalJobProperties,
+    );
     const descriptor = InstanceWriter.buildMultiInstanceDescriptor(jobs, baseDescriptor, descriptorSuffix);
     return TaskExecutor.executeTask({
       job: jobs,
@@ -70,8 +83,18 @@ export class InstanceWriter {
     });
   }
 
-  public static rebootInstances(instanceGroups: IMultiInstanceGroup[], application: Application): PromiseLike<ITask> {
-    return InstanceWriter.executeMultiInstanceTask(instanceGroups, application, 'rebootInstances', 'Reboot');
+  public static rebootInstances(
+    instanceGroups: IMultiInstanceGroup[],
+    application: Application,
+    providerServiceDelegate: DirectProviderServiceDelegate,
+  ): PromiseLike<ITask> {
+    return InstanceWriter.executeMultiInstanceTask(
+      instanceGroups,
+      application,
+      providerServiceDelegate,
+      'rebootInstances',
+      'Reboot',
+    );
   }
 
   public static rebootInstance(instance: IInstance, application: Application, params: any = {}): PromiseLike<ITask> {
@@ -94,8 +117,13 @@ export class InstanceWriter {
     instanceGroups: IMultiInstanceGroup[],
     application: Application,
     loadBalancerNames: string[],
+    providerServiceDelegate: DirectProviderServiceDelegate,
   ): PromiseLike<ITask> {
-    const jobs = InstanceWriter.buildMultiInstanceJob(instanceGroups, 'deregisterInstancesFromLoadBalancer');
+    const jobs = InstanceWriter.buildMultiInstanceJob(
+      instanceGroups,
+      providerServiceDelegate,
+      'deregisterInstancesFromLoadBalancer',
+    );
     jobs.forEach((job) => (job.loadBalancerNames = loadBalancerNames));
     const descriptor = InstanceWriter.buildMultiInstanceDescriptor(
       jobs,
@@ -131,8 +159,13 @@ export class InstanceWriter {
     instanceGroups: IMultiInstanceGroup[],
     application: Application,
     loadBalancerNames: string[],
+    providerServiceDelegate: DirectProviderServiceDelegate,
   ): PromiseLike<ITask> {
-    const jobs = InstanceWriter.buildMultiInstanceJob(instanceGroups, 'registerInstancesWithLoadBalancer');
+    const jobs = InstanceWriter.buildMultiInstanceJob(
+      instanceGroups,
+      providerServiceDelegate,
+      'registerInstancesWithLoadBalancer',
+    );
     jobs.forEach((job) => (job.loadBalancerNames = loadBalancerNames));
     const descriptor = InstanceWriter.buildMultiInstanceDescriptor(
       jobs,
@@ -167,10 +200,12 @@ export class InstanceWriter {
   public static enableInstancesInDiscovery(
     instanceGroups: IMultiInstanceGroup[],
     application: Application,
+    providerServiceDelegate: DirectProviderServiceDelegate,
   ): PromiseLike<ITask> {
     return InstanceWriter.executeMultiInstanceTask(
       instanceGroups,
       application,
+      providerServiceDelegate,
       'enableInstancesInDiscovery',
       'Enable',
       'in discovery',
@@ -203,10 +238,12 @@ export class InstanceWriter {
   public static disableInstancesInDiscovery(
     instanceGroups: IMultiInstanceGroup[],
     application: Application,
+    providerServiceDelegate: DirectProviderServiceDelegate,
   ): PromiseLike<ITask> {
     return InstanceWriter.executeMultiInstanceTask(
       instanceGroups,
       application,
+      providerServiceDelegate,
       'disableInstancesInDiscovery',
       'Disable',
       'in discovery',
@@ -239,10 +276,12 @@ export class InstanceWriter {
   public static terminateInstancesAndShrinkServerGroups(
     instanceGroups: IMultiInstanceGroup[],
     application: Application,
+    providerServiceDelegate: DirectProviderServiceDelegate,
   ): PromiseLike<ITask> {
     return InstanceWriter.executeMultiInstanceTask(
       instanceGroups,
       application,
+      providerServiceDelegate,
       'detachInstances',
       'Terminate',
       'and shrink server groups',
@@ -285,12 +324,15 @@ export class InstanceWriter {
 
   protected static buildMultiInstanceJob(
     instanceGroups: IMultiInstanceGroup[],
+    providerServiceDelegate: DirectProviderServiceDelegate,
     type: string,
     additionalJobProperties = {},
   ) {
     return instanceGroups
       .filter((instanceGroup) => instanceGroup.instances.length > 0)
-      .map((instanceGroup) => InstanceWriter.convertGroupToJob(instanceGroup, type, additionalJobProperties));
+      .map((instanceGroup) =>
+        InstanceWriter.convertGroupToJob(instanceGroup, providerServiceDelegate, type, additionalJobProperties),
+      );
   }
 
   protected static buildMultiInstanceDescriptor(jobs: IMultiInstanceJob[], base: string, suffix: string): string {
@@ -308,6 +350,7 @@ export class InstanceWriter {
 
   private static convertGroupToJob(
     instanceGroup: IMultiInstanceGroup,
+    providerServiceDelegate: DirectProviderServiceDelegate,
     type: string,
     additionalJobProperties: any = {},
   ): IMultiInstanceJob {
@@ -323,14 +366,17 @@ export class InstanceWriter {
 
     Object.assign(job, additionalJobProperties);
 
-    InstanceWriter.transform(instanceGroup, job);
+    InstanceWriter.transform(instanceGroup, job, providerServiceDelegate);
 
     return job;
   }
 
-  private static transform(instanceGroup: IMultiInstanceGroup, job: IMultiInstanceJob) {
+  private static transform(
+    instanceGroup: IMultiInstanceGroup,
+    job: IMultiInstanceJob,
+    providerServiceDelegate: DirectProviderServiceDelegate,
+  ) {
     const serviceKey = 'instance.multiInstanceTaskTransformer';
-    const { providerServiceDelegate } = AngularServices;
     if (providerServiceDelegate.hasDelegate(instanceGroup.cloudProvider, serviceKey)) {
       const transformer: any = providerServiceDelegate.getDelegate(instanceGroup.cloudProvider, serviceKey);
       transformer.transform(instanceGroup, job);

--- a/deck/packages/core/src/loadBalancer/CreateLoadBalancerButton.tsx
+++ b/deck/packages/core/src/loadBalancer/CreateLoadBalancerButton.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import type { IAccountDetails } from '../account';
 import type { Application } from '../application';
+import { DeckRuntimeContext } from '../bootstrap/DeckRuntimeContext';
 import type { ICloudProviderConfig } from '../cloudProvider';
 import { CloudProviderRegistry, ProviderSelectionService } from '../cloudProvider';
 import type { ILoadBalancer } from '../domain';
@@ -25,6 +26,9 @@ export interface ICreateLoadBalancerButtonProps {
 }
 
 export class CreateLoadBalancerButton extends React.Component<ICreateLoadBalancerButtonProps, { isDisabled: boolean }> {
+  public static contextType = DeckRuntimeContext;
+  public declare context: React.ContextType<typeof DeckRuntimeContext>;
+
   constructor(props: ICreateLoadBalancerButtonProps) {
     super(props);
 
@@ -52,13 +56,16 @@ export class CreateLoadBalancerButton extends React.Component<ICreateLoadBalance
       (selectedProvider) => {
         const provider = CloudProviderRegistry.getValue(selectedProvider, 'loadBalancer');
 
-        provider.CreateLoadBalancerModal.show({
-          app: app,
-          application: app,
-          forPipelineConfig: false,
-          loadBalancer: null,
-          isNew: true,
-        });
+        provider.CreateLoadBalancerModal.show(
+          {
+            app: app,
+            application: app,
+            forPipelineConfig: false,
+            loadBalancer: null,
+            isNew: true,
+          },
+          this.context.services,
+        );
       },
       () => {},
     );

--- a/deck/packages/core/src/loadBalancer/loadBalancer.dataSource.ts
+++ b/deck/packages/core/src/loadBalancer/loadBalancer.dataSource.ts
@@ -1,7 +1,6 @@
 import type { IQService } from 'angular';
 import { module } from 'angular';
 
-import { AngularServices } from '../angular/services';
 import type { Application } from '../application/application.model';
 import { INFRASTRUCTURE_KEY } from '../application/nav/defaultCategories';
 import { ApplicationDataSourceRegistry } from '../application/service/ApplicationDataSourceRegistry';
@@ -47,15 +46,13 @@ function createDataSourceConfig(
   };
 }
 
-export function registerLoadBalancerDataSource($q?: IQService, loadBalancerReader?: LoadBalancerReader): void {
+export function registerLoadBalancerDataSource($q: IQService, loadBalancerReader: LoadBalancerReader): void {
   if (ApplicationDataSourceRegistry.getDataSources().some((source) => source.key === 'loadBalancers')) {
     return;
   }
 
-  const resolvedQ = $q || AngularServices.$q;
-  const resolvedReader = loadBalancerReader || AngularServices.loadBalancerReader;
   ApplicationDataSourceRegistry.registerDataSource(
-    createDataSourceConfig(<T>(value: T | PromiseLike<T>) => resolvedQ.when(value), resolvedReader),
+    createDataSourceConfig(<T>(value: T | PromiseLike<T>) => $q.when(value), loadBalancerReader),
   );
 }
 

--- a/deck/packages/core/src/navigation/rootState.registration.spec.ts
+++ b/deck/packages/core/src/navigation/rootState.registration.spec.ts
@@ -11,7 +11,11 @@ describe('rootState registration', () => {
   let originalRegistrations: Array<(provider: StateConfigProvider) => void>;
 
   function createProvider(): StateConfigProvider {
-    return new StateConfigProvider({} as any, { setNestedState: jasmine.createSpy('setNestedState') } as any);
+    return new StateConfigProvider(
+      {} as any,
+      { setNestedState: jasmine.createSpy('setNestedState') } as any,
+      {} as any,
+    );
   }
 
   beforeEach(() => {
@@ -39,7 +43,7 @@ describe('rootState registration', () => {
 
     registerRootState(registration);
 
-    new StateConfigProvider(undefined as any, undefined as any);
+    new StateConfigProvider(undefined as any, undefined as any, {} as any);
 
     expect(registration).not.toHaveBeenCalled();
   });

--- a/deck/packages/core/src/navigation/router.spec.ts
+++ b/deck/packages/core/src/navigation/router.spec.ts
@@ -5,6 +5,7 @@ import React from 'react';
 
 import { ApplicationDataSourceRegistry } from '../application/service/ApplicationDataSourceRegistry';
 import { ApplicationReader } from '../application/service/ApplicationReader';
+import { createDeckRuntime } from '../bootstrap/DeckRuntime';
 import { RecentHistoryService } from '../history';
 import { PageTitleService } from '../pageTitle';
 import { SpinErrorBoundary } from '../presentation';
@@ -26,7 +27,10 @@ describe('configureRouter', () => {
   let originalRegistrations: ReturnType<typeof getRootStateRegistrationsForTests>;
 
   function createRouter(): UIRouterReact {
-    const router = configureRouter();
+    const router = new UIRouterReact();
+    const runtime = createDeckRuntime(router);
+    router.disposable(runtime);
+    configureRouter(router, runtime.services);
     routers.push(router);
     return router;
   }
@@ -325,7 +329,10 @@ describe('configureRouter', () => {
     const listen = spyOn(UrlService.prototype, 'listen');
     const sync = spyOn(UrlService.prototype, 'sync');
 
-    expect(() => configureRouter()).toThrow(failure);
+    const failedRouter = new UIRouterReact();
+    const runtime = createDeckRuntime(failedRouter);
+    failedRouter.disposable(runtime);
+    expect(() => configureRouter(failedRouter, runtime.services)).toThrow(failure);
 
     expect(getDirectRouter()).toBe(previousRouter);
     const ownershipDisposals = dispose.calls.all().filter(({ args }) => args.length === 0);

--- a/deck/packages/core/src/navigation/router.ts
+++ b/deck/packages/core/src/navigation/router.ts
@@ -1,8 +1,10 @@
-import { hashLocationPlugin, servicesPlugin, UIRouterReact } from '@uirouter/react';
+import type { UIRouterReact } from '@uirouter/react';
+import { hashLocationPlugin, servicesPlugin } from '@uirouter/react';
 import { UIRouterRxPlugin } from '@uirouter/rx';
 
 import { applyApplicationInitializers } from '../application/application.initializers';
 import { getActiveApplicationStateProvider } from '../application/applicationState.registration';
+import type { DeckRuntimeServices } from '../bootstrap/DeckRuntimeServices';
 import { setDirectRouter } from './directRouter';
 import { registerRouteErrorBoundary } from '../presentation/SpinErrorBoundary';
 import { applyRootStateRegistrations } from './rootState.registration';
@@ -16,7 +18,7 @@ import {
 } from './state.provider';
 import { StateHelper } from './stateHelper.provider';
 
-export function configureRouter(router = new UIRouterReact()): UIRouterReact {
+export function configureRouter(router: UIRouterReact, runtimeServices: DeckRuntimeServices): UIRouterReact {
   try {
     router.plugin(servicesPlugin);
     router.plugin(hashLocationPlugin);
@@ -31,7 +33,11 @@ export function configureRouter(router = new UIRouterReact()): UIRouterReact {
     router.urlRouter.otherwise('/');
     router.urlRouter.when('/{path:.*}/', (match: any) => '/' + match.path);
 
-    const stateConfig = new StateConfigProvider(router.urlRouter, new StateHelper(router.stateRegistry));
+    const stateConfig = new StateConfigProvider(
+      router.urlRouter,
+      new StateHelper(router.stateRegistry),
+      runtimeServices,
+    );
     applyRootStateRegistrations(stateConfig);
     const applicationStateProvider = getActiveApplicationStateProvider();
     stateConfig.setStates();

--- a/deck/packages/core/src/navigation/state.provider.spec.ts
+++ b/deck/packages/core/src/navigation/state.provider.spec.ts
@@ -16,7 +16,7 @@ describe('StateConfigProvider', () => {
     const stateHelper = { setNestedState: jasmine.createSpy('setNestedState') };
 
     return {
-      provider: new StateConfigProvider(urlRouter as any, stateHelper as any),
+      provider: new StateConfigProvider(urlRouter as any, stateHelper as any, {} as any),
       stateHelper,
       urlRouter,
     };

--- a/deck/packages/core/src/navigation/state.provider.ts
+++ b/deck/packages/core/src/navigation/state.provider.ts
@@ -2,6 +2,7 @@ import type { ParamDeclaration, StateDeclaration, UrlRouter } from '@uirouter/co
 import type { ParamTypeDefinition, ReactViewDeclaration } from '@uirouter/react';
 import { isEqual, isPlainObject } from 'lodash';
 
+import type { DeckRuntimeServices } from '../bootstrap/DeckRuntimeServices';
 import type { IFilterConfig } from '../filterModel/IFilterModel';
 import { applyRootStateRegistrations } from './rootState.registration';
 import type { StateHelper } from './stateHelper.provider';
@@ -34,7 +35,11 @@ export class StateConfigProvider {
     children: [],
   };
 
-  constructor(private $urlRouterProvider: UrlRouter, private stateHelperProvider: StateHelper) {
+  constructor(
+    private $urlRouterProvider: UrlRouter,
+    private stateHelperProvider: StateHelper,
+    public readonly runtimeServices: DeckRuntimeServices,
+  ) {
     if (stateHelperProvider) {
       applyRootStateRegistrations(this);
     }

--- a/deck/packages/core/src/pipeline/config/PipelineConfigPage.spec.tsx
+++ b/deck/packages/core/src/pipeline/config/PipelineConfigPage.spec.tsx
@@ -413,6 +413,45 @@ describe('PipelineConfigPage', () => {
     wrapper.unmount();
   });
 
+  it('keeps focus on a stage field after the new-stage type selector initially autofocuses', async () => {
+    registerStageTypes();
+    const requested = pipeline('target-id', 'Requested Pipeline');
+    requested.stages = [{ refId: '1', name: 'Build', type: 'wait', isNew: true, requisiteStageRefIds: [] } as any];
+    const app = createApp([requested]);
+    $stateParams.pipelineId = requested.id;
+    showStageConfig(requested.id);
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const wrapper = mount(<PipelineConfigPage app={app} />, { attachTo: host });
+
+    try {
+      await flush();
+      wrapper.update();
+
+      const typeInput = host.querySelector('.pipeline-stage-type-select input[role="combobox"]') as HTMLInputElement;
+      const stageNameInput = wrapper
+        .find('.pipeline-stage-config-heading input[type="text"]')
+        .filterWhere((node) => node.prop('value') === 'Build');
+      const stageNameElement = stageNameInput.getDOMNode() as HTMLInputElement;
+
+      expect(document.activeElement).toBe(typeInput);
+
+      stageNameElement.focus();
+      expect(document.activeElement).toBe(stageNameElement);
+
+      await act(async () => {
+        stageNameInput.prop('onChange')({ target: { value: 'Updated Build' } } as any);
+        await flush();
+      });
+      wrapper.update();
+
+      expect(document.activeElement).toBe(stageNameElement);
+    } finally {
+      wrapper.unmount();
+      host.remove();
+    }
+  });
+
   it('uses the custom multi selector for stage dependencies', async () => {
     registerStageTypes();
     const requested = pipeline('target-id', 'Requested Pipeline');

--- a/deck/packages/core/src/pipeline/config/PipelineConfigPage.spec.tsx
+++ b/deck/packages/core/src/pipeline/config/PipelineConfigPage.spec.tsx
@@ -8,7 +8,9 @@ import { AccountService } from '../../account/AccountService';
 import type { IAccountDetails } from '../../account/AccountService';
 import { ApplicationModelBuilder } from '../../application/applicationModel.builder';
 import { ApplicationReader } from '../../application/service/ApplicationReader';
-import { AngularServices } from '../../angular/services';
+import type { DeckRuntime } from '../../bootstrap/DeckRuntime';
+import { createDeckRuntime } from '../../bootstrap/DeckRuntime';
+import { DeckRuntimeContext } from '../../bootstrap/DeckRuntimeContext';
 import { ViewStateCache } from '../../cache';
 import { SETTINGS } from '../../config';
 import { PageNavigator, ReactSelectInput } from '../../presentation';
@@ -35,18 +37,21 @@ describe('PipelineConfigPage', () => {
   let fiatEnabled: boolean;
   let providerRenderStates: boolean[];
   let router: UIRouterReact;
+  let runtime: DeckRuntime;
   let stateGo: jasmine.Spy;
   let transitionCleanup: jasmine.Spy;
   let transitionOnBefore: jasmine.Spy;
 
   const PipelineConfigPage = (props: any) => (
     <UIRouterContext.Provider value={router}>
-      <PipelineConfigPageComponent
-        {...props}
-        router={router}
-        stateParams={$stateParams}
-        stateService={{ go: stateGo } as any}
-      />
+      <DeckRuntimeContext.Provider value={runtime}>
+        <PipelineConfigPageComponent
+          {...props}
+          router={router}
+          stateParams={$stateParams}
+          stateService={{ go: stateGo } as any}
+        />
+      </DeckRuntimeContext.Provider>
     </UIRouterContext.Provider>
   );
 
@@ -289,6 +294,7 @@ describe('PipelineConfigPage', () => {
   beforeEach(() => {
     $stateParams = {};
     router = new UIRouterReact();
+    runtime = createDeckRuntime(router);
     stateGo = jasmine.createSpy('stateGo');
     transitionCleanup = jasmine.createSpy('transitionCleanup');
     transitionOnBefore = spyOn(router.transitionService, 'onBefore').and.returnValue(transitionCleanup);
@@ -298,11 +304,12 @@ describe('PipelineConfigPage', () => {
     ViewStateCache.get('pipelineConfig').removeAll();
     spyOn(AccountService, 'applicationAccounts').and.callFake(() => Promise.resolve([account('aws')]) as any);
     spyOn(ApplicationReader, 'getApplicationPermissions').and.returnValue(Promise.resolve({}) as any);
-    spyOn(AngularServices.executionService, 'getExecutionsForConfigIds').and.returnValue(Promise.resolve([]));
+    spyOn(runtime.services.executionService, 'getExecutionsForConfigIds').and.returnValue(Promise.resolve([]));
   });
 
   afterEach(() => {
     router.dispose();
+    runtime.dispose();
     SETTINGS.feature = { ...SETTINGS.feature, fiatEnabled };
     Registry.reinitialize();
     ViewStateCache.get('pipelineConfig').removeAll();
@@ -745,7 +752,7 @@ describe('PipelineConfigPage', () => {
     $stateParams.pipelineId = requested.id;
     spyOn(PipelineTemplateReader, 'getPipelinePlan').and.returnValue(Promise.resolve(originalPlan));
     const executionEnrichment = deferred<any[]>();
-    (AngularServices.executionService.getExecutionsForConfigIds as jasmine.Spy).and.returnValue(
+    (runtime.services.executionService.getExecutionsForConfigIds as jasmine.Spy).and.returnValue(
       executionEnrichment.promise,
     );
     const modalResult = deferred<{ plan: IPipeline; config: IPipeline }>();

--- a/deck/packages/core/src/pipeline/config/PipelineConfigPage.tsx
+++ b/deck/packages/core/src/pipeline/config/PipelineConfigPage.tsx
@@ -15,9 +15,9 @@ import { EditPipelineJsonModal } from './actions/pipelineJson/EditPipelineJsonMo
 import { RenamePipelineModal } from './actions/rename/RenamePipelineModal';
 import { ShowPipelineTemplateJsonModal } from './actions/templateJson/ShowPipelineTemplateJsonModal';
 import { UnlockPipelineModal } from './actions/unlock/UnlockPipelineModal';
-import { AngularServices } from '../../angular/services';
 import type { Application } from '../../application';
 import { ApplicationReader } from '../../application/service/ApplicationReader';
+import { useDeckRuntimeServices } from '../../bootstrap/DeckRuntimeContext';
 import { ViewStateCache } from '../../cache';
 import { CloudProviderLogo } from '../../cloudProvider';
 import { SETTINGS } from '../../config/settings';
@@ -764,6 +764,7 @@ export function PipelineConfigPageComponent({
   stateParams: params,
   stateService,
 }: IPipelineConfigPageProps & IRouterInjectedProps) {
+  const { executionService } = useDeckRuntimeServices();
   const pipelineId = params.pipelineId as string;
   const executionId = params.executionId as string;
   const isNew = params.new as string;
@@ -914,7 +915,7 @@ export function PipelineConfigPageComponent({
       return undefined;
     }
     let cancelled = false;
-    AngularServices.executionService
+    executionService
       .getExecutionsForConfigIds([model.pipeline.id], {
         limit: 5,
         transform: true,
@@ -941,7 +942,7 @@ export function PipelineConfigPageComponent({
     return () => {
       cancelled = true;
     };
-  }, [model?.hasDynamicSource, model?.pipeline?.id]);
+  }, [app, executionId, executionService, model?.hasDynamicSource, model?.pipeline?.id]);
 
   React.useEffect(() => {
     if (model && viewState) {

--- a/deck/packages/core/src/pipeline/config/PipelineRegistry.ts
+++ b/deck/packages/core/src/pipeline/config/PipelineRegistry.ts
@@ -104,6 +104,11 @@ export class PipelineRegistry {
     this.clearStageConfigCache();
   }
 
+  public unregisterStage(stageConfig: IStageTypeConfig): void {
+    this.stageTypes = this.stageTypes.filter((registeredStage) => registeredStage !== stageConfig);
+    this.clearStageConfigCache();
+  }
+
   /**
    * Registers a custom UI for a preconfigured run job stage.
    *

--- a/deck/packages/core/src/pipeline/config/stages/common/ExecutionBarLabel.spec.tsx
+++ b/deck/packages/core/src/pipeline/config/stages/common/ExecutionBarLabel.spec.tsx
@@ -1,4 +1,7 @@
-import { ExecutionBarLabelComponent } from './ExecutionBarLabel';
+import { mount } from 'enzyme';
+import React from 'react';
+
+import { ExecutionBarLabel, ExecutionBarLabelComponent } from './ExecutionBarLabel';
 
 describe('ExecutionBarLabel', () => {
   it('uses injected route params to include the active grouped stage name', () => {
@@ -13,5 +16,36 @@ describe('ExecutionBarLabel', () => {
     } as any);
 
     expect((component as any).getRenderableStageName()).toBe('Parent stage: Child stage');
+  });
+
+  it('renders the default tooltip without runtime context in the overlay root', () => {
+    const stage = {
+      id: 'stage-id',
+      labelComponent: ExecutionBarLabel,
+      name: 'Default stage',
+      stages: [],
+      suspendedStageTypes: new Set(),
+      type: 'test',
+    } as any;
+    const wrapper = mount(
+      <ExecutionBarLabelComponent
+        application={{} as any}
+        deckRuntimeServices={{ executionService: {} } as any}
+        execution={{ hydrated: true } as any}
+        executionMarker={true}
+        router={{} as any}
+        stage={stage}
+        stateParams={{}}
+        stateService={{} as any}
+      >
+        <span className="tooltip-trigger">marker</span>
+      </ExecutionBarLabelComponent>,
+    );
+
+    try {
+      expect(() => wrapper.find('.tooltip-trigger').simulate('mouseOver')).not.toThrow();
+    } finally {
+      wrapper.unmount();
+    }
   });
 });

--- a/deck/packages/core/src/pipeline/config/stages/common/ExecutionBarLabel.tsx
+++ b/deck/packages/core/src/pipeline/config/stages/common/ExecutionBarLabel.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { OverlayTrigger, Tooltip } from 'react-bootstrap';
 
-import { AngularServices } from '../../../../angular/services';
+import type { IDeckRuntimeServicesInjectedProps } from '../../../../bootstrap/DeckRuntimeContext';
+import { withDeckRuntimeServices } from '../../../../bootstrap/DeckRuntimeContext';
 import type { IExecutionStageLabelProps } from '../../../../domain';
 import { ExecutionWindowActions } from '../executionWindows/ExecutionWindowActions';
 import type { IRouterInjectedProps } from '../../../../navigation/routerContext';
@@ -22,12 +23,12 @@ export interface IExecutionBarLabelState {
 }
 
 export class ExecutionBarLabelComponent extends React.Component<
-  IExecutionBarLabelProps & IRouterInjectedProps,
+  IExecutionBarLabelProps & IRouterInjectedProps & IDeckRuntimeServicesInjectedProps,
   IExecutionBarLabelState
 > {
   private mounted = false;
 
-  constructor(props: IExecutionBarLabelProps & IRouterInjectedProps) {
+  constructor(props: IExecutionBarLabelProps & IRouterInjectedProps & IDeckRuntimeServicesInjectedProps) {
     super(props);
     this.state = {
       hydrated: props.execution && props.execution.hydrated,
@@ -39,7 +40,7 @@ export class ExecutionBarLabelComponent extends React.Component<
     if (!this.requiresHydration() || !execution) {
       return;
     }
-    AngularServices.executionService.hydrate(application, execution).then(() => {
+    this.props.deckRuntimeServices.executionService.hydrate(application, execution).then(() => {
       if (this.mounted && !this.state.hydrated) {
         this.setState({ hydrated: true });
       }
@@ -64,11 +65,13 @@ export class ExecutionBarLabelComponent extends React.Component<
   private DefaultLabel = () => {
     const { stage, application, execution } = this.props;
     const LabelComponent = stage.labelComponent;
-    const tooltip = (
-      <Tooltip id={stage.id}>
+    const label =
+      LabelComponent === ExecutionBarLabel ? (
+        <span>{this.getRenderableStageName()}</span>
+      ) : (
         <LabelComponent application={application} execution={execution} stage={stage} />
-      </Tooltip>
-    );
+      );
+    const tooltip = <Tooltip id={stage.id}>{label}</Tooltip>;
     return (
       <OverlayTrigger placement="top" overlay={tooltip}>
         {this.props.children}
@@ -147,5 +150,5 @@ export class ExecutionBarLabelComponent extends React.Component<
   }
 }
 
-export const ExecutionBarLabel = withRouter(ExecutionBarLabelComponent);
+export const ExecutionBarLabel = withDeckRuntimeServices(withRouter(ExecutionBarLabelComponent));
 ExecutionBarLabel.displayName = 'ExecutionBarLabel';

--- a/deck/packages/core/src/pipeline/config/stages/common/StepExecutionDetails.tsx
+++ b/deck/packages/core/src/pipeline/config/stages/common/StepExecutionDetails.tsx
@@ -1,7 +1,8 @@
 import { isEqual } from 'lodash';
 import React from 'react';
 
-import { AngularServices } from '../../../../angular/services';
+import type { IDeckRuntimeServicesInjectedProps } from '../../../../bootstrap/DeckRuntimeContext';
+import { withDeckRuntimeServices } from '../../../../bootstrap/DeckRuntimeContext';
 import { ExecutionDetailsSectionNav } from '../../../details';
 import type { IExecutionDetailsProps, IExecutionDetailsState } from '../../../../domain';
 import type { IRouterInjectedProps } from '../../../../navigation/routerContext';
@@ -9,10 +10,10 @@ import { withRouter } from '../../../../navigation/routerContext';
 import { SpinErrorBoundary } from '../../../../presentation';
 
 export class StepExecutionDetailsComponent extends React.Component<
-  IExecutionDetailsProps & IRouterInjectedProps,
+  IExecutionDetailsProps & IRouterInjectedProps & IDeckRuntimeServicesInjectedProps,
   IExecutionDetailsState
 > {
-  constructor(props: IExecutionDetailsProps & IRouterInjectedProps) {
+  constructor(props: IExecutionDetailsProps & IRouterInjectedProps & IDeckRuntimeServicesInjectedProps) {
     super(props);
     this.state = {
       configSections: this.getDetailsSections(props).map((s) => s.title),
@@ -33,9 +34,9 @@ export class StepExecutionDetailsComponent extends React.Component<
 
   public syncDetails(
     configSections: string[],
-    props: IExecutionDetailsProps & IRouterInjectedProps = this.props,
+    props: IExecutionDetailsProps & IRouterInjectedProps & IDeckRuntimeServicesInjectedProps = this.props,
   ): void {
-    AngularServices.executionDetailsSectionService.synchronizeSection(configSections, () =>
+    props.deckRuntimeServices.executionDetailsSectionService.synchronizeSection(configSections, () =>
       this.updateCurrentSection(props),
     );
   }
@@ -44,7 +45,9 @@ export class StepExecutionDetailsComponent extends React.Component<
     this.syncDetails(this.state.configSections);
   }
 
-  public componentWillReceiveProps(nextProps: IExecutionDetailsProps & IRouterInjectedProps): void {
+  public componentWillReceiveProps(
+    nextProps: IExecutionDetailsProps & IRouterInjectedProps & IDeckRuntimeServicesInjectedProps,
+  ): void {
     const configSections = this.getDetailsSections(nextProps).map((s) => s.title);
     if (!isEqual(this.state.configSections, configSections)) {
       this.setState({ configSections });
@@ -69,4 +72,4 @@ export class StepExecutionDetailsComponent extends React.Component<
   }
 }
 
-export const StepExecutionDetails = withRouter(StepExecutionDetailsComponent);
+export const StepExecutionDetails = withDeckRuntimeServices(withRouter(StepExecutionDetailsComponent));

--- a/deck/packages/core/src/pipeline/config/stages/createLoadBalancer/CreateLoadBalancerStageConfig.spec.tsx
+++ b/deck/packages/core/src/pipeline/config/stages/createLoadBalancer/CreateLoadBalancerStageConfig.spec.tsx
@@ -2,9 +2,12 @@ import { mount } from 'enzyme';
 import React from 'react';
 
 import { CloudProviderRegistry, ProviderSelectionService } from '../../../../cloudProvider';
+import { DeckRuntimeContext } from '../../../../bootstrap/DeckRuntimeContext';
 import { CreateLoadBalancerStageConfig } from './CreateLoadBalancerStageConfig';
 
 describe('<CreateLoadBalancerStageConfig />', () => {
+  const runtimeServices = {} as any;
+
   function createProps(loadBalancers: any[] = []) {
     const stage = {
       loadBalancers,
@@ -41,13 +44,21 @@ describe('<CreateLoadBalancerStageConfig />', () => {
     await Promise.resolve();
   }
 
+  function mountConfig(props: ReturnType<typeof createProps>) {
+    return mount(
+      <DeckRuntimeContext.Provider value={{ services: runtimeServices }}>
+        <CreateLoadBalancerStageConfig {...props} />
+      </DeckRuntimeContext.Provider>,
+    );
+  }
+
   it('appends every operation returned when creating a load balancer', async () => {
     const existing = { name: 'existing' };
     const originalLoadBalancers = [existing];
     const created = [{ name: 'listener-1' }, { name: 'listener-2' }];
     const props = createProps(originalLoadBalancers);
     resolveModalWith(created);
-    const component = mount(<CreateLoadBalancerStageConfig {...props} />);
+    const component = mountConfig(props);
 
     component.find('button.add-new').simulate('click');
     await flushModalResult();
@@ -63,7 +74,7 @@ describe('<CreateLoadBalancerStageConfig />', () => {
     const created = { name: 'created' };
     const props = createProps([existing]);
     resolveModalWith(created);
-    const component = mount(<CreateLoadBalancerStageConfig {...props} />);
+    const component = mountConfig(props);
 
     component.find('button.add-new').simulate('click');
     await flushModalResult();
@@ -80,7 +91,7 @@ describe('<CreateLoadBalancerStageConfig />', () => {
     const replacements = [{ name: 'listener-1' }, { name: 'listener-2' }];
     const props = createProps(originalLoadBalancers);
     resolveModalWith(replacements);
-    const component = mount(<CreateLoadBalancerStageConfig {...props} />);
+    const component = mountConfig(props);
 
     component
       .find('button')
@@ -102,7 +113,7 @@ describe('<CreateLoadBalancerStageConfig />', () => {
     const replacement = { name: 'replacement' };
     const props = createProps([before, edited, after]);
     resolveModalWith(replacement);
-    const component = mount(<CreateLoadBalancerStageConfig {...props} />);
+    const component = mountConfig(props);
 
     component
       .find('button')

--- a/deck/packages/core/src/pipeline/config/stages/createLoadBalancer/CreateLoadBalancerStageConfig.tsx
+++ b/deck/packages/core/src/pipeline/config/stages/createLoadBalancer/CreateLoadBalancerStageConfig.tsx
@@ -2,6 +2,7 @@ import { cloneDeep } from 'lodash';
 import React from 'react';
 
 import { AccountTag } from '../../../../account/AccountTag';
+import { DeckRuntimeContext } from '../../../../bootstrap/DeckRuntimeContext';
 import { CloudProviderRegistry, ProviderSelectionService } from '../../../../cloudProvider';
 import type { IStageConfigProps } from '../common';
 import type { ILoadBalancer } from '../../../../domain';
@@ -16,6 +17,9 @@ export class CreateLoadBalancerStageConfig extends React.Component<
   IStageConfigProps,
   ICreateLoadBalancerStageConfigState
 > {
+  public static contextType = DeckRuntimeContext;
+  public declare context: React.ContextType<typeof DeckRuntimeContext>;
+
   constructor(props: IStageConfigProps) {
     super(props);
     this.ensureStageDefaults(props);
@@ -54,12 +58,16 @@ export class CreateLoadBalancerStageConfig extends React.Component<
           ),
         );
       }
-      return openLoadBalancerModal(provider.loadBalancer, {
-        application: this.props.application,
-        loadBalancer,
-        isNew,
-        forPipelineConfig: true,
-      });
+      return openLoadBalancerModal(
+        provider.loadBalancer,
+        {
+          application: this.props.application,
+          loadBalancer,
+          isNew,
+          forPipelineConfig: true,
+        },
+        this.context.services,
+      );
     });
   }
 

--- a/deck/packages/core/src/pipeline/config/stages/createLoadBalancer/createLoadBalancerStage.spec.js
+++ b/deck/packages/core/src/pipeline/config/stages/createLoadBalancer/createLoadBalancerStage.spec.js
@@ -43,27 +43,35 @@ describe('createLoadBalancerStage modal opener', () => {
     const application = { name: 'fnord' };
     const loadBalancer = { name: 'fnord-main' };
     const result = { name: 'fnord-main', type: 'upsertLoadBalancer' };
+    const runtimeServices = {};
     const config = {
       CreateLoadBalancerModal: {
         supportsPipelineConfig: true,
         show: jasmine.createSpy('show').and.returnValue(Promise.resolve(result)),
       },
     };
-    const command = await openLoadBalancerModal(config, {
-      application,
-      loadBalancer,
-      isNew: false,
-      forPipelineConfig: true,
-    });
+    const command = await openLoadBalancerModal(
+      config,
+      {
+        application,
+        loadBalancer,
+        isNew: false,
+        forPipelineConfig: true,
+      },
+      runtimeServices,
+    );
 
     expect(command).toBe(result);
-    expect(config.CreateLoadBalancerModal.show).toHaveBeenCalledWith({
-      app: application,
-      application,
-      loadBalancer,
-      isNew: false,
-      forPipelineConfig: true,
-    });
+    expect(config.CreateLoadBalancerModal.show).toHaveBeenCalledWith(
+      {
+        app: application,
+        application,
+        loadBalancer,
+        isNew: false,
+        forPipelineConfig: true,
+      },
+      runtimeServices,
+    );
   });
 
   it('rejects when a React modal does not support pipeline results', async () => {

--- a/deck/packages/core/src/pipeline/config/stages/createLoadBalancer/openLoadBalancerModal.ts
+++ b/deck/packages/core/src/pipeline/config/stages/createLoadBalancer/openLoadBalancerModal.ts
@@ -1,18 +1,26 @@
+import type { DeckRuntimeServices } from '../../../../bootstrap/DeckRuntimeServices';
 import type { ICloudProviderConfig } from '../../../../cloudProvider';
 
 export const hasPipelineLoadBalancerModal = (provider: ICloudProviderConfig): boolean => {
   return Boolean(provider?.loadBalancer?.CreateLoadBalancerModal?.supportsPipelineConfig);
 };
 
-export function openLoadBalancerModal(config: any, { application, loadBalancer, isNew, forPipelineConfig }: any) {
+export function openLoadBalancerModal(
+  config: any,
+  { application, loadBalancer, isNew, forPipelineConfig }: any,
+  runtimeServices: DeckRuntimeServices,
+) {
   if (config.CreateLoadBalancerModal && config.CreateLoadBalancerModal.supportsPipelineConfig) {
-    return config.CreateLoadBalancerModal.show({
-      app: application,
-      application,
-      loadBalancer,
-      isNew,
-      forPipelineConfig,
-    });
+    return config.CreateLoadBalancerModal.show(
+      {
+        app: application,
+        application,
+        loadBalancer,
+        isNew,
+        forPipelineConfig,
+      },
+      runtimeServices,
+    );
   }
 
   return Promise.reject(new Error('No React create load balancer modal is registered with pipeline support.'));

--- a/deck/packages/core/src/pipeline/config/stages/deploy/DeployChangesExecutionDetails.spec.tsx
+++ b/deck/packages/core/src/pipeline/config/stages/deploy/DeployChangesExecutionDetails.spec.tsx
@@ -2,6 +2,7 @@ import { mount } from 'enzyme';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 
+import { DeckRuntimeContext } from '../../../../bootstrap/DeckRuntimeContext';
 import type { IExecutionStage } from '../../../../domain';
 import { ViewChangesLink } from '../../../../diffs/ViewChangesLink';
 import { ServerGroupReader } from '../../../../serverGroup/serverGroupReader.service';
@@ -44,11 +45,18 @@ const createProps = (stage: IExecutionStage) =>
   } as any);
 
 describe('DeployChangesExecutionDetails', () => {
+  const RuntimeWrapper = ({ children }: React.PropsWithChildren<{}>) => (
+    <DeckRuntimeContext.Provider value={{ services: { executionService: {} } } as any}>
+      {children}
+    </DeckRuntimeContext.Provider>
+  );
+  const mountDetails = (component: React.ReactElement) => mount(component, { wrappingComponent: RuntimeWrapper });
+
   it('merges Jenkins metadata from the source server group into the changes config', async () => {
     const sourceServerGroup = deferred<any>();
     const getServerGroup = spyOn(ServerGroupReader, 'getServerGroup').and.returnValue(sourceServerGroup.promise);
     const stage = createStage('stage-1', 'app-v001');
-    const wrapper = mount(<DeployChangesExecutionDetails {...createProps(stage)} />);
+    const wrapper = mountDetails(<DeployChangesExecutionDetails {...createProps(stage)} />);
 
     expect(getServerGroup).toHaveBeenCalledWith('app', 'test', 'us-east-1', 'app-v001');
 
@@ -76,7 +84,7 @@ describe('DeployChangesExecutionDetails', () => {
     const firstStage = createStage('stage-1', 'app-v001');
     const secondStage = createStage('stage-2', 'app-v002');
     secondStage.context.buildInfo = { ancestor: '20', target: '21' };
-    const wrapper = mount(<DeployChangesExecutionDetails {...createProps(firstStage)} />);
+    const wrapper = mountDetails(<DeployChangesExecutionDetails {...createProps(firstStage)} />);
 
     wrapper.setProps(createProps(secondStage));
     await act(async () =>
@@ -103,7 +111,7 @@ describe('DeployChangesExecutionDetails', () => {
       secondRequest.promise,
     );
     const stage = createStage('stage-1', 'app-v001');
-    const wrapper = mount(<DeployChangesExecutionDetails {...createProps(stage)} />);
+    const wrapper = mountDetails(<DeployChangesExecutionDetails {...createProps(stage)} />);
 
     stage.context = {
       ...stage.context,
@@ -143,7 +151,9 @@ describe('DeployChangesExecutionDetails', () => {
     const sourceServerGroup = deferred<any>();
     spyOn(ServerGroupReader, 'getServerGroup').and.returnValue(sourceServerGroup.promise);
     const consoleError = spyOn(console, 'error');
-    const wrapper = mount(<DeployChangesExecutionDetails {...createProps(createStage('stage-1', 'app-v001'))} />);
+    const wrapper = mountDetails(
+      <DeployChangesExecutionDetails {...createProps(createStage('stage-1', 'app-v001'))} />,
+    );
 
     wrapper.unmount();
     await act(async () =>

--- a/deck/packages/core/src/pipeline/config/stages/deploy/DeployStageConfig.spec.tsx
+++ b/deck/packages/core/src/pipeline/config/stages/deploy/DeployStageConfig.spec.tsx
@@ -3,9 +3,11 @@ import React from 'react';
 
 import { AccountService } from '../../../../account/AccountService';
 import { ProviderSelectionService } from '../../../../cloudProvider/providerSelection/ProviderSelectionService';
-import { DeployStageConfig } from './DeployStageConfig';
+import { DeployStageConfigComponent } from './DeployStageConfig';
 
 describe('<DeployStageConfig />', () => {
+  const deckRuntimeServices = { serverGroupCommandBuilder: {}, serverGroupTransformer: {} } as any;
+
   function createProps(stageOverrides = {}) {
     const stage = {
       clusters: [],
@@ -30,7 +32,9 @@ describe('<DeployStageConfig />', () => {
     spyOn(ProviderSelectionService, 'selectProvider').and.returnValue(
       Promise.reject(new Error('No providers support serverGroup for this action.')),
     );
-    const component = mount(<DeployStageConfig {...createProps()} />);
+    const component = mount(
+      <DeployStageConfigComponent {...createProps()} deckRuntimeServices={deckRuntimeServices} />,
+    );
 
     component.find('button.add-new').simulate('click');
     await Promise.resolve();
@@ -48,7 +52,7 @@ describe('<DeployStageConfig />', () => {
       return Promise.reject(new Error('cancelled')) as any;
     });
     const props = createProps();
-    const component = mount(<DeployStageConfig {...props} />);
+    const component = mount(<DeployStageConfigComponent {...props} deckRuntimeServices={deckRuntimeServices} />);
 
     component.find('button.add-new').simulate('click');
 

--- a/deck/packages/core/src/pipeline/config/stages/deploy/DeployStageConfig.tsx
+++ b/deck/packages/core/src/pipeline/config/stages/deploy/DeployStageConfig.tsx
@@ -5,7 +5,8 @@ import { arrayMove, SortableContainer, SortableElement, SortableHandle } from 'r
 
 import { AccountService } from '../../../../account/AccountService';
 import { AccountTag } from '../../../../account/AccountTag';
-import { AngularServices } from '../../../../angular/services';
+import type { IDeckRuntimeServicesInjectedProps } from '../../../../bootstrap/DeckRuntimeContext';
+import { withDeckRuntimeServices } from '../../../../bootstrap/DeckRuntimeContext';
 import { CloudProviderLogo } from '../../../../cloudProvider/CloudProviderLogo';
 import { CloudProviderRegistry } from '../../../../cloudProvider/CloudProviderRegistry';
 import type { IProviderSelectionFilter } from '../../../../cloudProvider/providerSelection/ProviderSelectionService';
@@ -22,11 +23,14 @@ export interface IDeployStageConfigState {
   showProviderColumn: boolean;
 }
 
-export class DeployStageConfig extends React.Component<IStageConfigProps, IDeployStageConfigState> {
+export class DeployStageConfigComponent extends React.Component<
+  IStageConfigProps & IDeckRuntimeServicesInjectedProps,
+  IDeployStageConfigState
+> {
   private mounted = true;
   private subnetRenderers: { [cloudProvider: string]: any } = {};
 
-  constructor(props: IStageConfigProps) {
+  constructor(props: IStageConfigProps & IDeckRuntimeServicesInjectedProps) {
     super(props);
     this.ensureStageDefaults(props);
     this.state = {
@@ -120,11 +124,14 @@ export class DeployStageConfig extends React.Component<IStageConfigProps, IDeplo
       return Promise.reject(new Error(modalError));
     }
 
-    return CloneServerGroupModal.show({
-      title: 'Configure Deployment Cluster',
-      application: this.props.application,
-      command,
-    });
+    return CloneServerGroupModal.show(
+      {
+        title: 'Configure Deployment Cluster',
+        application: this.props.application,
+        command,
+      },
+      this.props.deckRuntimeServices,
+    );
   }
 
   private providerFilterFn: IProviderSelectionFilter = (_application, _account, provider) => {
@@ -139,12 +146,12 @@ export class DeployStageConfig extends React.Component<IStageConfigProps, IDeplo
     ProviderSelectionService.selectProvider(this.props.application, 'serverGroup', this.providerFilterFn)
       .then((selectedProvider) => {
         const serverGroupConfig = CloudProviderRegistry.getValue(selectedProvider, 'serverGroup');
-        return AngularServices.serverGroupCommandBuilder
+        return this.props.deckRuntimeServices.serverGroupCommandBuilder
           .buildNewServerGroupCommandForPipeline(selectedProvider, this.props.stage, this.props.pipeline)
           .then((command: any) => this.showCloneServerGroupModal(selectedProvider, serverGroupConfig, command))
           .then((command: any) => {
             command.provider = selectedProvider;
-            const stageCluster = AngularServices.serverGroupTransformer.convertServerGroupCommandToDeployConfiguration(
+            const stageCluster = this.props.deckRuntimeServices.serverGroupTransformer.convertServerGroupCommandToDeployConfiguration(
               command,
             );
             delete stageCluster.credentials;
@@ -163,13 +170,13 @@ export class DeployStageConfig extends React.Component<IStageConfigProps, IDeplo
     cluster.provider = cluster.cloudProvider || cluster.providerType || 'aws';
     const providerConfig = CloudProviderRegistry.getProvider(cluster.provider);
 
-    AngularServices.serverGroupCommandBuilder
+    this.props.deckRuntimeServices.serverGroupCommandBuilder
       .buildServerGroupCommandFromPipeline(this.props.application, cluster, this.props.stage, this.props.pipeline)
       .then((command: any) =>
         this.showCloneServerGroupModal(cluster.provider, providerConfig && providerConfig.serverGroup, command),
       )
       .then((command: any) => {
-        const stageCluster = AngularServices.serverGroupTransformer.convertServerGroupCommandToDeployConfiguration(
+        const stageCluster = this.props.deckRuntimeServices.serverGroupTransformer.convertServerGroupCommandToDeployConfiguration(
           command,
         );
         delete stageCluster.credentials;
@@ -288,6 +295,8 @@ export class DeployStageConfig extends React.Component<IStageConfigProps, IDeplo
     );
   }
 }
+
+export const DeployStageConfig = withDeckRuntimeServices(DeployStageConfigComponent);
 
 export interface IDeployClusterTableBodyProps extends SortableContainerProps {
   clusters: any[];

--- a/deck/packages/core/src/pipeline/config/stages/deploy/deployStage.ts
+++ b/deck/packages/core/src/pipeline/config/stages/deploy/deployStage.ts
@@ -1,66 +1,69 @@
 import { DeployChangesExecutionDetails, DeployExecutionDetails } from './DeployExecutionDetails';
 import { DeployStageConfig } from './DeployStageConfig';
-import { AngularServices } from '../../../../angular/services';
 import { ExecutionArtifactTab } from '../../../../artifact/react/ExecutionArtifactTab';
 import { CloudProviderRegistry } from '../../../../cloudProvider/CloudProviderRegistry';
+import type { ClusterService } from '../../../../cluster/cluster.service';
 import { ExecutionDetailsTasks } from '../common';
 import { deployStageTransformer } from './deployStage.transformer';
+import type { IStageTypeConfig } from '../../../../domain';
 import { Registry } from '../../../../registry';
 
 import './deployStage.less';
 
 Registry.pipeline.registerTransformer(deployStageTransformer);
 
-Registry.pipeline.registerStage({
-  label: 'Deploy',
-  description: 'Deploys the previously baked or found image',
-  strategyDescription: 'Deploys the image specified',
-  key: 'deploy',
-  alias: 'createServerGroup',
-  component: DeployStageConfig,
-  executionDetailsSections: [
-    DeployExecutionDetails,
-    ExecutionDetailsTasks,
-    ExecutionArtifactTab,
-    DeployChangesExecutionDetails,
-  ],
-  supportsCustomTimeout: true,
-  validators: [
-    {
-      type: 'stageBeforeType',
-      stageTypes: ['bake', 'findAmi', 'findImage', 'findImageFromTags'],
-      message: 'You must have a Bake or Find Image stage before any deploy stage.',
-      skipValidation: (_pipeline: any, stage: any) =>
-        (stage.clusters || []).every(
-          (cluster: any) =>
-            CloudProviderRegistry.getValue(cluster.provider, 'serverGroup.skipUpstreamStageCheck') ||
-            AngularServices.clusterService.isDeployingArtifact(cluster),
-        ),
+export function registerDeployStage(clusterService: ClusterService): IStageTypeConfig {
+  const stageConfig = {
+    label: 'Deploy',
+    description: 'Deploys the previously baked or found image',
+    strategyDescription: 'Deploys the image specified',
+    key: 'deploy',
+    alias: 'createServerGroup',
+    component: DeployStageConfig,
+    executionDetailsSections: [
+      DeployExecutionDetails,
+      ExecutionDetailsTasks,
+      ExecutionArtifactTab,
+      DeployChangesExecutionDetails,
+    ],
+    supportsCustomTimeout: true,
+    validators: [
+      {
+        type: 'stageBeforeType',
+        stageTypes: ['bake', 'findAmi', 'findImage', 'findImageFromTags'],
+        message: 'You must have a Bake or Find Image stage before any deploy stage.',
+        skipValidation: (_pipeline: any, stage: any) =>
+          (stage.clusters || []).every(
+            (cluster: any) =>
+              CloudProviderRegistry.getValue(cluster.provider, 'serverGroup.skipUpstreamStageCheck') ||
+              clusterService.isDeployingArtifact(cluster),
+          ),
+      },
+      {
+        type: 'imageProviderBeforeType',
+        message: 'You must provide the image metadata before any deploy stage.',
+        triggerTypes: ['docker', 'jenkins'],
+        skipValidation: (_pipeline: any, stage: any) =>
+          (stage.clusters || []).every(
+            (cluster: any) => !CloudProviderRegistry.getValue(cluster.provider, 'serverGroup.checkForImageProviders'),
+          ),
+      } as any,
+    ],
+    accountExtractor: (stage: any) => (stage.context.clusters || []).map((cluster: any) => cluster.account),
+    configAccountExtractor: (stage: any) => (stage.clusters || []).map((cluster: any) => cluster.account),
+    artifactExtractor: (stageContext: any) => {
+      const clusters = stageContext.clusters || [stageContext];
+      return clusters
+        .map(clusterService.extractArtifacts, clusterService)
+        .reduce((array: any[], items: any[]) => array.concat(items), []);
     },
-    {
-      type: 'imageProviderBeforeType',
-      message: 'You must provide the image metadata before any deploy stage.',
-      triggerTypes: ['docker', 'jenkins'],
-      skipValidation: (_pipeline: any, stage: any) =>
-        (stage.clusters || []).every(
-          (cluster: any) => !CloudProviderRegistry.getValue(cluster.provider, 'serverGroup.checkForImageProviders'),
-        ),
-    } as any,
-  ],
-  accountExtractor: (stage: any) => (stage.context.clusters || []).map((cluster: any) => cluster.account),
-  configAccountExtractor: (stage: any) => (stage.clusters || []).map((cluster: any) => cluster.account),
-  artifactExtractor: (stageContext: any) => {
-    const clusterService = AngularServices.clusterService;
-    const clusters = stageContext.clusters || [stageContext];
-    return clusters
-      .map(clusterService.extractArtifacts, clusterService)
-      .reduce((array: any[], items: any[]) => array.concat(items), []);
-  },
-  artifactRemover: (stage: any, artifactId: string) => {
-    const clusterService = AngularServices.clusterService;
-    (stage.clusters || []).forEach((cluster: any) =>
-      clusterService.getArtifactExtractor(cluster.cloudProvider).removeArtifact(cluster, artifactId),
-    );
-  },
-  strategy: true,
-} as any);
+    artifactRemover: (stage: any, artifactId: string) => {
+      (stage.clusters || []).forEach((cluster: any) =>
+        clusterService.getArtifactExtractor(cluster.cloudProvider).removeArtifact(cluster, artifactId),
+      );
+    },
+    strategy: true,
+  } as IStageTypeConfig;
+  Registry.pipeline.registerStage(stageConfig);
+  return stageConfig;
+}

--- a/deck/packages/core/src/pipeline/config/stages/evaluateVariables/ExecutionAndStagePicker.tsx
+++ b/deck/packages/core/src/pipeline/config/stages/evaluateVariables/ExecutionAndStagePicker.tsx
@@ -1,7 +1,7 @@
 import { isEqual, keyBy } from 'lodash';
 import React from 'react';
 import type { Option } from 'react-select';
-import { AngularServices } from '../../../../angular/services';
+import { useDeckRuntimeServices } from '../../../../bootstrap/DeckRuntimeContext';
 
 import { SETTINGS } from '../../../../config';
 import type { IExecution, IPipeline, IStage } from '../../../../domain';
@@ -18,7 +18,7 @@ export interface IExecutionAndStagePickerProps {
 
 export function ExecutionAndStagePicker(props: IExecutionAndStagePickerProps) {
   const { pipeline, pipelineStage, onChange } = props;
-  const { executionService } = AngularServices;
+  const { executionService } = useDeckRuntimeServices();
   const [execution, setExecution] = React.useState<IExecution>(null);
   const [stageId, setStageId] = React.useState<string>(null);
   const [showStageSelector, setShowStageSelector] = React.useState(false);

--- a/deck/packages/core/src/pipeline/config/stages/executionWindows/ExecutionWindowActions.tsx
+++ b/deck/packages/core/src/pipeline/config/stages/executionWindows/ExecutionWindowActions.tsx
@@ -1,8 +1,8 @@
 import { get } from 'lodash';
 import React from 'react';
-import { AngularServices } from '../../../../angular/services';
 
 import type { Application } from '../../../../application/application.model';
+import { DeckRuntimeContext } from '../../../../bootstrap/DeckRuntimeContext';
 import { ConfirmationModalService } from '../../../../confirmationModal';
 import { DAYS_OF_WEEK } from './daysOfWeek';
 import type { IExecution, IExecutionStage } from '../../../../domain';
@@ -33,6 +33,9 @@ export class ExecutionWindowActions extends React.Component<
   IExecutionWindowActionsProps,
   IExecutionWindowActionsState
 > {
+  public static contextType = DeckRuntimeContext;
+  public declare context: React.ContextType<typeof DeckRuntimeContext>;
+
   constructor(props: IExecutionWindowActionsProps) {
     super(props);
     const days = props.stage.context.restrictedExecutionWindow?.days;
@@ -46,7 +49,7 @@ export class ExecutionWindowActions extends React.Component<
   }
 
   private finishWaiting = (e: React.MouseEvent<HTMLElement>): void => {
-    const { executionService } = AngularServices;
+    const { executionService } = this.context.services;
     (e.target as HTMLElement).blur(); // forces closing of the popover when the modal opens
     const { application, execution, stage } = this.props;
 

--- a/deck/packages/core/src/pipeline/config/stages/group/GroupExecutionLabel.tsx
+++ b/deck/packages/core/src/pipeline/config/stages/group/GroupExecutionLabel.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
 import { GroupExecutionPopover } from './GroupExecutionPopover';
-import { AngularServices } from '../../../../angular/services';
 import type { Application } from '../../../../application/application.model';
+import { DeckRuntimeContext } from '../../../../bootstrap/DeckRuntimeContext';
 import { ExecutionBarLabel } from '../common/ExecutionBarLabel';
 import type { IExecution, IExecutionStageSummary } from '../../../../domain';
 
@@ -17,8 +17,11 @@ export interface IGroupExecutionLabelProps {
 }
 
 export class GroupExecutionLabel extends React.Component<IGroupExecutionLabelProps> {
+  public static contextType = DeckRuntimeContext;
+  public declare context: React.ContextType<typeof DeckRuntimeContext>;
+
   private subStageClicked = (groupStage: IExecutionStageSummary, stage: IExecutionStageSummary): void => {
-    const { executionService } = AngularServices;
+    const { executionService } = this.context.services;
     executionService.toggleDetails(this.props.execution, groupStage.index, stage.index);
   };
 

--- a/deck/packages/core/src/pipeline/config/stages/manualJudgment/ManualJudgmentApproval.tsx
+++ b/deck/packages/core/src/pipeline/config/stages/manualJudgment/ManualJudgmentApproval.tsx
@@ -5,8 +5,9 @@ import Select from 'react-select';
 import type { Application } from '../../../../application/application.model';
 import { ApplicationReader } from '../../../../application/service/ApplicationReader';
 import { AuthenticationService } from '../../../../authentication';
+import { DeckRuntimeContext } from '../../../../bootstrap/DeckRuntimeContext';
 import type { IExecution, IExecutionStage } from '../../../../domain';
-import { manualJudgmentService } from './manualJudgment.service';
+import { ManualJudgmentService } from './manualJudgment.service';
 import { Markdown } from '../../../../presentation/Markdown';
 import { Spinner } from '../../../../widgets/spinners/Spinner';
 
@@ -29,6 +30,9 @@ export class ManualJudgmentApproval extends React.Component<
   IManualJudgmentApprovalProps,
   IManualJudgmentApprovalState
 > {
+  public static contextType = DeckRuntimeContext;
+  public declare context: React.ContextType<typeof DeckRuntimeContext>;
+
   constructor(props: IManualJudgmentApprovalProps) {
     super(props);
     this.state = {
@@ -59,9 +63,15 @@ export class ManualJudgmentApproval extends React.Component<
     const { application, execution, stage } = this.props;
     const judgmentInput: string = this.state.judgmentInput ? this.state.judgmentInput.value : null;
     this.setState({ submitting: true, error: false, judgmentDecision });
-    manualJudgmentService.provideJudgment(application, execution, stage, judgmentDecision, judgmentInput).catch(() => {
-      this.setState({ submitting: false, error: true });
-    });
+    if (!this.context) {
+      throw new Error('Deck runtime services are unavailable outside DeckRuntimeContext');
+    }
+
+    new ManualJudgmentService(this.context.services.executionService)
+      .provideJudgment(application, execution, stage, judgmentDecision, judgmentInput)
+      .catch(() => {
+        this.setState({ submitting: false, error: true });
+      });
   }
 
   private isManualJudgmentStageNotAuthorized(): boolean {

--- a/deck/packages/core/src/pipeline/config/stages/manualJudgment/manualJudgment.service.ts
+++ b/deck/packages/core/src/pipeline/config/stages/manualJudgment/manualJudgment.service.ts
@@ -1,14 +1,9 @@
-import { AngularServices } from '../../../../angular/services';
 import type { Application } from '../../../../application';
 import type { IExecution, IExecutionStage } from '../../../../domain';
 import type { ExecutionService } from '../../../service/execution.service';
 
 export class ManualJudgmentService {
-  constructor(private executionService?: ExecutionService) {}
-
-  private getExecutionService(): ExecutionService {
-    return this.executionService || AngularServices.executionService;
-  }
+  constructor(private executionService: ExecutionService) {}
 
   public provideJudgment(
     application: Application,
@@ -17,7 +12,7 @@ export class ManualJudgmentService {
     judgmentStatus: string,
     judgmentInput?: string,
   ): PromiseLike<void> {
-    const executionService = this.getExecutionService();
+    const { executionService } = this;
     const matcher = (result: IExecution) => {
       const match = result.stages.find((test) => test.id === stage.id);
       return match && match.status !== 'RUNNING';
@@ -28,5 +23,3 @@ export class ManualJudgmentService {
       .then((updated) => executionService.updateExecution(application, updated));
   }
 }
-
-export const manualJudgmentService = new ManualJudgmentService();

--- a/deck/packages/core/src/pipeline/config/stages/wait/SkipWait.tsx
+++ b/deck/packages/core/src/pipeline/config/stages/wait/SkipWait.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import { AngularServices } from '../../../../angular/services';
-
 import type { Application } from '../../../../application/application.model';
+import { DeckRuntimeContext } from '../../../../bootstrap/DeckRuntimeContext';
 import { ConfirmationModalService } from '../../../../confirmationModal';
 import type { IExecution, IExecutionStage } from '../../../../domain';
 import { OrchestratedItemRunningTime } from '../../../executions/execution/OrchestratedItemRunningTime';
@@ -20,6 +19,9 @@ export interface ISkipWaitState {
 }
 
 export class SkipWait extends React.Component<ISkipWaitProps, ISkipWaitState> {
+  public static contextType = DeckRuntimeContext;
+  public declare context: React.ContextType<typeof DeckRuntimeContext>;
+
   private runningTime: OrchestratedItemRunningTime;
 
   constructor(props: ISkipWaitProps) {
@@ -34,7 +36,7 @@ export class SkipWait extends React.Component<ISkipWaitProps, ISkipWaitState> {
   };
 
   private skipRemainingWait = (e: React.MouseEvent<HTMLElement>): void => {
-    const { executionService } = AngularServices;
+    const { executionService } = this.context.services;
     (e.target as HTMLElement).blur(); // forces closing of the popover when the modal opens
     const { stage, application } = this.props;
     const matcher = (execution: IExecution) => {

--- a/deck/packages/core/src/pipeline/config/stages/waitForCondition/SkipConditionWait.tsx
+++ b/deck/packages/core/src/pipeline/config/stages/waitForCondition/SkipConditionWait.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import { AngularServices } from '../../../../angular/services';
 
 import type { Application } from '../../../../application/application.model';
+import { useDeckRuntimeServices } from '../../../../bootstrap/DeckRuntimeContext';
 import { ConfirmationModalService } from '../../../../confirmationModal';
 import type { IExecution, IExecutionStage } from '../../../../domain';
+import type { ExecutionService } from '../../../service/execution.service';
 import { duration } from '../../../../utils/timeFormatters';
 
 export const DEFAULT_SKIP_WAIT_TEXT = 'The pipeline will proceed immediately, marking this stage completed.';
@@ -19,8 +20,8 @@ const skipRemainingWait = (
   stage: IExecutionStage,
   execution: IExecution,
   application: Application,
+  executionService: ExecutionService,
 ): void => {
-  const { executionService } = AngularServices;
   (event.target as HTMLElement).blur(); // forces closing of the popover when the modal opens
   const matcher = ({ stages }: IExecution) => {
     const match = stages.find((test) => test.id === stage.id);
@@ -42,6 +43,7 @@ const skipRemainingWait = (
 };
 
 export const SkipConditionWait = ({ stage, execution, application }: ISkipConditionWaitProps) => {
+  const { executionService } = useDeckRuntimeServices();
   const { conditions } = stage.outputs;
   return (
     <div>
@@ -61,7 +63,7 @@ export const SkipConditionWait = ({ stage, execution, application }: ISkipCondit
         <div className="action-buttons">
           <button
             className="btn btn-xs btn-primary"
-            onClick={(event) => skipRemainingWait(event, stage, execution, application)}
+            onClick={(event) => skipRemainingWait(event, stage, execution, application, executionService)}
           >
             <span style={{ marginRight: '5px' }} className="small glyphicon glyphicon-fast-forward" />
             Skip remaining wait

--- a/deck/packages/core/src/pipeline/config/triggers/pipeline/PipelineTriggerTemplate.spec.tsx
+++ b/deck/packages/core/src/pipeline/config/triggers/pipeline/PipelineTriggerTemplate.spec.tsx
@@ -1,8 +1,8 @@
 import { mount, shallow } from 'enzyme';
 import React from 'react';
 
-import { PipelineTriggerTemplate } from './PipelineTriggerTemplate';
-import { AngularServices } from '../../../../angular/services';
+import { PipelineTriggerTemplateComponent } from './PipelineTriggerTemplate';
+import type { DeckRuntimeServices } from '../../../../bootstrap';
 import { SETTINGS } from '../../../../config/settings';
 import type { IExecution, IPipelineCommand, IPipelineTrigger } from '../../../../domain';
 import { ExecutionsTransformer } from '../../../service/ExecutionsTransformer';
@@ -19,6 +19,16 @@ import { ExecutionsTransformer } from '../../../service/ExecutionsTransformer';
 describe('<PipelineTriggerTemplate />', () => {
   let getExecutionsForConfigIdsSpy: jasmine.Spy;
   let addBuildInfoSpy: jasmine.Spy;
+
+  class PipelineTriggerTemplate extends PipelineTriggerTemplateComponent {
+    public static defaultProps = {
+      deckRuntimeServices: ({
+        executionService: {
+          getExecutionsForConfigIds: (...args: unknown[]) => getExecutionsForConfigIdsSpy(...args),
+        },
+      } as unknown) as DeckRuntimeServices,
+    };
+  }
 
   // Higher buildNumber = older execution (used for buildTime calculation)
   const createExecution = (id: string, buildNumber: number, overrides: Partial<IExecution> = {}): IExecution =>
@@ -75,10 +85,6 @@ describe('<PipelineTriggerTemplate />', () => {
 
   beforeEach(() => {
     getExecutionsForConfigIdsSpy = jasmine.createSpy('getExecutionsForConfigIds');
-    // AngularServices.executionService is a getter, not a method - use spyOnProperty
-    spyOnProperty(AngularServices, 'executionService', 'get').and.returnValue({
-      getExecutionsForConfigIds: getExecutionsForConfigIdsSpy,
-    });
     addBuildInfoSpy = spyOn(ExecutionsTransformer, 'addBuildInfo');
     updateCommandSpy.calls.reset();
   });

--- a/deck/packages/core/src/pipeline/config/triggers/pipeline/PipelineTriggerTemplate.tsx
+++ b/deck/packages/core/src/pipeline/config/triggers/pipeline/PipelineTriggerTemplate.tsx
@@ -1,8 +1,9 @@
 import { get, has } from 'lodash';
 import React from 'react';
 import type { Option } from 'react-select';
+import type { IDeckRuntimeServicesInjectedProps } from '../../../../bootstrap/DeckRuntimeContext';
+import { withDeckRuntimeServices } from '../../../../bootstrap/DeckRuntimeContext';
 
-import { AngularServices } from '../../../../angular/services';
 import { SETTINGS } from '../../../../config/settings';
 import type { IExecution, IPipeline, IPipelineCommand, IPipelineTrigger } from '../../../../domain';
 import { ExecutionBuildTitle } from '../../../executionBuild/ExecutionBuildTitle';
@@ -20,8 +21,8 @@ export interface IPipelineTriggerTemplateState {
   selectedExecution: string;
 }
 
-export class PipelineTriggerTemplate extends React.Component<
-  ITriggerTemplateComponentProps,
+export class PipelineTriggerTemplateComponent extends React.Component<
+  ITriggerTemplateComponentProps & IDeckRuntimeServicesInjectedProps,
   IPipelineTriggerTemplateState
 > {
   public static formatLabel(trigger: IPipelineTrigger): PromiseLike<string> {
@@ -42,7 +43,7 @@ export class PipelineTriggerTemplate extends React.Component<
     return PipelineConfigService.getPipelinesForApplication(application).then(loadSuccess, loadFailure);
   }
 
-  public constructor(props: ITriggerTemplateComponentProps) {
+  public constructor(props: ITriggerTemplateComponentProps & IDeckRuntimeServicesInjectedProps) {
     super(props);
     this.state = {
       executions: [],
@@ -76,7 +77,7 @@ export class PipelineTriggerTemplate extends React.Component<
       return;
     }
 
-    AngularServices.executionService
+    this.props.deckRuntimeServices.executionService
       .getExecutionsForConfigIds([trigger.pipeline], { limit: SETTINGS.maxPipelineTriggerExecutionOptions })
       .then(this.executionLoadSuccess, this.executionLoadFailure);
   };
@@ -212,3 +213,7 @@ export class PipelineTriggerTemplate extends React.Component<
     );
   }
 }
+
+export const PipelineTriggerTemplate = Object.assign(withDeckRuntimeServices(PipelineTriggerTemplateComponent), {
+  formatLabel: PipelineTriggerTemplateComponent.formatLabel,
+});

--- a/deck/packages/core/src/pipeline/details/SingleExecutionDetails.tsx
+++ b/deck/packages/core/src/pipeline/details/SingleExecutionDetails.tsx
@@ -1,9 +1,9 @@
 import { UISref, useCurrentStateAndParams, useRouter } from '@uirouter/react';
 import { set } from 'lodash';
 import React, { useEffect, useState } from 'react';
-import { AngularServices } from '../../angular/services';
 
 import type { Application } from '../../application/application.model';
+import { useDeckRuntimeServices } from '../../bootstrap/DeckRuntimeContext';
 import type { IExecution, IPipeline } from '../../domain';
 import { Execution } from '../executions/execution/Execution';
 import { ManualExecutionModal } from '../manualExecution';
@@ -11,6 +11,7 @@ import { useData, useLatestPromise } from '../../presentation';
 import type { IStateChange } from '../../reactShims';
 import { SchedulerFactory } from '../../scheduler';
 import { ExecutionsTransformer } from '../service/ExecutionsTransformer';
+import type { ExecutionService } from '../service/execution.service';
 import { ExecutionState } from '../../state';
 import { logger } from '../../utils';
 
@@ -30,8 +31,8 @@ export interface ISingleExecutionRouterStateChange extends IStateChange {
   toParams: ISingleExecutionStateParams;
 }
 
-export function getAndTransformExecution(id: string, app: Application) {
-  return AngularServices.executionService.getExecution(id, app.pipelineConfigs?.data).then((execution) => {
+export function getAndTransformExecution(id: string, app: Application, executionService: ExecutionService) {
+  return executionService.getExecution(id, app.pipelineConfigs?.data).then((execution) => {
     ExecutionsTransformer.transformExecution(app, execution);
     return execution;
   });
@@ -56,6 +57,8 @@ function traverseLineage(execution: IExecution, maxGenerations = 3): string[] {
 }
 
 export function SingleExecutionDetails(props: ISingleExecutionDetailsProps) {
+  const runtimeServices = useDeckRuntimeServices();
+  const { executionService } = runtimeServices;
   const scheduler = SchedulerFactory.createScheduler(5000);
   const { sortFilter } = ExecutionState.filterModel.asFilterModel;
   const { app } = props;
@@ -85,14 +88,16 @@ export function SingleExecutionDetails(props: ISingleExecutionDetailsProps) {
 
     return Promise.all(
       lineage.map((generation) =>
-        cache[generation] ? Promise.resolve(cache[generation]) : getAndTransformExecution(generation, app),
+        cache[generation]
+          ? Promise.resolve(cache[generation])
+          : getAndTransformExecution(generation, app, executionService),
       ),
     );
   };
 
   // responsible for getting execution whenever executionId (route param) changes
   const { result: execution, status: getExecutionStatus, refresh: refreshExecution } = useLatestPromise(
-    () => getAndTransformExecution(executionId, app),
+    () => getAndTransformExecution(executionId, app, executionService),
     [executionId],
   );
 
@@ -130,12 +135,14 @@ export function SingleExecutionDetails(props: ISingleExecutionDetailsProps) {
   };
 
   const rerunExecution = (execution: IExecution, application: Application, pipeline: IPipeline) => {
-    ManualExecutionModal.show({
-      pipeline,
-      application,
-      trigger: execution.trigger,
-    }).then((command) => {
-      const { executionService } = AngularServices;
+    ManualExecutionModal.show(
+      {
+        pipeline,
+        application,
+        trigger: execution.trigger,
+      },
+      runtimeServices,
+    ).then((command) => {
       executionService.startAndMonitorPipeline(application, command.pipelineName, command.trigger);
       stateService.go('^.^.executions');
     });

--- a/deck/packages/core/src/pipeline/details/StageSummaryWrapper.tsx
+++ b/deck/packages/core/src/pipeline/details/StageSummaryWrapper.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 
-import { AngularServices } from '../../angular/services';
 import { REST } from '../../api';
 import type { Application } from '../../application';
+import type { IDeckRuntimeServicesInjectedProps } from '../../bootstrap/DeckRuntimeContext';
+import { withDeckRuntimeServices } from '../../bootstrap/DeckRuntimeContext';
 import { ConfirmationModalService } from '../../confirmationModal';
 import type { IExecution, IExecutionStage, IExecutionStageSummary } from '../../domain';
 import type { IStage } from '../../domain';
@@ -21,8 +22,11 @@ export interface IStageSummaryWrapperProps {
   stageSummary: IExecutionStageSummary;
 }
 
-export function StageSummaryWrapperComponent(props: IStageSummaryWrapperProps & IRouterInjectedProps) {
-  const { application, execution, stage, stageSummary, stateParams, stateService } = props;
+export function StageSummaryWrapperComponent(
+  props: IStageSummaryWrapperProps & IRouterInjectedProps & IDeckRuntimeServicesInjectedProps,
+) {
+  const { application, deckRuntimeServices, execution, stage, stageSummary, stateParams, stateService } = props;
+  const { executionService } = deckRuntimeServices;
 
   const renderStepLabel = (step: IStage) => {
     const StepLabelComponent = Registry.pipeline.getStageConfig(step)?.executionStepLabelComponent;
@@ -116,15 +120,15 @@ export function StageSummaryWrapperComponent(props: IStageSummaryWrapperProps & 
         </div>
       `,
       submitMethod: (reason: string) =>
-        AngularServices.executionService
+        executionService
           .patchExecution(execution.id, topLevelStage.id, { manualSkip: true, reason })
           .then(() =>
-            AngularServices.executionService.waitUntilExecutionMatches(execution.id, (updatedExecution) => {
+            executionService.waitUntilExecutionMatches(execution.id, (updatedExecution) => {
               const updatedStage = updatedExecution.stages.find((candidate) => candidate.id === topLevelStage.id);
               return updatedStage && updatedStage.status === 'SKIPPED';
             }),
           )
-          .then((updated) => AngularServices.executionService.updateExecution(application, updated)),
+          .then((updated) => executionService.updateExecution(application, updated)),
     });
   };
 
@@ -220,4 +224,4 @@ export function StageSummaryWrapperComponent(props: IStageSummaryWrapperProps & 
   );
 }
 
-export const StageSummaryWrapper = withRouter(StageSummaryWrapperComponent);
+export const StageSummaryWrapper = withDeckRuntimeServices(withRouter(StageSummaryWrapperComponent));

--- a/deck/packages/core/src/pipeline/details/reactBridgeWrappers.spec.tsx
+++ b/deck/packages/core/src/pipeline/details/reactBridgeWrappers.spec.tsx
@@ -1,7 +1,6 @@
 import { mount, shallow } from 'enzyme';
 import React from 'react';
 
-import { AngularServices } from '../../angular/services';
 import { ConfirmationModalService } from '../../confirmationModal';
 import { setDirectRouter } from '../../navigation/directRouter';
 import { Registry } from '../../registry/Registry';
@@ -16,6 +15,7 @@ import { ExecutionStepDetails } from '../config/stages/common/ExecutionStepDetai
 
 describe('pipeline details bridge wrappers', () => {
   const routerProps = { router: {} as any, stateParams: {}, stateService: {} as any };
+  const deckRuntimeServices = { executionService: {} } as any;
 
   afterEach(() => setDirectRouter(null));
 
@@ -44,6 +44,7 @@ describe('pipeline details bridge wrappers', () => {
     const component = mount(
       <StageSummaryWrapperComponent
         {...routerProps}
+        deckRuntimeServices={deckRuntimeServices}
         application={{ attributes: {} } as any}
         execution={{ stages: [] } as any}
         sourceUrl="template.html"
@@ -73,6 +74,7 @@ describe('pipeline details bridge wrappers', () => {
     const component = mount(
       <StageSummaryWrapperComponent
         {...routerProps}
+        deckRuntimeServices={deckRuntimeServices}
         application={{ attributes: {} } as any}
         execution={{ stages: [] } as any}
         sourceUrl="template.html"
@@ -239,6 +241,7 @@ describe('pipeline details bridge wrappers', () => {
     const component = mount(
       <StageSummaryWrapperComponent
         {...routerProps}
+        deckRuntimeServices={deckRuntimeServices}
         application={{ attributes: {} } as any}
         execution={{ stages: [] } as any}
         sourceUrl="template.html"
@@ -271,11 +274,11 @@ describe('pipeline details bridge wrappers', () => {
         .and.returnValue(Promise.resolve(updatedExecution)),
     };
     spyOn(ConfirmationModalService, 'confirm').and.callFake((config: any) => config.submitMethod('operator reason'));
-    spyOnProperty(AngularServices, 'executionService', 'get').and.returnValue(executionService as any);
 
     const component = mount(
       <StageSummaryWrapperComponent
         {...routerProps}
+        deckRuntimeServices={{ executionService } as any}
         application={{ attributes: {} } as any}
         execution={
           {

--- a/deck/packages/core/src/pipeline/executions/Executions.spec.tsx
+++ b/deck/packages/core/src/pipeline/executions/Executions.spec.tsx
@@ -10,6 +10,7 @@ import type { IExecutionsProps, IExecutionsState } from './Executions';
 import { ExecutionsComponent } from './Executions';
 import type { Application } from '../../application';
 import { ApplicationModelBuilder } from '../../application/applicationModel.builder';
+import { DeckRuntimeContext } from '../../bootstrap/DeckRuntimeContext';
 import { ViewStateCache } from '../../cache';
 import { INSIGHT_FILTER_STATE_MODEL } from '../../insight/insightFilterState.model';
 import { OVERRIDE_REGISTRY } from '../../overrideRegistry';
@@ -23,6 +24,7 @@ describe('<Executions/>', () => {
   let application: Application;
   let router: UIRouterReact;
   let routerProps: any;
+  const runtimeServices = {} as any;
 
   async function settleInitialization() {
     await act(async () => {
@@ -46,9 +48,11 @@ describe('<Executions/>', () => {
     }
 
     component = mount(
-      <UIRouterContext.Provider value={router}>
-        <ExecutionsComponent {...routerProps} app={application} />
-      </UIRouterContext.Provider>,
+      <DeckRuntimeContext.Provider value={{ services: runtimeServices }}>
+        <UIRouterContext.Provider value={router}>
+          <ExecutionsComponent {...routerProps} app={application} />
+        </UIRouterContext.Provider>
+      </DeckRuntimeContext.Provider>,
     );
   }
 
@@ -109,24 +113,12 @@ describe('<Executions/>', () => {
     const pipeline = { id: 'pipeline-id', name: 'Test Pipeline' };
     routerProps.stateParams = { startManualExecution: pipeline.id };
     const showModal = spyOn(ManualExecutionModal, 'show').and.returnValue(Promise.reject());
-    set(application, 'executions.activate', noop);
-    set(application, 'pipelineConfigs.activate', noop);
-    application.executions.data = [];
-    application.executions.loaded = true;
-    application.pipelineConfigs.data = [pipeline] as any;
-    application.pipelineConfigs.loaded = true;
-    const executionComponent = shallow(<ExecutionsComponent {...routerProps} app={application} />, {
-      disableLifecycleMethods: true,
-    });
-    const instance = executionComponent.instance() as ExecutionsComponent;
-
-    instance.componentDidMount();
+    initializeApplication({ executions: [], pipelineConfigs: [pipeline] });
     await act(async () => {
       await Promise.resolve();
       await Promise.resolve();
     });
-    instance.componentWillUnmount();
 
-    expect(showModal).toHaveBeenCalledWith(jasmine.objectContaining({ application, pipeline }));
+    expect(showModal).toHaveBeenCalledWith(jasmine.objectContaining({ application, pipeline }), runtimeServices);
   });
 });

--- a/deck/packages/core/src/pipeline/executions/Executions.tsx
+++ b/deck/packages/core/src/pipeline/executions/Executions.tsx
@@ -5,6 +5,7 @@ import type { Subscription } from 'rxjs';
 import { AngularServices } from '../../angular/services';
 import type { Application } from '../../application';
 import type { IDefaultTagFilterConfig } from '../../application/config/defaultTagFilter/DefaultTagFilterConfig';
+import { DeckRuntimeContext } from '../../bootstrap/DeckRuntimeContext';
 import { CreatePipeline } from '../config/CreatePipeline';
 import { CreatePipelineButton } from '../create/CreatePipelineButton';
 import type { IExecution, IPipeline, IPipelineCommand } from '../../domain';
@@ -49,6 +50,9 @@ const forwardedExecutions = new Set();
 let disableForwarding = false;
 
 export class ExecutionsComponent extends React.Component<IExecutionsProps & IRouterInjectedProps, IExecutionsState> {
+  public static contextType = DeckRuntimeContext;
+  public declare context: React.ContextType<typeof DeckRuntimeContext>;
+
   private executionsRefreshUnsubscribe: Function;
   private groupsUpdatedSubscription: Subscription;
   private insightFilterStateModel = AngularServices.insightFilterStateModel;
@@ -158,7 +162,7 @@ export class ExecutionsComponent extends React.Component<IExecutionsProps & IRou
   };
 
   private startPipeline(command: IPipelineCommand): PromiseLike<void> {
-    const { executionService } = AngularServices;
+    const { executionService } = this.context.services;
     this.setState({ triggeringExecution: true });
     return executionService
       .startAndMonitorPipeline(this.props.app, command.pipelineName, command.trigger)
@@ -177,10 +181,13 @@ export class ExecutionsComponent extends React.Component<IExecutionsProps & IRou
 
   private triggerPipeline(pipeline: IPipeline = null): void {
     logger.log({ category: 'Pipelines', action: 'Trigger Pipeline (top level)' });
-    ManualExecutionModal.show({
-      pipeline: pipeline,
-      application: this.props.app,
-    })
+    ManualExecutionModal.show(
+      {
+        pipeline: pipeline,
+        application: this.props.app,
+      },
+      this.context.services,
+    )
       .then((command) => {
         this.startPipeline(command);
         this.clearManualExecutionParam();
@@ -193,7 +200,7 @@ export class ExecutionsComponent extends React.Component<IExecutionsProps & IRou
   }
 
   private handleAgedOutExecutions(executionId: string, forwardToPermalink: boolean): void {
-    const { executionService } = AngularServices;
+    const { executionService } = this.context.services;
     const { stateParams, stateService } = this.props;
     if (forwardToPermalink && executionId && !forwardedExecutions.has(executionId)) {
       // We only want to forward to permalink on initial load

--- a/deck/packages/core/src/pipeline/executions/execution/Execution.spec.tsx
+++ b/deck/packages/core/src/pipeline/executions/execution/Execution.spec.tsx
@@ -2,11 +2,11 @@ import { shallow } from 'enzyme';
 import React from 'react';
 
 import { ExecutionComponent } from './Execution';
-import { AngularServices } from '../../../angular/services';
 import { setDirectRouter } from '../../../navigation/directRouter';
 import { ExecutionState } from '../../../state';
 
 describe('Execution', () => {
+  const deckRuntimeServices = { executionService: {} } as any;
   const application = { name: 'test-app', pipelineConfigs: { data: [] } } as any;
   const execution = {
     deploymentTargets: [],
@@ -26,7 +26,6 @@ describe('Execution', () => {
       globals: { params: { executionId: 'other-execution', stage: '9', subStage: '8' } },
       stateService: { includes: () => false },
     } as any);
-    spyOnProperty(AngularServices, 'executionService', 'get').and.returnValue({} as any);
   });
 
   afterEach(() => {
@@ -37,6 +36,7 @@ describe('Execution', () => {
   it('derives its initial view from the injected route', () => {
     const component = shallow(
       <ExecutionComponent
+        deckRuntimeServices={deckRuntimeServices}
         {...({
           router: {},
           stateParams: { executionId: 'execution-id', stage: '2', subStage: '3' },
@@ -65,6 +65,7 @@ describe('Execution', () => {
     });
     const component = shallow(
       <ExecutionComponent
+        deckRuntimeServices={deckRuntimeServices}
         {...({
           router: { transitionService: { onSuccess } },
           stateParams: { executionId: 'other-execution' },
@@ -99,6 +100,7 @@ describe('Execution', () => {
     const stopPropagation = jasmine.createSpy('stopPropagation');
     const component = shallow(
       <ExecutionComponent
+        deckRuntimeServices={deckRuntimeServices}
         {...({ router: {}, stateParams: {}, stateService: { go, includes: () => false } } as any)}
         application={application}
         execution={{ ...execution, pipelineConfigId: 'pipeline-id' }}

--- a/deck/packages/core/src/pipeline/executions/execution/Execution.tsx
+++ b/deck/packages/core/src/pipeline/executions/execution/Execution.tsx
@@ -9,8 +9,9 @@ import { ExecutionMarker } from './ExecutionMarker';
 import { ExecutionPermalink } from './ExecutionPermalink';
 import { OrchestratedItemRunningTime } from './OrchestratedItemRunningTime';
 import { AccountTag } from '../../../account';
-import { AngularServices } from '../../../angular/services';
 import type { Application } from '../../../application/application.model';
+import type { IDeckRuntimeServicesInjectedProps } from '../../../bootstrap/DeckRuntimeContext';
+import { withDeckRuntimeServices } from '../../../bootstrap/DeckRuntimeContext';
 import { CancelModal } from '../../../cancelModal/CancelModal';
 import { PipelineGraph } from '../../config/graph/PipelineGraph';
 import type { IExecutionViewState, IPipelineGraphNode } from '../../config/graph/pipelineGraph.service';
@@ -67,7 +68,10 @@ const findChildIndex = (child: string, execution: IExecution) => {
   return result;
 };
 
-export class ExecutionComponent extends React.PureComponent<IExecutionProps & IRouterInjectedProps, IExecutionState> {
+export class ExecutionComponent extends React.PureComponent<
+  IExecutionProps & IRouterInjectedProps & IDeckRuntimeServicesInjectedProps,
+  IExecutionState
+> {
   public static defaultProps: Partial<IExecutionProps> = {
     dataSourceKey: 'executions',
     cancelHelpText: 'Cancel execution',
@@ -77,7 +81,7 @@ export class ExecutionComponent extends React.PureComponent<IExecutionProps & IR
   private runningTime: OrchestratedItemRunningTime;
   private wrapperRef = React.createRef<HTMLDivElement>();
 
-  constructor(props: IExecutionProps & IRouterInjectedProps) {
+  constructor(props: IExecutionProps & IRouterInjectedProps & IDeckRuntimeServicesInjectedProps) {
     super(props);
     const { execution, standalone } = this.props;
     const { stateParams } = this.props;
@@ -136,7 +140,7 @@ export class ExecutionComponent extends React.PureComponent<IExecutionProps & IR
   }
 
   private invalidateShowingDetails(props = this.props, forceScroll = false, stateParams = props.stateParams): boolean {
-    const { executionService } = AngularServices;
+    const { executionService } = this.props.deckRuntimeServices;
     const { stateService } = props;
     const { execution, application, standalone } = props;
     const showing =
@@ -171,7 +175,7 @@ export class ExecutionComponent extends React.PureComponent<IExecutionProps & IR
   }
 
   public toggleDetails = (stageIndex?: number, subIndex?: number): void => {
-    const { executionService } = AngularServices;
+    const { executionService } = this.props.deckRuntimeServices;
     const { execution, application } = this.props;
     executionService.hydrate(application, execution).then(() => {
       executionService.toggleDetails(execution, stageIndex, subIndex);
@@ -187,7 +191,7 @@ export class ExecutionComponent extends React.PureComponent<IExecutionProps & IR
   }
 
   public deleteExecution(): void {
-    const { executionService } = AngularServices;
+    const { executionService } = this.props.deckRuntimeServices;
     ConfirmationModalService.confirm({
       header: 'Really delete execution?',
       buttonText: 'Delete',
@@ -203,7 +207,7 @@ export class ExecutionComponent extends React.PureComponent<IExecutionProps & IR
 
   public cancelExecution(): void {
     const { application, execution, cancelConfirmationText } = this.props;
-    const { executionService } = AngularServices;
+    const { executionService } = this.props.deckRuntimeServices;
     const hasDeployStage =
       execution.stages &&
       execution.stages.some((stage) => stage.type === 'deploy' || stage.type === 'cloneServerGroup');
@@ -219,7 +223,7 @@ export class ExecutionComponent extends React.PureComponent<IExecutionProps & IR
   }
 
   public pauseExecution(): void {
-    const { executionService } = AngularServices;
+    const { executionService } = this.props.deckRuntimeServices;
     ConfirmationModalService.confirm({
       header: 'Really pause execution?',
       buttonText: 'Pause',
@@ -228,7 +232,7 @@ export class ExecutionComponent extends React.PureComponent<IExecutionProps & IR
   }
 
   public resumeExecution(): void {
-    const { executionService } = AngularServices;
+    const { executionService } = this.props.deckRuntimeServices;
     ConfirmationModalService.confirm({
       header: 'Really resume execution?',
       buttonText: 'Resume',
@@ -246,7 +250,9 @@ export class ExecutionComponent extends React.PureComponent<IExecutionProps & IR
     );
   }
 
-  public componentWillReceiveProps(nextProps: IExecutionProps & IRouterInjectedProps): void {
+  public componentWillReceiveProps(
+    nextProps: IExecutionProps & IRouterInjectedProps & IDeckRuntimeServicesInjectedProps,
+  ): void {
     if (nextProps.execution !== this.props.execution) {
       this.runningTime.checkStatus(nextProps.execution);
       this.setState({
@@ -544,4 +550,6 @@ export class ExecutionComponent extends React.PureComponent<IExecutionProps & IR
 }
 
 const OverridableExecution = overridableComponent(ExecutionComponent, 'PipelineExecution');
-export const Execution = withRouter<IExecutionProps & IRouterInjectedProps>(OverridableExecution);
+export const Execution = withDeckRuntimeServices(
+  withRouter<IExecutionProps & IRouterInjectedProps & IDeckRuntimeServicesInjectedProps>(OverridableExecution),
+);

--- a/deck/packages/core/src/pipeline/executions/executionGroup/ExecutionGroup.spec.tsx
+++ b/deck/packages/core/src/pipeline/executions/executionGroup/ExecutionGroup.spec.tsx
@@ -3,11 +3,13 @@ import React from 'react';
 import { Subject } from 'rxjs';
 
 import { ExecutionGroupComponent } from './ExecutionGroup';
-import { AngularServices } from '../../../angular/services';
 import { CollapsibleSectionStateCache } from '../../../cache';
 import { ExecutionState } from '../../../state';
 
 describe('ExecutionGroup', () => {
+  const deckRuntimeServices = {
+    executionService: { getSectionCacheKey: () => 'section-key' },
+  } as any;
   const application = {
     name: 'test-app',
     pipelineConfigs: { data: [] },
@@ -24,9 +26,6 @@ describe('ExecutionGroup', () => {
       expandSubject: new Subject<boolean>(),
     } as any;
     spyOn(CollapsibleSectionStateCache, 'isSet').and.returnValue(false);
-    spyOnProperty(AngularServices, 'executionService', 'get').and.returnValue({
-      getSectionCacheKey: () => 'section-key',
-    } as any);
   });
 
   afterEach(() => {
@@ -38,6 +37,7 @@ describe('ExecutionGroup', () => {
     const stateName = 'home.applications.application.pipelines.executions';
     const component = shallow(
       <ExecutionGroupComponent
+        deckRuntimeServices={deckRuntimeServices}
         {...({
           router: {},
           stateParams: {},
@@ -60,6 +60,7 @@ describe('ExecutionGroup', () => {
     const injectedOnSuccess = jasmine.createSpy('injectedOnSuccess').and.returnValue(injectedUnsubscribe);
     const component = shallow(
       <ExecutionGroupComponent
+        deckRuntimeServices={deckRuntimeServices}
         {...({
           router: { transitionService: { onSuccess: injectedOnSuccess } },
           stateParams: {},
@@ -92,6 +93,7 @@ describe('ExecutionGroup', () => {
     spyOn(CollapsibleSectionStateCache, 'isExpanded').and.returnValue(false);
     const component = shallow(
       <ExecutionGroupComponent
+        deckRuntimeServices={deckRuntimeServices}
         {...({
           router: { transitionService: { onSuccess: injectedOnSuccess } },
           stateParams: {},

--- a/deck/packages/core/src/pipeline/executions/executionGroup/ExecutionGroup.tsx
+++ b/deck/packages/core/src/pipeline/executions/executionGroup/ExecutionGroup.tsx
@@ -7,8 +7,9 @@ import { takeUntil } from 'rxjs/operators';
 
 import { MigrationTag } from './MigrationTag';
 import { AccountTag } from '../../../account';
-import { AngularServices } from '../../../angular/services';
 import type { Application } from '../../../application/application.model';
+import type { IDeckRuntimeServicesInjectedProps } from '../../../bootstrap/DeckRuntimeContext';
+import { withDeckRuntimeServices } from '../../../bootstrap/DeckRuntimeContext';
 import { CollapsibleSectionStateCache } from '../../../cache';
 import { PipelineConfigService } from '../../config/services/PipelineConfigService';
 import { SETTINGS } from '../../../config/settings';
@@ -63,7 +64,7 @@ export interface IExecutionGroupState {
 }
 
 export class ExecutionGroupComponent extends React.PureComponent<
-  IExecutionGroupProps & IRouterInjectedProps,
+  IExecutionGroupProps & IRouterInjectedProps & IDeckRuntimeServicesInjectedProps,
   IExecutionGroupState
 > {
   public state: IExecutionGroupState;
@@ -72,7 +73,7 @@ export class ExecutionGroupComponent extends React.PureComponent<
   private destroy$ = new Subject();
   private headerRef = React.createRef<HTMLDivElement>();
 
-  constructor(props: IExecutionGroupProps & IRouterInjectedProps) {
+  constructor(props: IExecutionGroupProps & IRouterInjectedProps & IDeckRuntimeServicesInjectedProps) {
     super(props);
     const { group, application } = props;
     const strategyConfig = application.strategyConfigs.data.find((c: IPipeline) => c.name === group.heading);
@@ -120,7 +121,7 @@ export class ExecutionGroupComponent extends React.PureComponent<
   }
 
   private getSectionCacheKey(): string {
-    const { executionService } = AngularServices;
+    const { executionService } = this.props.deckRuntimeServices;
     return executionService.getSectionCacheKey(
       ExecutionState.filterModel.asFilterModel.sortFilter.groupBy,
       this.props.application.name,
@@ -138,7 +139,7 @@ export class ExecutionGroupComponent extends React.PureComponent<
   };
 
   private startPipeline(command: IPipelineCommand): PromiseLike<void> {
-    const { executionService } = AngularServices;
+    const { executionService } = this.props.deckRuntimeServices;
     this.setState({ triggeringExecution: true });
     return executionService
       .startAndMonitorPipeline(this.props.application, command.pipelineName, command.trigger)
@@ -167,12 +168,15 @@ export class ExecutionGroupComponent extends React.PureComponent<
     )
       .pipe(takeUntil(this.destroy$))
       .subscribe((pipeline) =>
-        ManualExecutionModal.show({
-          pipeline,
-          application: this.props.application,
-          trigger: trigger,
-          currentlyRunningExecutions: this.props.group.runningExecutions,
-        })
+        ManualExecutionModal.show(
+          {
+            pipeline,
+            application: this.props.application,
+            trigger: trigger,
+            currentlyRunningExecutions: this.props.group.runningExecutions,
+          },
+          this.props.deckRuntimeServices,
+        )
           .then((command) => this.startPipeline(command))
           .catch(() => {}),
       );
@@ -422,4 +426,8 @@ export class ExecutionGroupComponent extends React.PureComponent<
 }
 
 const OverridableExecutionGroup = overridableComponent(ExecutionGroupComponent, 'PipelineExecutionGroup');
-export const ExecutionGroup = withRouter<IExecutionGroupProps & IRouterInjectedProps>(OverridableExecutionGroup);
+export const ExecutionGroup = withDeckRuntimeServices(
+  withRouter<IExecutionGroupProps & IRouterInjectedProps & IDeckRuntimeServicesInjectedProps>(
+    OverridableExecutionGroup,
+  ),
+);

--- a/deck/packages/core/src/pipeline/manualExecution/ManualPipelineExecutionModal.tsx
+++ b/deck/packages/core/src/pipeline/manualExecution/ManualPipelineExecutionModal.tsx
@@ -16,6 +16,7 @@ import type { ITriggerTemplateComponentProps } from './TriggerTemplate';
 import { Triggers } from './Triggers';
 import type { Application } from '../../application';
 import { AuthenticationService } from '../../authentication';
+import type { DeckRuntimeServices } from '../../bootstrap/DeckRuntimeServices';
 import { SETTINGS } from '../../config/settings';
 import type { IPipelineTemplateConfig } from '../config/templates';
 import { PipelineTemplateReader } from '../config/templates/PipelineTemplateReader';
@@ -157,11 +158,11 @@ export class ManualExecutionModal extends React.Component<IManualExecutionModalP
     this.destroy$.next();
   }
 
-  public static show(props: any): Promise<IPipelineCommand> {
+  public static show(props: any, runtimeServices: DeckRuntimeServices): Promise<IPipelineCommand> {
     const modalProps = {
       dialogClassName: 'manual-execution-dialog ' + 'modal-md',
     };
-    return ReactModal.show(ManualExecutionModal, props, modalProps);
+    return ReactModal.show(ManualExecutionModal, props, modalProps, runtimeServices);
   }
 
   private submit = (values: IPipelineCommand): void => {

--- a/deck/packages/core/src/pipeline/pipeline.dataSource.js
+++ b/deck/packages/core/src/pipeline/pipeline.dataSource.js
@@ -1,6 +1,5 @@
 import { module } from 'angular';
 
-import { AngularServices } from '../angular/services';
 import { DELIVERY_KEY } from '../application/nav/defaultCategories';
 import { ApplicationDataSourceRegistry } from '../application/service/ApplicationDataSourceRegistry';
 import { CLUSTER_SERVICE } from '../cluster/cluster.service';
@@ -12,9 +11,7 @@ import { EXECUTION_SERVICE } from './service/execution.service';
 export const CORE_PIPELINE_PIPELINE_DATASOURCE = 'spinnaker.core.pipeline.dataSource';
 export const name = CORE_PIPELINE_PIPELINE_DATASOURCE; // for backwards compatibility
 
-export function registerPipelineDataSources($q = AngularServices.$q, executionService, clusterService) {
-  const getExecutionService = () => executionService || AngularServices.executionService;
-  const getClusterService = () => clusterService || AngularServices.clusterService;
+export function registerPipelineDataSources($q, executionService, clusterService) {
   const registerOnce = (config) => {
     if (!ApplicationDataSourceRegistry.getDataSources().some(({ key }) => key === config.key)) {
       ApplicationDataSourceRegistry.registerDataSource(config);
@@ -22,12 +19,12 @@ export function registerPipelineDataSources($q = AngularServices.$q, executionSe
   };
 
   const addExecutions = (application, executions) => {
-    getExecutionService().transformExecutions(application, executions, application.executions.data);
-    return $q.when(getExecutionService().addExecutionsToApplication(application, executions));
+    executionService.transformExecutions(application, executions, application.executions.data);
+    return $q.when(executionService.addExecutionsToApplication(application, executions));
   };
 
   const loadExecutions = (application) => {
-    return getExecutionService().getExecutions(application.name, application);
+    return executionService.getExecutions(application.name, application);
   };
 
   const loadPipelineConfigs = (application) => {
@@ -44,30 +41,30 @@ export function registerPipelineDataSources($q = AngularServices.$q, executionSe
   };
 
   const loadRunningExecutions = (application) => {
-    return getExecutionService().getRunningExecutions(application.name);
+    return executionService.getRunningExecutions(application.name);
   };
 
   const addRunningExecutions = (application, data) => {
-    getExecutionService().transformExecutions(application, data);
+    executionService.transformExecutions(application, data);
     return $q.when(data);
   };
 
   const runningExecutionsLoaded = (application) => {
-    getExecutionService().mergeRunningExecutionsIntoExecutions(application);
+    executionService.mergeRunningExecutionsIntoExecutions(application);
 
     const serverGroups = application.getDataSource('serverGroups');
     if (!serverGroups) {
       return;
     }
 
-    getClusterService().addExecutionsToServerGroups(application);
+    clusterService.addExecutionsToServerGroups(application);
     serverGroups.dataUpdated();
   };
 
   const executionsLoaded = (application) => {
-    getExecutionService().mergeRunningExecutionsIntoExecutions(application);
+    executionService.mergeRunningExecutionsIntoExecutions(application);
     addExecutionTags(application);
-    getExecutionService().removeCompletedExecutionsFromRunningData(application);
+    executionService.removeCompletedExecutionsFromRunningData(application);
   };
 
   const addExecutionTags = (application) => {

--- a/deck/packages/core/src/pipeline/pipeline.dataSource.spec.ts
+++ b/deck/packages/core/src/pipeline/pipeline.dataSource.spec.ts
@@ -8,6 +8,10 @@ import { registerPipelineDataSources } from './pipeline.dataSource';
 import { EXECUTION_SERVICE } from './service/execution.service';
 
 describe('Pipeline Data Source', function () {
+  const promiseService = {
+    all: (promises: PromiseLike<any>[]) => Promise.all(promises),
+    when: <T>(value: T | PromiseLike<T>) => Promise.resolve(value),
+  };
   let application: Application, executionService: any, $scope: ng.IScope;
 
   beforeEach(() => ApplicationDataSourceRegistry.clearDataSources());
@@ -19,7 +23,7 @@ describe('Pipeline Data Source', function () {
       $scope = $rootScope.$new();
       executionService = _executionService_;
       ApplicationDataSourceRegistry.clearDataSources();
-      registerPipelineDataSources(undefined, executionService, _clusterService_);
+      registerPipelineDataSources(promiseService, executionService, _clusterService_);
     }),
   );
 

--- a/deck/packages/core/src/pipeline/pipeline.states.spec.ts
+++ b/deck/packages/core/src/pipeline/pipeline.states.spec.ts
@@ -3,8 +3,8 @@ import { UIRouterReact, UIView } from '@uirouter/react';
 import { shallow } from 'enzyme';
 import React from 'react';
 
-import { AngularServices } from '../angular/services';
 import { ApplicationReader } from '../application/service/ApplicationReader';
+import { createDeckRuntime } from '../bootstrap/DeckRuntime';
 import { setDirectRouter } from '../navigation/directRouter';
 import { configureRouter } from '../navigation/router';
 import { SpinErrorBoundary } from '../presentation';
@@ -14,8 +14,14 @@ import './pipeline.states';
 describe('pipeline states', () => {
   const routers: UIRouterReact[] = [];
 
-  function createRouter(): UIRouterReact {
-    const router = configureRouter();
+  function createRouter(getExecution?: jasmine.Spy): UIRouterReact {
+    const router = new UIRouterReact();
+    const runtime = createDeckRuntime(router);
+    if (getExecution) {
+      spyOn(runtime.services.executionService, 'getExecution').and.callFake(getExecution);
+    }
+    router.disposable({ dispose: runtime.dispose });
+    configureRouter(router, runtime.services);
     routers.push(router);
     return router;
   }
@@ -59,8 +65,8 @@ describe('pipeline states', () => {
       stageId: 'stage-id',
     };
 
-    function getRedirectTo() {
-      const router = createRouter();
+    function getRedirectTo(getExecution?: jasmine.Spy) {
+      const router = createRouter(getExecution);
       const executionLookup = router.stateRegistry.get('home.executionLookup');
       return executionLookup.redirectTo;
     }
@@ -75,11 +81,10 @@ describe('pipeline states', () => {
     it('resolves an execution permalink without a transition injector and preserves all target parameters', async () => {
       const execution = { application: 'resolved-application', id: params.executionId };
       const getExecution = jasmine.createSpy('getExecution').and.resolveTo(execution);
-      spyOnProperty(AngularServices, 'executionService', 'get').and.returnValue({ getExecution } as any);
       const targetResult = { redirected: true };
       const target = jasmine.createSpy('target').and.returnValue(targetResult);
 
-      const result = await getRedirectTo()(createTransition(params, target));
+      const result = await getRedirectTo(getExecution)(createTransition(params, target));
 
       expect(getExecution).toHaveBeenCalledOnceWith(params.executionId);
       expect(target).toHaveBeenCalledOnceWith('home.applications.application.pipelines.executionDetails.execution', {
@@ -98,12 +103,11 @@ describe('pipeline states', () => {
     it('resolves an execution permalink through a real direct transition', async () => {
       const execution = { application: 'resolved-application', id: params.executionId };
       const getExecution = jasmine.createSpy('getExecution').and.resolveTo(execution);
-      spyOnProperty(AngularServices, 'executionService', 'get').and.returnValue({ getExecution } as any);
       spyOn(ApplicationReader, 'getApplication').and.resolveTo({
         name: execution.application,
         dataSources: [],
       } as any);
-      const router = createRouter();
+      const router = createRouter(getExecution);
 
       await router.stateService.go('home.executionLookup', params, { location: false });
 
@@ -117,10 +121,9 @@ describe('pipeline states', () => {
 
     it('returns undefined without looking up an execution when the execution ID is missing', () => {
       const getExecution = jasmine.createSpy('getExecution');
-      spyOnProperty(AngularServices, 'executionService', 'get').and.returnValue({ getExecution } as any);
       const target = jasmine.createSpy('target');
 
-      const result = getRedirectTo()(createTransition({ ...params, executionId: undefined }, target));
+      const result = getRedirectTo(getExecution)(createTransition({ ...params, executionId: undefined }, target));
 
       expect(result).toBeUndefined();
       expect(getExecution).not.toHaveBeenCalled();
@@ -129,10 +132,9 @@ describe('pipeline states', () => {
 
     it('returns undefined when the execution lookup is rejected', async () => {
       const getExecution = jasmine.createSpy('getExecution').and.rejectWith(new Error('not found'));
-      spyOnProperty(AngularServices, 'executionService', 'get').and.returnValue({ getExecution } as any);
       const target = jasmine.createSpy('target');
 
-      const result = await getRedirectTo()(createTransition(params, target));
+      const result = await getRedirectTo(getExecution)(createTransition(params, target));
 
       expect(result).toBeUndefined();
       expect(target).not.toHaveBeenCalled();

--- a/deck/packages/core/src/pipeline/pipeline.states.ts
+++ b/deck/packages/core/src/pipeline/pipeline.states.ts
@@ -3,7 +3,6 @@ import { UIView } from '@uirouter/react';
 import { module } from 'angular';
 import React from 'react';
 
-import { AngularServices } from '../angular/services';
 import type { ApplicationStateProvider } from '../application/application.state.provider';
 import { registerApplicationState } from '../application/applicationState.registration';
 import { PipelineConfigPage } from './config/PipelineConfigPage';
@@ -115,6 +114,7 @@ registerApplicationState(
 );
 
 registerRootState((stateConfigProvider) => {
+  const { executionService } = stateConfigProvider.runtimeServices;
   const executionsLookup: INestedState = {
     name: 'executionLookup',
     url: '/executions/:executionId?refId&stage&subStage&step&details&stageId',
@@ -123,8 +123,6 @@ registerRootState((stateConfigProvider) => {
     },
     redirectTo: (transition) => {
       const { executionId, refId, stage, subStage, step, details, stageId } = transition.params();
-      const executionService = AngularServices.executionService;
-
       if (!executionId) {
         return undefined;
       }

--- a/deck/packages/core/src/pipeline/service/execution.service.ts
+++ b/deck/packages/core/src/pipeline/service/execution.service.ts
@@ -5,7 +5,6 @@ import { module } from 'angular';
 import { get, identity, pickBy, uniq } from 'lodash';
 
 import { ExecutionsTransformer } from './ExecutionsTransformer';
-import { AngularServices } from '../../angular/services';
 import { REST } from '../../api/ApiService';
 import type { Application } from '../../application/application.model';
 import type { ApplicationDataSource } from '../../application/service/applicationDataSource';
@@ -236,9 +235,8 @@ export class ExecutionService {
     pipeline: string,
     trigger: any,
   ): PromiseLike<IRetryablePromise<void>> {
-    const { executionService } = AngularServices;
     return PipelineConfigService.triggerPipeline(app.name, pipeline, trigger).then((triggerResult) =>
-      executionService.waitUntilTriggeredPipelineAppears(app, triggerResult),
+      this.waitUntilTriggeredPipelineAppears(app, triggerResult),
     );
   }
 

--- a/deck/packages/core/src/presentation/ReactModal.spec.tsx
+++ b/deck/packages/core/src/presentation/ReactModal.spec.tsx
@@ -2,6 +2,8 @@ import { UIRouterContext, UIRouterReact } from '@uirouter/react';
 import React from 'react';
 import ReactDOM from 'react-dom';
 
+import { DeckRuntimeContext } from '../bootstrap/DeckRuntimeContext';
+import type { DeckRuntimeServices } from '../bootstrap/DeckRuntimeServices';
 import { setDirectRouter } from '../navigation/directRouter';
 import type { IRouterInjectedProps } from '../navigation/routerContext';
 import { withRouter } from '../navigation/routerContext';
@@ -112,5 +114,28 @@ describe('ReactModal router context', () => {
     expect(provider.type).toBe(UIRouterContext.Provider);
     expect(provider.props.value).toBe(router);
     expect(provider.props.children.props.children.type).toBe(RoutedModalComponent);
+  });
+
+  it('provides explicitly supplied runtime services to modal components', () => {
+    const renders: React.ReactElement[] = [];
+    spyOn(ReactDOM, 'render').and.callFake((element) => {
+      renders.push(element as React.ReactElement);
+      return null;
+    });
+    const runtimeServices = {} as DeckRuntimeServices;
+
+    class RuntimeModalComponent extends React.Component<IModalComponentProps> {
+      public render(): React.ReactNode {
+        return null;
+      }
+    }
+
+    ReactModal.show(RuntimeModalComponent, {} as any, { animation: false }, runtimeServices);
+
+    const routerProvider = getLastRender(renders);
+    const runtimeProvider = routerProvider.props.children;
+    expect(runtimeProvider.type).toBe(DeckRuntimeContext.Provider);
+    expect(runtimeProvider.props.value.services).toBe(runtimeServices);
+    expect(runtimeProvider.props.children.props.children.type).toBe(RuntimeModalComponent);
   });
 });

--- a/deck/packages/core/src/presentation/ReactModal.tsx
+++ b/deck/packages/core/src/presentation/ReactModal.tsx
@@ -4,6 +4,8 @@ import type { ModalProps } from 'react-bootstrap';
 import { Modal } from 'react-bootstrap';
 import ReactDOM from 'react-dom';
 
+import { DeckRuntimeContext } from '../bootstrap/DeckRuntimeContext';
+import type { DeckRuntimeServices } from '../bootstrap/DeckRuntimeServices';
 import type { IModalComponentProps } from './modal';
 import { getDirectRouter } from '../navigation/directRouter';
 
@@ -27,12 +29,14 @@ export class ReactModal {
    * @param ModalComponent the component to be rendered inside a modal
    * @param componentProps to pass to the ModalComponent
    * @param modalProps to pass to the Modal
+   * @param runtimeServices to provide to modal components that use Deck runtime services
    * @returns {Promise<T>}
    */
   public static show<P extends IModalComponentProps, T = any>(
     ModalComponent: React.ComponentType<P>,
     componentProps?: P,
     modalProps?: Partial<ModalProps>,
+    runtimeServices?: DeckRuntimeServices,
   ): Promise<T> {
     const modalPromise = new Promise<T>((resolve, reject) => {
       let mountNode = document.createElement('div');
@@ -78,8 +82,13 @@ export class ReactModal {
             <ModalComponent {...componentProps} dismissModal={handleDismiss} closeModal={handleClose} />
           </Modal>
         );
+        const runtimeModal = runtimeServices ? (
+          <DeckRuntimeContext.Provider value={{ services: runtimeServices }}>{modal}</DeckRuntimeContext.Provider>
+        ) : (
+          modal
+        );
         ReactDOM.render(
-          router ? <UIRouterContext.Provider value={router}>{modal}</UIRouterContext.Provider> : modal,
+          router ? <UIRouterContext.Provider value={router}>{runtimeModal}</UIRouterContext.Provider> : runtimeModal,
           mountNode,
         );
       }

--- a/deck/packages/core/src/presentation/forms/inputs/ReactSelectInput.tsx
+++ b/deck/packages/core/src/presentation/forms/inputs/ReactSelectInput.tsx
@@ -89,7 +89,7 @@ export function ReactSelectInput<T = string>(props: IReactSelectInputProps<T>) {
 
   const commonProps = { className, style, ignoreAccents, ...fieldProps, ...otherProps } as any;
 
-  const SelectElement = ({ options }: { options: any[] }) =>
+  const renderSelectElement = (options: ReactSelectProps<any>['options']) =>
     mode === 'TETHERED' ? (
       <TetheredSelect {...commonProps} options={options} />
     ) : mode === 'VIRTUALIZED' ? (
@@ -101,11 +101,9 @@ export function ReactSelectInput<T = string>(props: IReactSelectInputProps<T>) {
     );
 
   if (isStringArray(stringOptions)) {
-    return (
-      <StringsAsOptions strings={stringOptions}>{(options) => <SelectElement options={options} />}</StringsAsOptions>
-    );
+    return <StringsAsOptions strings={stringOptions}>{(options) => renderSelectElement(options)}</StringsAsOptions>;
   } else {
-    return <SelectElement options={optionOptions} />;
+    return renderSelectElement(optionOptions);
   }
 }
 

--- a/deck/packages/core/src/projects/Projects.spec.tsx
+++ b/deck/packages/core/src/projects/Projects.spec.tsx
@@ -5,6 +5,7 @@ import * as React from 'react';
 import { act } from 'react-dom/test-utils';
 
 import { Projects } from './Projects';
+import { DeckRuntimeContext } from '../bootstrap/DeckRuntimeContext';
 import { ViewStateCache } from '../cache';
 import { OVERRIDE_REGISTRY } from '../overrideRegistry';
 import { REACT_MODULE } from '../reactShims';
@@ -57,7 +58,11 @@ describe('Projects', () => {
     });
 
     it('sets loaded flag and renders projects sorted by name asc', async () => {
-      const wrapper = await mountAndFlush(<Projects />);
+      const wrapper = await mountAndFlush(
+        <DeckRuntimeContext.Provider value={{ services: { cacheInitializer: {} } } as any}>
+          <Projects />
+        </DeckRuntimeContext.Provider>,
+      );
 
       const rows = wrapper.find('tbody tr');
       expect(rows.length).toBe(3);
@@ -71,7 +76,11 @@ describe('Projects', () => {
     });
 
     it('filters by name or email as the user types', async () => {
-      const wrapper = await mountAndFlush(<Projects />);
+      const wrapper = await mountAndFlush(
+        <DeckRuntimeContext.Provider value={{ services: { cacheInitializer: {} } } as any}>
+          <Projects />
+        </DeckRuntimeContext.Provider>,
+      );
 
       const input = wrapper.find('input[placeholder="Search projects"]');
       expect(input.exists()).toBeTrue();
@@ -102,7 +111,11 @@ describe('Projects', () => {
     });
 
     it('sorts by -name, -createTs, createTs, and combines with a filter', async () => {
-      const wrapper = await mountAndFlush(<Projects />);
+      const wrapper = await mountAndFlush(
+        <DeckRuntimeContext.Provider value={{ services: { cacheInitializer: {} } } as any}>
+          <Projects />
+        </DeckRuntimeContext.Provider>,
+      );
 
       const sortToggles = wrapper.find('SortToggle');
 

--- a/deck/packages/core/src/projects/dashboard/ProjectDashboard.spec.tsx
+++ b/deck/packages/core/src/projects/dashboard/ProjectDashboard.spec.tsx
@@ -2,7 +2,7 @@ import { mount } from 'enzyme';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 
-import { AngularServices } from '../../angular/services';
+import { DeckRuntimeContext } from '../../bootstrap/DeckRuntimeContext';
 import { RecentHistoryService } from '../../history/recentHistory.service';
 import { UrlBuilder } from '../../navigation';
 import { mountAndFlush } from '../../utils/testUtils';
@@ -71,6 +71,11 @@ const transition = (params: any = {}) =>
 
 describe('<ProjectDashboard />', () => {
   let executionService: { getProjectExecutions: jasmine.Spy };
+  const TestDashboard = (props: React.ComponentProps<typeof ProjectDashboard>) => (
+    <DeckRuntimeContext.Provider value={{ services: { executionService } } as any}>
+      <ProjectDashboard {...props} />
+    </DeckRuntimeContext.Provider>
+  );
 
   beforeEach(() => {
     spyOn(RecentHistoryService, 'addExtraDataToLatest').and.stub();
@@ -83,11 +88,10 @@ describe('<ProjectDashboard />', () => {
     executionService = {
       getProjectExecutions: jasmine.createSpy('getProjectExecutions').and.returnValue(Promise.resolve([execution])),
     };
-    spyOnProperty(AngularServices, 'executionService', 'get').and.returnValue(executionService as any);
   });
 
   it('loads clusters and executions and renders dashboard columns', async () => {
-    const wrapper = await mountAndFlush(<ProjectDashboard projectConfiguration={project} transition={transition()} />);
+    const wrapper = await mountAndFlush(<TestDashboard projectConfiguration={project} transition={transition()} />);
 
     expect(RecentHistoryService.addExtraDataToLatest).toHaveBeenCalledWith('projects', {
       config: { applications: ['kubernetesapp'] },
@@ -110,7 +114,7 @@ describe('<ProjectDashboard />', () => {
     };
 
     const wrapper = await mountAndFlush(
-      <ProjectDashboard projectConfiguration={emptyProject} transition={transition()} />,
+      <TestDashboard projectConfiguration={emptyProject} transition={transition()} />,
     );
 
     expect(ProjectReader.getProjectClusters).not.toHaveBeenCalled();
@@ -124,7 +128,7 @@ describe('<ProjectDashboard />', () => {
     (ProjectReader.getProjectClusters as jasmine.Spy).and.returnValue(Promise.reject(new Error('clusters failed')));
     executionService.getProjectExecutions.and.returnValue(Promise.reject(new Error('executions failed')));
 
-    const wrapper = await mountAndFlush(<ProjectDashboard projectConfiguration={project} transition={transition()} />);
+    const wrapper = await mountAndFlush(<TestDashboard projectConfiguration={project} transition={transition()} />);
 
     expect(wrapper.text()).toContain('There was a problem loading the clusters for this project.');
     expect(wrapper.text()).toContain('There was a problem loading the executions for this project.');
@@ -134,7 +138,7 @@ describe('<ProjectDashboard />', () => {
 
   it('toggles region filters and replaces the current route params', async () => {
     const tx = transition({ reg: { dev: true } });
-    const wrapper = await mountAndFlush(<ProjectDashboard projectConfiguration={project} transition={tx} />);
+    const wrapper = await mountAndFlush(<TestDashboard projectConfiguration={project} transition={tx} />);
 
     wrapper.find('RegionFilter h6.dropdown-toggle').simulate('click');
     await act(async () => {
@@ -149,7 +153,7 @@ describe('<ProjectDashboard />', () => {
 
   it('renders nothing for missing projects and removes recent history', () => {
     const wrapper = mount(
-      <ProjectDashboard projectConfiguration={{ ...project, notFound: true }} transition={transition()} />,
+      <TestDashboard projectConfiguration={{ ...project, notFound: true }} transition={transition()} />,
     );
 
     expect(RecentHistoryService.removeLastItem).toHaveBeenCalledWith('projects');

--- a/deck/packages/core/src/projects/dashboard/ProjectDashboard.tsx
+++ b/deck/packages/core/src/projects/dashboard/ProjectDashboard.tsx
@@ -4,8 +4,8 @@ import React from 'react';
 import { getAvailableProjectClusterRegions, ProjectCluster } from './ProjectCluster';
 import type { IProjectDashboardCluster, IRegionSelection } from './ProjectClusterModel';
 import { RegionFilter } from './RegionFilter';
-import { AngularServices } from '../../angular/services';
 import { ApplicationModelBuilder } from '../../application/applicationModel.builder';
+import { useDeckRuntimeServices } from '../../bootstrap/DeckRuntimeContext';
 import type { IExecution, IProject } from '../../domain';
 import { RecentHistoryService } from '../../history/recentHistory.service';
 import { ProjectPipeline } from './pipeline/ProjectPipeline';
@@ -80,6 +80,7 @@ const RefreshControl = ({ onRefresh, refreshing }: { onRefresh: () => void; refr
 );
 
 export const ProjectDashboard = ({ projectConfiguration: project, transition }: IProjectDashboardProps) => {
+  const { executionService } = useDeckRuntimeServices();
   const [clusters, setClusters] = React.useState<IProjectDashboardCluster[]>([]);
   const [executions, setExecutions] = React.useState<IExecution[]>([]);
   const [clusterState, setClusterState] = React.useState<ILoadState>(initialLoadState());
@@ -120,7 +121,7 @@ export const ProjectDashboard = ({ projectConfiguration: project, transition }: 
 
   const loadExecutions = () => {
     setExecutionState((state) => ({ ...state, refreshing: true, error: false }));
-    return AngularServices.executionService
+    return executionService
       .getProjectExecutions(project.name)
       .then((nextExecutions: IExecution[]) => {
         setExecutions(nextExecutions);

--- a/deck/packages/core/src/search/global/GlobalSearch.tsx
+++ b/deck/packages/core/src/search/global/GlobalSearch.tsx
@@ -6,7 +6,7 @@ import { debounceTime, map, switchMap, takeUntil, tap } from 'rxjs/operators';
 
 import { GlobalSearchRecentItems } from './GlobalSearchRecentItems';
 import { GlobalSearchResults } from './GlobalSearchResults';
-import { AngularServices } from '../../angular/services';
+import { DeckRuntimeContext } from '../../bootstrap/DeckRuntimeContext';
 import type { IChildComponentProps } from '../infrastructure/RecentlyViewedItems';
 import { RecentlyViewedItems } from '../infrastructure/RecentlyViewedItems';
 import type { ISearchResultSet } from '../infrastructure/infrastructureSearch.service';
@@ -34,6 +34,9 @@ export interface IGlobalSearchState {
 }
 
 class GlobalSearchComponent extends React.Component<IRouterInjectedProps, IGlobalSearchState> {
+  public static contextType = DeckRuntimeContext;
+  public declare context: React.ContextType<typeof DeckRuntimeContext>;
+
   private container: HTMLElement;
   private searchField: HTMLInputElement;
   private resultRefs: HTMLElement[][];
@@ -56,7 +59,7 @@ class GlobalSearchComponent extends React.Component<IRouterInjectedProps, IGloba
     window.addEventListener('keyup', this.handleWindowKeyup);
     window.addEventListener('click', this.handleWindowClick);
 
-    const { infrastructureSearchService } = AngularServices;
+    const { infrastructureSearchService } = this.context.services;
     const search = infrastructureSearchService.getSearcher();
 
     this.query$

--- a/deck/packages/core/src/search/infrastructure/RecentlyViewedItems.tsx
+++ b/deck/packages/core/src/search/infrastructure/RecentlyViewedItems.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import type { ISearchResult, ISearchResultPodData } from './SearchResultPods';
 import { SearchResultPods } from './SearchResultPods';
-import { AngularServices } from '../../angular/services';
+import { useDeckRuntimeServices } from '../../bootstrap/DeckRuntimeContext';
 import type { IRecentHistoryEntry } from '../../history';
 import { RecentHistoryService } from '../../history';
 import { useData } from '../../presentation/hooks';
@@ -21,10 +21,11 @@ export interface IRecentlyViewedItemsProps {
 }
 
 export function RecentlyViewedItems(props: IRecentlyViewedItemsProps) {
+  const { infrastructureSearchService } = useDeckRuntimeServices();
   const { Component } = props;
   const categoryNames = ['projects', 'applications', 'loadBalancers', 'serverGroups', 'instances', 'securityGroups'];
   // useMemo to get a single searcher per mount. The Searcher immediately performs work when instantiated.
-  const search = React.useMemo(() => AngularServices.infrastructureSearchService.getSearcher(), []);
+  const search = React.useMemo(() => infrastructureSearchService.getSearcher(), [infrastructureSearchService]);
 
   /** fetches the displayName and adds it to the history entry */
   function getFullHistoryEntry(category: string, item: IRecentHistoryEntry): PromiseLike<ISearchResult> {

--- a/deck/packages/core/src/search/infrastructure/SearchV1.spec.tsx
+++ b/deck/packages/core/src/search/infrastructure/SearchV1.spec.tsx
@@ -6,7 +6,6 @@ import { BehaviorSubject } from 'rxjs';
 import { SearchV1Component as SearchV1 } from './SearchV1';
 import { SearchResult } from './SearchResult';
 import type { ISearchResultSet } from './infrastructureSearch.service';
-import { AngularServices } from '../../angular/services';
 import { RecentlyViewedItems } from './RecentlyViewedItems';
 import { SearchStatus } from '../searchResult';
 
@@ -30,22 +29,25 @@ describe('SearchV1', () => {
   let query: jasmine.Spy;
   let go: jasmine.Spy;
   let wrapper: ShallowWrapper | undefined;
+  const deckRuntimeServices = {
+    infrastructureSearchService: { getSearcher: () => ({ query: (...args: any[]) => query(...args) }) },
+    pageTitleService: { handleRoutingSuccess: jasmine.createSpy('handleRoutingSuccess') },
+  } as any;
 
   const renderSearch = () =>
     shallow(
-      <SearchV1 router={{ globals: { params$ } } as any} stateParams={params$.value} stateService={{ go } as any} />,
+      <SearchV1
+        deckRuntimeServices={deckRuntimeServices}
+        router={{ globals: { params$ } } as any}
+        stateParams={params$.value}
+        stateService={{ go } as any}
+      />,
     );
 
   beforeEach(() => {
     params$ = new BehaviorSubject({ q: null, route: null });
     query = jasmine.createSpy('query').and.returnValue(Promise.resolve([]));
     go = jasmine.createSpy('go');
-    spyOnProperty(AngularServices, 'infrastructureSearchService', 'get').and.returnValue({
-      getSearcher: () => ({ query }),
-    } as any);
-    spyOnProperty(AngularServices, 'pageTitleService', 'get').and.returnValue({
-      handleRoutingSuccess: jasmine.createSpy(),
-    } as any);
     jasmine.clock().install();
   });
 

--- a/deck/packages/core/src/search/infrastructure/SearchV1.tsx
+++ b/deck/packages/core/src/search/infrastructure/SearchV1.tsx
@@ -6,7 +6,8 @@ import { ProjectSummaryPod } from './ProjectSummaryPod';
 import { RecentlyViewedItems } from './RecentlyViewedItems';
 import { SearchResult } from './SearchResult';
 import { SearchResultPods } from './SearchResultPods';
-import { AngularServices } from '../../angular/services';
+import type { IDeckRuntimeServicesInjectedProps } from '../../bootstrap/DeckRuntimeContext';
+import { withDeckRuntimeServices } from '../../bootstrap/DeckRuntimeContext';
 import type { ISearchResultSet } from './infrastructureSearch.service';
 import { InsightMenu } from '../../insight/InsightMenu';
 import type { IRouterInjectedProps } from '../../navigation/routerContext';
@@ -30,8 +31,11 @@ export interface ISearchV1State {
   showMinLengthWarning: boolean;
 }
 
-export class SearchV1Component extends React.Component<IRouterInjectedProps, ISearchV1State> {
-  private search = AngularServices.infrastructureSearchService.getSearcher();
+export class SearchV1Component extends React.Component<
+  IRouterInjectedProps & IDeckRuntimeServicesInjectedProps,
+  ISearchV1State
+> {
+  private search = this.props.deckRuntimeServices.infrastructureSearchService.getSearcher();
   private autoNavigateQuery: string | null = this.props.stateParams.route ? this.props.stateParams.q || '' : null;
   private destroy$ = new Subject<void>();
   private query$ = new Subject<string>();
@@ -146,7 +150,7 @@ export class SearchV1Component extends React.Component<IRouterInjectedProps, ISe
   }
 
   private updatePageTitle(query: string): void {
-    AngularServices.pageTitleService.handleRoutingSuccess({
+    this.props.deckRuntimeServices.pageTitleService.handleRoutingSuccess({
       pageTitleMain: { field: undefined, label: query ? ` search results for "${query}"` : 'Infrastructure' },
     });
   }
@@ -282,4 +286,4 @@ export class SearchV1Component extends React.Component<IRouterInjectedProps, ISe
   }
 }
 
-export const SearchV1 = withRouter(SearchV1Component);
+export const SearchV1 = withDeckRuntimeServices(withRouter(SearchV1Component));

--- a/deck/packages/core/src/search/infrastructure/SearchV2.spec.tsx
+++ b/deck/packages/core/src/search/infrastructure/SearchV2.spec.tsx
@@ -3,19 +3,17 @@ import React from 'react';
 import { BehaviorSubject } from 'rxjs';
 
 import { SearchV2Component } from './SearchV2';
-import { AngularServices } from '../../angular/services';
 
 describe('SearchV2', () => {
-  beforeEach(() => {
-    spyOnProperty(AngularServices, 'pageTitleService', 'get').and.returnValue({
-      handleRoutingSuccess: jasmine.createSpy('handleRoutingSuccess'),
-    } as any);
-  });
+  const deckRuntimeServices = {
+    pageTitleService: { handleRoutingSuccess: jasmine.createSpy('handleRoutingSuccess') },
+  } as any;
 
   it('uses injected route state for tab selection and filter navigation', () => {
     const go = jasmine.createSpy('go');
     const component = shallow(
       <SearchV2Component
+        deckRuntimeServices={deckRuntimeServices}
         router={{ globals: { params$: new BehaviorSubject({ tab: 'applications' }) } } as any}
         stateParams={{ tab: 'applications' }}
         stateService={{ go } as any}

--- a/deck/packages/core/src/search/infrastructure/SearchV2.tsx
+++ b/deck/packages/core/src/search/infrastructure/SearchV2.tsx
@@ -3,7 +3,8 @@ import React from 'react';
 import type { Observable } from 'rxjs';
 import { empty as observableEmpty, Subject } from 'rxjs';
 import { distinctUntilChanged, map, scan, switchMap, takeUntil, tap } from 'rxjs/operators';
-import { AngularServices } from '../../angular/services';
+import type { IDeckRuntimeServicesInjectedProps } from '../../bootstrap/DeckRuntimeContext';
+import { withDeckRuntimeServices } from '../../bootstrap/DeckRuntimeContext';
 
 import { RecentlyViewedItems } from '../infrastructure/RecentlyViewedItems';
 import { SearchResultPods } from '../infrastructure/SearchResultPods';
@@ -28,7 +29,9 @@ export interface ISearchV2State {
   refreshingCache: boolean;
 }
 
-export class SearchV2Component extends React.Component<IRouterInjectedProps, ISearchV2State> {
+type SearchV2Props = IRouterInjectedProps & IDeckRuntimeServicesInjectedProps;
+
+export class SearchV2Component extends React.Component<SearchV2Props, ISearchV2State> {
   private searchResultTypes = searchResultTypeRegistry.getAll();
 
   private INITIAL_RESULTS: ISearchResultSet[] = this.searchResultTypes.map((type) => ({
@@ -39,7 +42,7 @@ export class SearchV2Component extends React.Component<IRouterInjectedProps, ISe
 
   private destroy$ = new Subject();
 
-  constructor(props: IRouterInjectedProps) {
+  constructor(props: SearchV2Props) {
     super(props);
 
     this.state = {
@@ -51,7 +54,9 @@ export class SearchV2Component extends React.Component<IRouterInjectedProps, ISe
     };
 
     // just set the page title - don't try to get fancy w/ the search terms
-    AngularServices.pageTitleService.handleRoutingSuccess({ pageTitleMain: { field: undefined, label: 'Search' } });
+    props.deckRuntimeServices.pageTitleService.handleRoutingSuccess({
+      pageTitleMain: { field: undefined, label: 'Search' },
+    });
   }
 
   // returns parameter values that are OK to send through to the back end search API as filters
@@ -193,4 +198,4 @@ export class SearchV2Component extends React.Component<IRouterInjectedProps, ISe
   }
 }
 
-export const SearchV2 = withRouter(SearchV2Component);
+export const SearchV2 = withDeckRuntimeServices(withRouter(SearchV2Component));

--- a/deck/packages/core/src/search/infrastructure/infrastructure.states.spec.ts
+++ b/deck/packages/core/src/search/infrastructure/infrastructure.states.spec.ts
@@ -1,6 +1,8 @@
 import { shallow } from 'enzyme';
 import React from 'react';
+import { UIRouterReact } from '@uirouter/react';
 
+import { createDeckRuntime } from '../../bootstrap/DeckRuntime';
 import { SETTINGS } from '../../config/settings';
 import { configureRouter } from '../../navigation/router';
 import { SpinErrorBoundary } from '../../presentation';
@@ -12,13 +14,20 @@ import './infrastructure.states';
 describe('infrastructure states', () => {
   const originalSearchVersion = SETTINGS.searchVersion;
 
+  function createRouter(): UIRouterReact {
+    const router = new UIRouterReact();
+    const runtime = createDeckRuntime(router);
+    router.disposable(runtime);
+    return configureRouter(router, runtime.services);
+  }
+
   afterEach(() => {
     SETTINGS.searchVersion = originalSearchVersion;
   });
 
   it('registers direct V1 search and its one-shot route parameter', () => {
     SETTINGS.searchVersion = 1;
-    const router = configureRouter();
+    const router = createRouter();
     const searchState = router.stateRegistry.get('home.search');
     const view = searchState.views['main@'];
     const errorBoundary = shallow(React.createElement(view.component));
@@ -31,11 +40,12 @@ describe('infrastructure states', () => {
     expect(view.templateUrl).toBeUndefined();
     expect(searchState.url).toContain('&route');
     expect(searchState.params.route.dynamic).toBe(true);
+    router.dispose();
   });
 
   it('registers direct V2 search when configured', () => {
     SETTINGS.searchVersion = 2;
-    const router = configureRouter();
+    const router = createRouter();
     const searchState = router.stateRegistry.get('home.search');
     const view = searchState.views['main@'];
     const errorBoundary = shallow(React.createElement(view.component));
@@ -46,5 +56,6 @@ describe('infrastructure states', () => {
     expect(view.controller).toBeUndefined();
     expect(view.template).toBeUndefined();
     expect(view.templateUrl).toBeUndefined();
+    router.dispose();
   });
 });

--- a/deck/packages/core/src/securityGroup/CreateSecurityGroupButton.spec.tsx
+++ b/deck/packages/core/src/securityGroup/CreateSecurityGroupButton.spec.tsx
@@ -1,14 +1,16 @@
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import React from 'react';
 
 import type { IQService, IRootScopeService } from 'angular';
 import { mock } from 'angular';
 
 import { CloudProviderRegistry, ProviderSelectionService } from '../cloudProvider';
+import { DeckRuntimeContext } from '../bootstrap/DeckRuntimeContext';
 import { SETTINGS } from '../config/settings';
 import { CreateSecurityGroupButton } from './CreateSecurityGroupButton';
 
 describe('<CreateSecurityGroupButton />', () => {
+  const runtimeServices = {} as any;
   let $q: IQService;
   let $rootScope: IRootScopeService;
 
@@ -41,18 +43,25 @@ describe('<CreateSecurityGroupButton />', () => {
       CreateSecurityGroupModal: modal,
     });
 
-    shallow(<CreateSecurityGroupButton app={app} />)
+    mount(
+      <DeckRuntimeContext.Provider value={{ services: runtimeServices }}>
+        <CreateSecurityGroupButton app={app} />
+      </DeckRuntimeContext.Provider>,
+    )
       .find('button')
       .simulate('click');
     await settle();
     $rootScope.$digest();
 
-    expect(modal.show).toHaveBeenCalledWith({
-      application: app,
-      credentials: 'button-test-account',
-      isNew: true,
-      region: 'dev',
-    });
+    expect(modal.show).toHaveBeenCalledWith(
+      {
+        application: app,
+        credentials: 'button-test-account',
+        isNew: true,
+        region: 'dev',
+      },
+      runtimeServices,
+    );
   });
 
   it('opens a React security group modal for providers without configured defaults', async () => {
@@ -67,18 +76,25 @@ describe('<CreateSecurityGroupButton />', () => {
       CreateSecurityGroupModal: modal,
     });
 
-    shallow(<CreateSecurityGroupButton app={app} />)
+    mount(
+      <DeckRuntimeContext.Provider value={{ services: runtimeServices }}>
+        <CreateSecurityGroupButton app={app} />
+      </DeckRuntimeContext.Provider>,
+    )
       .find('button')
       .simulate('click');
     await settle();
     $rootScope.$digest();
 
-    expect(modal.show).toHaveBeenCalledWith({
-      application: app,
-      credentials: undefined,
-      isNew: true,
-      region: undefined,
-    });
+    expect(modal.show).toHaveBeenCalledWith(
+      {
+        application: app,
+        credentials: undefined,
+        isNew: true,
+        region: undefined,
+      },
+      runtimeServices,
+    );
   });
 });
 

--- a/deck/packages/core/src/securityGroup/CreateSecurityGroupButton.tsx
+++ b/deck/packages/core/src/securityGroup/CreateSecurityGroupButton.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 
 import type { IAccountDetails } from '../account';
 import type { Application } from '../application';
+import { useDeckRuntimeServices } from '../bootstrap/DeckRuntimeContext';
 import type { ICloudProviderConfig } from '../cloudProvider';
 import { CloudProviderRegistry, ProviderSelectionService } from '../cloudProvider';
 import { SETTINGS } from '../config/settings';
@@ -29,11 +30,13 @@ const getReactModalOptions = (selectedProvider: string, app: Application) => ({
 });
 
 export const CreateSecurityGroupButton = ({ app }: { app: Application }) => {
+  const runtimeServices = useDeckRuntimeServices();
+
   const createSecurityGroup = (): void => {
     ProviderSelectionService.selectProvider(app, 'securityGroup', providerFilterFn).then((selectedProvider) => {
       const provider = CloudProviderRegistry.getValue(selectedProvider, 'securityGroup');
 
-      provider.CreateSecurityGroupModal.show(getReactModalOptions(selectedProvider, app));
+      provider.CreateSecurityGroupModal.show(getReactModalOptions(selectedProvider, app), runtimeServices);
     }, noop);
   };
 

--- a/deck/packages/core/src/securityGroup/securityGroup.dataSource.ts
+++ b/deck/packages/core/src/securityGroup/securityGroup.dataSource.ts
@@ -1,6 +1,5 @@
 import type { IQService } from 'angular';
 import { module } from 'angular';
-import { AngularServices } from '../angular/services';
 import type { Application } from '../application/application.model';
 import { INFRASTRUCTURE_KEY } from '../application/nav/defaultCategories';
 import { ApplicationDataSourceRegistry } from '../application/service/ApplicationDataSourceRegistry';
@@ -9,9 +8,7 @@ import { EntityTagsReader } from '../entityTag/EntityTagsReader';
 import { addManagedResourceMetadataToSecurityGroups } from '../managed';
 
 import type { SecurityGroupReader } from './securityGroupReader.service';
-import { SecurityGroupReader as SecurityGroupReaderImpl } from './securityGroupReader.service';
 import { SECURITY_GROUP_READER } from './securityGroupReader.service';
-import { SecurityGroupTransformerService } from './securityGroupTransformer.service';
 
 export const SECURITY_GROUP_DATA_SOURCE = 'spinnaker.core.securityGroup.dataSource';
 function createDataSourceConfig(securityGroupReader: SecurityGroupReader) {
@@ -47,29 +44,9 @@ function createDataSourceConfig(securityGroupReader: SecurityGroupReader) {
   };
 }
 
-export function registerSecurityGroupDataSource($q?: IQService, securityGroupReader?: SecurityGroupReader): void {
+export function registerSecurityGroupDataSource(_$q: IQService, securityGroupReader: SecurityGroupReader): void {
   if (ApplicationDataSourceRegistry.getDataSources().some((source) => source.key === 'securityGroups')) {
     return;
-  }
-
-  if (!securityGroupReader) {
-    const securityGroupTransformer = new SecurityGroupTransformerService(AngularServices.providerServiceDelegate);
-    const safeSecurityGroupTransformer = {
-      normalizeSecurityGroup: (securityGroup: ISecurityGroup) => {
-        const provider = securityGroup.provider || securityGroup.type;
-        if (provider && AngularServices.providerServiceDelegate.hasDelegate(provider, 'securityGroup.transformer')) {
-          return securityGroupTransformer.normalizeSecurityGroup(securityGroup);
-        }
-        return Promise.resolve(securityGroup);
-      },
-    } as SecurityGroupTransformerService;
-
-    securityGroupReader = new SecurityGroupReaderImpl(
-      console as any,
-      $q || AngularServices.$q,
-      safeSecurityGroupTransformer,
-      AngularServices.providerServiceDelegate,
-    );
   }
 
   ApplicationDataSourceRegistry.registerDataSource(createDataSourceConfig(securityGroupReader));

--- a/deck/packages/core/src/securityGroup/securityGroup.states.spec.ts
+++ b/deck/packages/core/src/securityGroup/securityGroup.states.spec.ts
@@ -2,7 +2,7 @@ import { UIRouterReact } from '@uirouter/react';
 
 import { StandaloneSecurityGroupDetails } from './StandaloneSecurityGroupDetails';
 import { getStandaloneFirewallState } from './securityGroup.states';
-import { AngularServices } from '../angular/services';
+import { createDeckRuntime } from '../bootstrap/DeckRuntime';
 import { setDirectRouter } from '../navigation/directRouter';
 import { configureRouter } from '../navigation/router';
 
@@ -15,7 +15,7 @@ describe('security group states', () => {
   });
 
   it('uses the React standalone security group details wrapper for standalone firewall routes', () => {
-    const state = getStandaloneFirewallState();
+    const state = getStandaloneFirewallState({} as any);
 
     expect(state.views['main@']).toEqual(
       jasmine.objectContaining({
@@ -30,8 +30,11 @@ describe('security group states', () => {
   it('resolves a standalone firewall through the direct security group reader', async () => {
     const securityGroupsIndex = { aws: { prod: {} } };
     const loadSecurityGroups = jasmine.createSpy('loadSecurityGroups').and.resolveTo(securityGroupsIndex);
-    spyOnProperty(AngularServices, 'securityGroupReader', 'get').and.returnValue({ loadSecurityGroups } as any);
-    const router = configureRouter();
+    const router = new UIRouterReact();
+    const runtime = createDeckRuntime(router);
+    spyOn(runtime.services.securityGroupReader, 'loadSecurityGroups').and.callFake(loadSecurityGroups);
+    router.disposable({ dispose: runtime.dispose });
+    configureRouter(router, runtime.services);
     routers.push(router);
 
     await router.stateService.go(

--- a/deck/packages/core/src/securityGroup/securityGroup.states.ts
+++ b/deck/packages/core/src/securityGroup/securityGroup.states.ts
@@ -4,7 +4,6 @@ import { module } from 'angular';
 import { SecurityGroupDetails } from './SecurityGroupDetails';
 import { SecurityGroups } from './SecurityGroups';
 import { StandaloneSecurityGroupDetails } from './StandaloneSecurityGroupDetails';
-import { AngularServices } from '../angular/services';
 import type { Application, ApplicationStateProvider } from '../application';
 import { ApplicationModelBuilder, registerApplicationState } from '../application';
 import { filterModelConfig } from './filter/SecurityGroupFilterModel';
@@ -12,10 +11,11 @@ import { SecurityGroupFilters } from './filter/SecurityGroupFilters';
 import { FirewallLabels } from './label';
 import type { INestedState, StateConfigProvider } from '../navigation';
 import { registerRootState } from '../navigation/rootState.registration';
+import type { SecurityGroupReader } from './securityGroupReader.service';
 
 export const SECURITY_GROUP_STATES = 'spinnaker.core.securityGroup.states';
 
-export function getStandaloneFirewallState(): INestedState {
+export function getStandaloneFirewallState(securityGroupReader: SecurityGroupReader): INestedState {
   return {
     name: 'firewallDetails',
     url: '/firewallDetails/:provider/:accountId/:region/:vpcId/:name',
@@ -49,7 +49,7 @@ export function getStandaloneFirewallState(): INestedState {
         ($stateParams: StateParams): PromiseLike<Application> => {
           // we need the application to have a firewall index (so rules get attached and linked properly)
           // and its name should just be the name of the firewall (so cloning works as expected)
-          return AngularServices.securityGroupReader.loadSecurityGroups().then((securityGroupsIndex) => {
+          return securityGroupReader.loadSecurityGroups().then((securityGroupsIndex) => {
             const application: Application = ApplicationModelBuilder.createStandaloneApplication($stateParams.name);
             application['securityGroupsIndex'] = securityGroupsIndex; // TODO: refactor the securityGroupsIndex out
             return application;
@@ -148,4 +148,8 @@ registerApplicationState(
   },
 );
 
-registerRootState((stateConfigProvider) => stateConfigProvider.addToRootState(getStandaloneFirewallState()));
+registerRootState((stateConfigProvider) =>
+  stateConfigProvider.addToRootState(
+    getStandaloneFirewallState(stateConfigProvider.runtimeServices.securityGroupReader),
+  ),
+);

--- a/deck/packages/core/src/serverGroup/configure/common/DeployInitializer.tsx
+++ b/deck/packages/core/src/serverGroup/configure/common/DeployInitializer.tsx
@@ -4,8 +4,9 @@ import { Modal } from 'react-bootstrap';
 import type { Option } from 'react-select';
 
 import { AccountTag } from '../../../account';
-import { AngularServices } from '../../../angular/services';
 import type { Application } from '../../../application';
+import type { IDeckRuntimeServicesInjectedProps } from '../../../bootstrap/DeckRuntimeContext';
+import { withDeckRuntimeServices } from '../../../bootstrap/DeckRuntimeContext';
 import type { IDeployTemplate, ITemplateSelectionText } from './deployInitializer.component';
 import type { IServerGroup } from '../../../domain';
 import { ModalClose } from '../../../modal';
@@ -27,10 +28,13 @@ export interface IDeployInitializerState {
   templates: IDeployTemplate[];
 }
 
-export class DeployInitializer extends React.Component<IDeployInitializerProps, IDeployInitializerState> {
+export class DeployInitializerComponent extends React.Component<
+  IDeployInitializerProps & IDeckRuntimeServicesInjectedProps,
+  IDeployInitializerState
+> {
   private noTemplate: IDeployTemplate = { label: 'None', serverGroup: null, cluster: null };
 
-  constructor(props: IDeployInitializerProps) {
+  constructor(props: IDeployInitializerProps & IDeckRuntimeServicesInjectedProps) {
     super(props);
 
     const templates: IDeployTemplate[] = [];
@@ -95,7 +99,7 @@ export class DeployInitializer extends React.Component<IDeployInitializerProps, 
   private buildCommandFromTemplate(serverGroup: IServerGroup): PromiseLike<any> {
     const { application, cloudProvider } = this.props;
 
-    const commandBuilder: any = AngularServices.providerServiceDelegate.getDelegate(
+    const commandBuilder: any = this.props.deckRuntimeServices.providerServiceDelegate.getDelegate(
       cloudProvider,
       'serverGroup.commandBuilder',
     );
@@ -112,7 +116,7 @@ export class DeployInitializer extends React.Component<IDeployInitializerProps, 
 
   private buildEmptyCommand = (): PromiseLike<any> => {
     const { application, cloudProvider } = this.props;
-    const commandBuilder: any = AngularServices.providerServiceDelegate.getDelegate(
+    const commandBuilder: any = this.props.deckRuntimeServices.providerServiceDelegate.getDelegate(
       cloudProvider,
       'serverGroup.commandBuilder',
     );
@@ -252,3 +256,5 @@ export class DeployInitializer extends React.Component<IDeployInitializerProps, 
     );
   };
 }
+
+export const DeployInitializer = withDeckRuntimeServices(DeployInitializerComponent);

--- a/deck/packages/core/src/serverGroup/configure/common/InstanceArchetypeSelector.spec.tsx
+++ b/deck/packages/core/src/serverGroup/configure/common/InstanceArchetypeSelector.spec.tsx
@@ -1,14 +1,22 @@
-import { mount } from 'enzyme';
+import { mount as enzymeMount } from 'enzyme';
 import React from 'react';
 
-import { AngularServices } from '../../../angular/services';
+import { DeckRuntimeContext } from '../../../bootstrap/DeckRuntimeContext';
 import { CloudProviderRegistry } from '../../../cloudProvider';
 import { ModalWizard } from '../../../modal/wizard/ModalWizard';
 import { InstanceArchetypeSelector } from './InstanceArchetypeSelector';
 import { v2InstanceArchetypeSelector } from './v2instanceArchetypeSelector.component';
 
 describe('InstanceArchetypeSelector', () => {
+  let runtimeServices: any;
+  const RuntimeWrapper = ({ children }: React.PropsWithChildren<{}>) => (
+    <DeckRuntimeContext.Provider value={{ services: runtimeServices } as any}>{children}</DeckRuntimeContext.Provider>
+  );
+  const mount = (component: React.ReactElement) => enzymeMount(component, { wrappingComponent: RuntimeWrapper });
+
   beforeEach(() => {
+    runtimeServices = {};
+    Object.defineProperty(runtimeServices, 'instanceTypeService', { configurable: true, get: () => undefined });
     spyOn(CloudProviderRegistry, 'getValue').and.returnValue(null);
   });
 
@@ -23,7 +31,7 @@ describe('InstanceArchetypeSelector', () => {
   });
 
   it('renders without the AngularJS adapter and mutates the selected profile', async () => {
-    spyOnProperty(AngularServices, 'instanceTypeService', 'get').and.returnValue(instanceTypeService() as any);
+    spyOnProperty(runtimeServices, 'instanceTypeService', 'get').and.returnValue(instanceTypeService() as any);
     const onProfileChanged = jasmine.createSpy('onProfileChanged');
     const command = { selectedProvider: 'aws', viewState: {}, backingData: { filtered: { instanceTypes: [] } } } as any;
 
@@ -44,7 +52,7 @@ describe('InstanceArchetypeSelector', () => {
   });
 
   it('shows the selected profile indicator after a profile is clicked', async () => {
-    spyOnProperty(AngularServices, 'instanceTypeService', 'get').and.returnValue(instanceTypeService() as any);
+    spyOnProperty(runtimeServices, 'instanceTypeService', 'get').and.returnValue(instanceTypeService() as any);
     const command = { selectedProvider: 'aws', viewState: {}, backingData: { filtered: { instanceTypes: [] } } } as any;
 
     const component = mount(
@@ -63,7 +71,7 @@ describe('InstanceArchetypeSelector', () => {
   });
 
   it('keeps the selected profile when the command prop is replaced with the selected profile', async () => {
-    spyOnProperty(AngularServices, 'instanceTypeService', 'get').and.returnValue(instanceTypeService() as any);
+    spyOnProperty(runtimeServices, 'instanceTypeService', 'get').and.returnValue(instanceTypeService() as any);
     const command = { selectedProvider: 'aws', viewState: {}, backingData: { filtered: { instanceTypes: [] } } } as any;
 
     const component = mount(
@@ -88,7 +96,7 @@ describe('InstanceArchetypeSelector', () => {
   });
 
   it('provides the direct React layout hooks for inline archetype columns', async () => {
-    spyOnProperty(AngularServices, 'instanceTypeService', 'get').and.returnValue(
+    spyOnProperty(runtimeServices, 'instanceTypeService', 'get').and.returnValue(
       instanceTypeService('general', 3) as any,
     );
     const command = { selectedProvider: 'aws', viewState: {}, backingData: { filtered: { instanceTypes: [] } } } as any;
@@ -107,7 +115,7 @@ describe('InstanceArchetypeSelector', () => {
   });
 
   it('uses the old three-column layout for six profile providers', async () => {
-    spyOnProperty(AngularServices, 'instanceTypeService', 'get').and.returnValue(
+    spyOnProperty(runtimeServices, 'instanceTypeService', 'get').and.returnValue(
       instanceTypeService('general', 6) as any,
     );
     const command = { selectedProvider: 'gce', viewState: {}, backingData: { filtered: { instanceTypes: [] } } } as any;
@@ -125,7 +133,7 @@ describe('InstanceArchetypeSelector', () => {
   });
 
   it('clears the current instance type when selecting a non-custom profile that does not contain it', async () => {
-    spyOnProperty(AngularServices, 'instanceTypeService', 'get').and.returnValue(instanceTypeService() as any);
+    spyOnProperty(runtimeServices, 'instanceTypeService', 'get').and.returnValue(instanceTypeService() as any);
     const command = {
       selectedProvider: 'aws',
       cloudProvider: 'aws',
@@ -149,7 +157,7 @@ describe('InstanceArchetypeSelector', () => {
   });
 
   it('uses the profile selection path for initial custom selection', async () => {
-    spyOnProperty(AngularServices, 'instanceTypeService', 'get').and.returnValue(instanceTypeService() as any);
+    spyOnProperty(runtimeServices, 'instanceTypeService', 'get').and.returnValue(instanceTypeService() as any);
     const onProfileChanged = jasmine.createSpy('onProfileChanged');
     const command = {
       selectedProvider: 'aws',
@@ -178,7 +186,7 @@ describe('InstanceArchetypeSelector', () => {
     (CloudProviderRegistry.getValue as any).and.callFake((_provider: string, key: string) =>
       key === 'instance.CustomInstanceBuilder' ? CustomInstanceBuilder : null,
     );
-    spyOnProperty(AngularServices, 'instanceTypeService', 'get').and.returnValue(
+    spyOnProperty(runtimeServices, 'instanceTypeService', 'get').and.returnValue(
       instanceTypeService('buildCustom') as any,
     );
     const command = {
@@ -204,7 +212,7 @@ describe('InstanceArchetypeSelector', () => {
   });
 
   it('shows dirty warning in the custom instance type path', async () => {
-    spyOnProperty(AngularServices, 'instanceTypeService', 'get').and.returnValue(instanceTypeService('custom') as any);
+    spyOnProperty(runtimeServices, 'instanceTypeService', 'get').and.returnValue(instanceTypeService('custom') as any);
     const command = {
       selectedProvider: 'aws',
       cloudProvider: 'aws',
@@ -225,7 +233,7 @@ describe('InstanceArchetypeSelector', () => {
   });
 
   it('uses the selection path for an initial profile without notifying unchanged profile', async () => {
-    spyOnProperty(AngularServices, 'instanceTypeService', 'get').and.returnValue(instanceTypeService() as any);
+    spyOnProperty(runtimeServices, 'instanceTypeService', 'get').and.returnValue(instanceTypeService() as any);
     const onProfileChanged = jasmine.createSpy('onProfileChanged');
     const command = {
       selectedProvider: 'aws',
@@ -249,7 +257,7 @@ describe('InstanceArchetypeSelector', () => {
   });
 
   it('marks the instance type wizard page complete or incomplete when instance type changes', async () => {
-    spyOnProperty(AngularServices, 'instanceTypeService', 'get').and.returnValue(instanceTypeService('custom') as any);
+    spyOnProperty(runtimeServices, 'instanceTypeService', 'get').and.returnValue(instanceTypeService('custom') as any);
     spyOn(ModalWizard, 'markComplete');
     spyOn(ModalWizard, 'markIncomplete');
     ModalWizard.pageRegistry = [{ key: 'instance-type', state: { done: false } } as any];
@@ -283,7 +291,7 @@ describe('InstanceArchetypeSelector', () => {
     (CloudProviderRegistry.getValue as any).and.callFake((_provider: string, key: string) =>
       key === 'instance.CustomInstanceBuilder' ? CustomInstanceBuilder : null,
     );
-    spyOnProperty(AngularServices, 'instanceTypeService', 'get').and.returnValue(
+    spyOnProperty(runtimeServices, 'instanceTypeService', 'get').and.returnValue(
       instanceTypeService('buildCustom') as any,
     );
     spyOn(ModalWizard, 'markComplete');

--- a/deck/packages/core/src/serverGroup/configure/common/InstanceArchetypeSelector.tsx
+++ b/deck/packages/core/src/serverGroup/configure/common/InstanceArchetypeSelector.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { DirtyInstanceTypeWarning } from './InstanceTypeSelector';
-import { AngularServices } from '../../../angular/services';
+import { useDeckRuntimeServices } from '../../../bootstrap/DeckRuntimeContext';
 import { CloudProviderRegistry } from '../../../cloudProvider';
 import type { IInstanceTypeCategory } from '../../../instance';
 import { ModalWizard } from '../../../modal/wizard/ModalWizard';
@@ -19,6 +19,7 @@ export interface IInstanceArchetypeSelectorProps {
 }
 
 export function InstanceArchetypeSelector(props: IInstanceArchetypeSelectorProps) {
+  const { instanceTypeService } = useDeckRuntimeServices();
   const { command, onProfileChanged, onTypeChanged } = props;
   const [instanceProfiles, setInstanceProfiles] = React.useState<IInstanceTypeCategory[]>([]);
   const [selectedInstanceProfile, setSelectedInstanceProfile] = React.useState<IInstanceTypeCategory | null>(null);
@@ -56,7 +57,7 @@ export function InstanceArchetypeSelector(props: IInstanceArchetypeSelectorProps
   };
 
   React.useEffect(() => {
-    AngularServices.instanceTypeService.getCategories(command.selectedProvider).then((categories) => {
+    instanceTypeService.getCategories(command.selectedProvider).then((categories) => {
       setInstanceProfiles(categories);
       if (command.region && command.instanceType && !command.viewState.instanceProfile) {
         selectInstanceType('custom', categories, false);
@@ -67,7 +68,7 @@ export function InstanceArchetypeSelector(props: IInstanceArchetypeSelectorProps
   }, [command]);
 
   const updateInstanceTypeDetails = () => {
-    AngularServices.instanceTypeService
+    instanceTypeService
       .getInstanceTypeDetails(command.selectedProvider, command.instanceType)
       .then((instanceTypeDetails) => {
         command.viewState.instanceTypeDetails = instanceTypeDetails;

--- a/deck/packages/core/src/serverGroup/configure/common/InstanceTypeSelector.spec.tsx
+++ b/deck/packages/core/src/serverGroup/configure/common/InstanceTypeSelector.spec.tsx
@@ -1,11 +1,22 @@
-import { mount } from 'enzyme';
+import { mount as enzymeMount } from 'enzyme';
 import React from 'react';
 
-import { AngularServices } from '../../../angular/services';
+import { DeckRuntimeContext } from '../../../bootstrap/DeckRuntimeContext';
 import { InstanceTypeSelector } from './InstanceTypeSelector';
 import { V2InstanceTypeSelectorController, v2InstanceTypeSelector } from './v2InstanceTypeSelector.component';
 
 describe('InstanceTypeSelector', () => {
+  let runtimeServices: any;
+  const RuntimeWrapper = ({ children }: React.PropsWithChildren<{}>) => (
+    <DeckRuntimeContext.Provider value={{ services: runtimeServices } as any}>{children}</DeckRuntimeContext.Provider>
+  );
+  const mount = (component: React.ReactElement) => enzymeMount(component, { wrappingComponent: RuntimeWrapper });
+
+  beforeEach(() => {
+    runtimeServices = {};
+    Object.defineProperty(runtimeServices, 'instanceTypeService', { configurable: true, get: () => undefined });
+  });
+
   it('registers the Angular v2 component with a custom change-checking React controller', () => {
     expect(v2InstanceTypeSelector.templateUrl).toBeUndefined();
     expect(v2InstanceTypeSelector.controller).toBe(V2InstanceTypeSelectorController);
@@ -14,7 +25,7 @@ describe('InstanceTypeSelector', () => {
 
   it('renders without the AngularJS adapter and ignores unavailable instance types', async () => {
     const instanceTypeService = serviceWithCategories();
-    spyOnProperty(AngularServices, 'instanceTypeService', 'get').and.returnValue(instanceTypeService as any);
+    spyOnProperty(runtimeServices, 'instanceTypeService', 'get').and.returnValue(instanceTypeService as any);
     const command = commandWithFilteredTypes(['m5.large']);
 
     const component = mount(<InstanceTypeSelector command={command as any} onTypeChanged={jasmine.createSpy()} />);
@@ -30,7 +41,7 @@ describe('InstanceTypeSelector', () => {
   it('selects an available instance type, clears dirty state, loads details, and notifies', async () => {
     const instanceTypeDetails = { name: 'm5.large' };
     const instanceTypeService = serviceWithCategories(instanceTypeDetails);
-    spyOnProperty(AngularServices, 'instanceTypeService', 'get').and.returnValue(instanceTypeService as any);
+    spyOnProperty(runtimeServices, 'instanceTypeService', 'get').and.returnValue(instanceTypeService as any);
     const onTypeChanged = jasmine.createSpy('onTypeChanged');
     const command = commandWithFilteredTypes(['m5.large']);
 
@@ -48,7 +59,7 @@ describe('InstanceTypeSelector', () => {
 
   it('recomputes unavailable types when filtered instance types are replaced', async () => {
     const instanceTypeService = serviceWithCategories();
-    spyOnProperty(AngularServices, 'instanceTypeService', 'get').and.returnValue(instanceTypeService as any);
+    spyOnProperty(runtimeServices, 'instanceTypeService', 'get').and.returnValue(instanceTypeService as any);
     const command = commandWithFilteredTypes(['m5.large']);
 
     const component = mount(<InstanceTypeSelector command={command as any} onTypeChanged={jasmine.createSpy()} />);
@@ -65,7 +76,7 @@ describe('InstanceTypeSelector', () => {
   });
 
   it('shows dirty warning, unavailable marker, and storage override display', async () => {
-    spyOnProperty(AngularServices, 'instanceTypeService', 'get').and.returnValue(serviceWithCategories() as any);
+    spyOnProperty(runtimeServices, 'instanceTypeService', 'get').and.returnValue(serviceWithCategories() as any);
     const command = commandWithFilteredTypes(['m5.large']);
     command.instanceType = 'm5.large';
     command.viewState.overriddenStorageDescription = 'Custom storage';
@@ -81,7 +92,7 @@ describe('InstanceTypeSelector', () => {
   });
 
   it('hides the dirty warning immediately when dismissed', async () => {
-    spyOnProperty(AngularServices, 'instanceTypeService', 'get').and.returnValue(serviceWithCategories() as any);
+    spyOnProperty(runtimeServices, 'instanceTypeService', 'get').and.returnValue(serviceWithCategories() as any);
     const command = commandWithFilteredTypes(['m5.large']);
 
     const component = mount(<InstanceTypeSelector command={command as any} onTypeChanged={jasmine.createSpy()} />);

--- a/deck/packages/core/src/serverGroup/configure/common/InstanceTypeSelector.tsx
+++ b/deck/packages/core/src/serverGroup/configure/common/InstanceTypeSelector.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { AngularServices } from '../../../angular/services';
+import { useDeckRuntimeServices } from '../../../bootstrap/DeckRuntimeContext';
 import { HelpField } from '../../../help';
 import type { IInstanceTypeCategory, IPreferredInstanceType } from '../../../instance';
 import type { IServerGroupCommand } from './serverGroupCommandBuilder.service';
@@ -11,6 +11,7 @@ export interface IInstanceTypeSelectorProps {
 }
 
 export function InstanceTypeSelector(props: IInstanceTypeSelectorProps) {
+  const { instanceTypeService } = useDeckRuntimeServices();
   const { command, onTypeChanged } = props;
   const [selectedInstanceProfile, setSelectedInstanceProfile] = React.useState<IInstanceTypeCategory | null>(null);
   const previousInstanceProfile = React.useRef<string>();
@@ -20,7 +21,7 @@ export function InstanceTypeSelector(props: IInstanceTypeSelectorProps) {
   const updateFamilies = () => {
     const availableTypes =
       command.backingData && command.backingData.filtered ? command.backingData.filtered.instanceTypes || [] : [];
-    AngularServices.instanceTypeService.getCategories(command.selectedProvider).then((categories) => {
+    instanceTypeService.getCategories(command.selectedProvider).then((categories) => {
       const profile = categories.find((category) => category.type === command.viewState.instanceProfile);
       if (profile && !command.viewState.disableImageSelection) {
         setSelectedInstanceProfile({
@@ -62,11 +63,9 @@ export function InstanceTypeSelector(props: IInstanceTypeSelectorProps) {
     if (command.viewState.dirty && command.viewState.dirty.instanceType) {
       delete command.viewState.dirty.instanceType;
     }
-    AngularServices.instanceTypeService
-      .getInstanceTypeDetails(command.selectedProvider, type.name)
-      .then((instanceTypeDetails) => {
-        command.viewState.instanceTypeDetails = instanceTypeDetails;
-      });
+    instanceTypeService.getInstanceTypeDetails(command.selectedProvider, type.name).then((instanceTypeDetails) => {
+      command.viewState.instanceTypeDetails = instanceTypeDetails;
+    });
     onTypeChanged && onTypeChanged(type.name);
   };
 

--- a/deck/packages/core/src/serverGroup/configure/common/serverGroupCommandBuilder.service.ts
+++ b/deck/packages/core/src/serverGroup/configure/common/serverGroupCommandBuilder.service.ts
@@ -1,8 +1,8 @@
 import { module } from 'angular';
 import type { IAggregatedAccounts, IRegion } from '../../../account/AccountService';
 import type { Application } from '../../../application/application.model';
-import type { ProviderServiceDelegate } from '../../../cloudProvider';
-import { PROVIDER_SERVICE_DELEGATE } from '../../../cloudProvider';
+import type { ProviderServiceDelegate } from '../../../cloudProvider/providerService.delegate';
+import { PROVIDER_SERVICE_DELEGATE } from '../../../cloudProvider/providerService.delegate';
 import type { IDeploymentStrategy } from '../../../deploymentStrategy';
 import type {
   ILoadBalancer,
@@ -13,7 +13,7 @@ import type {
   ISubnet,
 } from '../../../domain';
 import type { IPreferredInstanceType } from '../../../instance';
-import { getKindName } from '../../../managed';
+import { getKindName } from '../../../managed/ManagedReader';
 import type { IMoniker } from '../../../naming/IMoniker';
 import type { ISecurityGroupsByAccountSourceData } from '../../../securityGroup/securityGroupReader.service';
 

--- a/deck/packages/core/src/serverGroup/details/MultipleServerGroupsDetails.spec.tsx
+++ b/deck/packages/core/src/serverGroup/details/MultipleServerGroupsDetails.spec.tsx
@@ -5,7 +5,7 @@ import { mount } from 'enzyme';
 import React from 'react';
 
 import { AccountService } from '../../account';
-import { AngularServices } from '../../angular/services';
+import { DeckRuntimeContext } from '../../bootstrap/DeckRuntimeContext';
 import { ProviderSelectionService } from '../../cloudProvider/providerSelection/ProviderSelectionService';
 import { ConfirmationModalService } from '../../confirmationModal';
 import { REACT_MODULE } from '../../reactShims';
@@ -51,7 +51,23 @@ describe('<MultipleServerGroupsDetails />', () => {
             context: $uiRouter.stateRegistry.get('application.insight.multipleServerGroups') as any,
           }}
         >
-          <MultipleServerGroupsDetails app={app} />
+          <DeckRuntimeContext.Provider
+            value={
+              {
+                services: {
+                  providerServiceDelegate: {
+                    getDelegate: () => ({
+                      destroyServerGroup: (serverGroup: any) => ({ mixinName: serverGroup.name }),
+                    }),
+                    hasDelegate: () => true,
+                  },
+                  serverGroupWriter,
+                },
+              } as any
+            }
+          >
+            <MultipleServerGroupsDetails app={app} />
+          </DeckRuntimeContext.Provider>
         </UIViewContext.Provider>
       </UIRouterContext.Provider>,
     );
@@ -83,13 +99,6 @@ describe('<MultipleServerGroupsDetails />', () => {
     spyOn(AccountService, 'challengeDestructiveActions').and.returnValue(Promise.resolve(false));
     spyOn(ProviderSelectionService, 'isDisabled').and.returnValue(Promise.resolve(false));
     spyOn(ConfirmationModalService, 'confirm').and.stub();
-    spyOnProperty(AngularServices, 'serverGroupWriter', 'get').and.returnValue(serverGroupWriter);
-    spyOnProperty(AngularServices, 'providerServiceDelegate', 'get').and.returnValue({
-      getDelegate: () => ({
-        destroyServerGroup: (serverGroup: any) => ({ mixinName: serverGroup.name }),
-      }),
-      hasDelegate: () => true,
-    } as any);
     spyOn(ClusterState.multiselectModel.serverGroupsStream, 'subscribe').and.callFake((callback: any) => {
       callback();
       return { unsubscribe: jasmine.createSpy('unsubscribe') } as any;

--- a/deck/packages/core/src/serverGroup/details/MultipleServerGroupsDetails.tsx
+++ b/deck/packages/core/src/serverGroup/details/MultipleServerGroupsDetails.tsx
@@ -3,10 +3,11 @@ import React from 'react';
 import { Dropdown, MenuItem } from 'react-bootstrap';
 
 import { AccountTag } from '../../account';
-import { AngularServices } from '../../angular/services';
 import type { Application } from '../../application';
+import { useDeckRuntimeServices } from '../../bootstrap/DeckRuntimeContext';
 import { CloudProviderLogo } from '../../cloudProvider';
 import { ProviderSelectionService } from '../../cloudProvider/providerSelection/ProviderSelectionService';
+import type { DirectProviderServiceDelegate } from '../../cloudProvider/providerService.delegate';
 import { ConfirmationModalService } from '../../confirmationModal';
 import type { IServerGroup } from '../../domain';
 import { HealthCounts } from '../../healthCounts';
@@ -55,9 +56,12 @@ function getSelectedServerGroups(app: Application): IServerGroup[] {
   });
 }
 
-function getMixinParams(submitMethodName: ServerGroupAction, serverGroup: IServerGroup): any {
+function getMixinParams(
+  providerServiceDelegate: DirectProviderServiceDelegate,
+  submitMethodName: ServerGroupAction,
+  serverGroup: IServerGroup,
+): any {
   const provider = getProvider(serverGroup);
-  const { providerServiceDelegate } = AngularServices;
   const providerParamsMixin = providerServiceDelegate.hasDelegate(provider, 'serverGroup.paramsMixin')
     ? providerServiceDelegate.getDelegate<any>(provider, 'serverGroup.paramsMixin')
     : {};
@@ -67,6 +71,7 @@ function getMixinParams(submitMethodName: ServerGroupAction, serverGroup: IServe
 }
 
 export function MultipleServerGroupsDetails({ app }: IMultipleServerGroupsDetailsProps): JSX.Element {
+  const { providerServiceDelegate, serverGroupWriter } = useDeckRuntimeServices();
   const [isDisabled, setIsDisabled] = React.useState(false);
   const [serverGroups, setServerGroups] = React.useState<IServerGroup[]>(() => getSelectedServerGroups(app));
 
@@ -93,14 +98,13 @@ export function MultipleServerGroupsDetails({ app }: IMultipleServerGroupsDetail
     const descriptor = getDescriptor(groups);
     const monitorInterval = groups.length * 1000;
     const taskMonitorConfigs = groups.map((serverGroup) => {
-      const mixinParams = getMixinParams(submitMethodName, serverGroup);
-      const serverGroupWriter = AngularServices.serverGroupWriter as any;
+      const mixinParams = getMixinParams(providerServiceDelegate, submitMethodName, serverGroup);
+      const writer = serverGroupWriter as any;
 
       return {
         application: app,
         monitorInterval,
-        submitMethod: (params?: any) =>
-          serverGroupWriter[submitMethodName](serverGroup, app, { ...params, ...mixinParams }),
+        submitMethod: (params?: any) => writer[submitMethodName](serverGroup, app, { ...params, ...mixinParams }),
         title: serverGroup.name,
       };
     });

--- a/deck/packages/core/src/serverGroup/serverGroup.dataSource.ts
+++ b/deck/packages/core/src/serverGroup/serverGroup.dataSource.ts
@@ -1,13 +1,11 @@
 import type { IQService } from 'angular';
 import { module } from 'angular';
 
-import { AngularServices } from '../angular/services';
 import type { Application } from '../application/application.model';
 import { INFRASTRUCTURE_KEY } from '../application/nav/defaultCategories';
 import { ApplicationDataSourceRegistry } from '../application/service/ApplicationDataSourceRegistry';
 import type { ClusterService } from '../cluster/cluster.service';
 import { CLUSTER_SERVICE } from '../cluster/cluster.service';
-import { ClusterService as ClusterServiceImpl } from '../cluster/cluster.service';
 import type { IServerGroup } from '../domain';
 import { EntityTagsReader } from '../entityTag/EntityTagsReader';
 import { addManagedResourceMetadataToServerGroups } from '../managed';
@@ -63,18 +61,13 @@ function createDataSourceConfig(
   };
 }
 
-export function registerServerGroupDataSource($q?: IQService, clusterService?: ClusterService): void {
+export function registerServerGroupDataSource($q: IQService, clusterService: ClusterService): void {
   if (ApplicationDataSourceRegistry.getDataSources().some((source) => source.key === 'serverGroups')) {
     return;
   }
 
   const dataSourceConfig = createDataSourceConfig(
-    clusterService ||
-      new ClusterServiceImpl(
-        AngularServices.$q,
-        AngularServices.serverGroupTransformer,
-        AngularServices.providerServiceDelegate,
-      ),
+    clusterService,
     $q ? <T>(value: T | PromiseLike<T>) => $q.when(value) : <T>(value: T | PromiseLike<T>) => Promise.resolve(value),
   );
   ApplicationDataSourceRegistry.registerDataSource(dataSourceConfig);

--- a/deck/packages/core/src/serverGroup/serverGroup.states.spec.ts
+++ b/deck/packages/core/src/serverGroup/serverGroup.states.spec.ts
@@ -1,5 +1,6 @@
 import { UIRouterReact } from '@uirouter/react';
 
+import { createDeckRuntime } from '../bootstrap/DeckRuntime';
 import { ApplicationReader } from '../application/service/ApplicationReader';
 import { ClusterMaster } from '../cluster/ClusterMaster';
 import { ClusterFilters } from '../cluster/filter/ClusterFilters';
@@ -46,7 +47,10 @@ describe('server group states', () => {
 
   it('resolves a relative insight detail view during a direct transition', async () => {
     spyOn(ApplicationReader, 'getApplication').and.resolveTo({ name: 'payments', dataSources: [] } as any);
-    const router = configureRouter();
+    const router = new UIRouterReact();
+    const runtime = createDeckRuntime(router);
+    router.disposable(runtime);
+    configureRouter(router, runtime.services);
     routers.push(router);
 
     await router.stateService.go(

--- a/deck/packages/core/src/task/task.dataSource.js
+++ b/deck/packages/core/src/task/task.dataSource.js
@@ -1,6 +1,5 @@
 import * as angular from 'angular';
 
-import { AngularServices } from '../angular/services';
 import { ApplicationDataSourceRegistry } from '../application/service/ApplicationDataSourceRegistry';
 import { CLUSTER_SERVICE } from '../cluster/cluster.service';
 import { SETTINGS } from '../config';
@@ -9,7 +8,7 @@ import { TaskReader } from './task.read.service';
 export const CORE_TASK_TASK_DATASOURCE = 'spinnaker.core.task.dataSource';
 export const name = CORE_TASK_TASK_DATASOURCE; // for backwards compatibility
 
-export function registerTaskDataSources($q = AngularServices.$q, clusterService = AngularServices.clusterService) {
+export function registerTaskDataSources($q, clusterService) {
   const registerOnce = (config) => {
     if (!ApplicationDataSourceRegistry.getDataSources().some(({ key }) => key === config.key)) {
       ApplicationDataSourceRegistry.registerDataSource(config);

--- a/deck/packages/core/src/task/task.dataSource.spec.ts
+++ b/deck/packages/core/src/task/task.dataSource.spec.ts
@@ -7,6 +7,7 @@ import { registerTaskDataSources } from './task.dataSource';
 import { TaskReader } from './task.read.service';
 
 describe('Task Data Source', function () {
+  const promiseService = { when: <T>(value: T | PromiseLike<T>) => Promise.resolve(value) };
   let application: Application, $scope: any;
 
   beforeEach(() => ApplicationDataSourceRegistry.clearDataSources());
@@ -17,7 +18,7 @@ describe('Task Data Source', function () {
     mock.inject(function (_clusterService_: any, $rootScope: any) {
       $scope = $rootScope.$new();
       ApplicationDataSourceRegistry.clearDataSources();
-      registerTaskDataSources(undefined, _clusterService_);
+      registerTaskDataSources(promiseService, _clusterService_);
     }),
   );
 

--- a/deck/packages/core/src/task/task.states.spec.ts
+++ b/deck/packages/core/src/task/task.states.spec.ts
@@ -1,5 +1,6 @@
 import { UIRouterReact } from '@uirouter/react';
 
+import { createDeckRuntime } from '../bootstrap/DeckRuntime';
 import { getTasksState } from './task.states';
 import { TaskReader } from './task.read.service';
 import { ApplicationReader } from '../application/service/ApplicationReader';
@@ -30,7 +31,10 @@ describe('task states', () => {
   it('resolves a task permalink through a real direct transition', async () => {
     spyOn(TaskReader, 'getTask').and.resolveTo({ application: 'payments' } as any);
     spyOn(ApplicationReader, 'getApplication').and.resolveTo({ name: 'payments', dataSources: [] } as any);
-    const router = configureRouter();
+    const router = new UIRouterReact();
+    const runtime = createDeckRuntime(router);
+    router.disposable(runtime);
+    configureRouter(router, runtime.services);
     routers.push(router);
 
     await router.stateService.go('home.taskLookup', { taskId: 'task-123' }, { location: false });

--- a/deck/packages/ecs/src/securityGroup/details/EcsSecurityGroupDetails.tsx
+++ b/deck/packages/ecs/src/securityGroup/details/EcsSecurityGroupDetails.tsx
@@ -12,9 +12,9 @@ import type {
 } from '@spinnaker/core';
 import {
   AccountTag,
-  AngularServices,
   CloudProviderLogo,
   CollapsibleSection,
+  DeckRuntimeContext,
   FirewallLabels,
   RecentHistoryService,
   Spinner,
@@ -47,6 +47,9 @@ export class EcsSecurityGroupDetailsComponent extends React.Component<
   IEcsSecurityGroupDetailsProps & IRouterInjectedProps,
   IEcsSecurityGroupDetailsState
 > {
+  public static contextType = DeckRuntimeContext;
+  public declare context: React.ContextType<typeof DeckRuntimeContext>;
+
   public state: IEcsSecurityGroupDetailsState = { loading: true };
 
   private isUnmounted = false;
@@ -86,7 +89,7 @@ export class EcsSecurityGroupDetailsComponent extends React.Component<
   }
 
   private getSecurityGroupReader(): SecurityGroupReader {
-    return this.props.securityGroupReader || AngularServices.securityGroupReader;
+    return this.props.securityGroupReader || this.context.services.securityGroupReader;
   }
 
   private getVpcReader(): Pick<typeof VpcReader, 'getVpcName'> {

--- a/deck/packages/ecs/src/serverGroup/configure/wizard/EcsCloneServerGroupModal.spec.tsx
+++ b/deck/packages/ecs/src/serverGroup/configure/wizard/EcsCloneServerGroupModal.spec.tsx
@@ -5,7 +5,6 @@ import React from 'react';
 import {
   AccountService,
   AccountSelectInput,
-  AngularServices,
   DeploymentStrategySelector,
   RegionSelectInput,
   RequestBuilder,
@@ -94,9 +93,6 @@ const renderCapacityProvider = (command: IEcsServerGroupCommand): ShallowWrapper
 
 describe('EcsCloneServerGroupModal', () => {
   beforeEach(() => {
-    spyOnProperty(AngularServices, 'serverGroupWriter', 'get').and.returnValue({
-      cloneServerGroup: () => Promise.resolve(),
-    } as any);
     spyOn(TaskMonitor, 'modalInstanceEmulation').and.returnValue({
       dismiss: jasmine.createSpy('dismiss'),
       result: Promise.resolve(),
@@ -565,7 +561,7 @@ describe('EcsCloneServerGroupModal', () => {
     it(`returns the transformed command without executing infrastructure in ${mode} mode`, () => {
       const command = buildCommand({ viewState: { contextImages: [], dirty: {}, mode } as any });
       const modal = buildUnrenderedModal(command) as any;
-      const cloneServerGroup = spyOn(AngularServices.serverGroupWriter, 'cloneServerGroup');
+      const cloneServerGroup = jasmine.createSpy('cloneServerGroup');
 
       modal.submit();
 
@@ -731,9 +727,8 @@ describe('EcsCloneServerGroupModal', () => {
       const props = buildProps(command);
       const modal = new EcsCloneServerGroupModal(props) as any;
       const task = Promise.resolve({ id: 'task-id' });
-      const cloneServerGroup = spyOn(AngularServices.serverGroupWriter, 'cloneServerGroup').and.returnValue(
-        task as any,
-      );
+      const cloneServerGroup = jasmine.createSpy('cloneServerGroup').and.returnValue(task as any);
+      modal.context = { services: { serverGroupWriter: { cloneServerGroup } } };
       const monitorSubmit = spyOn(
         modal.state.taskMonitor,
         'submit',
@@ -792,9 +787,10 @@ describe('EcsCloneServerGroupModal', () => {
     const command = buildCommand({ viewState: { contextImages: [], dirty: {}, mode: 'create' } as any });
     const props = buildProps(command);
     const modal = new EcsCloneServerGroupModal(props) as any;
-    spyOn(AngularServices.serverGroupWriter, 'cloneServerGroup').and.callFake(
-      () => Promise.reject({ failureMessage: 'create failed' }) as any,
-    );
+    const cloneServerGroup = jasmine
+      .createSpy('cloneServerGroup')
+      .and.callFake(() => Promise.reject({ failureMessage: 'create failed' }) as any);
+    modal.context = { services: { serverGroupWriter: { cloneServerGroup } } };
 
     modal.submit();
     await Promise.resolve();

--- a/deck/packages/ecs/src/serverGroup/configure/wizard/EcsCloneServerGroupModal.tsx
+++ b/deck/packages/ecs/src/serverGroup/configure/wizard/EcsCloneServerGroupModal.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 
 import type {
   Application,
+  DeckRuntimeServices,
   IModalComponentProps,
   IRouterInjectedProps,
   ISubnet,
@@ -10,7 +11,7 @@ import type {
 } from '@spinnaker/core';
 import {
   AccountService,
-  AngularServices,
+  DeckRuntimeContext,
   DeployInitializer,
   NameUtils,
   noop,
@@ -71,6 +72,9 @@ export class EcsCloneServerGroupModalComponent extends React.Component<
   IEcsCloneServerGroupModalProps & IRouterInjectedProps,
   IEcsCloneServerGroupModalState
 > {
+  public static contextType = DeckRuntimeContext;
+  public declare context: React.ContextType<typeof DeckRuntimeContext>;
+
   private command: IEcsServerGroupCommand;
   private configureRequest = 0;
   private formik: EcsFormikProps = null;
@@ -87,9 +91,12 @@ export class EcsCloneServerGroupModalComponent extends React.Component<
   private placementStrategyService = new PlacementStrategyService();
   private secretReader = new SecretReader();
 
-  public static show(props: IEcsCloneServerGroupModalProps): Promise<IEcsServerGroupCommand> {
+  public static show(
+    props: IEcsCloneServerGroupModalProps,
+    runtimeServices: DeckRuntimeServices,
+  ): Promise<IEcsServerGroupCommand> {
     const modalProps = { dialogClassName: 'wizard-modal modal-lg' };
-    return ReactModal.show(EcsCloneServerGroupModal, props, modalProps);
+    return ReactModal.show(EcsCloneServerGroupModal, props, modalProps, runtimeServices);
   }
 
   constructor(props: IEcsCloneServerGroupModalProps & IRouterInjectedProps) {
@@ -556,7 +563,7 @@ export class EcsCloneServerGroupModalComponent extends React.Component<
       return this.props.closeModal(command);
     }
     return taskMonitor.submit(() =>
-      AngularServices.serverGroupWriter.cloneServerGroup(command as any, this.props.application),
+      this.context.services.serverGroupWriter.cloneServerGroup(command as any, this.props.application),
     );
   };
 

--- a/deck/packages/ecs/src/serverGroup/details/EcsServerGroupActions.spec.tsx
+++ b/deck/packages/ecs/src/serverGroup/details/EcsServerGroupActions.spec.tsx
@@ -1,12 +1,12 @@
-import { shallow } from 'enzyme';
+import { mount as enzymeMount } from 'enzyme';
 import React from 'react';
 import { Dropdown, Tooltip } from 'react-bootstrap';
 
 import { AWSProviderSettings } from '@spinnaker/amazon';
 import {
   AddEntityTagLinks,
-  AngularServices,
   ConfirmationModalService,
+  DeckRuntimeContext,
   ManagedMenuItem,
   SETTINGS,
   ServerGroupWarningMessageService,
@@ -18,6 +18,11 @@ import { EcsRollbackServerGroupModal } from './rollback/EcsRollbackServerGroupMo
 
 describe('<EcsServerGroupActions />', () => {
   const originalAdHocInfraWritesEnabled = AWSProviderSettings.adHocInfraWritesEnabled;
+  let runtimeServices: any;
+  const RuntimeWrapper = ({ children }: React.PropsWithChildren<{}>) => (
+    <DeckRuntimeContext.Provider value={{ services: runtimeServices } as any}>{children}</DeckRuntimeContext.Provider>
+  );
+  const shallow = (component: React.ReactElement) => enzymeMount(component, { wrappingComponent: RuntimeWrapper });
 
   const buildServerGroup = (overrides: any = {}) => ({
     account: 'test-account',
@@ -48,11 +53,13 @@ describe('<EcsServerGroupActions />', () => {
 
   beforeEach(() => {
     AWSProviderSettings.adHocInfraWritesEnabled = true;
-    spyOnProperty(AngularServices, 'serverGroupWriter', 'get').and.returnValue({
-      destroyServerGroup: () => Promise.resolve(),
-      disableServerGroup: () => Promise.resolve(),
-      enableServerGroup: () => Promise.resolve(),
-    } as any);
+    runtimeServices = {
+      serverGroupWriter: {
+        destroyServerGroup: () => Promise.resolve(),
+        disableServerGroup: () => Promise.resolve(),
+        enableServerGroup: () => Promise.resolve(),
+      },
+    };
   });
 
   afterEach(() => {
@@ -130,7 +137,7 @@ describe('<EcsServerGroupActions />', () => {
 
     action(wrapper, 'Rollback').prop('onClick')();
 
-    expect(show).toHaveBeenCalledOnceWith({ application: app, serverGroup });
+    expect(show).toHaveBeenCalledOnceWith({ application: app, serverGroup }, runtimeServices);
   });
 
   it('opens the completed resize modal with the enriched server group', () => {
@@ -141,7 +148,7 @@ describe('<EcsServerGroupActions />', () => {
 
     action(wrapper, 'Resize').prop('onClick')();
 
-    expect(show).toHaveBeenCalledOnceWith({ application: app, serverGroup });
+    expect(show).toHaveBeenCalledOnceWith({ application: app, serverGroup }, runtimeServices);
   });
 
   ['Disable', 'Enable', 'Destroy'].forEach((label) => {
@@ -149,7 +156,7 @@ describe('<EcsServerGroupActions />', () => {
       const app = buildApp();
       const serverGroup = buildServerGroup({ isDisabled: label === 'Enable' });
       const writerMethod = `${label.toLowerCase()}ServerGroup`;
-      const writer = AngularServices.serverGroupWriter as any;
+      const writer = runtimeServices.serverGroupWriter as any;
       const write = spyOn(writer, writerMethod).and.returnValue(Promise.resolve());
       const confirm = spyOn(ConfirmationModalService, 'confirm').and.returnValue(Promise.resolve());
       const stateService = {

--- a/deck/packages/ecs/src/serverGroup/details/EcsServerGroupActions.tsx
+++ b/deck/packages/ecs/src/serverGroup/details/EcsServerGroupActions.tsx
@@ -5,12 +5,12 @@ import { AWSProviderSettings } from '@spinnaker/amazon';
 import type { IOwnerOption, IRouterInjectedProps, IServerGroupActionsProps, IServerGroupJob } from '@spinnaker/core';
 import {
   AddEntityTagLinks,
-  AngularServices,
   ClusterTargetBuilder,
   ConfirmationModalService,
   ManagedMenuItem,
   ServerGroupWarningMessageService,
   SETTINGS,
+  useDeckRuntimeServices,
   withRouter,
 } from '@spinnaker/core';
 
@@ -30,6 +30,8 @@ export function EcsServerGroupActionsComponent({
   serverGroup,
   stateService,
 }: IServerGroupActionsProps & IRouterInjectedProps) {
+  const runtimeServices = useDeckRuntimeServices();
+  const { serverGroupWriter } = runtimeServices;
   if (!AWSProviderSettings.adHocInfraWritesEnabled) {
     return null;
   }
@@ -68,12 +70,12 @@ export function EcsServerGroupActionsComponent({
         app.attributes.platformHealthOnlyShowOverride && app.attributes.platformHealthOnly ? ['Ecs'] : undefined,
       submitMethod: (params: IServerGroupJob) => {
         if (action === 'destroy') {
-          return AngularServices.serverGroupWriter.destroyServerGroup(serverGroup, app, params);
+          return serverGroupWriter.destroyServerGroup(serverGroup, app, params);
         }
         if (action === 'disable') {
-          return AngularServices.serverGroupWriter.disableServerGroup(serverGroup, app.name, params);
+          return serverGroupWriter.disableServerGroup(serverGroup, app.name, params);
         }
-        return AngularServices.serverGroupWriter.enableServerGroup(serverGroup, app, params);
+        return serverGroupWriter.enableServerGroup(serverGroup, app, params);
       },
       askForReason: true,
     };
@@ -95,7 +97,7 @@ export function EcsServerGroupActionsComponent({
           <ManagedMenuItem
             resource={serverGroup}
             application={app}
-            onClick={() => EcsRollbackServerGroupModal.show({ application: app, serverGroup })}
+            onClick={() => EcsRollbackServerGroupModal.show({ application: app, serverGroup }, runtimeServices)}
           >
             Rollback
           </ManagedMenuItem>
@@ -103,7 +105,7 @@ export function EcsServerGroupActionsComponent({
         <ManagedMenuItem
           resource={serverGroup}
           application={app}
-          onClick={() => EcsResizeServerGroupModal.show({ application: app, serverGroup })}
+          onClick={() => EcsResizeServerGroupModal.show({ application: app, serverGroup }, runtimeServices)}
         >
           Resize
         </ManagedMenuItem>

--- a/deck/packages/ecs/src/serverGroup/details/resize/EcsResizeServerGroupModal.spec.tsx
+++ b/deck/packages/ecs/src/serverGroup/details/resize/EcsResizeServerGroupModal.spec.tsx
@@ -2,7 +2,6 @@ import { shallow } from 'enzyme';
 import React from 'react';
 
 import {
-  AngularServices,
   PlatformHealthOverride,
   ReactModal,
   SpinFormik,
@@ -56,8 +55,8 @@ describe('EcsResizeServerGroupModal', () => {
   it('submits the exact shared resize writer contract through its task monitor', () => {
     const app = application({ platformHealthOnly: true, platformHealthOnlyShowOverride: true });
     const writer = { resizeServerGroup: jasmine.createSpy('resizeServerGroup').and.returnValue(Promise.resolve()) };
-    spyOnProperty(AngularServices, 'serverGroupWriter', 'get').and.returnValue(writer as any);
     const component = new EcsResizeServerGroupModal(props(app));
+    (component as any).context = { services: { serverGroupWriter: writer } };
     component.setState = ((update: any) => {
       component.state = { ...component.state, ...(typeof update === 'function' ? update(component.state) : update) };
     }) as any;
@@ -80,8 +79,8 @@ describe('EcsResizeServerGroupModal', () => {
 
   it('does not submit invalid or unverified resize commands', () => {
     const writer = { resizeServerGroup: jasmine.createSpy('resizeServerGroup') };
-    spyOnProperty(AngularServices, 'serverGroupWriter', 'get').and.returnValue(writer as any);
     const component = new EcsResizeServerGroupModal(props());
+    (component as any).context = { services: { serverGroupWriter: writer } };
     spyOn(component.state.taskMonitor, 'submit');
 
     (component as any).submit({ capacity: { desired: 9, max: 8, min: 2 } });
@@ -122,9 +121,10 @@ describe('EcsResizeServerGroupModal', () => {
   it('exports a show primitive for later actions integration', () => {
     const show = spyOn(ReactModal, 'show').and.returnValue(Promise.resolve() as any);
     const modalProps = props();
+    const runtimeServices = {} as any;
 
-    EcsResizeServerGroupModal.show(modalProps);
+    EcsResizeServerGroupModal.show(modalProps, runtimeServices);
 
-    expect(show).toHaveBeenCalledOnceWith(EcsResizeServerGroupModal, modalProps);
+    expect(show).toHaveBeenCalledOnceWith(EcsResizeServerGroupModal, modalProps, undefined, runtimeServices);
   });
 });

--- a/deck/packages/ecs/src/serverGroup/details/resize/EcsResizeServerGroupModal.tsx
+++ b/deck/packages/ecs/src/serverGroup/details/resize/EcsResizeServerGroupModal.tsx
@@ -1,9 +1,15 @@
 import React from 'react';
 import { Modal } from 'react-bootstrap';
 
-import type { Application, IModalComponentProps, IServerGroup, IServerGroupJob } from '@spinnaker/core';
+import type {
+  Application,
+  DeckRuntimeServices,
+  IModalComponentProps,
+  IServerGroup,
+  IServerGroupJob,
+} from '@spinnaker/core';
 import {
-  AngularServices,
+  DeckRuntimeContext,
   FormikFormField,
   MinMaxDesiredChanges,
   ModalClose,
@@ -85,13 +91,19 @@ export class EcsResizeServerGroupModal extends React.Component<
   IEcsResizeServerGroupModalProps,
   IEcsResizeServerGroupModalState
 > {
+  public static contextType = DeckRuntimeContext;
+  public declare context: React.ContextType<typeof DeckRuntimeContext>;
+
   public static defaultProps: Partial<IEcsResizeServerGroupModalProps> = {
     closeModal: noop,
     dismissModal: noop,
   };
 
-  public static show(props: IEcsResizeServerGroupModalProps): Promise<IEcsResizeServerGroupJob> {
-    return ReactModal.show(EcsResizeServerGroupModal, props);
+  public static show(
+    props: IEcsResizeServerGroupModalProps,
+    runtimeServices: DeckRuntimeServices,
+  ): Promise<IEcsResizeServerGroupJob> {
+    return ReactModal.show(EcsResizeServerGroupModal, props, undefined, runtimeServices);
   }
 
   public constructor(props: IEcsResizeServerGroupModalProps) {
@@ -132,7 +144,7 @@ export class EcsResizeServerGroupModal extends React.Component<
       reason: values.reason,
     };
     this.state.taskMonitor.submit(() =>
-      AngularServices.serverGroupWriter.resizeServerGroup(serverGroup, application, command),
+      this.context.services.serverGroupWriter.resizeServerGroup(serverGroup, application, command),
     );
   };
 

--- a/deck/packages/ecs/src/serverGroup/details/rollback/EcsRollbackServerGroupModal.spec.tsx
+++ b/deck/packages/ecs/src/serverGroup/details/rollback/EcsRollbackServerGroupModal.spec.tsx
@@ -2,7 +2,6 @@ import { shallow } from 'enzyme';
 import React from 'react';
 
 import {
-  AngularServices,
   PlatformHealthOverride,
   ReactModal,
   SpinFormik,
@@ -91,8 +90,8 @@ describe('EcsRollbackServerGroupModal', () => {
   it('does not submit a rollback target outside the eligible disabled set', () => {
     const app = application();
     const writer = { rollbackServerGroup: jasmine.createSpy('rollbackServerGroup') };
-    spyOnProperty(AngularServices, 'serverGroupWriter', 'get').and.returnValue(writer as any);
     const component = new EcsRollbackServerGroupModal(props(app));
+    (component as any).context = { services: { serverGroupWriter: writer } };
     component.state.verified = true;
     spyOn(component.state.taskMonitor, 'submit');
 
@@ -108,8 +107,8 @@ describe('EcsRollbackServerGroupModal', () => {
   it('submits the exact shared rollback writer contract through its task monitor', () => {
     const app = application({ platformHealthOnly: true, platformHealthOnlyShowOverride: true });
     const writer = { rollbackServerGroup: jasmine.createSpy('rollbackServerGroup').and.returnValue(Promise.resolve()) };
-    spyOnProperty(AngularServices, 'serverGroupWriter', 'get').and.returnValue(writer as any);
     const component = new EcsRollbackServerGroupModal(props(app));
+    (component as any).context = { services: { serverGroupWriter: writer } };
     component.setState = ((update: any) => {
       component.state = { ...component.state, ...(typeof update === 'function' ? update(component.state) : update) };
     }) as any;
@@ -165,9 +164,10 @@ describe('EcsRollbackServerGroupModal', () => {
   it('exports a show primitive for later actions integration', () => {
     const show = spyOn(ReactModal, 'show').and.returnValue(Promise.resolve() as any);
     const modalProps = props();
+    const runtimeServices = {} as any;
 
-    EcsRollbackServerGroupModal.show(modalProps);
+    EcsRollbackServerGroupModal.show(modalProps, runtimeServices);
 
-    expect(show).toHaveBeenCalledOnceWith(EcsRollbackServerGroupModal, modalProps);
+    expect(show).toHaveBeenCalledOnceWith(EcsRollbackServerGroupModal, modalProps, undefined, runtimeServices);
   });
 });

--- a/deck/packages/ecs/src/serverGroup/details/rollback/EcsRollbackServerGroupModal.tsx
+++ b/deck/packages/ecs/src/serverGroup/details/rollback/EcsRollbackServerGroupModal.tsx
@@ -1,9 +1,15 @@
 import React from 'react';
 import { Modal } from 'react-bootstrap';
 
-import type { Application, IModalComponentProps, IServerGroup, IServerGroupJob } from '@spinnaker/core';
+import type {
+  Application,
+  DeckRuntimeServices,
+  IModalComponentProps,
+  IServerGroup,
+  IServerGroupJob,
+} from '@spinnaker/core';
 import {
-  AngularServices,
+  DeckRuntimeContext,
   FormikFormField,
   ModalClose,
   noop,
@@ -103,13 +109,19 @@ export class EcsRollbackServerGroupModal extends React.Component<
   IEcsRollbackServerGroupModalProps,
   IEcsRollbackServerGroupModalState
 > {
+  public static contextType = DeckRuntimeContext;
+  public declare context: React.ContextType<typeof DeckRuntimeContext>;
+
   public static defaultProps: Partial<IEcsRollbackServerGroupModalProps> = {
     closeModal: noop,
     dismissModal: noop,
   };
 
-  public static show(props: IEcsRollbackServerGroupModalProps): Promise<IEcsRollbackServerGroupJob> {
-    return ReactModal.show(EcsRollbackServerGroupModal, props);
+  public static show(
+    props: IEcsRollbackServerGroupModalProps,
+    runtimeServices: DeckRuntimeServices,
+  ): Promise<IEcsRollbackServerGroupJob> {
+    return ReactModal.show(EcsRollbackServerGroupModal, props, undefined, runtimeServices);
   }
 
   public constructor(props: IEcsRollbackServerGroupModalProps) {
@@ -156,7 +168,7 @@ export class EcsRollbackServerGroupModal extends React.Component<
     };
 
     this.state.taskMonitor.submit(() =>
-      AngularServices.serverGroupWriter.rollbackServerGroup(serverGroup, application, command),
+      this.context.services.serverGroupWriter.rollbackServerGroup(serverGroup, application, command),
     );
   };
 

--- a/deck/packages/google/src/gce.module.spec.ts
+++ b/deck/packages/google/src/gce.module.spec.ts
@@ -1,14 +1,14 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount as enzymeMount } from 'enzyme';
 
 import {
   CloudProviderRegistry,
   ConfirmationModalService,
+  DeckRuntimeContext,
   ErrorModalService,
   InfrastructureCaches,
   LoadBalancerWriter,
   ManagedMenuItem,
-  AngularServices,
   Registry,
   ServerGroupReader,
   ServerGroupWarningMessageService,
@@ -41,6 +41,19 @@ import { GceServerGroupTransformer } from './serverGroup/serverGroup.transformer
 import { GceSubnetRenderer } from './subnet/subnet.renderer';
 
 describe('Google provider registration', () => {
+  let runtimeServices: any;
+  const RuntimeWrapper = ({ children }: React.PropsWithChildren<{}>) =>
+    React.createElement(DeckRuntimeContext.Provider, { value: { services: runtimeServices } as any }, children);
+  const mount = (component: React.ReactElement) => enzymeMount(component, { wrappingComponent: RuntimeWrapper });
+
+  beforeEach(() => {
+    runtimeServices = {
+      securityGroupReader: { getAllSecurityGroups: () => Promise.resolve({}) },
+      serverGroupCommandBuilder: {},
+      serverGroupWriter: {},
+    };
+  });
+
   const legacyCtrlKey = ['Cont', 'roller'].join('');
   const legacyViewKey = ['Template', 'Url'].join('');
   const legacyModuleExport = ['GOOGLE', 'MODULE'].join('_');
@@ -168,10 +181,10 @@ describe('Google provider registration', () => {
   });
 
   it('allows GCE firewalls that apply to all target tags', async () => {
-    spyOnProperty(AngularServices, 'securityGroupReader', 'get').and.returnValue({
+    runtimeServices.securityGroupReader = {
       getAllSecurityGroups: () => Promise.resolve({}),
-    } as any);
-    const wrapper = shallow(
+    };
+    const wrapper = mount(
       React.createElement(GceSecurityGroupModal, {
         application: { name: 'fnord', securityGroups: { data: [] } },
         credentials: 'test-account',
@@ -299,7 +312,7 @@ describe('Google provider registration', () => {
       urlMapName: 'frontend-map',
     };
 
-    const wrapper = shallow(React.createElement(GceLoadBalancerActions, { app, loadBalancer }));
+    const wrapper = mount(React.createElement(GceLoadBalancerActions, { app, loadBalancer }));
     wrapper
       .find(ManagedMenuItem)
       .filterWhere((item) => item.prop('children') === 'Delete Load Balancer')
@@ -418,9 +431,9 @@ describe('Google provider registration', () => {
   it('does not force Google health provider params when platform-health override is disabled', async () => {
     const confirmSpy = spyOn(ConfirmationModalService, 'confirm').and.returnValue(Promise.resolve({}) as any);
     const writer = { enableServerGroup: jasmine.createSpy('enableServerGroup').and.returnValue(Promise.resolve({})) };
-    spyOnProperty(AngularServices, 'serverGroupWriter', 'get').and.returnValue(writer as any);
+    runtimeServices.serverGroupWriter = writer;
 
-    shallow(
+    mount(
       React.createElement(GceServerGroupActions, {
         app: { attributes: { platformHealthOnly: true, platformHealthOnlyShowOverride: false }, name: 'fnord' },
         serverGroup: { account: 'test-account', isDisabled: true, name: 'fnord-v001', region: 'us-central1' },
@@ -444,11 +457,11 @@ describe('Google provider registration', () => {
       destroyServerGroup: jasmine.createSpy('destroyServerGroup').and.returnValue(Promise.resolve({})),
       disableServerGroup: jasmine.createSpy('disableServerGroup').and.returnValue(Promise.resolve({})),
     };
-    spyOnProperty(AngularServices, 'serverGroupWriter', 'get').and.returnValue(writer as any);
+    runtimeServices.serverGroupWriter = writer;
     const app = { attributes: { platformHealthOnly: true, platformHealthOnlyShowOverride: true }, name: 'fnord' };
     const serverGroup = { account: 'test-account', isDisabled: false, name: 'fnord-v001', region: 'us-central1' };
 
-    const wrapper = shallow(React.createElement(GceServerGroupActions, { app, serverGroup }));
+    const wrapper = mount(React.createElement(GceServerGroupActions, { app, serverGroup }));
     wrapper
       .find('a')
       .filterWhere((link) => link.text() === 'Disable')

--- a/deck/packages/google/src/loadBalancer/details/gceLoadBalancerDetails.tsx
+++ b/deck/packages/google/src/loadBalancer/details/gceLoadBalancerDetails.tsx
@@ -3,7 +3,6 @@ import React, { useCallback, useEffect, useState } from 'react';
 import {
   AccountService,
   AccountTag,
-  AngularServices,
   CloudProviderRegistry,
   CollapsibleSection,
   ConfirmationModalService,
@@ -12,6 +11,7 @@ import {
   ManagedMenuItem,
   TaskExecutor,
   useDataSource,
+  useDeckRuntimeServices,
 } from '@spinnaker/core';
 
 import { GceLoadBalancerChoiceModal } from '../configure/choice/GceLoadBalancerChoiceModal';
@@ -188,6 +188,7 @@ export async function loadGceLoadBalancerDetails({
 }
 
 export function useGceLoadBalancerDetails({ app, autoClose, loadBalancerParams }: IUseDetailsProps): any {
+  const { loadBalancerReader } = useDeckRuntimeServices();
   const dataSource = app.getDataSource('loadBalancers');
   const { data: loadBalancers, loaded, refresh, error } = useDataSource<any[]>(dataSource);
   const [data, setData] = useState<any>();
@@ -208,7 +209,7 @@ export function useGceLoadBalancerDetails({ app, autoClose, loadBalancerParams }
           autoClose,
           loadBalancers,
           loadBalancerParams,
-          loadBalancerReader: AngularServices.loadBalancerReader,
+          loadBalancerReader,
         }),
       );
     } catch (e) {
@@ -216,7 +217,7 @@ export function useGceLoadBalancerDetails({ app, autoClose, loadBalancerParams }
     } finally {
       setLoadingDetails(false);
     }
-  }, [app, autoClose, error, loadBalancers, loadBalancerParams, loaded]);
+  }, [app, autoClose, error, loadBalancerReader, loadBalancers, loadBalancerParams, loaded]);
 
   useEffect(() => {
     refetch();

--- a/deck/packages/google/src/securityGroup/configure/GceSecurityGroupModal.spec.tsx
+++ b/deck/packages/google/src/securityGroup/configure/GceSecurityGroupModal.spec.tsx
@@ -1,11 +1,21 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount as enzymeMount } from 'enzyme';
 
-import { AngularServices, SecurityGroupWriter, SubmitButton } from '@spinnaker/core';
+import { DeckRuntimeContext, SecurityGroupWriter, SubmitButton } from '@spinnaker/core';
 
 import { GceSecurityGroupModalComponent as GceSecurityGroupModal } from './GceSecurityGroupModal';
 
 describe('GceSecurityGroupModal', () => {
+  let runtimeServices: any;
+  const RuntimeWrapper = ({ children }: React.PropsWithChildren<{}>) => (
+    <DeckRuntimeContext.Provider value={{ services: runtimeServices } as any}>{children}</DeckRuntimeContext.Provider>
+  );
+  const mount = (component: React.ReactElement) => enzymeMount(component, { wrappingComponent: RuntimeWrapper });
+
+  beforeEach(() => {
+    runtimeServices = { securityGroupReader: { getAllSecurityGroups: () => Promise.resolve({}) } };
+  });
+
   const application = {
     name: 'my-app',
     securityGroups: { refresh: jasmine.createSpy('refresh') },
@@ -53,8 +63,8 @@ describe('GceSecurityGroupModal', () => {
         finishLoading = resolve;
       }),
     );
-    spyOnProperty(AngularServices, 'securityGroupReader', 'get').and.returnValue({ getAllSecurityGroups } as any);
-    const wrapper = shallow(
+    runtimeServices.securityGroupReader = { getAllSecurityGroups };
+    const wrapper = mount(
       <GceSecurityGroupModal
         application={{ ...application, securityGroups: { data: [] } } as any}
         credentials="my-account"
@@ -76,8 +86,8 @@ describe('GceSecurityGroupModal', () => {
       const getAllSecurityGroups = jasmine
         .createSpy('getAllSecurityGroups')
         .and.returnValue(Promise.resolve(globalSecurityGroups()));
-      spyOnProperty(AngularServices, 'securityGroupReader', 'get').and.returnValue({ getAllSecurityGroups } as any);
-      const wrapper = shallow(
+      runtimeServices.securityGroupReader = { getAllSecurityGroups };
+      const wrapper = mount(
         <GceSecurityGroupModal
           application={{ ...application, securityGroups: { data: [] } } as any}
           credentials="my-account"
@@ -99,10 +109,10 @@ describe('GceSecurityGroupModal', () => {
     const getAllSecurityGroups = jasmine
       .createSpy('getAllSecurityGroups')
       .and.returnValue(Promise.resolve(globalSecurityGroups()));
-    spyOnProperty(AngularServices, 'securityGroupReader', 'get').and.returnValue({ getAllSecurityGroups } as any);
-    const createWrapper = shallow(<GceSecurityGroupModal application={application as any} credentials="my-account" />);
+    runtimeServices.securityGroupReader = { getAllSecurityGroups };
+    const createWrapper = mount(<GceSecurityGroupModal application={application as any} credentials="my-account" />);
     createWrapper.setState({ securityGroup: validSecurityGroup({ name: 'cross-account-firewall' }) } as any);
-    const editWrapper = shallow(
+    const editWrapper = mount(
       <GceSecurityGroupModal application={application as any} mode="edit" securityGroup={validSecurityGroup()} />,
     );
 
@@ -118,8 +128,8 @@ describe('GceSecurityGroupModal', () => {
     const getAllSecurityGroups = jasmine
       .createSpy('getAllSecurityGroups')
       .and.returnValue(Promise.reject(new Error('inventory unavailable')));
-    spyOnProperty(AngularServices, 'securityGroupReader', 'get').and.returnValue({ getAllSecurityGroups } as any);
-    const wrapper = shallow(<GceSecurityGroupModal application={application as any} credentials="my-account" />);
+    runtimeServices.securityGroupReader = { getAllSecurityGroups };
+    const wrapper = mount(<GceSecurityGroupModal application={application as any} credentials="my-account" />);
     wrapper.setState({ securityGroup: validSecurityGroup({ name: 'new-firewall' }) } as any);
 
     await flush();

--- a/deck/packages/google/src/securityGroup/configure/GceSecurityGroupModal.tsx
+++ b/deck/packages/google/src/securityGroup/configure/GceSecurityGroupModal.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
-import type { IRouterInjectedProps, ISecurityGroupsByAccountSourceData } from '@spinnaker/core';
+import type { DeckRuntimeServices, IRouterInjectedProps, ISecurityGroupsByAccountSourceData } from '@spinnaker/core';
 import {
-  AngularServices,
+  DeckRuntimeContext,
   FirewallLabels,
   ModalClose,
   ReactModal,
@@ -186,10 +186,13 @@ export class GceSecurityGroupModalComponent extends React.Component<
   IGceSecurityGroupModalProps & IRouterInjectedProps,
   IGceSecurityGroupModalState
 > {
+  public static contextType = DeckRuntimeContext;
+  public declare context: React.ContextType<typeof DeckRuntimeContext>;
+
   private mounted = false;
 
-  public static show(props: IGceSecurityGroupModalProps): Promise<any> {
-    return ReactModal.show(GceSecurityGroupModal, props, { dialogClassName: 'modal-lg' });
+  public static show(props: IGceSecurityGroupModalProps, runtimeServices: DeckRuntimeServices): Promise<any> {
+    return ReactModal.show(GceSecurityGroupModal, props, { dialogClassName: 'modal-lg' }, runtimeServices);
   }
 
   public constructor(props: IGceSecurityGroupModalProps & IRouterInjectedProps) {
@@ -217,7 +220,7 @@ export class GceSecurityGroupModalComponent extends React.Component<
       return;
     }
 
-    AngularServices.securityGroupReader.getAllSecurityGroups().then(
+    this.context.services.securityGroupReader.getAllSecurityGroups().then(
       (securityGroupInventory) => {
         if (this.mounted) {
           this.setState({ securityGroupInventory, securityGroupInventoryLoaded: true });

--- a/deck/packages/google/src/securityGroup/details/GceSecurityGroupDetails.spec.tsx
+++ b/deck/packages/google/src/securityGroup/details/GceSecurityGroupDetails.spec.tsx
@@ -1,12 +1,23 @@
 import React from 'react';
-import { mount, shallow } from 'enzyme';
+import { mount as enzymeMount, shallow } from 'enzyme';
 
-import { AngularServices, ConfirmationModalService, SecurityGroupWriter } from '@spinnaker/core';
+import { AccountService, ConfirmationModalService, DeckRuntimeContext, SecurityGroupWriter } from '@spinnaker/core';
 
 import { GceSecurityGroupModal } from '../configure/GceSecurityGroupModal';
 import { GceSecurityGroupActions, GceSecurityGroupDetails } from './GceSecurityGroupDetails';
 
 describe('GceSecurityGroupDetails', () => {
+  let runtimeServices: any;
+  const RuntimeWrapper = ({ children }: React.PropsWithChildren<{}>) => (
+    <DeckRuntimeContext.Provider value={{ services: runtimeServices } as any}>{children}</DeckRuntimeContext.Provider>
+  );
+  const mount = (component: React.ReactElement) => enzymeMount(component, { wrappingComponent: RuntimeWrapper });
+
+  beforeEach(() => {
+    runtimeServices = {};
+    spyOn(AccountService, 'challengeDestructiveActions').and.resolveTo(false);
+  });
+
   const firstRoute = {
     accountId: 'my-account',
     name: 'first-firewall',
@@ -60,7 +71,7 @@ describe('GceSecurityGroupDetails', () => {
           Promise.resolve(details('first-firewall', 'after refresh')),
         ),
     };
-    spyOnProperty(AngularServices, 'securityGroupReader', 'get').and.returnValue(reader as any);
+    runtimeServices.securityGroupReader = reader;
     const wrapper = mount(<GceSecurityGroupDetails app={app as any} resolvedSecurityGroup={firstRoute} />);
 
     await flush();
@@ -89,7 +100,7 @@ describe('GceSecurityGroupDetails', () => {
           thirdRequest.promise,
         ),
     };
-    spyOnProperty(AngularServices, 'securityGroupReader', 'get').and.returnValue(reader as any);
+    runtimeServices.securityGroupReader = reader;
     const app = { securityGroups: { onRefresh: () => jasmine.createSpy('unsubscribe') } };
     const wrapper = mount(<GceSecurityGroupDetails app={app as any} resolvedSecurityGroup={firstRoute} />);
 
@@ -118,6 +129,12 @@ describe('GceSecurityGroupDetails', () => {
 });
 
 describe('GceSecurityGroupActions', () => {
+  const runtimeServices = {} as any;
+  const RuntimeWrapper = ({ children }: React.PropsWithChildren<{}>) => (
+    <DeckRuntimeContext.Provider value={{ services: runtimeServices }}>{children}</DeckRuntimeContext.Provider>
+  );
+  const mountActions = (component: React.ReactElement) => enzymeMount(component, { wrappingComponent: RuntimeWrapper });
+
   const app = {
     name: 'my-app',
     securityGroups: { refresh: jasmine.createSpy('refresh') },
@@ -142,7 +159,7 @@ describe('GceSecurityGroupActions', () => {
     spyOn(GceSecurityGroupModal, 'show');
     spyOn(ConfirmationModalService, 'confirm');
     spyOn(SecurityGroupWriter, 'deleteSecurityGroup').and.returnValue(Promise.resolve({} as any));
-    const wrapper = shallow(
+    const wrapper = mountActions(
       <GceSecurityGroupActions
         app={app as any}
         resolvedSecurityGroup={resolvedSecurityGroup}
@@ -163,16 +180,22 @@ describe('GceSecurityGroupActions', () => {
       region: 'global',
       vpcId: 'default',
     });
-    expect(GceSecurityGroupModal.show).toHaveBeenCalledWith({
-      application: app as any,
-      mode: 'edit',
-      securityGroup: firewallWithIdentity,
-    });
-    expect(GceSecurityGroupModal.show).toHaveBeenCalledWith({
-      application: app as any,
-      mode: 'clone',
-      securityGroup: firewallWithIdentity,
-    });
+    expect(GceSecurityGroupModal.show).toHaveBeenCalledWith(
+      {
+        application: app as any,
+        mode: 'edit',
+        securityGroup: firewallWithIdentity,
+      },
+      runtimeServices,
+    );
+    expect(GceSecurityGroupModal.show).toHaveBeenCalledWith(
+      {
+        application: app as any,
+        mode: 'clone',
+        securityGroup: firewallWithIdentity,
+      },
+      runtimeServices,
+    );
     expect(ConfirmationModalService.confirm).toHaveBeenCalledWith(
       jasmine.objectContaining({
         account: 'my-account',
@@ -192,7 +215,7 @@ describe('GceSecurityGroupActions', () => {
   });
 
   it('disables host-project shared-VPC actions and explains why they are read-only', () => {
-    const wrapper = shallow(
+    const wrapper = mountActions(
       <GceSecurityGroupActions
         app={app as any}
         resolvedSecurityGroup={resolvedSecurityGroup}

--- a/deck/packages/google/src/securityGroup/details/GceSecurityGroupDetails.tsx
+++ b/deck/packages/google/src/securityGroup/details/GceSecurityGroupDetails.tsx
@@ -2,11 +2,11 @@ import React, { useEffect, useState } from 'react';
 
 import {
   AccountTag,
-  AngularServices,
   CollapsibleSection,
   ConfirmationModalService,
   FirewallLabels,
   SecurityGroupWriter,
+  useDeckRuntimeServices,
 } from '@spinnaker/core';
 
 import { GceSecurityGroupModal } from '../configure/GceSecurityGroupModal';
@@ -70,15 +70,16 @@ export function GceSecurityGroupActions({
   resolvedSecurityGroup?: any;
   securityGroup: any;
 }): JSX.Element {
+  const runtimeServices = useDeckRuntimeServices();
   const [menuOpen, setMenuOpen] = useState(false);
   const firewall = withResolvedCoordinates(securityGroup, resolvedSecurityGroup);
   const sharedVpcHostFirewall = typeof firewall.id === 'string' && firewall.id.includes('/');
   const readOnlyExplanation = 'You cannot modify shared VPC host project firewall rules.';
   const editInboundRules = (): void => {
-    GceSecurityGroupModal.show({ application: app, mode: 'edit', securityGroup: firewall });
+    GceSecurityGroupModal.show({ application: app, mode: 'edit', securityGroup: firewall }, runtimeServices);
   };
   const cloneSecurityGroup = (): void => {
-    GceSecurityGroupModal.show({ application: app, mode: 'clone', securityGroup: firewall });
+    GceSecurityGroupModal.show({ application: app, mode: 'clone', securityGroup: firewall }, runtimeServices);
   };
   const deleteSecurityGroup = (): void => {
     ConfirmationModalService.confirm({
@@ -153,6 +154,7 @@ export function GceSecurityGroupActions({
 }
 
 export function GceSecurityGroupDetails({ app, resolvedSecurityGroup }: IGceSecurityGroupDetailsProps): JSX.Element {
+  const { securityGroupReader } = useDeckRuntimeServices();
   const routeKey = securityGroupCoordinatesKey(resolvedSecurityGroup);
   const [loadedSecurityGroup, setLoadedSecurityGroup] = useState<{ key: string; value: any }>();
 
@@ -160,7 +162,7 @@ export function GceSecurityGroupDetails({ app, resolvedSecurityGroup }: IGceSecu
     let cancelled = false;
 
     const loadSecurityGroup = (): PromiseLike<any> => {
-      return AngularServices.securityGroupReader
+      return securityGroupReader
         .getSecurityGroupDetails(
           app,
           resolvedSecurityGroup.accountId,
@@ -190,7 +192,7 @@ export function GceSecurityGroupDetails({ app, resolvedSecurityGroup }: IGceSecu
       cancelled = true;
       unsubscribeFromRefresh?.();
     };
-  }, [app, routeKey]);
+  }, [app, routeKey, securityGroupReader]);
 
   const loading = loadedSecurityGroup?.key !== routeKey;
   const securityGroup = loading ? resolvedSecurityGroup : loadedSecurityGroup.value;

--- a/deck/packages/google/src/serverGroup/configure/serverGroupConfiguration.service.js
+++ b/deck/packages/google/src/serverGroup/configure/serverGroupConfiguration.service.js
@@ -2,7 +2,7 @@
 
 import _ from 'lodash';
 
-import { AccountService, AngularServices, InfrastructureCaches, NetworkReader, SubnetReader } from '@spinnaker/core';
+import { AccountService, InfrastructureCaches, NetworkReader, SubnetReader } from '@spinnaker/core';
 
 import { GCEProviderSettings } from '../../gce.settings';
 import { GceHealthCheckReader } from '../../healthCheck/healthCheck.read.service';
@@ -19,10 +19,12 @@ export const GOOGLE_SERVERGROUP_CONFIGURE_SERVERGROUPCONFIGURATION_SERVICE =
   'spinnaker.serverGroup.configure.gce.configuration.service';
 export const name = GOOGLE_SERVERGROUP_CONFIGURE_SERVERGROUPCONFIGURATION_SERVICE; // for backwards compatibility
 export class GceServerGroupConfigurationService {
-  constructor($q = { all: (values) => Promise.all(values), when: (value) => Promise.resolve(value) }) {
-    const securityGroupReader = () => AngularServices.securityGroupReader;
+  constructor(
+    $q = { all: (values) => Promise.all(values), when: (value) => Promise.resolve(value) },
+    securityGroupReader,
+    loadBalancerReader,
+  ) {
     const gceInstanceTypeService = new GceInstanceTypeService($q);
-    const loadBalancerReader = () => AngularServices.loadBalancerReader;
     const gceCustomInstanceBuilderService = new GceCustomInstanceBuilderService();
     const gceHttpLoadBalancerUtils = new GceHttpLoadBalancerUtils();
     const gceHealthCheckReader = new GceHealthCheckReader();
@@ -59,10 +61,10 @@ export class GceServerGroupConfigurationService {
       return $q
         .all([
           AccountService.getCredentialsKeyedByAccount('gce'),
-          securityGroupReader().getAllSecurityGroups(),
+          securityGroupReader.getAllSecurityGroups(),
           NetworkReader.listNetworksByProvider('gce'),
           SubnetReader.listSubnetsByProvider('gce'),
-          loadBalancerReader().listLoadBalancers('gce'),
+          loadBalancerReader.listLoadBalancers('gce'),
           loadAllImages(command.credentials),
           gceInstanceTypeService.getAllTypesByRegion(),
           $q.when(_.cloneDeep(persistentDiskTypes)),

--- a/deck/packages/google/src/serverGroup/configure/wizard/GceCloneServerGroupModal.spec.tsx
+++ b/deck/packages/google/src/serverGroup/configure/wizard/GceCloneServerGroupModal.spec.tsx
@@ -2,7 +2,7 @@ import { cloneDeep } from 'lodash';
 import React from 'react';
 import { mount, shallow } from 'enzyme';
 
-import { AngularServices, ReactModal, TaskMonitor, WizardModal, WizardPage } from '@spinnaker/core';
+import { ReactModal, TaskMonitor, WizardModal, WizardPage } from '@spinnaker/core';
 
 import {
   GceCloneServerGroupModal as RoutedGceCloneServerGroupModal,
@@ -20,8 +20,6 @@ const application = {
 } as any;
 
 describe('GceCloneServerGroupModal', () => {
-  const serverGroupWriter = { cloneServerGroup: () => Promise.resolve() };
-
   beforeEach(() => {
     application.serverGroups.onNextRefresh.calls.reset();
     application.serverGroups.refresh.calls.reset();
@@ -29,18 +27,21 @@ describe('GceCloneServerGroupModal', () => {
       dismiss: jasmine.createSpy('dismiss'),
       result: Promise.resolve(),
     } as any);
-    spyOnProperty(AngularServices, 'serverGroupWriter', 'get').and.returnValue(serverGroupWriter as any);
   });
 
   it('opens as a wizard modal', () => {
     const props = buildProps(buildCommand());
+    const runtimeServices = {} as any;
     spyOn(ReactModal, 'show').and.returnValue(Promise.resolve());
 
-    GceCloneServerGroupModal.show(props);
+    GceCloneServerGroupModal.show(props, runtimeServices);
 
-    expect(ReactModal.show).toHaveBeenCalledWith(RoutedGceCloneServerGroupModal, props, {
-      dialogClassName: 'wizard-modal modal-lg',
-    });
+    expect(ReactModal.show).toHaveBeenCalledWith(
+      RoutedGceCloneServerGroupModal,
+      props,
+      { dialogClassName: 'wizard-modal modal-lg' },
+      runtimeServices,
+    );
   });
 
   it('renders the eight GCE pages in parity order without requiring a source template', () => {
@@ -820,7 +821,7 @@ describe('GceCloneServerGroupModal', () => {
       });
       const props = buildProps(command);
       const modal = new GceCloneServerGroupModal(props) as any;
-      const cloneServerGroup = spyOn(AngularServices.serverGroupWriter, 'cloneServerGroup');
+      const cloneServerGroup = jasmine.createSpy('cloneServerGroup');
 
       modal.submit(command);
 
@@ -859,9 +860,8 @@ describe('GceCloneServerGroupModal', () => {
       const props = buildProps(command);
       const modal = new GceCloneServerGroupModal(props) as any;
       const task = Promise.resolve({ id: 'task-id' });
-      const cloneServerGroup = spyOn(AngularServices.serverGroupWriter, 'cloneServerGroup').and.returnValue(
-        task as any,
-      );
+      const cloneServerGroup = jasmine.createSpy('cloneServerGroup').and.returnValue(task as any);
+      modal.context = { services: { serverGroupWriter: { cloneServerGroup } } };
       const monitorSubmit = spyOn(
         modal.state.taskMonitor,
         'submit',

--- a/deck/packages/google/src/serverGroup/configure/wizard/GceCloneServerGroupModal.tsx
+++ b/deck/packages/google/src/serverGroup/configure/wizard/GceCloneServerGroupModal.tsx
@@ -3,12 +3,21 @@ import React from 'react';
 
 import type {
   Application,
+  DeckRuntimeServices,
   IModalComponentProps,
   IRouterInjectedProps,
   IStage,
   IWizardPageInjectedProps,
 } from '@spinnaker/core';
-import { AngularServices, noop, ReactModal, TaskMonitor, withRouter, WizardModal, WizardPage } from '@spinnaker/core';
+import {
+  DeckRuntimeContext,
+  noop,
+  ReactModal,
+  TaskMonitor,
+  withRouter,
+  WizardModal,
+  WizardPage,
+} from '@spinnaker/core';
 
 import { validateGceServerGroupCommand } from './GceServerGroupWizard.helpers';
 import type {
@@ -207,6 +216,9 @@ export class GceCloneServerGroupModalComponent extends React.Component<
   IGceCloneServerGroupModalProps & IRouterInjectedProps,
   IGceCloneServerGroupModalState
 > {
+  public static contextType = DeckRuntimeContext;
+  public declare context: React.ContextType<typeof DeckRuntimeContext>;
+
   public static defaultProps: Partial<IGceCloneServerGroupModalProps & IRouterInjectedProps> = {
     closeModal: noop,
     dismissModal: noop,
@@ -220,13 +232,25 @@ export class GceCloneServerGroupModalComponent extends React.Component<
   private formik: IWizardPageInjectedProps<IGceServerGroupCommand>['formik'] = null;
   private unmounted = false;
 
-  public static show(props: IGceCloneServerGroupModalProps): Promise<any> {
-    return ReactModal.show(GceCloneServerGroupModal, props, { dialogClassName: 'wizard-modal modal-lg' });
+  public static show(props: IGceCloneServerGroupModalProps, runtimeServices: DeckRuntimeServices): Promise<any> {
+    return ReactModal.show(
+      GceCloneServerGroupModal,
+      props,
+      { dialogClassName: 'wizard-modal modal-lg' },
+      runtimeServices,
+    );
   }
 
-  public constructor(props: IGceCloneServerGroupModalProps & IRouterInjectedProps) {
-    super(props);
-    this.adapter = props.adapter || new GceServerGroupWizardAdapter();
+  public constructor(
+    props: IGceCloneServerGroupModalProps & IRouterInjectedProps,
+    context: React.ContextType<typeof DeckRuntimeContext>,
+  ) {
+    super(props, context);
+    this.adapter =
+      props.adapter ||
+      (context?.services
+        ? GceServerGroupWizardAdapter.fromRuntimeServices(context.services)
+        : new GceServerGroupWizardAdapter());
     this.command = cloneDeep(props.command);
     this.commandState = createGceServerGroupWizardCommandState(this.command);
     this.state = {
@@ -300,7 +324,7 @@ export class GceCloneServerGroupModalComponent extends React.Component<
       return this.props.closeModal(transformed);
     }
     return this.state.taskMonitor.submit(() =>
-      AngularServices.serverGroupWriter.cloneServerGroup(transformed as any, this.props.application),
+      this.context.services.serverGroupWriter.cloneServerGroup(transformed as any, this.props.application),
     );
   };
 

--- a/deck/packages/google/src/serverGroup/configure/wizard/GceServerGroupWizardAdapter.ts
+++ b/deck/packages/google/src/serverGroup/configure/wizard/GceServerGroupWizardAdapter.ts
@@ -1,6 +1,6 @@
 import { cloneDeep } from 'lodash';
 
-import type { Application, IPipeline, IServerGroup, IStage } from '@spinnaker/core';
+import type { Application, DeckRuntimeServices, IPipeline, IServerGroup, IStage } from '@spinnaker/core';
 
 import type {
   GceCommandHandlerName,
@@ -21,6 +21,19 @@ import { GceServerGroupConfigurationService } from '../serverGroupConfiguration.
 const EMPTY_UPDATE_RESULT: IGceServerGroupCommandUpdateResult = { dirty: {} };
 
 export class GceServerGroupWizardAdapter implements IGceServerGroupWizardAdapter {
+  public static fromRuntimeServices(
+    runtimeServices: Pick<DeckRuntimeServices, 'loadBalancerReader' | 'securityGroupReader'>,
+  ): GceServerGroupWizardAdapter {
+    return new GceServerGroupWizardAdapter(
+      undefined,
+      (new GceServerGroupConfigurationService(
+        undefined,
+        runtimeServices.securityGroupReader,
+        runtimeServices.loadBalancerReader,
+      ) as unknown) as IGceServerGroupConfigurationAdapter,
+    );
+  }
+
   public constructor(
     private commandBuilder = (new GceServerGroupCommandBuilder() as unknown) as IGceServerGroupCommandBuilderAdapter,
     private configurationService = (new GceServerGroupConfigurationService() as unknown) as IGceServerGroupConfigurationAdapter,

--- a/deck/packages/google/src/serverGroup/configure/wizard/customInstance/GceCustomInstanceBuilder.spec.tsx
+++ b/deck/packages/google/src/serverGroup/configure/wizard/customInstance/GceCustomInstanceBuilder.spec.tsx
@@ -1,13 +1,23 @@
-import { mount } from 'enzyme';
+import { mount as enzymeMount } from 'enzyme';
 import React from 'react';
 
-import { AngularServices } from '@spinnaker/core';
+import { DeckRuntimeContext } from '@spinnaker/core';
 import { CustomInstanceConfigurer } from './CustomInstanceConfigurer';
 import { GceCustomInstanceBuilder } from './GceCustomInstanceBuilder';
 
 describe('GceCustomInstanceBuilder', () => {
+  let runtimeServices: any;
+  const RuntimeWrapper = ({ children }: React.PropsWithChildren<{}>) => (
+    <DeckRuntimeContext.Provider value={{ services: runtimeServices } as any}>{children}</DeckRuntimeContext.Provider>
+  );
+  const mount = (component: React.ReactElement) => enzymeMount(component, { wrappingComponent: RuntimeWrapper });
+
+  beforeEach(() => {
+    runtimeServices = {};
+  });
+
   it('parses the current instance type and provides valid custom instance choices', () => {
-    spyOnProperty(AngularServices, 'instanceTypeService', 'get').and.returnValue(instanceTypeService() as any);
+    runtimeServices.instanceTypeService = instanceTypeService();
     const command = commandWithCustomInstance('n2-custom-4-16384-ext');
 
     const component = mount(<GceCustomInstanceBuilder command={command as any} onTypeChanged={jasmine.createSpy()} />);
@@ -24,9 +34,7 @@ describe('GceCustomInstanceBuilder', () => {
 
   it('updates command.instanceType, notifies, and loads details when custom choices change', async () => {
     const instanceTypeDetails = { name: 'n2-custom-8-32768' };
-    spyOnProperty(AngularServices, 'instanceTypeService', 'get').and.returnValue(
-      instanceTypeService(instanceTypeDetails) as any,
-    );
+    runtimeServices.instanceTypeService = instanceTypeService(instanceTypeDetails);
     const onTypeChanged = jasmine.createSpy('onTypeChanged');
     const command = commandWithCustomInstance('n2-custom-4-16384');
 
@@ -46,7 +54,7 @@ describe('GceCustomInstanceBuilder', () => {
   });
 
   it('initializes missing custom values from valid lists', () => {
-    spyOnProperty(AngularServices, 'instanceTypeService', 'get').and.returnValue(instanceTypeService() as any);
+    runtimeServices.instanceTypeService = instanceTypeService();
     const command = commandWithCustomInstance(null);
 
     const component = mount(<GceCustomInstanceBuilder command={command as any} onTypeChanged={jasmine.createSpy()} />);
@@ -64,7 +72,7 @@ describe('GceCustomInstanceBuilder', () => {
   });
 
   it('keeps valid defaults when memory changes before cores', async () => {
-    spyOnProperty(AngularServices, 'instanceTypeService', 'get').and.returnValue(instanceTypeService() as any);
+    runtimeServices.instanceTypeService = instanceTypeService();
     const onTypeChanged = jasmine.createSpy('onTypeChanged');
     const command = commandWithCustomInstance(null);
 

--- a/deck/packages/google/src/serverGroup/configure/wizard/customInstance/GceCustomInstanceBuilder.tsx
+++ b/deck/packages/google/src/serverGroup/configure/wizard/customInstance/GceCustomInstanceBuilder.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import type { ICustomInstanceBuilderProps } from '@spinnaker/core';
-import { AngularServices } from '@spinnaker/core';
+import { useDeckRuntimeServices } from '@spinnaker/core';
 
 import type { ICustomInstanceConfig } from './CustomInstanceConfigurer';
 import { CustomInstanceConfigurer } from './CustomInstanceConfigurer';
@@ -10,6 +10,7 @@ import { GceCustomInstanceBuilderService } from '../../../../instance/custom/cus
 const customInstanceBuilderService = new GceCustomInstanceBuilderService();
 
 export function GceCustomInstanceBuilder({ command, onTypeChanged }: ICustomInstanceBuilderProps) {
+  const { instanceTypeService } = useDeckRuntimeServices();
   const gceCommand = command as any;
   const [config, setConfig] = React.useState<ICustomInstanceConfig>(() => getInitialConfig(gceCommand));
   const choices = getChoices(gceCommand, config);
@@ -28,7 +29,7 @@ export function GceCustomInstanceBuilder({ command, onTypeChanged }: ICustomInst
     gceCommand.instanceType = nextInstanceType;
     gceCommand.customInstanceChanged && gceCommand.customInstanceChanged(gceCommand);
     setConfig(completeConfig);
-    AngularServices.instanceTypeService
+    instanceTypeService
       .getInstanceTypeDetails(gceCommand.selectedProvider, nextInstanceType)
       .then((instanceTypeDetails) => {
         gceCommand.viewState.instanceTypeDetails = instanceTypeDetails;

--- a/deck/packages/google/src/serverGroup/configure/wizard/pages/ServerGroupInstanceType.spec.tsx
+++ b/deck/packages/google/src/serverGroup/configure/wizard/pages/ServerGroupInstanceType.spec.tsx
@@ -1,8 +1,8 @@
-import { shallow } from 'enzyme';
+import { mount as enzymeMount } from 'enzyme';
 import type { FormikProps } from 'formik';
 import React from 'react';
 
-import { AngularServices } from '@spinnaker/core';
+import { DeckRuntimeContext } from '@spinnaker/core';
 
 import type {
   IGceServerGroupCommand,
@@ -12,6 +12,22 @@ import type {
 import { ServerGroupInstanceType } from './ServerGroupInstanceType';
 
 describe('ServerGroupInstanceType', () => {
+  let runtimeServices: any;
+  const RuntimeWrapper = ({ children }: React.PropsWithChildren<{}>) => (
+    <DeckRuntimeContext.Provider value={{ services: runtimeServices } as any}>{children}</DeckRuntimeContext.Provider>
+  );
+  const shallow = (component: React.ReactElement) => enzymeMount(component, { wrappingComponent: RuntimeWrapper });
+
+  beforeEach(() => {
+    runtimeServices = {
+      instanceTypeService: {
+        getInstanceTypeDetails: jasmine
+          .createSpy('getInstanceTypeDetails')
+          .and.returnValue(new Promise(() => undefined)),
+      },
+    };
+  });
+
   it('renders accessible instance controls and preserves persisted unavailable references', () => {
     const values = command({
       instanceType: 'retired-machine',
@@ -29,9 +45,9 @@ describe('ServerGroupInstanceType', () => {
   });
 
   it('selects standard machine types without mutating current Formik values', () => {
-    spyOnProperty(AngularServices, 'instanceTypeService', 'get').and.returnValue({
+    runtimeServices.instanceTypeService = {
       getInstanceTypeDetails: jasmine.createSpy('getInstanceTypeDetails').and.returnValue(new Promise(() => undefined)),
-    } as any);
+    };
     const values = command({ instanceType: 'n1-standard-1' });
     const testProps = props(values);
     const wrapper = shallow(<ServerGroupInstanceType {...testProps} />);
@@ -56,7 +72,7 @@ describe('ServerGroupInstanceType', () => {
       const instanceTypeService = {
         getInstanceTypeDetails: jasmine.createSpy('getInstanceTypeDetails'),
       };
-      spyOnProperty(AngularServices, 'instanceTypeService', 'get').and.returnValue(instanceTypeService as any);
+      runtimeServices.instanceTypeService = instanceTypeService;
       const values = command({
         viewState: { mode: 'editPipeline', instanceProfile: 'custom', acceleratorTypes: [] },
       });
@@ -77,7 +93,7 @@ describe('ServerGroupInstanceType', () => {
     const instanceTypeService = {
       getInstanceTypeDetails: jasmine.createSpy('getInstanceTypeDetails').and.returnValue(detailsRequest.promise),
     };
-    spyOnProperty(AngularServices, 'instanceTypeService', 'get').and.returnValue(instanceTypeService as any);
+    runtimeServices.instanceTypeService = instanceTypeService;
     const values = command({
       disks: [
         { type: 'pd-standard', sizeGb: 100 },
@@ -147,7 +163,7 @@ describe('ServerGroupInstanceType', () => {
           instanceType === 'n2-standard-2' ? oldRequest.promise : newRequest.promise,
         ),
     };
-    spyOnProperty(AngularServices, 'instanceTypeService', 'get').and.returnValue(instanceTypeService as any);
+    runtimeServices.instanceTypeService = instanceTypeService;
     const values = command();
     const adapter = adapterForHandlers();
     const testProps = props(values, adapter);
@@ -171,9 +187,9 @@ describe('ServerGroupInstanceType', () => {
 
   it('ignores standard machine type details after the user switches to a custom type', async () => {
     const detailsRequest = deferred<any>();
-    spyOnProperty(AngularServices, 'instanceTypeService', 'get').and.returnValue({
+    runtimeServices.instanceTypeService = {
       getInstanceTypeDetails: jasmine.createSpy('getInstanceTypeDetails').and.returnValue(detailsRequest.promise),
-    } as any);
+    };
     const values = command();
     const adapter = adapterForHandlers();
     const testProps = props(values, adapter);
@@ -197,9 +213,9 @@ describe('ServerGroupInstanceType', () => {
 
   it('preserves a disk edit made while machine type details are loading', async () => {
     const detailsRequest = deferred<any>();
-    spyOnProperty(AngularServices, 'instanceTypeService', 'get').and.returnValue({
+    runtimeServices.instanceTypeService = {
       getInstanceTypeDetails: jasmine.createSpy('getInstanceTypeDetails').and.returnValue(detailsRequest.promise),
-    } as any);
+    };
     const values = command();
     const testProps = props(values);
     const wrapper = shallow(<ServerGroupInstanceType {...testProps} />);

--- a/deck/packages/google/src/serverGroup/configure/wizard/pages/ServerGroupInstanceType.tsx
+++ b/deck/packages/google/src/serverGroup/configure/wizard/pages/ServerGroupInstanceType.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { AngularServices, HelpField, SpelService } from '@spinnaker/core';
+import { DeckRuntimeContext, HelpField, SpelService } from '@spinnaker/core';
 
 import type { IGceServerGroupCommand } from '../GceServerGroupWizard.types';
 import { GceServerGroupWizardPage } from '../GceServerGroupWizardPage';
@@ -39,6 +39,9 @@ interface IGceInstanceTypeValidationErrors {
 }
 
 export class ServerGroupInstanceType extends GceServerGroupWizardPage {
+  public static contextType = DeckRuntimeContext;
+  public declare context: React.ContextType<typeof DeckRuntimeContext>;
+
   private instanceTypeRequestGeneration = 0;
 
   public validate(values: IGceServerGroupCommand): IGceInstanceTypeValidationErrors {
@@ -93,7 +96,7 @@ export class ServerGroupInstanceType extends GceServerGroupWizardPage {
       return;
     }
     void this.runLatestCommandRequest(nextValues, async (latestCommand) => {
-      const instanceTypeDetails = await AngularServices.instanceTypeService.getInstanceTypeDetails(
+      const instanceTypeDetails = await this.context.services.instanceTypeService.getInstanceTypeDetails(
         latestCommand.selectedProvider || 'gce',
         instanceType,
       );

--- a/deck/packages/google/src/serverGroup/details/gceServerGroupDetails.spec.tsx
+++ b/deck/packages/google/src/serverGroup/details/gceServerGroupDetails.spec.tsx
@@ -1,7 +1,7 @@
-import { shallow } from 'enzyme';
+import { mount as enzymeMount, shallow } from 'enzyme';
 import React from 'react';
 
-import { AngularServices, CloudProviderRegistry, CollapsibleSection, ManagedMenuItem } from '@spinnaker/core';
+import { CloudProviderRegistry, CollapsibleSection, DeckRuntimeContext, ManagedMenuItem } from '@spinnaker/core';
 
 import { GceAutoscalingPolicyWriter } from '../../autoscalingPolicy';
 import { registerGoogleProvider } from '../../gce.module';
@@ -12,7 +12,18 @@ import { GceResizeServerGroupModal } from './resize/GceResizeServerGroupModal';
 import { GceRollbackServerGroupModal } from './rollback/GceRollbackServerGroupModal';
 
 describe('GCE server group details integration', () => {
-  const serverGroupWriter = {} as any;
+  let runtimeServices: any;
+  const RuntimeWrapper = ({ children }: React.PropsWithChildren<{}>) => (
+    <DeckRuntimeContext.Provider value={{ services: runtimeServices } as any}>{children}</DeckRuntimeContext.Provider>
+  );
+  const mount = (component: React.ReactElement) => enzymeMount(component, { wrappingComponent: RuntimeWrapper });
+
+  beforeEach(() => {
+    runtimeServices = {
+      serverGroupCommandBuilder: {},
+      serverGroupWriter: {},
+    };
+  });
   const serverGroup = {
     account: 'prod',
     app: 'fnord',
@@ -49,10 +60,6 @@ describe('GCE server group details integration', () => {
 
   const linkAction = (wrapper: any, label: string) =>
     wrapper.find('a').filterWhere((link: any) => link.text() === label);
-
-  beforeEach(() => {
-    spyOnProperty(AngularServices, 'serverGroupWriter', 'get').and.returnValue(serverGroupWriter);
-  });
 
   it('registers autoscaling and auto-healing sections backed by the completed details components', () => {
     registerGoogleProvider();
@@ -123,7 +130,7 @@ describe('GCE server group details integration', () => {
   });
 
   it('adds rollback and resize without changing existing enabled action visibility', () => {
-    const wrapper = shallow(<GceServerGroupActions app={app} serverGroup={serverGroup} />);
+    const wrapper = mount(<GceServerGroupActions app={app} serverGroup={serverGroup} />);
 
     expect(managedAction(wrapper, 'Rollback').length).toBe(1);
     expect(managedAction(wrapper, 'Resize').length).toBe(1);
@@ -134,7 +141,7 @@ describe('GCE server group details integration', () => {
   });
 
   it('keeps rollback hidden for a disabled server group without changing existing disabled action visibility', () => {
-    const wrapper = shallow(<GceServerGroupActions app={app} serverGroup={{ ...serverGroup, isDisabled: true }} />);
+    const wrapper = mount(<GceServerGroupActions app={app} serverGroup={{ ...serverGroup, isDisabled: true }} />);
 
     expect(managedAction(wrapper, 'Rollback').length).toBe(0);
     expect(managedAction(wrapper, 'Resize').length).toBe(1);
@@ -144,7 +151,7 @@ describe('GCE server group details integration', () => {
 
   it('opens rollback with filtered candidates and the existing server group writer', () => {
     const show = spyOn(GceRollbackServerGroupModal, 'show').and.returnValue(Promise.resolve({} as any));
-    const wrapper = shallow(<GceServerGroupActions app={app} serverGroup={serverGroup} />);
+    const wrapper = mount(<GceServerGroupActions app={app} serverGroup={serverGroup} />);
 
     managedAction(wrapper, 'Rollback').prop('onClick')();
 
@@ -152,14 +159,14 @@ describe('GCE server group details integration', () => {
       application: app,
       serverGroup,
       serverGroups: [eligibleRollbackCandidate],
-      serverGroupWriter: AngularServices.serverGroupWriter,
+      serverGroupWriter: runtimeServices.serverGroupWriter,
     });
   });
 
   it('keeps rollback available when there are no candidates and delegates empty handling to the modal', () => {
     const appWithoutCandidates = { ...app, serverGroups: { ...app.serverGroups, data: [] } };
     const show = spyOn(GceRollbackServerGroupModal, 'show').and.returnValue(Promise.resolve({} as any));
-    const wrapper = shallow(<GceServerGroupActions app={appWithoutCandidates} serverGroup={serverGroup} />);
+    const wrapper = mount(<GceServerGroupActions app={appWithoutCandidates} serverGroup={serverGroup} />);
 
     expect(managedAction(wrapper, 'Rollback').length).toBe(1);
     managedAction(wrapper, 'Rollback').prop('onClick')();
@@ -171,7 +178,7 @@ describe('GCE server group details integration', () => {
 
   it('opens resize with the completed writers', () => {
     const show = spyOn(GceResizeServerGroupModal, 'show').and.returnValue(Promise.resolve());
-    const wrapper = shallow(<GceServerGroupActions app={app} serverGroup={serverGroup} />);
+    const wrapper = mount(<GceServerGroupActions app={app} serverGroup={serverGroup} />);
 
     managedAction(wrapper, 'Resize').prop('onClick')();
 
@@ -179,12 +186,12 @@ describe('GCE server group details integration', () => {
       application: app,
       autoscalingPolicyWriter: GceAutoscalingPolicyWriter,
       serverGroup,
-      serverGroupWriter: AngularServices.serverGroupWriter,
+      serverGroupWriter: runtimeServices.serverGroupWriter,
     });
   });
 
   it('protects rollback and resize with the managed-resource interstitial', () => {
-    const wrapper = shallow(<GceServerGroupActions app={app} serverGroup={{ ...serverGroup, isManaged: true }} />);
+    const wrapper = mount(<GceServerGroupActions app={app} serverGroup={{ ...serverGroup, isManaged: true }} />);
 
     ['Rollback', 'Resize'].forEach((label) => {
       expect(managedAction(wrapper, label).props()).toEqual(
@@ -196,7 +203,7 @@ describe('GCE server group details integration', () => {
   it('hides server group actions when GCE ad-hoc infrastructure writes are disabled', () => {
     spyOn(CloudProviderRegistry, 'isDisabled').and.returnValue(true);
 
-    const wrapper = shallow(<GceServerGroupActions app={app} serverGroup={serverGroup} />);
+    const wrapper = mount(<GceServerGroupActions app={app} serverGroup={serverGroup} />);
 
     expect(wrapper.isEmptyRender()).toBe(true);
   });

--- a/deck/packages/google/src/serverGroup/details/gceServerGroupDetails.tsx
+++ b/deck/packages/google/src/serverGroup/details/gceServerGroupDetails.tsx
@@ -3,7 +3,6 @@ import { Observable } from 'rxjs';
 
 import {
   AccountTag,
-  AngularServices,
   CloudProviderRegistry,
   CollapsibleSection,
   ConfirmationModalService,
@@ -11,6 +10,7 @@ import {
   ManagedMenuItem,
   ServerGroupReader,
   ServerGroupWarningMessageService,
+  useDeckRuntimeServices,
 } from '@spinnaker/core';
 import type { Application } from '@spinnaker/core';
 
@@ -18,7 +18,6 @@ import { GceAutoHealingPolicyDetails } from './autoHealingPolicy';
 import { GceAutoscalingPolicyWriter } from '../../autoscalingPolicy';
 import { GceAutoscalingPolicyDetails } from './autoscalingPolicy';
 import { GceXpnNamingService } from '../../common/xpnNaming.gce.service';
-import { GceServerGroupCommandBuilder } from '../configure/serverGroupCommandBuilder.service';
 import { GceCloneServerGroupModal } from '../configure/wizard/GceCloneServerGroupModal';
 import type { IGceServerGroup } from '../../domain';
 import { GceResizeServerGroupModal } from './resize/GceResizeServerGroupModal';
@@ -114,12 +113,13 @@ function withGcePlatformHealthParams(app: any, params: any = {}): any {
 export function cloneGceServerGroup(
   app: any,
   serverGroup: any,
-  commandBuilder: any = new GceServerGroupCommandBuilder(),
+  commandBuilder: any,
+  runtimeServices: ReturnType<typeof useDeckRuntimeServices>,
 ): PromiseLike<void> {
   return commandBuilder
     .buildServerGroupCommandFromExisting(app, serverGroup)
     .then((command: any) => {
-      GceCloneServerGroupModal.show({ application: app, command, title: `Clone ${serverGroup.name}` });
+      GceCloneServerGroupModal.show({ application: app, command, title: `Clone ${serverGroup.name}` }, runtimeServices);
     })
     .catch((error: any) => {
       ErrorModalService.error({
@@ -130,6 +130,8 @@ export function cloneGceServerGroup(
 }
 
 export function GceServerGroupActions({ app, serverGroup }: { app: any; serverGroup: any }): JSX.Element {
+  const runtimeServices = useDeckRuntimeServices();
+  const { serverGroupCommandBuilder, serverGroupWriter } = runtimeServices;
   if (CloudProviderRegistry.isDisabled('gce')) {
     return null;
   }
@@ -142,7 +144,7 @@ export function GceServerGroupActions({ app, serverGroup }: { app: any; serverGr
   };
 
   const cloneServerGroup = () => {
-    cloneGceServerGroup(app, serverGroup);
+    cloneGceServerGroup(app, serverGroup, serverGroupCommandBuilder, runtimeServices);
   };
 
   const rollbackServerGroup = () => {
@@ -151,7 +153,7 @@ export function GceServerGroupActions({ app, serverGroup }: { app: any; serverGr
       application: app,
       serverGroup,
       serverGroups,
-      serverGroupWriter: AngularServices.serverGroupWriter,
+      serverGroupWriter,
     });
   };
 
@@ -160,7 +162,7 @@ export function GceServerGroupActions({ app, serverGroup }: { app: any; serverGr
       application: app,
       autoscalingPolicyWriter: GceAutoscalingPolicyWriter,
       serverGroup,
-      serverGroupWriter: AngularServices.serverGroupWriter,
+      serverGroupWriter,
     });
   };
 
@@ -170,11 +172,7 @@ export function GceServerGroupActions({ app, serverGroup }: { app: any; serverGr
       buttonText: `Destroy ${serverGroup.name}`,
       header: `Really destroy ${serverGroup.name}?`,
       submitMethod: (params: any) =>
-        AngularServices.serverGroupWriter.destroyServerGroup(
-          serverGroup,
-          app,
-          withGcePlatformHealthParams(app, params),
-        ),
+        serverGroupWriter.destroyServerGroup(serverGroup, app, withGcePlatformHealthParams(app, params)),
       taskMonitorConfig: { application: app, title: `Destroying ${serverGroup.name}` },
     };
     ServerGroupWarningMessageService.addDestroyWarningMessage(app, serverGroup, confirmationModalParams);
@@ -187,11 +185,7 @@ export function GceServerGroupActions({ app, serverGroup }: { app: any; serverGr
       buttonText: `Disable ${serverGroup.name}`,
       header: `Really disable ${serverGroup.name}?`,
       submitMethod: (params: any) =>
-        AngularServices.serverGroupWriter.disableServerGroup(
-          serverGroup,
-          app.name,
-          withGcePlatformHealthParams(app, params),
-        ),
+        serverGroupWriter.disableServerGroup(serverGroup, app.name, withGcePlatformHealthParams(app, params)),
       taskMonitorConfig: { application: app, title: `Disabling ${serverGroup.name}` },
     };
     ServerGroupWarningMessageService.addDisableWarningMessage(app, serverGroup, confirmationModalParams);
@@ -204,7 +198,7 @@ export function GceServerGroupActions({ app, serverGroup }: { app: any; serverGr
       buttonText: `Enable ${serverGroup.name}`,
       header: `Really enable ${serverGroup.name}?`,
       submitMethod: (params: any) =>
-        AngularServices.serverGroupWriter.enableServerGroup(serverGroup, app, withGcePlatformHealthParams(app, params)),
+        serverGroupWriter.enableServerGroup(serverGroup, app, withGcePlatformHealthParams(app, params)),
       taskMonitorConfig: { application: app, title: `Enabling ${serverGroup.name}` },
     });
   };

--- a/deck/packages/kubernetes/src/manifest/selector/ManifestSelector.spec.tsx
+++ b/deck/packages/kubernetes/src/manifest/selector/ManifestSelector.spec.tsx
@@ -312,6 +312,26 @@ describe('<ManifestSelector />', () => {
       expect(searchService).toHaveBeenCalledWith('configMap', 'default', 'my-other-account');
     });
 
+    it('waits for complete manifest search criteria', async () => {
+      const wrapper = await component({ mode: SelectorMode.Static });
+      wrapper.setState({
+        accounts: [{ name: 'my-account', namespaces: ['default'] }],
+      } as IManifestSelectorState);
+      searchService.calls.reset();
+
+      const account = wrapper.find(AccountSelectInput).first();
+      account.props().onChange(createFakeReactSyntheticEvent({ value: 'my-account' }));
+      expect(searchService).not.toHaveBeenCalled();
+
+      const namespace = wrapper.find({ label: 'Namespace' }).find(Creatable).first();
+      namespace.props().onChange({ value: 'default', label: 'default' });
+      expect(searchService).not.toHaveBeenCalled();
+
+      const kind = wrapper.find({ label: 'Kind' }).find(Creatable).first();
+      kind.props().onChange({ value: 'deployment', label: 'deployment' });
+      expect(searchService).toHaveBeenCalledOnceWith('deployment', 'default', 'my-account');
+    });
+
     it('clears namespace when changing account if account does not have selected namespace', async () => {
       const wrapper = await component({
         manifestName: 'configMap my-config-map',

--- a/deck/packages/kubernetes/src/manifest/selector/ManifestSelector.tsx
+++ b/deck/packages/kubernetes/src/manifest/selector/ManifestSelector.tsx
@@ -245,7 +245,7 @@ export class ManifestSelector extends React.Component<IManifestSelectorProps, IM
   private isExpression = (value: string): boolean => (typeof value === 'string' ? value.includes('${') : false);
 
   private search = (kind: string, namespace: string, account: string): PromiseLike<string[]> => {
-    if (this.isExpression(account)) {
+    if (!kind || !namespace || !account || this.isExpression(account)) {
       return Promise.resolve([]);
     }
     return ManifestKindSearchService.search(kind, namespace, account).then((results) =>

--- a/deck/packages/kubernetes/src/securityGroup/details/KubernetesSecurityGroupDetails.tsx
+++ b/deck/packages/kubernetes/src/securityGroup/details/KubernetesSecurityGroupDetails.tsx
@@ -12,9 +12,9 @@ import type {
 import {
   AccountTag,
   AddEntityTagLinks,
-  AngularServices,
   CloudProviderLogo,
   CollapsibleSection,
+  DeckRuntimeContext,
   EntityNotifications,
   FirewallLabels,
   ManifestReader,
@@ -61,6 +61,9 @@ export class KubernetesSecurityGroupDetailsComponent extends React.Component<
   IKubernetesSecurityGroupDetailsProps & IRouterInjectedProps,
   IKubernetesSecurityGroupDetailsState
 > {
+  public static contextType = DeckRuntimeContext;
+  public declare context: React.ContextType<typeof DeckRuntimeContext>;
+
   public state: IKubernetesSecurityGroupDetailsState = {
     loading: true,
   };
@@ -107,7 +110,7 @@ export class KubernetesSecurityGroupDetailsComponent extends React.Component<
   }
 
   private getSecurityGroupReader(): SecurityGroupReader {
-    return this.props.securityGroupReader || AngularServices.securityGroupReader;
+    return this.props.securityGroupReader || this.context.services.securityGroupReader;
   }
 
   private getCoordinatesKey(props: IKubernetesSecurityGroupDetailsProps): string {

--- a/deck/packages/oracle/src/serverGroup/configure/serverGroupConfiguration.service.js
+++ b/deck/packages/oracle/src/serverGroup/configure/serverGroupConfiguration.service.js
@@ -2,7 +2,7 @@
 
 import _ from 'lodash';
 
-import { AccountService, AngularServices, NetworkReader, SubnetReader } from '@spinnaker/core';
+import { AccountService, NetworkReader, SubnetReader } from '@spinnaker/core';
 
 import { OracleImageReader } from '../../image/image.reader';
 import { OracleProviderSettings } from '../../oracle.settings';
@@ -10,13 +10,16 @@ import { OracleProviderSettings } from '../../oracle.settings';
 const oracle = 'oracle';
 
 export class OracleServerGroupConfigurationService {
-  constructor() {
+  static requiresDeckRuntimeServices = true;
+
+  constructor(_promiseService, runtimeServices) {
     this.oracleImageReader = new OracleImageReader();
+    this.securityGroupReader = runtimeServices.securityGroupReader;
   }
 
   configureCommand(application, command) {
     const oracleImageReader = this.oracleImageReader;
-    const securityGroupReader = AngularServices.securityGroupReader;
+    const securityGroupReader = this.securityGroupReader;
 
     const getShapes = (image) => {
       if (!image || !image.compatibleShapes) {

--- a/deck/packages/oracle/src/serverGroup/details/OracleServerGroupDetails.tsx
+++ b/deck/packages/oracle/src/serverGroup/details/OracleServerGroupDetails.tsx
@@ -4,11 +4,11 @@ import { catchError } from 'rxjs/operators';
 
 import {
   AccountTag,
-  AngularServices,
   CollapsibleSection,
   ConfirmationModalService,
   ServerGroupReader,
   timestamp,
+  useDeckRuntimeServices,
 } from '@spinnaker/core';
 
 import { OracleImageReader } from '../../image/image.reader';
@@ -36,13 +36,14 @@ export function oracleServerGroupDetailsGetter(props: any, autoClose: () => void
 }
 
 export function OracleServerGroupActions({ app, serverGroup }: any) {
+  const { serverGroupWriter } = useDeckRuntimeServices();
   const destroyServerGroup = () => {
     ConfirmationModalService.confirm({
       header: `Really destroy ${serverGroup.name}?`,
       buttonText: `Destroy ${serverGroup.name}`,
       account: serverGroup.account,
       taskMonitorConfig: { application: app, title: `Destroying ${serverGroup.name}` },
-      submitMethod: () => AngularServices.serverGroupWriter.destroyServerGroup(serverGroup, app),
+      submitMethod: () => serverGroupWriter.destroyServerGroup(serverGroup, app),
     });
   };
 

--- a/deck/packages/titus/src/instance/details/TitusInstanceDetails.tsx
+++ b/deck/packages/titus/src/instance/details/TitusInstanceDetails.tsx
@@ -25,6 +25,7 @@ import {
   SETTINGS,
   Spinner,
   useData,
+  useDeckRuntimeServices,
 } from '@spinnaker/core';
 
 import { TitusInstanceDns } from './TitusInstanceDns';
@@ -124,6 +125,7 @@ const OverridableTitusInstanceDetailsContent = overridableComponent<
 >(TitusInstanceDetailsContent, 'titus.instance.details.content');
 
 export const TitusInstanceDetails = ({ app, environment, instance, moniker }: ITitusInstanceDetailsProps) => {
+  const { providerServiceDelegate } = useDeckRuntimeServices();
   const { instanceId } = instance;
   const serverGroup = app.serverGroups.data.find((sg: ITitusServerGroup) =>
     sg.instances.some((possibleMatch) => possibleMatch.id === instanceId),
@@ -172,7 +174,7 @@ export const TitusInstanceDetails = ({ app, environment, instance, moniker }: IT
     [instanceId, serverGroup],
   );
 
-  const taskActions = buildTaskActions(currentInstance, app);
+  const taskActions = buildTaskActions(currentInstance, app, providerServiceDelegate);
   const healthMetrics = extractHealthMetrics(
     currentInstance.health as IAmazonHealth[],
     app.loadBalancers.data,

--- a/deck/packages/titus/src/instance/details/titusInstanceDetailsUtils.ts
+++ b/deck/packages/titus/src/instance/details/titusInstanceDetailsUtils.ts
@@ -6,7 +6,7 @@ import type {
   ITargetGroup,
 } from '@spinnaker/amazon';
 import { getAllTargetGroups } from '@spinnaker/amazon';
-import type { Action, Application, IInstance, IJob } from '@spinnaker/core';
+import type { Action, Application, DirectProviderServiceDelegate, IInstance, IJob } from '@spinnaker/core';
 import { ConfirmationModalService, getDirectRouter, InstanceWriter } from '@spinnaker/core';
 
 export const applyTargetGroupInfoToHealthMetric = (
@@ -79,7 +79,11 @@ const terminateInstance = (instance: IInstance, app: Application) => {
   };
 };
 
-const terminateInstanceAndShrinkServerGroup = (instance: IInstance, app: Application) => {
+const terminateInstanceAndShrinkServerGroup = (
+  instance: IInstance,
+  app: Application,
+  providerServiceDelegate: DirectProviderServiceDelegate,
+) => {
   return () => {
     const taskMonitorConfig = {
       application: app,
@@ -105,6 +109,7 @@ const terminateInstanceAndShrinkServerGroup = (instance: IInstance, app: Applica
           },
         ],
         app,
+        providerServiceDelegate,
       );
     };
 
@@ -156,10 +161,17 @@ const disableInstanceInDiscovery = (instance: IInstance, app: Application) => {
   };
 };
 
-export const buildTaskActions = (instance: IInstance, app: Application): Action[] => {
+export const buildTaskActions = (
+  instance: IInstance,
+  app: Application,
+  providerServiceDelegate: DirectProviderServiceDelegate,
+): Action[] => {
   const taskActions = [
     { label: 'Terminate', triggerAction: terminateInstance(instance, app) },
-    { label: 'Terminate and Shrink Server Group', triggerAction: terminateInstanceAndShrinkServerGroup(instance, app) },
+    {
+      label: 'Terminate and Shrink Server Group',
+      triggerAction: terminateInstanceAndShrinkServerGroup(instance, app, providerServiceDelegate),
+    },
   ];
 
   const discoveryHealth = (instance.health || []).filter((h) => h.type === 'Discovery');

--- a/deck/packages/titus/src/pipeline/stages/runJob/TitusSecurityGroupPicker.tsx
+++ b/deck/packages/titus/src/pipeline/stages/runJob/TitusSecurityGroupPicker.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import { SecurityGroupSelector, ServerGroupSecurityGroupsRemoved, VpcReader } from '@spinnaker/amazon';
 import type { IAccountDetails, IAggregatedAccounts, ISecurityGroup, IVpc } from '@spinnaker/core';
-import { AccountService, AccountTag, AngularServices, FirewallLabels } from '@spinnaker/core';
+import { AccountService, AccountTag, DeckRuntimeContext, FirewallLabels } from '@spinnaker/core';
 
 export interface ITitusSecurityGroupPickerProps {
   account: string;
@@ -25,6 +25,9 @@ export class TitusSecurityGroupPicker extends React.Component<
   ITitusSecurityGroupPickerProps,
   ITitusSecurityGroupPickerState
 > {
+  public static contextType = DeckRuntimeContext;
+  public declare context: React.ContextType<typeof DeckRuntimeContext>;
+
   public state: ITitusSecurityGroupPickerState = {
     availableGroups: [],
     removedGroups: [],
@@ -72,8 +75,8 @@ export class TitusSecurityGroupPicker extends React.Component<
   }
 
   public refreshSecurityGroups(skipCommandReconfiguration?: boolean) {
-    return AngularServices.cacheInitializer.refreshCache('securityGroups').then(() => {
-      return AngularServices.securityGroupReader.getAllSecurityGroups().then((securityGroups) => {
+    return this.context.services.cacheInitializer.refreshCache('securityGroups').then(() => {
+      return this.context.services.securityGroupReader.getAllSecurityGroups().then((securityGroups) => {
         this.securityGroups = securityGroups;
         if (!skipCommandReconfiguration) {
           this.configureSecurityGroupOptions();
@@ -122,7 +125,7 @@ export class TitusSecurityGroupPicker extends React.Component<
         this.credentials = credentials;
       },
     );
-    const groupLoader = AngularServices.securityGroupReader.getAllSecurityGroups().then((groups) => {
+    const groupLoader = this.context.services.securityGroupReader.getAllSecurityGroups().then((groups) => {
       this.securityGroups = groups;
     });
     const vpcLoader = VpcReader.listVpcs().then((vpcs: IVpc[]) => (this.vpcs = vpcs));

--- a/deck/packages/titus/src/serverGroup/configure/serverGroupConfiguration.service.spec.ts
+++ b/deck/packages/titus/src/serverGroup/configure/serverGroupConfiguration.service.spec.ts
@@ -1,18 +1,20 @@
-import { AngularServices } from '@spinnaker/core';
-
 import { getTitusServerGroupConfigurationService } from './serverGroupConfiguration.service';
 
 describe('getTitusServerGroupConfigurationService', () => {
-  it('does not resolve Angular-backed services while creating the service', () => {
-    const cacheInitializer = spyOnProperty(AngularServices, 'cacheInitializer', 'get').and.throwError(
-      'cacheInitializer should not be resolved during construction',
-    );
-    const securityGroupReader = spyOnProperty(AngularServices, 'securityGroupReader', 'get').and.throwError(
-      'securityGroupReader should not be resolved during construction',
-    );
+  it('does not invoke explicit dependencies while creating the service', () => {
+    const refreshCaches = jasmine.createSpy('refreshCaches');
+    const getLoadBalancers = jasmine.createSpy('getLoadBalancers');
+    const getAllSecurityGroups = jasmine.createSpy('getAllSecurityGroups');
 
-    expect(() => getTitusServerGroupConfigurationService()).not.toThrow();
-    expect(cacheInitializer).not.toHaveBeenCalled();
-    expect(securityGroupReader).not.toHaveBeenCalled();
+    expect(() =>
+      getTitusServerGroupConfigurationService(
+        { refreshCaches } as any,
+        { getLoadBalancers } as any,
+        { getAllSecurityGroups } as any,
+      ),
+    ).not.toThrow();
+    expect(refreshCaches).not.toHaveBeenCalled();
+    expect(getLoadBalancers).not.toHaveBeenCalled();
+    expect(getAllSecurityGroups).not.toHaveBeenCalled();
   });
 });

--- a/deck/packages/titus/src/serverGroup/configure/serverGroupConfiguration.service.ts
+++ b/deck/packages/titus/src/serverGroup/configure/serverGroupConfiguration.service.ts
@@ -10,6 +10,7 @@ import { VpcReader } from '@spinnaker/amazon';
 import type {
   Application,
   CacheInitializerService,
+  DeckRuntimeServices,
   IAccountDetails,
   ICluster,
   IDeploymentStrategy,
@@ -21,14 +22,7 @@ import type {
   LoadBalancerReader,
   SecurityGroupReader,
 } from '@spinnaker/core';
-import {
-  AccountService,
-  AngularServices,
-  NameUtils,
-  REST,
-  setMatchingResourceSummary,
-  SubnetReader,
-} from '@spinnaker/core';
+import { AccountService, NameUtils, REST, setMatchingResourceSummary, SubnetReader } from '@spinnaker/core';
 
 import type { IJobDisruptionBudget, ITitusResources } from '../../domain';
 import type { ITitusServiceJobProcesses } from '../../domain/ITitusServiceJobProcesses';
@@ -117,7 +111,7 @@ export class TitusServerGroupConfigurationService {
   ) {}
 
   private getCacheInitializer(): CacheInitializerService {
-    return this.cacheInitializer || AngularServices.cacheInitializer;
+    return this.cacheInitializer;
   }
 
   private getLoadBalancerReader(): Pick<LoadBalancerReader, 'listLoadBalancers'> {
@@ -129,7 +123,7 @@ export class TitusServerGroupConfigurationService {
   }
 
   private getSecurityGroupReader(): SecurityGroupReader {
-    return this.securityGroupReader || AngularServices.securityGroupReader;
+    return this.securityGroupReader;
   }
 
   public configureZones(command: ITitusServerGroupCommand) {
@@ -420,11 +414,17 @@ export class TitusServerGroupConfigurationService {
 }
 
 export class TitusServerGroupConfigurationServiceFactory extends TitusServerGroupConfigurationService {
-  constructor() {
-    super(null, null, null);
+  public static readonly requiresDeckRuntimeServices = true;
+
+  constructor(_promiseService: unknown, runtimeServices: DeckRuntimeServices) {
+    super(runtimeServices.cacheInitializer, runtimeServices.loadBalancerReader, runtimeServices.securityGroupReader);
   }
 }
 
-export function getTitusServerGroupConfigurationService(): TitusServerGroupConfigurationService {
-  return new TitusServerGroupConfigurationService(null, null, null);
+export function getTitusServerGroupConfigurationService(
+  cacheInitializer: CacheInitializerService,
+  loadBalancerReader: LoadBalancerReader,
+  securityGroupReader: SecurityGroupReader,
+): TitusServerGroupConfigurationService {
+  return new TitusServerGroupConfigurationService(cacheInitializer, loadBalancerReader, securityGroupReader);
 }

--- a/deck/packages/titus/src/serverGroup/configure/wizard/TitusCloneServerGroupModal.tsx
+++ b/deck/packages/titus/src/serverGroup/configure/wizard/TitusCloneServerGroupModal.tsx
@@ -2,10 +2,16 @@ import { get, isEqual } from 'lodash';
 import React from 'react';
 
 import { ServerGroupCapacity, ServerGroupLoadBalancers, ServerGroupSecurityGroups } from '@spinnaker/amazon';
-import type { Application, IModalComponentProps, IRouterInjectedProps, IStage } from '@spinnaker/core';
+import type {
+  Application,
+  DeckRuntimeServices,
+  IModalComponentProps,
+  IRouterInjectedProps,
+  IStage,
+} from '@spinnaker/core';
 import {
   AccountTag,
-  AngularServices,
+  DeckRuntimeContext,
   DeployInitializer,
   FirewallLabels,
   noop,
@@ -19,10 +25,8 @@ import {
 import { ServerGroupBasicSettings, ServerGroupParameters, ServerGroupResources } from './pages';
 import { JobDisruptionBudget } from './pages/disruptionBudget/JobDisruptionBudget';
 import type { ITitusServerGroupCommand } from '../serverGroupConfiguration.service';
-import {
-  getDefaultJobDisruptionBudgetForApp,
-  getTitusServerGroupConfigurationService,
-} from '../serverGroupConfiguration.service';
+import { getDefaultJobDisruptionBudgetForApp } from '../serverGroupConfiguration.service';
+import type { TitusServerGroupConfigurationService } from '../serverGroupConfiguration.service';
 
 export interface ITitusCloneServerGroupModalProps extends IModalComponentProps {
   title: string;
@@ -41,6 +45,9 @@ export class TitusCloneServerGroupModalComponent extends React.Component<
   ITitusCloneServerGroupModalProps & IRouterInjectedProps,
   ITitusCloneServerGroupModalState
 > {
+  public static contextType = DeckRuntimeContext;
+  public declare context: React.ContextType<typeof DeckRuntimeContext>;
+
   public static defaultProps: Partial<ITitusCloneServerGroupModalProps> = {
     closeModal: noop,
     dismissModal: noop,
@@ -49,19 +56,18 @@ export class TitusCloneServerGroupModalComponent extends React.Component<
   private _isUnmounted = false;
   private refreshUnsubscribe: () => void;
 
-  public static show(props: ITitusCloneServerGroupModalProps): Promise<ITitusServerGroupCommand> {
+  public static show(
+    props: ITitusCloneServerGroupModalProps,
+    runtimeServices: DeckRuntimeServices,
+  ): Promise<ITitusServerGroupCommand> {
     const modalProps = { dialogClassName: 'wizard-modal modal-lg' };
-    return ReactModal.show(TitusCloneServerGroupModal, props, modalProps);
+    return ReactModal.show(TitusCloneServerGroupModal, props, modalProps, runtimeServices);
   }
 
   constructor(props: ITitusCloneServerGroupModalProps & IRouterInjectedProps) {
     super(props);
 
     const requiresTemplateSelection = get(props, 'command.viewState.requiresTemplateSelection', false);
-    if (!requiresTemplateSelection) {
-      this.configureCommand();
-    }
-
     this.state = {
       firewallsLabel: FirewallLabels.get('Firewalls'),
       loaded: false,
@@ -73,6 +79,12 @@ export class TitusCloneServerGroupModalComponent extends React.Component<
         onTaskComplete: this.onTaskComplete,
       }),
     };
+  }
+
+  public componentDidMount(): void {
+    if (!this.state.requiresTemplateSelection) {
+      this.configureCommand();
+    }
   }
 
   private templateSelected = () => {
@@ -122,7 +134,9 @@ export class TitusCloneServerGroupModalComponent extends React.Component<
 
   private configureCommand = () => {
     const { command } = this.props;
-    const configurationService = getTitusServerGroupConfigurationService();
+    const configurationService = this.context.services.providerServiceDelegate.getDelegate<
+      TitusServerGroupConfigurationService
+    >('titus', 'serverGroup.configurationService');
     configurationService.configureCommand(command).then(() => {
       configurationService.configureSubnets(command);
       if (!command.credentials.includes('${')) {
@@ -155,7 +169,7 @@ export class TitusCloneServerGroupModalComponent extends React.Component<
       this.props.closeModal && this.props.closeModal(toSubmit);
     } else {
       this.state.taskMonitor.submit(() =>
-        AngularServices.serverGroupWriter.cloneServerGroup(toSubmit, this.props.application),
+        this.context.services.serverGroupWriter.cloneServerGroup(toSubmit, this.props.application),
       );
     }
   };

--- a/deck/packages/titus/src/serverGroup/details/TitusCapacityDetailsSection.tsx
+++ b/deck/packages/titus/src/serverGroup/details/TitusCapacityDetailsSection.tsx
@@ -4,6 +4,7 @@ import type { Application } from '@spinnaker/core';
 import {
   confirmNotManaged,
   CurrentCapacity,
+  DeckRuntimeContext,
   DesiredCapacity,
   Overridable,
   ReactModal,
@@ -22,6 +23,9 @@ interface ICapacityDetailsSectionProps {
 
 @Overridable('titus.serverGroup.CapacityDetailsSection')
 export class TitusCapacityDetailsSection extends React.Component<ICapacityDetailsSectionProps> {
+  public static contextType = DeckRuntimeContext;
+  public declare context: React.ContextType<typeof DeckRuntimeContext>;
+
   public render(): JSX.Element {
     const { serverGroup, app: application } = this.props;
     const { capacity } = serverGroup;
@@ -31,7 +35,12 @@ export class TitusCapacityDetailsSection extends React.Component<ICapacityDetail
     const resizeServerGroup = () =>
       confirmNotManaged(serverGroup, application).then((notManaged) => {
         notManaged &&
-          ReactModal.show<ITitusResizeServerGroupModalProps>(TitusResizeServerGroupModal, { serverGroup, application });
+          ReactModal.show<ITitusResizeServerGroupModalProps>(
+            TitusResizeServerGroupModal,
+            { serverGroup, application },
+            undefined,
+            this.context.services,
+          );
       });
 
     return (

--- a/deck/packages/titus/src/serverGroup/details/TitusSecurityGroups.tsx
+++ b/deck/packages/titus/src/serverGroup/details/TitusSecurityGroups.tsx
@@ -3,7 +3,7 @@ import { sortBy } from 'lodash';
 import React from 'react';
 
 import type { Application, ISecurityGroup } from '@spinnaker/core';
-import { AccountService, AngularServices, CollapsibleSection, FirewallLabels } from '@spinnaker/core';
+import { AccountService, CollapsibleSection, DeckRuntimeContext, FirewallLabels } from '@spinnaker/core';
 
 import type { ITitusServerGroupView } from '../../domain';
 import { TitusSecurityGroupReader } from '../../securityGroup/securityGroup.read.service';
@@ -21,6 +21,9 @@ export class TitusSecurityGroupsDetailsSection extends React.Component<
   ITitusServerGroupDetailsSectionProps,
   ISecurityGroupsDetailsSectionState
 > {
+  public static contextType = DeckRuntimeContext;
+  public declare context: React.ContextType<typeof DeckRuntimeContext>;
+
   constructor(props: ITitusServerGroupDetailsSectionProps) {
     super(props);
     this.state = {};
@@ -46,7 +49,7 @@ export class TitusSecurityGroupsDetailsSection extends React.Component<
       AccountService.listAllAccounts('titus').then((accounts) => {
         const titusAccount = accounts.find((a) => a.name === serverGroup.account);
         if (titusAccount && titusAccount.awsAccount) {
-          AngularServices.securityGroupReader.getAllSecurityGroups().then((allSecurityGroups) => {
+          this.context.services.securityGroupReader.getAllSecurityGroups().then((allSecurityGroups) => {
             const regionalGroups = allSecurityGroups[titusAccount.awsAccount]['aws'][region];
             const securityGroups = serverGroup.securityGroups
               .map((sgId) => regionalGroups.find((rg) => rg.id === sgId))

--- a/deck/packages/titus/src/serverGroup/details/TitusServerGroupActions.spec.tsx
+++ b/deck/packages/titus/src/serverGroup/details/TitusServerGroupActions.spec.tsx
@@ -9,6 +9,7 @@ import { TitusServerGroupActionsComponent as TitusServerGroupActions } from './T
 import { TitusRollbackServerGroupModal } from './rollback/TitusRollbackServerGroupModal';
 
 describe('<TitusServerGroupActions />', () => {
+  const runtimeServices = {} as any;
   let $rootScope: IRootScopeService;
 
   beforeEach(
@@ -63,17 +64,21 @@ describe('<TitusServerGroupActions />', () => {
     const app = buildApp([previousServerGroup, serverGroup]);
     const show = spyOn(TitusRollbackServerGroupModal, 'show').and.returnValue(Promise.resolve({} as any));
     const wrapper = shallow(<TitusServerGroupActions app={app} serverGroup={serverGroup} />);
+    (wrapper.instance() as any).context = { services: runtimeServices };
 
     rollbackLinks(wrapper).simulate('click');
     $rootScope.$digest();
     await settle();
 
-    expect(show).toHaveBeenCalledOnceWith({
-      allServerGroups: [previousServerGroup],
-      application: app,
-      previousServerGroup,
-      serverGroup,
-    } as any);
+    expect(show).toHaveBeenCalledOnceWith(
+      {
+        allServerGroups: [previousServerGroup],
+        application: app,
+        previousServerGroup,
+        serverGroup,
+      } as any,
+      runtimeServices,
+    );
   });
 
   it('does not throw when rollback candidates disappear before click handling', () => {

--- a/deck/packages/titus/src/serverGroup/details/TitusServerGroupActions.tsx
+++ b/deck/packages/titus/src/serverGroup/details/TitusServerGroupActions.tsx
@@ -5,9 +5,9 @@ import { Dropdown } from 'react-bootstrap';
 import type { IRouterInjectedProps, IServerGroupActionsProps } from '@spinnaker/core';
 import {
   AddEntityTagLinks,
-  AngularServices,
   ConfirmationModalService,
   confirmNotManaged,
+  DeckRuntimeContext,
   ReactModal,
   ServerGroupWarningMessageService,
   SETTINGS,
@@ -20,6 +20,9 @@ import { TitusResizeServerGroupModal } from './resize/TitusResizeServerGroupModa
 import { TitusRollbackServerGroupModal } from './rollback/TitusRollbackServerGroupModal';
 
 export class TitusServerGroupActionsComponent extends React.Component<IServerGroupActionsProps & IRouterInjectedProps> {
+  public static contextType = DeckRuntimeContext;
+  public declare context: React.ContextType<typeof DeckRuntimeContext>;
+
   private destroyServerGroup = (): void => {
     const { app, serverGroup } = this.props;
     const taskMonitorConfig = {
@@ -40,7 +43,7 @@ export class TitusServerGroupActionsComponent extends React.Component<IServerGro
       platformHealthOnlyShowOverride: app.attributes.platformHealthOnlyShowOverride,
       platformHealthType: 'Titus',
       submitMethod: () =>
-        AngularServices.serverGroupWriter.destroyServerGroup(serverGroup, app, {
+        this.context.services.serverGroupWriter.destroyServerGroup(serverGroup, app, {
           cloudProvider: 'titus',
           serverGroupName: serverGroup.name,
           region: serverGroup.region,
@@ -62,7 +65,7 @@ export class TitusServerGroupActionsComponent extends React.Component<IServerGro
       platformHealthOnlyShowOverride: app.attributes.platformHealthOnlyShowOverride,
       platformHealthType: 'Titus',
       submitMethod: () =>
-        AngularServices.serverGroupWriter.disableServerGroup(serverGroup, app.name, {
+        this.context.services.serverGroupWriter.disableServerGroup(serverGroup, app.name, {
           cloudProvider: 'titus',
           serverGroupName: serverGroup.name,
           region: serverGroup.region,
@@ -85,7 +88,7 @@ export class TitusServerGroupActionsComponent extends React.Component<IServerGro
       platformHealthOnlyShowOverride: app.attributes.platformHealthOnlyShowOverride,
       platformHealthType: 'Titus',
       submitMethod: () =>
-        AngularServices.serverGroupWriter.enableServerGroup(serverGroup, app, {
+        this.context.services.serverGroupWriter.enableServerGroup(serverGroup, app, {
           cloudProvider: 'titus',
           serverGroupName: serverGroup.name,
           region: serverGroup.region,
@@ -172,12 +175,15 @@ export class TitusServerGroupActionsComponent extends React.Component<IServerGro
       if (!notManaged) {
         return;
       }
-      TitusRollbackServerGroupModal.show({
-        allServerGroups,
-        application: app,
-        previousServerGroup,
-        serverGroup,
-      } as any);
+      TitusRollbackServerGroupModal.show(
+        {
+          allServerGroups,
+          application: app,
+          previousServerGroup,
+          serverGroup,
+        } as any,
+        this.context.services,
+      );
     });
   };
 
@@ -185,14 +191,23 @@ export class TitusServerGroupActionsComponent extends React.Component<IServerGro
     const { app, serverGroup } = this.props;
     confirmNotManaged(serverGroup, app).then(
       (notManaged) =>
-        notManaged && ReactModal.show(TitusResizeServerGroupModal, { serverGroup, application: app } as any),
+        notManaged &&
+        ReactModal.show(
+          TitusResizeServerGroupModal,
+          { serverGroup, application: app } as any,
+          undefined,
+          this.context.services,
+        ),
     );
   };
 
   private cloneServerGroup = (): void => {
     const { app, serverGroup } = this.props;
     TitusServerGroupCommandBuilder.buildServerGroupCommandFromExisting(app, serverGroup).then((command: any) => {
-      TitusCloneServerGroupModal.show({ title: `Clone ${serverGroup.name}`, application: app, command });
+      TitusCloneServerGroupModal.show(
+        { title: `Clone ${serverGroup.name}`, application: app, command },
+        this.context.services,
+      );
     });
   };
 

--- a/deck/packages/titus/src/serverGroup/details/resize/TitusResizeServerGroupModal.tsx
+++ b/deck/packages/titus/src/serverGroup/details/resize/TitusResizeServerGroupModal.tsx
@@ -5,7 +5,6 @@ import { Modal } from 'react-bootstrap';
 
 import type { Application, ICapacity, IModalComponentProps } from '@spinnaker/core';
 import {
-  AngularServices,
   FormikFormField,
   MinMaxDesiredChanges,
   ModalClose,
@@ -13,6 +12,7 @@ import {
   PlatformHealthOverride,
   SpinFormik,
   TaskMonitorWrapper,
+  useDeckRuntimeServices,
   UserVerification,
   useTaskMonitor,
   ValidationMessage,
@@ -215,6 +215,7 @@ function validateResizeCommand(values: ITitusResizeServerGroupCommand) {
 }
 
 export function TitusResizeServerGroupModal(props: ITitusResizeServerGroupModalProps) {
+  const { serverGroupWriter } = useDeckRuntimeServices();
   const { serverGroup, application, dismissModal } = props;
 
   const initialAdvancedMode = useMemo(() => {
@@ -236,7 +237,7 @@ export function TitusResizeServerGroupModal(props: ITitusResizeServerGroupModalP
     dismissModal,
   );
   const submit = (command: ITitusResizeServerGroupCommand) =>
-    taskMonitor.submit(() => AngularServices.serverGroupWriter.resizeServerGroup(serverGroup, application, command));
+    taskMonitor.submit(() => serverGroupWriter.resizeServerGroup(serverGroup, application, command));
 
   const initialValues = { capacity: serverGroup.capacity } as ITitusResizeServerGroupCommand;
 

--- a/deck/packages/titus/src/serverGroup/details/rollback/TitusRollbackServerGroupModal.tsx
+++ b/deck/packages/titus/src/serverGroup/details/rollback/TitusRollbackServerGroupModal.tsx
@@ -2,9 +2,9 @@ import { get } from 'lodash';
 import React from 'react';
 import { Modal, ModalFooter } from 'react-bootstrap';
 
-import type { Application, IModalComponentProps, IServerGroupJob } from '@spinnaker/core';
+import type { Application, DeckRuntimeServices, IModalComponentProps, IServerGroupJob } from '@spinnaker/core';
 import {
-  AngularServices,
+  DeckRuntimeContext,
   FormikFormField,
   ModalClose,
   noop,
@@ -59,13 +59,19 @@ export class TitusRollbackServerGroupModal extends React.Component<
   ITitusRollbackServerGroupModalProps,
   ITitusRollbackServerGroupModalState
 > {
+  public static contextType = DeckRuntimeContext;
+  public declare context: React.ContextType<typeof DeckRuntimeContext>;
+
   public static defaultProps: Partial<ITitusRollbackServerGroupModalProps> = {
     closeModal: noop,
     dismissModal: noop,
   };
 
-  public static show(props: ITitusRollbackServerGroupModalProps): Promise<ITitusRollbackJob> {
-    return ReactModal.show(TitusRollbackServerGroupModal, props);
+  public static show(
+    props: ITitusRollbackServerGroupModalProps,
+    runtimeServices: DeckRuntimeServices,
+  ): Promise<ITitusRollbackJob> {
+    return ReactModal.show(TitusRollbackServerGroupModal, props, undefined, runtimeServices);
   }
 
   constructor(props: ITitusRollbackServerGroupModalProps) {
@@ -177,7 +183,7 @@ export class TitusRollbackServerGroupModal extends React.Component<
     };
 
     this.state.taskMonitor.submit(() =>
-      AngularServices.serverGroupWriter.rollbackServerGroup(serverGroup, application, command),
+      this.context.services.serverGroupWriter.rollbackServerGroup(serverGroup, application, command),
     );
   };
 

--- a/deck/test/functional/cypress/integration/google/clone.spec.js
+++ b/deck/test/functional/cypress/integration/google/clone.spec.js
@@ -549,13 +549,9 @@ function installGceTestHarness() {
     const core = win.spinnaker?.plugins?.sharedLibraries?._spinnaker_core;
     expect(core, 'shared @spinnaker/core library').to.exist;
 
-    const actualSecurityGroupReader = core.AngularServices.securityGroupReader;
-    const securityGroupReader = new Proxy(actualSecurityGroupReader, {
-      get: (target, property) => {
-        const value = target[property];
-        return typeof value === 'function' ? value.bind(target) : value;
-      },
-    });
+    const securityGroupReader = {
+      getAllSecurityGroups: () => core.REST('/securityGroups').get(),
+    };
     const instanceTypeService = createInstanceTypeService(core);
     const commandBuilder = createCommandBuilder(core, instanceTypeService);
     const lifecycle = [];
@@ -563,7 +559,7 @@ function installGceTestHarness() {
       ...createWizardAdapter(core, instanceTypeService, securityGroupReader, win, lifecycle),
       ...commandBuilder,
     };
-    const facade = core.AngularServices.serverGroupCommandBuilder;
+    const facade = core.ServerGroupCommandBuilderService.prototype;
     facade.buildNewServerGroupCommand = (application, _provider, defaults) =>
       commandBuilder.buildNewServerGroupCommand(application, defaults);
     facade.buildNewServerGroupCommandForPipeline = (_provider, stage, pipeline) =>
@@ -573,9 +569,18 @@ function installGceTestHarness() {
 
     const CloneServerGroupModal = core.CloudProviderRegistry.getValue('gce', 'serverGroup.CloneServerGroupModal');
     const showModal = CloneServerGroupModal.show.bind(CloneServerGroupModal);
-    const showModalWithAdapter = (props) => showModal({ ...props, adapter });
+    const runtime = core.createDeckRuntime(core.getDirectRouter());
+    const showModalWithAdapter = (props, runtimeServices = runtime.services) =>
+      showModal({ ...props, adapter }, runtimeServices);
     core.CloudProviderRegistry.overrideValue('gce', 'serverGroup.CloneServerGroupModal.show', showModalWithAdapter);
-    win.__gceFunctionalHarness = { adapter, commandBuilder, core, lifecycle, showModal: showModalWithAdapter };
+    win.__gceFunctionalHarness = {
+      adapter,
+      commandBuilder,
+      core,
+      lifecycle,
+      runtime,
+      showModal: showModalWithAdapter,
+    };
   });
 }
 


### PR DESCRIPTION
Migrate all consumers of `AngularService` to native equivalents.