### PR TITLE
Fix(CVE): bump versions

### DIFF
--- a/kork/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/kork/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -29,6 +29,10 @@ ext {
     // https://github.com/springdoc/springdoc-openapi/blob/v2.8.17/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/providers/ObjectMapperProvider.java#L85
     // referencing a field that didn't come in... until 2.2.30
     swagger          : "2.2.49",
+    httpcore5        : "5.4.3",
+    logback          : "1.5.37",
+    tomcat           : "10.1.56",
+    commonsCompress  : "1.27.1",
   ]
 }
 
@@ -48,6 +52,23 @@ dependencies {
   //kotlinVersion comes from gradle.properties since we have kotlin code in
   // this project and need to configure gradle plugins etc.
   api(platform(libs.kotlin.bom))
+  // log4j-bom and netty-bom are declared here, before spring-boot-dependencies (and every
+  // other BOM below), so that our pinned versions win when this platform is published as a
+  // Maven POM and consumed by a downstream Maven-style build via an imported/enforced
+  // platform. Gradle's own conflict resolution picks the highest version regardless of
+  // declaration order, but Maven's <dependencyManagement> import resolution is strictly
+  // "first import wins" - so if these came after spring-boot-dependencies in the generated
+  // POM, Maven consumers would silently fall back to spring's older, nested netty-bom/log4j-bom
+  // versions even though Gradle-based, build-from-source consumers would never see the problem.
+  api(platform("org.apache.logging.log4j:log4j-bom:${versions.log4j}"))
+  api(platform("io.netty:netty-bom:4.1.136.Final"))// 3.5.16 of spring brings in 4.1.135 which has a new CVE.  https://nvd.nist.gov/vuln/detail/CVE-2026-55831.  Remove post upgrade to latest 4 with a fix
+  // httpcore5-parent is the officially published Maven coordinate management POM for the
+  // httpcore5/httpcore5-h2 artifact family (see the "Maven Coordinates" section of the
+  // Apache HttpComponents Core release docs). It has a real <dependencyManagement> pinning
+  // httpcore5/httpcore5-h2 to ${project.version}, so it's a safe drop-in for our former
+  // constraints{} pin. Declared here, before spring-boot-dependencies, for the same
+  // import-order-safety reason as log4j-bom/netty-bom above.
+  api(platform("org.apache.httpcomponents.core5:httpcore5-parent:${versions.httpcore5}"))
   api(platform("org.springframework.boot:spring-boot-dependencies:${versions.springBoot}"))
   api(platform("com.amazonaws:aws-java-sdk-bom:${versions.aws}"))
   api(platform("com.google.protobuf:protobuf-bom:${versions.protobuf}"))
@@ -58,8 +79,6 @@ dependencies {
   api(platform("org.spockframework:spock-bom:2.4-groovy-4.0"))
   api(platform("com.oracle.oci.sdk:oci-java-sdk-bom:3.21.0"))
   api(platform("io.arrow-kt:arrow-stack:${versions.arrow}"))
-  api(platform("org.apache.logging.log4j:log4j-bom:${versions.log4j}"))
-  api(platform("io.netty:netty-bom:4.1.136.Final"))// 3.5.16 of spring brings in 4.1.135 which has a new CVE.  https://nvd.nist.gov/vuln/detail/CVE-2026-55831.  Remove post upgrade to latest 4 with a fix
   constraints {
     api("cglib:cglib-nodep:3.3.0")
     api("com.amazonaws:aws-java-sdk:${versions.aws}")
@@ -113,6 +132,7 @@ dependencies {
     api("commons-configuration:commons-configuration:1.8")
     api("commons-io:commons-io:2.22.0")
     api("commons-fileupload:commons-fileupload:1.6.0")// Multiple CVEs from 1.4
+    api("org.apache.commons:commons-compress:${versions.commonsCompress}")
     // CVE's in 3.2.1
     api("commons-collections:commons-collections:[3.2.2,3.3)")
     api("org.apache.commons:commons-collections4:4.5.0")
@@ -124,6 +144,17 @@ dependencies {
     api("io.swagger.core.v3:swagger-core:${versions.swagger}")
     api("javax.xml.bind:jaxb-api:2.3.1")
     api("net.logstash.logback:logstash-logback-encoder:4.11")
+    // No official logback BOM exists (qos-ch/logback removed logback-bom in 2017; the
+    // internal logback-parent reactor POM is not documented/published for external
+    // consumers to import as a platform), so we keep pinning these two explicitly.
+    api("ch.qos.logback:logback-core:${versions.logback}")
+    api("ch.qos.logback:logback-classic:${versions.logback}")
+    // No official Tomcat BOM exists (no tomcat-embed-bom is published); Tomcat expects
+    // consumers to pin org.apache.tomcat.embed:* artifacts individually, or via Spring
+    // Boot's BOM, so we keep pinning these explicitly with a shared version variable.
+    api("org.apache.tomcat.embed:tomcat-embed-core:${versions.tomcat}")
+    api("org.apache.tomcat.embed:tomcat-embed-el:${versions.tomcat}")
+    api("org.apache.tomcat.embed:tomcat-embed-websocket:${versions.tomcat}")
     api("org.apache.commons:commons-exec:1.3")
     api("org.apache.logging.log4j:log4j-api-kotlin:${versions.log4jKotlin}")
     api("org.bitbucket.b_c:jose4j:0.9.6")

--- a/rosco/rosco-manifests/rosco-manifests.gradle
+++ b/rosco/rosco-manifests/rosco-manifests.gradle
@@ -8,7 +8,7 @@ dependencies {
   implementation "io.spinnaker.kork:kork-security"
   implementation "io.spinnaker.kork:kork-core"
   implementation "commons-io:commons-io"
-  implementation "org.apache.commons:commons-compress:1.21"
+  implementation "org.apache.commons:commons-compress"
   implementation "org.yaml:snakeyaml"
 
   implementation "com.squareup.retrofit2:retrofit"

--- a/rosco/rosco-web/rosco-web.gradle
+++ b/rosco/rosco-web/rosco-web.gradle
@@ -28,7 +28,7 @@ dependencies {
   testImplementation "com.squareup.retrofit2:retrofit"
   testImplementation "com.squareup.retrofit2:converter-jackson"
   testImplementation "com.github.tomakehurst:wiremock-jre8-standalone"
-  testImplementation "org.apache.commons:commons-compress:1.21"
+  testImplementation "org.apache.commons:commons-compress"
   testImplementation "org.assertj:assertj-core"
 }
 


### PR DESCRIPTION
## Summary

Bumps several transitive dependencies in `spinnaker-dependencies` to clear known High CVE findings in published OSS jars, and fixes a BOM import-order issue that caused Netty / Log4j pins to be ignored by Maven consumers of the published platform POM.

### Dependency bumps
| Component | From | To |
|---|---|---|
| `org.apache.commons:commons-compress` | 1.21 (local hardcodes / unconstrained) | **1.27.1** |
| `ch.qos.logback:logback-core` / `logback-classic` | Spring Boot managed | **1.5.37** |
| `org.apache.httpcomponents.core5:httpcore5` / `httpcore5-h2` | Spring Boot managed | **5.4.3** (via `httpcore5-parent` platform) |
| `org.apache.tomcat.embed:tomcat-embed-*` | Spring Boot managed | **10.1.56** |

Also removes hardcoded `commons-compress:1.21` versions in `rosco-manifests` / `rosco-web` so they pick up the central pin.

### Netty / Log4j BOM ordering
`netty-bom` (`4.1.136.Final`) and `log4j-bom` were already declared in `spinnaker-dependencies`, but **after** `spring-boot-dependencies`. That works for build-from-source Gradle conflict resolution (highest version wins), but when `spinnaker-dependencies` is published as a Maven POM and consumed via `platform()` / `enforcedPlatform()`, Maven's `<dependencyManagement>` import rule is **first import wins**. Spring's nested Netty/Log4j BOMs therefore silently won, leaving consumers on older vulnerable versions.

This PR moves `log4j-bom`, `netty-bom`, and `httpcore5-parent` **above** `spring-boot-dependencies` so the published platform POM honors the intended pins for both Gradle and Maven consumers.

### Why some pins stay as constraints
- **logback** / **tomcat-embed**: no official consumer-facing BOM is published, so explicit version constraints are the correct approach.
- **httpcore5**: uses the official `httpcore5-parent` platform instead of a bare constraint.

## Test plan
- [x] Resolve `clouddriver` / `rosco` runtimeClasspath and confirm bumped versions
- [x] Confirm Netty resolves to `4.1.136.Final` and Log4j to the pinned BOM version when consuming the published `spinnaker-dependencies` POM via `enforcedPlatform`
- [ ] CI green on this PR (note: known flaky `front50` `multi-threaded cache refresh` test is unrelated)