### PR TITLE
feat(gitlab-ci): Add pipeline trigger, cancel, and StoppableBuildService interface

### DIFF
--- a/igor/PR_DESCRIPTION.md
+++ b/igor/PR_DESCRIPTION.md
@@ -1,0 +1,86 @@
+# GitLab CI: Add pipeline trigger, cancel, and StoppableBuildService interface
+
+## Summary
+
+This PR adds native pipeline trigger and cancel support for GitLab CI in Igor, and introduces a `StoppableBuildService` interface to decouple build cancellation from Jenkins-specific code.
+
+Currently, cancelling a running CI build in Spinnaker only works for Jenkins (`BuildController.stopJob()` checks `instanceof JenkinsService`). This change makes cancellation extensible to any CI provider by introducing a common interface.
+
+## Changes
+
+### New: `StoppableBuildService` interface (`igor-core`)
+
+```java
+public interface StoppableBuildService {
+    void stopRunningBuild(String jobName, long buildNumber);
+    default void stopQueuedBuild(String queuedId) { /* throws UnsupportedOperationException */ }
+}
+```
+
+Any CI service that supports stopping/cancelling builds implements this interface. The `stopQueuedBuild` method has a default implementation since not all providers support queue cancellation.
+
+### GitLab CI: Trigger and Cancel (`igor-web`)
+
+- **`GitlabCiClient.java`** — Added `triggerPipeline()` and `cancelPipeline()` Retrofit endpoints
+- **`GitlabCiProperties.java`** — Added `triggerToken` configuration field to `GitlabCiHost`
+- **`GitlabCiService.java`** — Implemented `triggerBuildWithParameters()` (was `UnsupportedOperationException`) and added `cancelPipeline()`. Implements `StoppableBuildService`. Overrides `queuedBuild()` to return pipeline ID directly (GitLab CI has no queue concept).
+- **`GitlabCiResultConverter.java`** — Added handling for all GitLab pipeline statuses (`created`, `waitingForResource`, `preparing`, `scheduled`, `manual`). Previously these threw `IllegalArgumentException` when the monitor polled a newly-triggered pipeline.
+
+### BuildController: Generic stop logic
+
+- **`BuildController.groovy`** — `stopJob()` now uses `instanceof StoppableBuildService` instead of `instanceof JenkinsService`. Removed Groovy `metaClass.respondsTo` reflection in favor of direct interface method calls.
+
+### JenkinsService: Backward compatibility
+
+- **`JenkinsService.java`** — Implements `StoppableBuildService` with bridge methods to existing `stopRunningBuild(String, Long)` and `stopQueuedBuild(String)` methods. No behavior change for Jenkins users.
+
+## Configuration
+
+To enable GitLab CI pipeline triggering, add `triggerToken` to the master config:
+
+```yaml
+gitlab-ci:
+  enabled: true
+  masters:
+    - name: my-gitlab
+      address: https://gitlab.example.com
+      privateToken: <api-token>
+      triggerToken: <pipeline-trigger-token>
+      permissions:
+        READ:
+        - my-team
+        WRITE:
+        - my-team
+```
+
+The `triggerToken` is a [GitLab Pipeline Trigger Token](https://docs.gitlab.com/ee/ci/triggers/) created in the GitLab project settings. It is stored server-side in Igor's configuration — never exposed in pipeline JSON.
+
+The `triggerToken` is optional — if not configured, pipeline monitoring and status polling still work (using `privateToken`), but triggering will fail with a clear error message.
+
+Fiat `permissions` must be configured on the master to control access (same as Jenkins masters).
+
+## Testing
+
+- **`GitlabCiServiceSpec`** — 5 new test cases: trigger happy path, default ref, missing token validation, cancel, stopRunningBuild delegation
+- **`BuildControllerStopSpec`** — 7 new test cases: stopRunningBuild routing, stopQueuedBuild routing, 404 handling, error propagation, UnsupportedOperationException handling, non-stoppable service rejection, unknown master handling
+- **`JenkinsServiceSpec`** — 3 new test cases: bridge method delegation for stopRunningBuild, stopQueuedBuild, and interface implementation check
+- All existing tests pass (no regressions)
+- Manually tested end-to-end on a live Spinnaker deployment:
+  - Trigger: Spinnaker UI → Orca → Igor → GitLab CI pipeline triggered
+  - Monitor: Stage polls until GitLab pipeline completes, marks SUCCEEDED
+  - Cancel: Spinnaker stage cancels correctly from UI (stops monitoring)
+    - Note: Cancel does not yet propagate to GitLab CI (requires Orca-side CancelStageHandler wiring — documented as follow-up)
+  - Status handling: Pipeline in "created" state handled gracefully (no crash)
+
+## Follow-up Work
+
+- **Orca**: Create `GitlabCiStage.java` for a dedicated stage type (currently uses the Jenkins stage type via `CIStage`)
+- **Orca**: Wire cancel propagation via `CancelStageHandler` to call Igor's stop route for CI stages
+- **Deck**: Add a GitLab CI stage selector with project/ref/variables form fields
+- **Igor**: Implement `CiBuildService` for the CI view in the UI and Managed Delivery artifact metadata
+- **Task renaming**: Rename `StartJenkinsJobTask` → `StartBuildJobTask`, `StopJenkinsJobTask` → `StopBuildJobTask` (requires backward compatibility validation with stored pipeline executions)
+- **Fiat permissions**: Document configuration for GitLab CI masters
+
+## Related Discussion
+
+Community discussion on task naming and `StoppableBuildService` approach: https://spinnakerteam.slack.com/archives/C091CCWRJ/p1782487022482969

--- a/igor/igor-core/src/main/java/com/netflix/spinnaker/igor/service/StoppableBuildService.java
+++ b/igor/igor-core/src/main/java/com/netflix/spinnaker/igor/service/StoppableBuildService.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.igor.service;
+
+/**
+ * Interface for CI build services that support stopping/cancelling running or queued builds.
+ *
+ * <p>Implement this interface alongside {@link BuildOperations} to enable Spinnaker's pipeline
+ * cancel functionality for a given CI provider.
+ */
+public interface StoppableBuildService {
+
+  /**
+   * Stop a running build.
+   *
+   * @param jobName The name or identifier of the job (e.g., Jenkins job path, GitLab project ID)
+   * @param buildNumber The build number to stop
+   */
+  void stopRunningBuild(String jobName, long buildNumber);
+
+  /**
+   * Stop a queued build that has not yet started execution.
+   *
+   * <p>Not all CI providers support this operation. The default implementation throws {@link
+   * UnsupportedOperationException}.
+   *
+   * @param queuedId The identifier of the queued item
+   */
+  default void stopQueuedBuild(String queuedId) {
+    throw new UnsupportedOperationException("Stopping queued builds is not supported");
+  }
+}

--- a/igor/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/BuildController.groovy
+++ b/igor/igor-web/src/main/groovy/com/netflix/spinnaker/igor/build/BuildController.groovy
@@ -30,6 +30,7 @@ import com.netflix.spinnaker.igor.service.ArtifactDecorator
 import com.netflix.spinnaker.igor.service.BuildOperations
 import com.netflix.spinnaker.igor.service.BuildProperties
 import com.netflix.spinnaker.igor.service.BuildServices
+import com.netflix.spinnaker.igor.service.StoppableBuildService
 import com.netflix.spinnaker.kork.artifacts.model.Artifact
 import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerHttpException
 import com.netflix.spinnaker.kork.web.exceptions.InvalidRequestException
@@ -189,28 +190,28 @@ class BuildController {
 
   void stopJob(String master, long buildNumber, String jobName, String queuedBuild) {
     def buildService = getBuildService(master)
-    if (buildService instanceof JenkinsService) {
+    if (buildService instanceof StoppableBuildService) {
+      StoppableBuildService stoppable = (StoppableBuildService) buildService
       // Jobs that haven't been started yet won't have a buildNumber
       // (They're still in the queue). We use 0 to denote that case
-      if (buildNumber != 0 &&
-        buildService.metaClass.respondsTo(buildService, 'stopRunningBuild')) {
-        buildService.stopRunningBuild(jobName, buildNumber)
+      if (buildNumber != 0) {
+        stoppable.stopRunningBuild(jobName, buildNumber)
       } else {
-        // The jenkins api for removing a job from the queue (http://<Jenkins_URL>/queue/cancelItem?id=<queuedBuild>)
-        // always returns a 404. This try catch block insures that the exception is eaten instead
-        // of being handled by the handleOtherException handler and returning a 500 to orca
+        // Some CI providers (e.g., Jenkins) return a 404 when cancelling a queued build.
+        // We catch that to avoid returning a 500 to Orca.
         try {
-          if (buildService.metaClass.respondsTo(buildService, 'stopQueuedBuild')) {
-            buildService.stopQueuedBuild(queuedBuild)
-          }
+          stoppable.stopQueuedBuild(queuedBuild)
         } catch (SpinnakerHttpException e) {
           if (e.getResponseCode() != NOT_FOUND.value()) {
             throw e
           }
+        } catch (UnsupportedOperationException e) {
+          log.debug("Queued build stop not supported for master '{}', ignoring", master)
         }
       }
+    } else {
+      throw new InvalidRequestException("Build service '${master}' does not support stopping builds")
     }
-
   }
 
   @RequestMapping(value = "/masters/{name}/jobs/**/update/{buildNumber}", method = RequestMethod.PATCH)

--- a/igor/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/GitlabCiProperties.java
+++ b/igor/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/GitlabCiProperties.java
@@ -50,6 +50,7 @@ public class GitlabCiProperties implements BuildServerProperties<GitlabCiPropert
     @NotEmpty private String name;
     @NotEmpty private String address;
     private String privateToken;
+    private String triggerToken;
     private boolean limitByMembership = true;
     private boolean limitByOwnership = false;
     private Integer defaultHttpPageLength = 100;
@@ -81,6 +82,14 @@ public class GitlabCiProperties implements BuildServerProperties<GitlabCiPropert
 
     public void setPrivateToken(String privateToken) {
       this.privateToken = privateToken;
+    }
+
+    public String getTriggerToken() {
+      return triggerToken;
+    }
+
+    public void setTriggerToken(String triggerToken) {
+      this.triggerToken = triggerToken;
     }
 
     public boolean getLimitByMembership() {

--- a/igor/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/client/GitlabCiClient.java
+++ b/igor/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/client/GitlabCiClient.java
@@ -23,6 +23,7 @@ import java.util.List;
 import okhttp3.ResponseBody;
 import retrofit2.Call;
 import retrofit2.http.GET;
+import retrofit2.http.POST;
 import retrofit2.http.Path;
 import retrofit2.http.Query;
 
@@ -55,5 +56,17 @@ public interface GitlabCiClient {
   // GitLabCI pipelines can spawn other child pipelines, which are linked by bridges
   @GET("api/v4/projects/{projectId}/pipelines/{pipelineId}/bridges")
   Call<List<Bridge>> getBridges(
+      @Path("projectId") String projectId, @Path("pipelineId") long pipelineId);
+
+  // Trigger a new pipeline on a given branch using a pipeline trigger token
+  @POST("api/v4/projects/{projectId}/trigger/pipeline")
+  Call<Pipeline> triggerPipeline(
+      @Path("projectId") String projectId,
+      @Query("token") String triggerToken,
+      @Query("ref") String ref);
+
+  // Cancel a running pipeline
+  @POST("api/v4/projects/{projectId}/pipelines/{pipelineId}/cancel")
+  Call<Pipeline> cancelPipeline(
       @Path("projectId") String projectId, @Path("pipelineId") long pipelineId);
 }

--- a/igor/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/service/GitlabCiResultConverter.java
+++ b/igor/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/service/GitlabCiResultConverter.java
@@ -26,6 +26,10 @@ public class GitlabCiResultConverter {
   public static Result getResultFromGitlabCiState(PipelineStatus status) {
     switch (status) {
       case pending:
+      case created:
+      case waitingForResource:
+      case preparing:
+      case scheduled:
         return Result.NOT_BUILT;
       case running:
         return Result.BUILDING;
@@ -37,6 +41,8 @@ public class GitlabCiResultConverter {
         return Result.FAILURE;
       case skipped:
         return Result.NOT_BUILT;
+      case manual:
+        return Result.NOT_BUILT;
       default:
         log.info("could not convert " + String.valueOf(status));
         throw new IllegalArgumentException("status: " + String.valueOf(status) + " is not known");
@@ -47,6 +53,10 @@ public class GitlabCiResultConverter {
     switch (status) {
       case pending:
       case running:
+      case created:
+      case waitingForResource:
+      case preparing:
+      case scheduled:
         return true;
       default:
         return false;

--- a/igor/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/service/GitlabCiService.java
+++ b/igor/igor-web/src/main/groovy/com/netflix/spinnaker/igor/gitlabci/service/GitlabCiService.java
@@ -29,6 +29,7 @@ import com.netflix.spinnaker.igor.gitlabci.client.model.*;
 import com.netflix.spinnaker.igor.model.BuildServiceProvider;
 import com.netflix.spinnaker.igor.service.BuildOperations;
 import com.netflix.spinnaker.igor.service.BuildProperties;
+import com.netflix.spinnaker.igor.service.StoppableBuildService;
 import com.netflix.spinnaker.igor.travis.client.logparser.PropertyParser;
 import com.netflix.spinnaker.kork.core.RetrySupport;
 import com.netflix.spinnaker.kork.retrofit.Retrofit2SyncCall;
@@ -45,7 +46,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 
 @Slf4j
-public class GitlabCiService implements BuildOperations, BuildProperties {
+public class GitlabCiService implements BuildOperations, BuildProperties, StoppableBuildService {
   private final String name;
   private final GitlabCiClient client;
   private final GitlabCiProperties.GitlabCiHost hostConfig;
@@ -104,9 +105,58 @@ public class GitlabCiService implements BuildOperations, BuildProperties {
     throw new UnsupportedOperationException("getJobConfig is not yet implemented for Gitlab CI");
   }
 
+  /**
+   * For GitLab CI, there is no queue concept. The trigger returns the pipeline ID directly, so we
+   * simply return it as the build number to satisfy MonitorQueuedJenkinsJobTask.
+   */
+  @Override
+  public Object queuedBuild(String master, long item) {
+    return Map.of("number", item);
+  }
+
   @Override
   public long triggerBuildWithParameters(String job, Map<String, String> queryParameters) {
-    throw new UnsupportedOperationException();
+    String ref = queryParameters.getOrDefault("ref", "main");
+    String triggerToken = this.hostConfig.getTriggerToken();
+    if (triggerToken == null || triggerToken.isEmpty()) {
+      throw new IllegalStateException(
+          "Cannot trigger GitLab CI pipeline: triggerToken is not configured for master '"
+              + this.name
+              + "'");
+    }
+    Pipeline pipeline = Retrofit2SyncCall.execute(client.triggerPipeline(job, triggerToken, ref));
+    log.info(
+        "Triggered GitLab CI pipeline {} for {} on ref {}",
+        kv("pipelineId", pipeline.getId()),
+        kv("projectId", job),
+        kv("ref", ref));
+    return pipeline.getId();
+  }
+
+  /**
+   * Cancel a running GitLab CI pipeline.
+   *
+   * @param projectId The GitLab project ID
+   * @param pipelineId The pipeline ID to cancel
+   * @return The pipeline object after cancellation
+   */
+  public Pipeline cancelPipeline(String projectId, long pipelineId) {
+    Pipeline pipeline = Retrofit2SyncCall.execute(client.cancelPipeline(projectId, pipelineId));
+    log.info(
+        "Cancelled GitLab CI pipeline {} for {}",
+        kv("pipelineId", pipelineId),
+        kv("projectId", projectId));
+    return pipeline;
+  }
+
+  /**
+   * Implements {@link StoppableBuildService#stopRunningBuild(String, long)} by cancelling the
+   * GitLab CI pipeline. In the GitLab CI context, jobName maps to the project ID and buildNumber
+   * maps to the pipeline ID.
+   */
+  @Override
+  public void stopRunningBuild(String jobName, long buildNumber) {
+    cancelPipeline(jobName, buildNumber);
   }
 
   @Override

--- a/igor/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/service/JenkinsService.java
+++ b/igor/igor-web/src/main/groovy/com/netflix/spinnaker/igor/jenkins/service/JenkinsService.java
@@ -42,6 +42,7 @@ import com.netflix.spinnaker.igor.model.BuildServiceProvider;
 import com.netflix.spinnaker.igor.model.Crumb;
 import com.netflix.spinnaker.igor.service.BuildOperations;
 import com.netflix.spinnaker.igor.service.BuildProperties;
+import com.netflix.spinnaker.igor.service.StoppableBuildService;
 import com.netflix.spinnaker.kork.core.RetrySupport;
 import com.netflix.spinnaker.kork.retrofit.Retrofit2SyncCall;
 import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerConversionException;
@@ -70,7 +71,7 @@ import org.yaml.snakeyaml.Yaml;
 import retrofit2.Response;
 
 @Slf4j
-public class JenkinsService implements BuildOperations, BuildProperties {
+public class JenkinsService implements BuildOperations, BuildProperties, StoppableBuildService {
   private final ObjectMapper objectMapper = new ObjectMapper();
   private final String serviceName;
   private final JenkinsClient jenkinsClient;
@@ -359,8 +360,14 @@ public class JenkinsService implements BuildOperations, BuildProperties {
                 jenkinsClient.stopRunningBuild(encode(jobName), buildNumber, "", getCrumb())));
   }
 
-  public ResponseBody stopQueuedBuild(String queuedBuild) {
-    return circuitBreaker.executeSupplier(
+  @Override
+  public void stopRunningBuild(String jobName, long buildNumber) {
+    stopRunningBuild(jobName, Long.valueOf(buildNumber));
+  }
+
+  @Override
+  public void stopQueuedBuild(String queuedBuild) {
+    circuitBreaker.executeSupplier(
         () ->
             Retrofit2SyncCall.execute(jenkinsClient.stopQueuedBuild(queuedBuild, "", getCrumb())));
   }

--- a/igor/igor-web/src/test/groovy/com/netflix/spinnaker/igor/build/BuildControllerStopSpec.groovy
+++ b/igor/igor-web/src/test/groovy/com/netflix/spinnaker/igor/build/BuildControllerStopSpec.groovy
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2026 LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.igor.build
+
+import com.netflix.spinnaker.igor.PendingOperationsCache
+import com.netflix.spinnaker.igor.helpers.TestUtils
+import com.netflix.spinnaker.igor.service.BuildOperations
+import com.netflix.spinnaker.igor.service.BuildServices
+import com.netflix.spinnaker.igor.service.StoppableBuildService
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerHttpException
+import com.netflix.spinnaker.kork.web.exceptions.InvalidRequestException
+import com.netflix.spinnaker.kork.web.exceptions.NotFoundException
+import okhttp3.MediaType
+import okhttp3.ResponseBody
+import spock.lang.Specification
+
+class BuildControllerStopSpec extends Specification {
+
+  BuildServices buildServices
+  PendingOperationsCache pendingOperationsCache
+  BuildController controller
+
+  void setup() {
+    buildServices = Mock(BuildServices)
+    pendingOperationsCache = Mock(PendingOperationsCache)
+    controller = new BuildController(
+      buildServices,
+      pendingOperationsCache,
+      Optional.empty(),
+      Optional.empty(),
+      Optional.empty()
+    )
+  }
+
+  def "stopJob calls stopRunningBuild when buildNumber is non-zero"() {
+    given:
+    def stoppableService = Mock(StoppableBuildOperations)
+    buildServices.getService("my-master") >> stoppableService
+
+    when:
+    controller.stopJob("my-master", 42L, "my-job", "queue-123")
+
+    then:
+    1 * stoppableService.stopRunningBuild("my-job", 42L)
+    0 * stoppableService.stopQueuedBuild(_)
+  }
+
+  def "stopJob calls stopQueuedBuild when buildNumber is zero"() {
+    given:
+    def stoppableService = Mock(StoppableBuildOperations)
+    buildServices.getService("my-master") >> stoppableService
+
+    when:
+    controller.stopJob("my-master", 0L, "my-job", "queue-123")
+
+    then:
+    0 * stoppableService.stopRunningBuild(_, _)
+    1 * stoppableService.stopQueuedBuild("queue-123")
+  }
+
+  def "stopJob swallows 404 from stopQueuedBuild"() {
+    given:
+    def stoppableService = Mock(StoppableBuildOperations)
+    buildServices.getService("my-master") >> stoppableService
+    stoppableService.stopQueuedBuild(_) >> {
+      throw TestUtils.makeSpinnakerHttpException("http://test.net", 404,
+        ResponseBody.create("not found", MediaType.parse("text/plain")))
+    }
+
+    when:
+    controller.stopJob("my-master", 0L, "my-job", "queue-123")
+
+    then:
+    noExceptionThrown()
+  }
+
+  def "stopJob propagates non-404 errors from stopQueuedBuild"() {
+    given:
+    def stoppableService = Mock(StoppableBuildOperations)
+    buildServices.getService("my-master") >> stoppableService
+    stoppableService.stopQueuedBuild(_) >> {
+      throw TestUtils.makeSpinnakerHttpException("http://test.net", 500,
+        ResponseBody.create("server error", MediaType.parse("text/plain")))
+    }
+
+    when:
+    controller.stopJob("my-master", 0L, "my-job", "queue-123")
+
+    then:
+    thrown SpinnakerHttpException
+  }
+
+  def "stopJob handles UnsupportedOperationException from stopQueuedBuild gracefully"() {
+    given:
+    def stoppableService = Mock(StoppableBuildOperations)
+    buildServices.getService("my-master") >> stoppableService
+    stoppableService.stopQueuedBuild(_) >> { throw new UnsupportedOperationException("not supported") }
+
+    when:
+    controller.stopJob("my-master", 0L, "my-job", "queue-123")
+
+    then:
+    noExceptionThrown()
+  }
+
+  def "stopJob throws InvalidRequestException for non-stoppable services"() {
+    given:
+    def nonStoppableService = Mock(BuildOperations)
+    buildServices.getService("my-master") >> nonStoppableService
+
+    when:
+    controller.stopJob("my-master", 42L, "my-job", "queue-123")
+
+    then:
+    thrown InvalidRequestException
+  }
+
+  def "stopJob throws NotFoundException for unknown master"() {
+    given:
+    buildServices.getService("unknown") >> null
+
+    when:
+    controller.stopJob("unknown", 42L, "my-job", "queue-123")
+
+    then:
+    thrown NotFoundException
+  }
+
+  /**
+   * Helper interface that combines BuildOperations and StoppableBuildService
+   * so Spock can mock both on one object.
+   */
+  static interface StoppableBuildOperations extends BuildOperations, StoppableBuildService {}
+}

--- a/igor/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gitlabci/service/GitlabCiServiceSpec.groovy
+++ b/igor/igor-web/src/test/groovy/com/netflix/spinnaker/igor/gitlabci/service/GitlabCiServiceSpec.groovy
@@ -44,6 +44,7 @@ class GitlabCiServiceSpec extends Specification {
     void setup() {
         client = Mock(GitlabCiClient)
         hostConfig = new GitlabCiHost()
+        hostConfig.setTriggerToken("test-trigger-token")
         service = new GitlabCiService(client, "gitlab", hostConfig, Permissions.EMPTY)
     }
 
@@ -170,5 +171,78 @@ class GitlabCiServiceSpec extends Specification {
     0 * client.getJobLog(PROJECT_ID, JOB_ID)
 
     thrown SpinnakerHttpException
+  }
+
+  def "triggerBuildWithParameters triggers a pipeline and returns its ID"() {
+    given:
+    final String PROJECT_ID = "9729"
+    final String REF = "main"
+    final long PIPELINE_ID = 12345
+
+    Pipeline triggeredPipeline = new Pipeline(id: PIPELINE_ID)
+
+    when:
+    long result = service.triggerBuildWithParameters(PROJECT_ID, [ref: REF])
+
+    then:
+    1 * client.triggerPipeline(PROJECT_ID, "test-trigger-token", REF) >> Calls.response(triggeredPipeline)
+    result == PIPELINE_ID
+  }
+
+  def "triggerBuildWithParameters uses 'main' as default ref"() {
+    given:
+    final String PROJECT_ID = "9729"
+    final long PIPELINE_ID = 99
+
+    Pipeline triggeredPipeline = new Pipeline(id: PIPELINE_ID)
+
+    when:
+    long result = service.triggerBuildWithParameters(PROJECT_ID, [:])
+
+    then:
+    1 * client.triggerPipeline(PROJECT_ID, "test-trigger-token", "main") >> Calls.response(triggeredPipeline)
+    result == PIPELINE_ID
+  }
+
+  def "triggerBuildWithParameters throws when triggerToken is not configured"() {
+    given:
+    def hostConfigNoToken = new GitlabCiHost()
+    def serviceNoToken = new GitlabCiService(client, "gitlab-no-token", hostConfigNoToken, Permissions.EMPTY)
+
+    when:
+    serviceNoToken.triggerBuildWithParameters("9729", [ref: "main"])
+
+    then:
+    def ex = thrown(IllegalStateException)
+    ex.message.contains("triggerToken is not configured")
+  }
+
+  def "cancelPipeline calls the client and returns the pipeline"() {
+    given:
+    final String PROJECT_ID = "9729"
+    final long PIPELINE_ID = 12345
+
+    Pipeline cancelledPipeline = new Pipeline(id: PIPELINE_ID)
+
+    when:
+    Pipeline result = service.cancelPipeline(PROJECT_ID, PIPELINE_ID)
+
+    then:
+    1 * client.cancelPipeline(PROJECT_ID, PIPELINE_ID) >> Calls.response(cancelledPipeline)
+    result.id == PIPELINE_ID
+  }
+
+  def "stopRunningBuild delegates to cancelPipeline"() {
+    given:
+    final String PROJECT_ID = "9729"
+    final long PIPELINE_ID = 12345
+
+    Pipeline cancelledPipeline = new Pipeline(id: PIPELINE_ID)
+
+    when:
+    service.stopRunningBuild(PROJECT_ID, PIPELINE_ID)
+
+    then:
+    1 * client.cancelPipeline(PROJECT_ID, PIPELINE_ID) >> Calls.response(cancelledPipeline)
   }
 }

--- a/igor/igor-web/src/test/groovy/com/netflix/spinnaker/igor/jenkins/service/JenkinsServiceSpec.groovy
+++ b/igor/igor-web/src/test/groovy/com/netflix/spinnaker/igor/jenkins/service/JenkinsServiceSpec.groovy
@@ -768,4 +768,32 @@ class JenkinsServiceSpec extends Specification {
 
       properties == [:]
     }
+
+    def "stopRunningBuild interface method delegates to existing Jenkins stop"() {
+      given:
+      def jobName = "my-job"
+      long buildNumber = 42
+
+      when:
+      service.stopRunningBuild(jobName, buildNumber)
+
+      then:
+      1 * client.stopRunningBuild("my-job", 42L, '', null) >> Calls.response(null)
+    }
+
+    def "stopQueuedBuild interface method calls Jenkins queue cancel"() {
+      given:
+      def queuedBuild = "queue-123"
+
+      when:
+      service.stopQueuedBuild(queuedBuild)
+
+      then:
+      1 * client.stopQueuedBuild("queue-123", '', null) >> Calls.response(null)
+    }
+
+    def "JenkinsService implements StoppableBuildService"() {
+      expect:
+      service instanceof com.netflix.spinnaker.igor.service.StoppableBuildService
+    }
 }


### PR DESCRIPTION
## Summary

This PR adds native pipeline trigger and cancel support for GitLab CI in Igor, and introduces a `StoppableBuildService` interface to decouple build cancellation from Jenkins-specific code.

Currently, cancelling a running CI build in Spinnaker only works for Jenkins (`BuildController.stopJob()` checks `instanceof JenkinsService`). This change makes cancellation extensible to any CI provider by introducing a common interface.

## Changes

### New: `StoppableBuildService` interface (`igor-core`)

```java
public interface StoppableBuildService {
    void stopRunningBuild(String jobName, long buildNumber);
    default void stopQueuedBuild(String queuedId) { /* throws UnsupportedOperationException */ }
}
```

Any CI service that supports stopping/cancelling builds implements this interface. The `stopQueuedBuild` method has a default implementation since not all providers support queue cancellation.

### GitLab CI: Trigger and Cancel (`igor-web`)

- **`GitlabCiClient.java`** — Added `triggerPipeline()` and `cancelPipeline()` Retrofit endpoints
- **`GitlabCiProperties.java`** — Added `triggerToken` configuration field to `GitlabCiHost`
- **`GitlabCiService.java`** — Implemented `triggerBuildWithParameters()` (was `UnsupportedOperationException`) and added `cancelPipeline()`. Implements `StoppableBuildService`. Overrides `queuedBuild()` to return pipeline ID directly (GitLab CI has no queue concept).
- **`GitlabCiResultConverter.java`** — Added handling for all GitLab pipeline statuses (`created`, `waitingForResource`, `preparing`, `scheduled`, `manual`). Previously these threw `IllegalArgumentException` when the monitor polled a newly-triggered pipeline.

### BuildController: Generic stop logic

- **`BuildController.groovy`** — `stopJob()` now uses `instanceof StoppableBuildService` instead of `instanceof JenkinsService`. Removed Groovy `metaClass.respondsTo` reflection in favor of direct interface method calls.

### JenkinsService: Backward compatibility

- **`JenkinsService.java`** — Implements `StoppableBuildService` with bridge methods to existing `stopRunningBuild(String, Long)` and `stopQueuedBuild(String)` methods. No behavior change for Jenkins users.

## Configuration

To enable GitLab CI pipeline triggering, add `triggerToken` to the master config:

```yaml
gitlab-ci:
  enabled: true
  masters:
    - name: my-gitlab
      address: https://gitlab.example.com
      privateToken: <api-token>
      triggerToken: <pipeline-trigger-token>
      permissions:
        READ:
        - my-team
        WRITE:
        - my-team
```

The `triggerToken` is a [GitLab Pipeline Trigger Token](https://docs.gitlab.com/ee/ci/triggers/) created in the GitLab project settings. It is stored server-side in Igor's configuration — never exposed in pipeline JSON.

The `triggerToken` is optional — if not configured, pipeline monitoring and status polling still work (using `privateToken`), but triggering will fail with a clear error message.

Fiat `permissions` must be configured on the master to control access (same as Jenkins masters).

## Testing

- **`GitlabCiServiceSpec`** — 5 new test cases: trigger happy path, default ref, missing token validation, cancel, stopRunningBuild delegation
- **`BuildControllerStopSpec`** — 7 new test cases: stopRunningBuild routing, stopQueuedBuild routing, 404 handling, error propagation, UnsupportedOperationException handling, non-stoppable service rejection, unknown master handling
- **`JenkinsServiceSpec`** — 3 new test cases: bridge method delegation for stopRunningBuild, stopQueuedBuild, and interface implementation check
- All existing tests pass (no regressions)
- Manually tested end-to-end on a live Spinnaker deployment:
  - Trigger: Spinnaker UI → Orca → Igor → GitLab CI pipeline triggered
  - Monitor: Stage polls until GitLab pipeline completes, marks SUCCEEDED
  - Cancel: Spinnaker stage cancels correctly from UI (stops monitoring)
    - Note: Cancel does not yet propagate to GitLab CI (requires Orca-side CancelStageHandler wiring — documented as follow-up)
  - Status handling: Pipeline in "created" state handled gracefully (no crash)

## Follow-up Work

- **Orca**: Create `GitlabCiStage.java` for a dedicated stage type (currently uses the Jenkins stage type via `CIStage`)
- **Orca**: Wire cancel propagation via `CancelStageHandler` to call Igor's stop route for CI stages
- **Deck**: Add a GitLab CI stage selector with project/ref/variables form fields
- **Igor**: Implement `CiBuildService` for the CI view in the UI and Managed Delivery artifact metadata
- **Task renaming**: Rename `StartJenkinsJobTask` → `StartBuildJobTask`, `StopJenkinsJobTask` → `StopBuildJobTask` (requires backward compatibility validation with stored pipeline executions)
- **Fiat permissions**: Document configuration for GitLab CI masters

## Related Discussion

Community discussion on task naming and `StoppableBuildService` approach: https://spinnakerteam.slack.com/archives/C091CCWRJ/p1782487022482969
