### PR TITLE
feat(orca): make MonitorAwsCodeBuildTask backoffPeriod and timeout configurable

### DIFF
--- a/orca/orca-igor/src/main/java/com/netflix/spinnaker/orca/igor/tasks/MonitorAwsCodeBuildProperties.java
+++ b/orca/orca-igor/src/main/java/com/netflix/spinnaker/orca/igor/tasks/MonitorAwsCodeBuildProperties.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2024 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.igor.tasks;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "tasks.monitor-aws-code-build")
+public class MonitorAwsCodeBuildProperties {
+  /** Polling interval in milliseconds between build status checks. */
+  private long backoffPeriod = 10000;
+
+  /** Maximum time in milliseconds to wait for a build to complete. */
+  private long timeout = 28800000;
+}

--- a/orca/orca-igor/src/main/java/com/netflix/spinnaker/orca/igor/tasks/MonitorAwsCodeBuildTask.java
+++ b/orca/orca-igor/src/main/java/com/netflix/spinnaker/orca/igor/tasks/MonitorAwsCodeBuildTask.java
@@ -25,22 +25,31 @@ import com.netflix.spinnaker.orca.igor.model.AwsCodeBuildExecution;
 import com.netflix.spinnaker.orca.igor.model.AwsCodeBuildStageDefinition;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnull;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
+@EnableConfigurationProperties(MonitorAwsCodeBuildProperties.class)
 @Slf4j
 public class MonitorAwsCodeBuildTask extends RetryableIgorTask<AwsCodeBuildStageDefinition>
     implements OverridableTimeoutRetryableTask {
-  @Getter protected long backoffPeriod = TimeUnit.SECONDS.toMillis(10);
-  @Getter protected long timeout = TimeUnit.HOURS.toMillis(8); // maximum build timeout
 
   private final IgorService igorService;
+  private final MonitorAwsCodeBuildProperties properties;
+
+  @Override
+  public long getBackoffPeriod() {
+    return properties.getBackoffPeriod();
+  }
+
+  @Override
+  public long getTimeout() {
+    return properties.getTimeout();
+  }
 
   @Override
   @Nonnull

--- a/orca/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/MonitorAwsCodeBuildTaskSpec.groovy
+++ b/orca/orca-igor/src/test/groovy/com/netflix/spinnaker/orca/igor/tasks/MonitorAwsCodeBuildTaskSpec.groovy
@@ -29,6 +29,8 @@ import spock.lang.Specification
 import spock.lang.Subject
 import spock.lang.Unroll
 
+import java.util.concurrent.TimeUnit
+
 class MonitorAwsCodeBuildTaskSpec extends Specification {
   String ACCOUNT = "my-account"
   String BUILD_ID = "test:c7715bbf-5c12-44d6-87ef-8149473e02f7"
@@ -37,8 +39,13 @@ class MonitorAwsCodeBuildTaskSpec extends Specification {
   PipelineExecutionImpl execution = Mock(PipelineExecutionImpl)
   IgorService igorService = Mock(IgorService)
 
+  def properties = new MonitorAwsCodeBuildProperties(
+    backoffPeriod: TimeUnit.SECONDS.toMillis(10),
+    timeout: TimeUnit.HOURS.toMillis(8)
+  )
+
   @Subject
-  MonitorAwsCodeBuildTask task = new MonitorAwsCodeBuildTask(igorService)
+  MonitorAwsCodeBuildTask task = new MonitorAwsCodeBuildTask(igorService, properties)
 
   @Unroll
   def "task returns #executionStatus when build returns #buildStatus"() {


### PR DESCRIPTION
## Summary

Makes `MonitorAwsCodeBuildTask`'s `backoffPeriod` and `timeout` configurable via a `@ConfigurationProperties` class, allowing operators to tune the CodeBuild polling interval without maintaining a custom image.

Closes https://github.com/spinnaker/spinnaker/issues/7849

## Changes

- Added `MonitorAwsCodeBuildProperties` class with `@ConfigurationProperties(prefix = "tasks.monitor-aws-code-build")`
- Updated `MonitorAwsCodeBuildTask` to inject and delegate to the properties class
- Updated `MonitorAwsCodeBuildTaskSpec` to pass properties via constructor

## Configuration

```yaml
tasks:
  monitorAwsCodeBuild:
    backoffPeriod: 30000   # default: 10000 (10s)
    timeout: 28800000      # default: 28800000 (8h)
```

## Why

At scale, the hardcoded 10s polling interval generates excessive `BatchGetBuilds` API calls, causing AWS throttling. We've been running this patch in production — setting `backoffPeriod` to 30s reduced API call volume by ~3x.

## Notes

- Non-breaking: defaults are identical to current hardcoded values
- Follows the same `@ConfigurationProperties` + `@EnableConfigurationProperties` pattern used elsewhere in the codebase (e.g. `IgorFeatureFlagProperties`)
- Spring relaxed binding means both `tasks.monitor-aws-code-build.backoff-period` and `tasks.monitorAwsCodeBuild.backoffPeriod` work in YAML

---