### PR TITLE
feat(lambdaInvoke): Opt-In in resolving in Orca the Invoke payload artifact

### DIFF
--- a/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/aws/lambda/LambdaInvokeStage.java
+++ b/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/aws/lambda/LambdaInvokeStage.java
@@ -16,15 +16,18 @@
 
 package com.netflix.spinnaker.orca.clouddriver.pipeline.providers.aws.lambda;
 
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService;
 import com.netflix.spinnaker.orca.api.pipeline.graph.StageDefinitionBuilder;
 import com.netflix.spinnaker.orca.api.pipeline.graph.TaskNode;
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
 import com.netflix.spinnaker.orca.clouddriver.tasks.providers.aws.lambda.LambdaCacheRefreshTask;
 import com.netflix.spinnaker.orca.clouddriver.tasks.providers.aws.lambda.LambdaInvokeTask;
 import com.netflix.spinnaker.orca.clouddriver.tasks.providers.aws.lambda.LambdaInvokeVerificationTask;
+import com.netflix.spinnaker.orca.clouddriver.tasks.providers.aws.lambda.LambdaResolveInvokeArtifactTask;
 import javax.annotation.Nonnull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -32,15 +35,30 @@ import org.springframework.stereotype.Component;
 public class LambdaInvokeStage implements StageDefinitionBuilder {
   private static final Logger logger = LoggerFactory.getLogger(LambdaInvokeStage.class);
 
-  public LambdaInvokeStage() {
+  private static final String RESOLVE_PAYLOAD_ARTIFACT_FLAG =
+      "stages.lambda-invoke.resolve-payload-artifact";
+
+  private final DynamicConfigService dynamicConfigService;
+
+  @Autowired
+  public LambdaInvokeStage(DynamicConfigService dynamicConfigService) {
+    this.dynamicConfigService = dynamicConfigService;
     logger.debug("Constructing Aws.LambdaInvokeStage");
   }
 
   @Override
   public void taskGraph(@Nonnull StageExecution stage, @Nonnull TaskNode.Builder builder) {
     logger.debug("taskGraph for Aws.LambdaInvokeStage");
+    if (shouldResolvePayloadArtifact(stage)) {
+      builder.withTask(
+          LambdaResolveInvokeArtifactTask.TASK_NAME, LambdaResolveInvokeArtifactTask.class);
+    }
     builder.withTask("lambdaInvokeTask", LambdaInvokeTask.class);
     builder.withTask("lambdaInvokeVerificationTask", LambdaInvokeVerificationTask.class);
     builder.withTask("lambdaCacheRefreshTask", LambdaCacheRefreshTask.class);
+  }
+
+  private boolean shouldResolvePayloadArtifact(StageExecution stage) {
+    return dynamicConfigService.isEnabled(RESOLVE_PAYLOAD_ARTIFACT_FLAG, false);
   }
 }

--- a/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/aws/lambda/LambdaStageConstants.java
+++ b/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/aws/lambda/LambdaStageConstants.java
@@ -45,6 +45,8 @@ public class LambdaStageConstants {
   public static final String resourceIdKey = "resourceId";
   public static final String functionNameKey = "functionName";
   public static final String urlKey = "url";
+  public static final String resolvedPayloadKey = "resolvedPayload";
+  public static final String resolvedPayloadArtifactKey = "resolvedPayloadArtifact";
 
   public static List<String> allUrlKeys =
       List.of(

--- a/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/lambda/LambdaInvokeTask.java
+++ b/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/lambda/LambdaInvokeTask.java
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.orca.clouddriver.tasks.providers.aws.lambda;
 import com.netflix.spinnaker.orca.api.pipeline.TaskResult;
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
 import com.netflix.spinnaker.orca.clouddriver.config.CloudDriverConfigurationProperties;
+import com.netflix.spinnaker.orca.clouddriver.pipeline.providers.aws.lambda.LambdaStageConstants;
 import com.netflix.spinnaker.orca.clouddriver.tasks.providers.aws.lambda.model.LambdaCloudDriverResponse;
 import com.netflix.spinnaker.orca.clouddriver.tasks.providers.aws.lambda.model.LambdaDefinition;
 import com.netflix.spinnaker.orca.clouddriver.tasks.providers.aws.lambda.model.input.LambdaInvokeStageInput;
@@ -55,8 +56,18 @@ public class LambdaInvokeTask implements LambdaStageBaseTask {
       return this.formErrorTaskResult(stage, "No such lambda found.");
     }
     LambdaInvokeStageInput ldi = utils.getInput(stage, LambdaInvokeStageInput.class);
-    LambdaTrafficUpdateInput tui = utils.getInput(stage, LambdaTrafficUpdateInput.class);
-    ldi.setPayloadArtifact(tui.getPayloadArtifact().getArtifact());
+
+    Object resolvedPayload = stage.getContext().get(LambdaStageConstants.resolvedPayloadKey);
+    if (resolvedPayload != null) {
+      ldi.setPayload(resolvedPayload.toString());
+      ldi.setPayloadArtifact(null);
+    } else {
+      LambdaTrafficUpdateInput tui = utils.getInput(stage, LambdaTrafficUpdateInput.class);
+      if (tui != null && tui.getPayloadArtifact() != null) {
+        ldi.setPayloadArtifact(tui.getPayloadArtifact().getArtifact());
+      }
+    }
+
     ldi.setQualifier(
         StringUtils.isNullOrEmpty(ldi.getAliasName()) ? "$LATEST" : ldi.getAliasName());
     ldi.setAppName(stage.getExecution().getApplication());

--- a/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/lambda/LambdaResolveInvokeArtifactTask.java
+++ b/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/lambda/LambdaResolveInvokeArtifactTask.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2026 Harness, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.tasks.providers.aws.lambda;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import com.netflix.spinnaker.kork.retrofit.Retrofit2SyncCall;
+import com.netflix.spinnaker.orca.api.pipeline.Task;
+import com.netflix.spinnaker.orca.api.pipeline.TaskResult;
+import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus;
+import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
+import com.netflix.spinnaker.orca.clouddriver.OortService;
+import com.netflix.spinnaker.orca.clouddriver.pipeline.providers.aws.lambda.LambdaStageConstants;
+import com.netflix.spinnaker.orca.clouddriver.tasks.providers.aws.lambda.model.LambdaHealthCheckArtifact;
+import com.netflix.spinnaker.orca.clouddriver.tasks.providers.aws.lambda.model.LambdaPipelineArtifact;
+import com.netflix.spinnaker.orca.clouddriver.tasks.providers.aws.lambda.model.input.LambdaTrafficUpdateInput;
+import com.netflix.spinnaker.orca.pipeline.util.ArtifactUtils;
+import java.io.IOException;
+import java.util.Collections;
+import javax.annotation.Nonnull;
+import okhttp3.ResponseBody;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class LambdaResolveInvokeArtifactTask implements Task {
+  private static final Logger logger =
+      LoggerFactory.getLogger(LambdaResolveInvokeArtifactTask.class);
+
+  public static final String TASK_NAME = "lambdaResolveInvokeArtifact";
+
+  private final ArtifactUtils artifactUtils;
+  private final OortService oortService;
+  private final ObjectMapper objectMapper;
+
+  @Autowired
+  public LambdaResolveInvokeArtifactTask(
+      ArtifactUtils artifactUtils, OortService oortService, ObjectMapper objectMapper) {
+    this.artifactUtils = artifactUtils;
+    this.oortService = oortService;
+    this.objectMapper = objectMapper;
+  }
+
+  @Nonnull
+  @Override
+  public TaskResult execute(@Nonnull StageExecution stage) {
+    logger.debug("Executing LambdaResolveInvokeArtifactTask...");
+
+    LambdaTrafficUpdateInput input =
+        objectMapper.convertValue(stage.getContext(), LambdaTrafficUpdateInput.class);
+    LambdaHealthCheckArtifact payloadArtifact = input == null ? null : input.getPayloadArtifact();
+
+    if (payloadArtifact == null) {
+      logger.debug("No payload artifact configured; skipping resolution.");
+      return TaskResult.SUCCEEDED;
+    }
+
+    String artifactId = payloadArtifact.getId();
+    LambdaPipelineArtifact defaultArtifact = payloadArtifact.getArtifact();
+
+    if (StringUtils.isBlank(artifactId) && defaultArtifact == null) {
+      logger.debug("Payload artifact is empty; skipping resolution.");
+      return TaskResult.SUCCEEDED;
+    }
+
+    Artifact artifact =
+        artifactUtils.getBoundArtifactForStage(
+            stage,
+            StringUtils.isBlank(artifactId) ? null : artifactId,
+            toKorkArtifact(defaultArtifact));
+
+    if (artifact == null || StringUtils.isBlank(artifact.getReference())) {
+      throw new IllegalStateException("Could not resolve payload artifact for Lambda invoke.");
+    }
+
+    String payload = fetchArtifactContent(artifact);
+    logger.debug("Resolved Lambda invoke payload artifact, content length: {}", payload.length());
+
+    return TaskResult.builder(ExecutionStatus.SUCCEEDED)
+        .context(
+            ImmutableMap.of(
+                LambdaStageConstants.resolvedPayloadKey,
+                payload,
+                LambdaStageConstants.resolvedPayloadArtifactKey,
+                artifact))
+        .outputs(Collections.singletonMap(LambdaStageConstants.resolvedPayloadKey, payload))
+        .build();
+  }
+
+  private Artifact toKorkArtifact(LambdaPipelineArtifact artifact) {
+    if (artifact == null) {
+      return null;
+    }
+    return Artifact.builder()
+        .uuid(artifact.getId())
+        .artifactAccount(artifact.getArtifactAccount())
+        .type(artifact.getType())
+        .reference(artifact.getReference())
+        .name(artifact.getName())
+        .version(artifact.getVersion())
+        .location(artifact.getLocation())
+        .provenance(artifact.getProvenance())
+        .build();
+  }
+
+  private String fetchArtifactContent(Artifact artifact) {
+    try (ResponseBody body = Retrofit2SyncCall.execute(oortService.fetchArtifact(artifact))) {
+      return body.string();
+    } catch (IOException e) {
+      throw new IllegalStateException("Failed to fetch payload artifact content", e);
+    }
+  }
+}

--- a/orca/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/aws/lambda/LambdaInvokeStageTest.java
+++ b/orca/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/pipeline/providers/aws/lambda/LambdaInvokeStageTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2026 Harness, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.pipeline.providers.aws.lambda;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService;
+import com.netflix.spinnaker.orca.api.pipeline.Task;
+import com.netflix.spinnaker.orca.api.pipeline.graph.TaskNode;
+import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionType;
+import com.netflix.spinnaker.orca.clouddriver.tasks.providers.aws.lambda.LambdaCacheRefreshTask;
+import com.netflix.spinnaker.orca.clouddriver.tasks.providers.aws.lambda.LambdaInvokeTask;
+import com.netflix.spinnaker.orca.clouddriver.tasks.providers.aws.lambda.LambdaInvokeVerificationTask;
+import com.netflix.spinnaker.orca.clouddriver.tasks.providers.aws.lambda.LambdaResolveInvokeArtifactTask;
+import com.netflix.spinnaker.orca.pipeline.model.PipelineExecutionImpl;
+import com.netflix.spinnaker.orca.pipeline.model.StageExecutionImpl;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class LambdaInvokeStageTest {
+
+  private DynamicConfigService dynamicConfigService;
+  private LambdaInvokeStage lambdaInvokeStage;
+
+  @BeforeEach
+  void setUp() {
+    dynamicConfigService = mock(DynamicConfigService.class);
+    lambdaInvokeStage = new LambdaInvokeStage(dynamicConfigService);
+  }
+
+  @Test
+  void taskGraph_includesResolveTaskWhenFlagEnabled() {
+    when(dynamicConfigService.isEnabled("stages.lambda-invoke.resolve-payload-artifact", false))
+        .thenReturn(true);
+
+    StageExecutionImpl stage = buildStage(new HashMap<>());
+
+    TaskNode.TaskGraph graph =
+        TaskNode.build(
+            TaskNode.GraphType.FULL, builder -> lambdaInvokeStage.taskGraph(stage, builder));
+
+    assertThat(getTaskClasses(graph))
+        .containsExactly(
+            LambdaResolveInvokeArtifactTask.class,
+            LambdaInvokeTask.class,
+            LambdaInvokeVerificationTask.class,
+            LambdaCacheRefreshTask.class);
+  }
+
+  @Test
+  void taskGraph_excludesResolveTaskWhenFlagDisabled() {
+    when(dynamicConfigService.isEnabled("stages.lambda-invoke.resolve-payload-artifact", false))
+        .thenReturn(false);
+
+    StageExecutionImpl stage = buildStage(new HashMap<>());
+
+    TaskNode.TaskGraph graph =
+        TaskNode.build(
+            TaskNode.GraphType.FULL, builder -> lambdaInvokeStage.taskGraph(stage, builder));
+
+    assertThat(getTaskClasses(graph))
+        .containsExactly(
+            LambdaInvokeTask.class,
+            LambdaInvokeVerificationTask.class,
+            LambdaCacheRefreshTask.class);
+  }
+
+  private StageExecutionImpl buildStage(Map<String, Object> context) {
+    PipelineExecutionImpl pipeline =
+        new PipelineExecutionImpl(ExecutionType.PIPELINE, "1", "lambdaApp");
+    StageExecutionImpl stage =
+        new StageExecutionImpl(pipeline, "Aws.LambdaInvokeStage", "Invoke Lambda", context);
+    pipeline.getStages().add(stage);
+    return stage;
+  }
+
+  private List<Class<? extends Task>> getTaskClasses(TaskNode.TaskGraph graph) {
+    List<Class<? extends Task>> classes = new ArrayList<>();
+    for (TaskNode node : graph) {
+      classes.add(((TaskNode.TaskDefinition) node).getImplementingClass());
+    }
+    return classes;
+  }
+}

--- a/orca/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/lambda/LambdaInvokeTaskTest.java
+++ b/orca/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/lambda/LambdaInvokeTaskTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2026 Harness, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.tasks.providers.aws.lambda;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus;
+import com.netflix.spinnaker.orca.api.pipeline.models.PipelineExecution;
+import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
+import com.netflix.spinnaker.orca.clouddriver.config.CloudDriverConfigurationProperties;
+import com.netflix.spinnaker.orca.clouddriver.pipeline.providers.aws.lambda.LambdaStageConstants;
+import com.netflix.spinnaker.orca.clouddriver.tasks.providers.aws.lambda.model.LambdaCloudDriverResponse;
+import com.netflix.spinnaker.orca.clouddriver.tasks.providers.aws.lambda.model.LambdaDefinition;
+import com.netflix.spinnaker.orca.clouddriver.tasks.providers.aws.lambda.model.LambdaHealthCheckArtifact;
+import com.netflix.spinnaker.orca.clouddriver.tasks.providers.aws.lambda.model.LambdaPipelineArtifact;
+import com.netflix.spinnaker.orca.clouddriver.tasks.providers.aws.lambda.model.input.LambdaInvokeStageInput;
+import com.netflix.spinnaker.orca.clouddriver.tasks.providers.aws.lambda.model.input.LambdaTrafficUpdateInput;
+import com.netflix.spinnaker.orca.clouddriver.utils.LambdaCloudDriverUtils;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class LambdaInvokeTaskTest {
+
+  @InjectMocks private LambdaInvokeTask lambdaInvokeTask;
+
+  @Mock private CloudDriverConfigurationProperties propsMock;
+
+  @Mock private LambdaCloudDriverUtils lambdaCloudDriverUtilsMock;
+
+  @Mock private StageExecution stageExecution;
+
+  @Mock private PipelineExecution pipelineExecution;
+
+  @BeforeEach
+  void init() {
+    when(stageExecution.getExecution()).thenReturn(pipelineExecution);
+    when(pipelineExecution.getApplication()).thenReturn("lambdaApp");
+    when(stageExecution.getContext()).thenReturn(new HashMap<>());
+  }
+
+  @Test
+  void execute_usesResolvedPayloadWhenPresent() {
+    LambdaDefinition lambdaDefinition = LambdaDefinition.builder().build();
+    when(lambdaCloudDriverUtilsMock.retrieveLambdaFromCache(stageExecution, true))
+        .thenReturn(lambdaDefinition);
+
+    LambdaInvokeStageInput ldi =
+        LambdaInvokeStageInput.builder().functionName("fn").executionCount(1).build();
+    when(lambdaCloudDriverUtilsMock.getInput(stageExecution, LambdaInvokeStageInput.class))
+        .thenReturn(ldi);
+
+    Map<String, Object> context = new HashMap<>();
+    context.put(LambdaStageConstants.resolvedPayloadKey, "resolved-payload");
+    when(stageExecution.getContext()).thenReturn(context);
+
+    LambdaCloudDriverResponse response =
+        LambdaCloudDriverResponse.builder().resourceUri("/resourceUri").build();
+    when(lambdaCloudDriverUtilsMock.postToCloudDriver(any(), any())).thenReturn(response);
+    when(propsMock.getCloudDriverBaseUrl()).thenReturn("http://clouddriver");
+
+    assertEquals(ExecutionStatus.SUCCEEDED, lambdaInvokeTask.execute(stageExecution).getStatus());
+
+    assertEquals("resolved-payload", ldi.getPayload());
+    assertNull(ldi.getPayloadArtifact());
+  }
+
+  @Test
+  void execute_fallsBackToPayloadArtifactWhenResolvedPayloadAbsent() {
+    LambdaDefinition lambdaDefinition = LambdaDefinition.builder().build();
+    when(lambdaCloudDriverUtilsMock.retrieveLambdaFromCache(stageExecution, true))
+        .thenReturn(lambdaDefinition);
+
+    LambdaInvokeStageInput ldi =
+        LambdaInvokeStageInput.builder().functionName("fn").executionCount(1).build();
+    when(lambdaCloudDriverUtilsMock.getInput(stageExecution, LambdaInvokeStageInput.class))
+        .thenReturn(ldi);
+
+    LambdaPipelineArtifact artifact =
+        LambdaPipelineArtifact.builder()
+            .type("s3/object")
+            .reference("s3://bucket/payload.json")
+            .build();
+    LambdaTrafficUpdateInput tui =
+        LambdaTrafficUpdateInput.builder()
+            .payloadArtifact(LambdaHealthCheckArtifact.builder().artifact(artifact).build())
+            .build();
+    when(lambdaCloudDriverUtilsMock.getInput(stageExecution, LambdaTrafficUpdateInput.class))
+        .thenReturn(tui);
+
+    LambdaCloudDriverResponse response =
+        LambdaCloudDriverResponse.builder().resourceUri("/resourceUri").build();
+    when(lambdaCloudDriverUtilsMock.postToCloudDriver(any(), any())).thenReturn(response);
+    when(propsMock.getCloudDriverBaseUrl()).thenReturn("http://clouddriver");
+
+    assertEquals(ExecutionStatus.SUCCEEDED, lambdaInvokeTask.execute(stageExecution).getStatus());
+
+    assertNull(ldi.getPayload());
+    assertNotNull(ldi.getPayloadArtifact());
+    assertEquals("s3://bucket/payload.json", ldi.getPayloadArtifact().getReference());
+  }
+}

--- a/orca/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/lambda/LambdaResolveInvokeArtifactTaskTest.java
+++ b/orca/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/tasks/providers/aws/lambda/LambdaResolveInvokeArtifactTaskTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2026 Harness, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.tasks.providers.aws.lambda;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus;
+import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
+import com.netflix.spinnaker.orca.clouddriver.OortService;
+import com.netflix.spinnaker.orca.clouddriver.pipeline.providers.aws.lambda.LambdaStageConstants;
+import com.netflix.spinnaker.orca.jackson.OrcaObjectMapper;
+import com.netflix.spinnaker.orca.pipeline.model.StageExecutionImpl;
+import com.netflix.spinnaker.orca.pipeline.util.ArtifactUtils;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import okhttp3.ResponseBody;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import retrofit2.mock.Calls;
+
+@ExtendWith(MockitoExtension.class)
+class LambdaResolveInvokeArtifactTaskTest {
+
+  private static final ObjectMapper objectMapper = OrcaObjectMapper.getInstance();
+
+  @Mock private ArtifactUtils artifactUtils;
+
+  @Mock private OortService oortService;
+
+  private LambdaResolveInvokeArtifactTask task;
+
+  @BeforeEach
+  void setUp() {
+    task = new LambdaResolveInvokeArtifactTask(artifactUtils, oortService, objectMapper);
+  }
+
+  @Test
+  void execute_resolvesInlineArtifactAndStoresPayload() throws IOException {
+    Map<String, Object> context = new HashMap<>();
+    context.put(
+        "payloadArtifact",
+        Map.of(
+            "id", "",
+            "account", "my-account",
+            "artifact",
+                Map.of(
+                    "type", "s3/object",
+                    "reference", "s3://bucket/payload.json",
+                    "artifactAccount", "s3-account")));
+
+    StageExecution stage = new StageExecutionImpl();
+    stage.setContext(context);
+
+    Artifact resolvedArtifact =
+        Artifact.builder()
+            .type("s3/object")
+            .reference("s3://bucket/payload.json")
+            .artifactAccount("s3-account")
+            .build();
+
+    when(artifactUtils.getBoundArtifactForStage(any(), any(), any())).thenReturn(resolvedArtifact);
+    when(oortService.fetchArtifact(resolvedArtifact))
+        .thenReturn(
+            Calls.response(
+                ResponseBody.create(
+                    okhttp3.MediaType.parse("application/json"), "{\"key\": \"value\"}")));
+
+    var result = task.execute(stage);
+
+    assertEquals(ExecutionStatus.SUCCEEDED, result.getStatus());
+    assertEquals(
+        "{\"key\": \"value\"}", result.getContext().get(LambdaStageConstants.resolvedPayloadKey));
+    assertTrue(result.getContext().containsKey(LambdaStageConstants.resolvedPayloadArtifactKey));
+  }
+
+  @Test
+  void execute_noPayloadArtifact_skips() {
+    Map<String, Object> context = new HashMap<>();
+    StageExecution stage = new StageExecutionImpl();
+    stage.setContext(context);
+
+    var result = task.execute(stage);
+
+    assertEquals(ExecutionStatus.SUCCEEDED, result.getStatus());
+    assertTrue(result.getContext().isEmpty());
+  }
+
+  @Test
+  void execute_unresolvableArtifact_throws() {
+    Map<String, Object> context = new HashMap<>();
+    context.put(
+        "payloadArtifact",
+        Map.of(
+            "id", "expected-artifact-id",
+            "account", "",
+            "artifact", Map.of()));
+
+    StageExecution stage = new StageExecutionImpl();
+    stage.setContext(context);
+
+    when(artifactUtils.getBoundArtifactForStage(any(), any(), any())).thenReturn(null);
+
+    assertThrows(IllegalStateException.class, () -> task.execute(stage));
+  }
+}


### PR DESCRIPTION
Moves Lambda invoke payload artifact resolution from Clouddriver into Orca, enabling SpEL expression evaluation and expected-artifact binding for Lambda invocation payloads. The change is gated behind a dynamic-config feature flag and preserves full backwards
compatibility.

### Problem

SpEL expressions in Lambda invoke payload artifacts did not work because:

  1. Lambda invocation used a custom LambdaPipelineArtifact class that did not participate in Orca's standard artifact resolution flow.
  2. The artifact was fetched inside Clouddriver's atomic invokeLambdaFunction operation, so Orca could not evaluate expressions or bind expected artifacts before invocation.

### With this PR

Introduced a new Orca task, LambdaResolveInvokeArtifactTask, that runs before LambdaInvokeTask when the feature flag is enabled:

  1. Reads the payloadArtifact from stage context.
  2. Converts the custom artifact to the standard com.netflix.spinnaker.kork.artifacts.model.Artifact.
  3. Uses ArtifactUtils.getBoundArtifactForStage(...) to resolve expected-artifact IDs and evaluate SpEL.
  4. Fetches the artifact content via OortService.fetchArtifact(...).
  5. Stores the resolved content in stage context as resolvedPayload.

LambdaInvokeTask then:

  • Uses resolvedPayload and omits payloadArtifact when resolution happened.
  • Falls back to the legacy behavior of passing payloadArtifact to Clouddriver when resolvedPayload is absent.

Enabled by Feature flag/dynamic config key:

`stages.lambda-invoke.resolve-payload-artifact: true`

Default is false. When disabled, the stage graph and task behavior are unchanged.
