### PR TITLE
feat(front50): deprecate non-SQL metadata storage backends

### DIFF
--- a/front50/README.md
+++ b/front50/README.md
@@ -12,12 +12,22 @@ All metadata is durably stored and served out of an in-memory cache.
 
 The following storage backends are supported:
 
-- Amazon S3
-- Google Cloud Storage
-- Redis
-- [SQL](https://github.com/spinnaker/front50/blob/master/front50-sql/src/main/kotlin/com/netflix/spinnaker/front50/model/SqlStorageService.kt) - _recommended_
+- [SQL](https://github.com/spinnaker/spinnaker/blob/main/front50/front50-sql/src/main/kotlin/com/netflix/spinnaker/front50/model/SqlStorageService.kt) — **recommended** (required after Spinnaker 2027.0.0)
+- Amazon S3 — **deprecated** (removal after Spinnaker 2027.0.0)
+- Google Cloud Storage — **deprecated** (removal after Spinnaker 2027.0.0)
+- Redis — **deprecated** (removal after Spinnaker 2027.0.0)
+- Azure Blob / Oracle Object Storage / OpenStack Swift — **deprecated** (removal after Spinnaker 2027.0.0)
+
+Front50 is moving to **SQL-only** metadata persistence. Non-SQL backends still work so
+operators can migrate, but enabling them logs a startup warning. Prefer SQL now:
+
+https://spinnaker.io/docs/setup/productionize/persistence/front50-sql/
 
 `SQL` is a cloud agnostic storage backend that offers strong read-after-write consistency and metadata versioning.
+
+> **Note:** S3 *plugin-binary* storage (`spinnaker.s3.plugin-storage`) is separate from
+> Front50 metadata storage and is not covered by this deprecation. Orca's artifact store
+> also continues to support S3.
 
 ### Metadata
 

--- a/front50/front50-azure/src/main/java/com/netflix/spinnaker/front50/config/AzureStorageConfig.java
+++ b/front50/front50-azure/src/main/java/com/netflix/spinnaker/front50/config/AzureStorageConfig.java
@@ -17,6 +17,8 @@
 package com.netflix.spinnaker.front50.config;
 
 import com.netflix.spinnaker.front50.model.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -24,10 +26,21 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestTemplate;
 
+/**
+ * Azure Blob metadata storage configuration.
+ *
+ * @deprecated Front50 is moving to SQL-only persistence. Azure metadata storage remains available
+ *     through Spinnaker 2027.0.0 and is scheduled for removal afterward. Prefer SQL; see {@link
+ *     DeprecatedStorageBackend}.
+ */
+@Deprecated
 @Configuration
 @ConditionalOnExpression("${spinnaker.azs.enabled:false}")
 @EnableConfigurationProperties(AzureStorageProperties.class)
 public class AzureStorageConfig {
+
+  private static final Logger log = LoggerFactory.getLogger(AzureStorageConfig.class);
+
   @Bean
   @ConditionalOnMissingBean(RestTemplate.class)
   public RestTemplate restTemplate() {
@@ -35,7 +48,9 @@ public class AzureStorageConfig {
   }
 
   @Bean
+  @SuppressWarnings("deprecation")
   public AzureStorageService azureStorageService(AzureStorageProperties azureStorageProperties) {
+    DeprecatedStorageBackend.warn(log, "Azure");
     return new AzureStorageService(
         azureStorageProperties.getStorageConnectionString(),
         azureStorageProperties.getStorageContainerName());

--- a/front50/front50-azure/src/main/java/com/netflix/spinnaker/front50/model/AzureStorageService.java
+++ b/front50/front50-azure/src/main/java/com/netflix/spinnaker/front50/model/AzureStorageService.java
@@ -38,6 +38,13 @@ import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Azure Blob-backed Front50 metadata storage.
+ *
+ * @deprecated Front50 is moving to SQL-only persistence. Remains available through Spinnaker
+ *     2027.0.0; scheduled for removal afterward. Prefer SQL.
+ */
+@Deprecated
 public class AzureStorageService implements StorageService {
   private static final Logger log = LoggerFactory.getLogger(AzureStorageService.class);
   private String containerName;

--- a/front50/front50-core/src/main/java/com/netflix/spinnaker/front50/config/DeprecatedStorageBackend.java
+++ b/front50/front50-core/src/main/java/com/netflix/spinnaker/front50/config/DeprecatedStorageBackend.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 Harness, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.front50.config;
+
+import org.slf4j.Logger;
+
+/**
+ * Emits a consistent deprecation warning when a non-SQL Front50 metadata storage backend is
+ * enabled.
+ *
+ * <p>Front50 is moving to SQL-only persistence. Object-store and Redis backends remain functional
+ * through Spinnaker 2027.0.0 to give operators time to migrate, and are scheduled for removal
+ * afterward.
+ *
+ * @see <a href="https://spinnaker.io/docs/setup/productionize/persistence/front50-sql/">Set up
+ *     Front50 to use SQL</a>
+ * @see <a href="https://spinnaker.io/docs/releases/roadmap/">Spinnaker roadmap</a>
+ */
+public final class DeprecatedStorageBackend {
+
+  public static final String REMOVAL_RELEASE = "2027.0.0";
+  public static final String MIGRATION_DOCS_URL =
+      "https://spinnaker.io/docs/setup/productionize/persistence/front50-sql/";
+
+  private DeprecatedStorageBackend() {}
+
+  /**
+   * Builds the standard deprecation warning for {@code backend} (e.g. {@code "S3"}, {@code "GCS"}).
+   */
+  public static String message(String backend) {
+    return "Front50 "
+        + backend
+        + " metadata storage is deprecated and scheduled for removal after Spinnaker "
+        + REMOVAL_RELEASE
+        + ". Migrate to SQL ("
+        + MIGRATION_DOCS_URL
+        + ").";
+  }
+
+  /** Logs {@link #message(String)} at WARN on {@code log}. */
+  public static void warn(Logger log, String backend) {
+    log.warn(message(backend));
+  }
+}

--- a/front50/front50-core/src/test/java/com/netflix/spinnaker/front50/config/DeprecatedStorageBackendTest.java
+++ b/front50/front50-core/src/test/java/com/netflix/spinnaker/front50/config/DeprecatedStorageBackendTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 Harness, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.front50.config;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+
+public class DeprecatedStorageBackendTest {
+
+  @Test
+  public void messageNamesBackendAndRemovalTarget() {
+    String message = DeprecatedStorageBackend.message("S3");
+
+    assertTrue(message.contains("S3"), message);
+    assertTrue(message.contains(DeprecatedStorageBackend.REMOVAL_RELEASE), message);
+    assertTrue(message.contains("SQL"), message);
+    assertTrue(message.contains(DeprecatedStorageBackend.MIGRATION_DOCS_URL), message);
+  }
+
+  @Test
+  public void warnLogsStandardMessage() {
+    Logger log = mock(Logger.class);
+
+    DeprecatedStorageBackend.warn(log, "GCS");
+
+    verify(log).warn(DeprecatedStorageBackend.message("GCS"));
+  }
+}

--- a/front50/front50-gcs/src/main/java/com/netflix/spinnaker/front50/config/GcsConfig.java
+++ b/front50/front50-gcs/src/main/java/com/netflix/spinnaker/front50/config/GcsConfig.java
@@ -52,6 +52,14 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestTemplate;
 
+/**
+ * GCS metadata storage configuration.
+ *
+ * @deprecated Front50 is moving to SQL-only persistence. GCS metadata storage remains available
+ *     through Spinnaker 2027.0.0 and is scheduled for removal afterward. Prefer SQL; see {@link
+ *     DeprecatedStorageBackend}.
+ */
+@Deprecated
 @Configuration
 @ConditionalOnExpression("${spinnaker.gcs.enabled:false}")
 @EnableConfigurationProperties(GcsProperties.class)
@@ -65,11 +73,14 @@ public class GcsConfig {
       ObjectType.APPLICATION_PERMISSION.getDefaultMetadataFilename(true);
 
   @Bean
+  @SuppressWarnings("deprecation")
   public GcsStorageService defaultGoogleCloudStorageService(
       Storage storage, GcsProperties gcsProperties) {
+    DeprecatedStorageBackend.warn(log, "GCS");
     return googleCloudStorageService(storage, DATA_FILENAME, gcsProperties);
   }
 
+  @SuppressWarnings("deprecation")
   private GcsStorageService googleCloudStorageService(
       Storage storage, String dataFilename, GcsProperties gcsProperties) {
     var executor =
@@ -137,6 +148,7 @@ public class GcsConfig {
   }
 
   @Bean
+  @SuppressWarnings("deprecation")
   public ApplicationPermissionDAO applicationPermissionDAO(
       Storage storage,
       StorageServiceConfigurationProperties storageServiceConfigurationProperties,

--- a/front50/front50-gcs/src/main/kotlin/com/netflix/spinnaker/front50/model/GcsStorageService.kt
+++ b/front50/front50-gcs/src/main/kotlin/com/netflix/spinnaker/front50/model/GcsStorageService.kt
@@ -41,6 +41,13 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 import jakarta.annotation.PostConstruct
 
+/**
+ * GCS-backed Front50 metadata storage.
+ *
+ * @deprecated Front50 is moving to SQL-only persistence. Remains available through Spinnaker
+ * 2027.0.0; scheduled for removal afterward. Prefer SqlStorageService.
+ */
+@Deprecated("Front50 GCS metadata storage is deprecated; migrate to SQL. Removal after 2027.0.0.")
 class GcsStorageService(
   private val storage: Storage,
   private val bucketName: String,

--- a/front50/front50-oracle/src/main/java/com/netflix/spinnaker/front50/config/OracleConfig.java
+++ b/front50/front50-oracle/src/main/java/com/netflix/spinnaker/front50/config/OracleConfig.java
@@ -10,6 +10,8 @@ package com.netflix.spinnaker.front50.config;
 
 import com.netflix.spinnaker.front50.model.OracleStorageService;
 import java.io.IOException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -17,14 +19,26 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestTemplate;
 
+/**
+ * Oracle Object Storage metadata storage configuration.
+ *
+ * @deprecated Front50 is moving to SQL-only persistence. Oracle metadata storage remains available
+ *     through Spinnaker 2027.0.0 and is scheduled for removal afterward. Prefer SQL; see {@link
+ *     DeprecatedStorageBackend}.
+ */
+@Deprecated
 @Configuration
 @ConditionalOnExpression("${spinnaker.oracle.enabled:false}")
 @EnableConfigurationProperties(OracleProperties.class)
 public class OracleConfig {
 
+  private static final Logger log = LoggerFactory.getLogger(OracleConfig.class);
+
   @Bean
+  @SuppressWarnings("deprecation")
   public OracleStorageService oracleStorageService(OracleProperties oracleProperties)
       throws IOException {
+    DeprecatedStorageBackend.warn(log, "Oracle");
     OracleStorageService oracleStorageService = new OracleStorageService(oracleProperties);
     oracleStorageService.ensureBucketExists();
     return oracleStorageService;

--- a/front50/front50-oracle/src/main/java/com/netflix/spinnaker/front50/model/OracleStorageService.java
+++ b/front50/front50-oracle/src/main/java/com/netflix/spinnaker/front50/model/OracleStorageService.java
@@ -48,6 +48,13 @@ import java.util.function.Supplier;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.UriBuilder;
 
+/**
+ * Oracle Object Storage-backed Front50 metadata storage.
+ *
+ * @deprecated Front50 is moving to SQL-only persistence. Remains available through Spinnaker
+ *     2027.0.0; scheduled for removal afterward. Prefer SQL.
+ */
+@Deprecated
 public class OracleStorageService implements StorageService {
 
   private final Client client;

--- a/front50/front50-redis/src/main/groovy/com/netflix/spinnaker/front50/redis/RedisConfig.groovy
+++ b/front50/front50-redis/src/main/groovy/com/netflix/spinnaker/front50/redis/RedisConfig.groovy
@@ -17,11 +17,14 @@
 package com.netflix.spinnaker.front50.redis
 
 import com.netflix.spinnaker.front50.api.model.pipeline.Pipeline;
+import com.netflix.spinnaker.front50.config.DeprecatedStorageBackend
 import com.netflix.spinnaker.front50.model.application.Application
 import com.netflix.spinnaker.front50.model.notification.Notification
 
 import com.netflix.spinnaker.front50.model.pipeline.PipelineTemplate
 import com.netflix.spinnaker.front50.model.project.Project
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
@@ -32,12 +35,23 @@ import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer
 import org.springframework.data.redis.serializer.StringRedisSerializer
 
+/**
+ * Redis-backed Front50 metadata storage configuration.
+ *
+ * @deprecated Front50 is moving to SQL-only persistence. Redis metadata storage remains available
+ * through Spinnaker 2027.0.0 and is scheduled for removal afterward. Prefer SQL.
+ */
+@Deprecated
 @Configuration
 @EnableConfigurationProperties(RedisConfigurationProperties)
 @ConditionalOnExpression('${spinnaker.redis.enabled:false}')
 class RedisConfig {
+
+  private static final Logger log = LoggerFactory.getLogger(RedisConfig)
+
   @Bean
   RedisApplicationDAO redisApplicationDAO(RedisTemplate<String, Application> template) {
+    DeprecatedStorageBackend.warn(log, "Redis")
     new RedisApplicationDAO(redisTemplate: template)
   }
 

--- a/front50/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3Config.java
+++ b/front50/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3Config.java
@@ -15,6 +15,8 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Optional;
 import java.util.concurrent.Executors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -27,11 +29,20 @@ import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.sns.SnsClient;
 import software.amazon.awssdk.services.sqs.SqsClient;
 
+/**
+ * S3 configuration for Front50.
+ *
+ * <p>S3 <em>metadata</em> storage ({@link S3StorageService} / {@code spinnaker.s3.storage-service})
+ * is deprecated — prefer SQL; see {@link DeprecatedStorageBackend}. S3 plugin-binary storage
+ * ({@code spinnaker.s3.plugin-storage}) is not covered by that deprecation.
+ */
 @Configuration
 @ConditionalOnProperty("spinnaker.s3.enabled")
 @Import(BastionConfig.class)
 @EnableConfigurationProperties({S3MetadataStorageProperties.class, S3PluginStorageProperties.class})
 public class S3Config {
+
+  private static final Logger log = LoggerFactory.getLogger(S3Config.class);
 
   @Bean
   @ConditionalOnProperty(value = "spinnaker.s3.storage-service.enabled", matchIfMissing = true)
@@ -42,8 +53,11 @@ public class S3Config {
 
   @Bean
   @ConditionalOnProperty(value = "spinnaker.s3.storage-service.enabled", matchIfMissing = true)
+  @SuppressWarnings("deprecation")
   public S3StorageService s3StorageService(
       S3Client awsS3MetadataClient, S3MetadataStorageProperties s3Properties) {
+    DeprecatedStorageBackend.warn(log, "S3");
+
     ObjectMapper awsObjectMapper =
         new ObjectMapper()
             .addMixIn(Timestamped.class, TimestampedMixins.class)

--- a/front50/front50-s3/src/main/java/com/netflix/spinnaker/front50/model/S3StorageService.java
+++ b/front50/front50-s3/src/main/java/com/netflix/spinnaker/front50/model/S3StorageService.java
@@ -62,6 +62,13 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.S3Object;
 import software.amazon.awssdk.services.s3.model.VersioningConfiguration;
 
+/**
+ * S3-backed Front50 metadata storage.
+ *
+ * @deprecated Front50 is moving to SQL-only persistence. Remains available through Spinnaker
+ *     2027.0.0; scheduled for removal afterward. Prefer {@code SqlStorageService}.
+ */
+@Deprecated
 public class S3StorageService implements StorageService {
   private static final Logger log = LoggerFactory.getLogger(S3StorageService.class);
 

--- a/front50/front50-sql/README.md
+++ b/front50/front50-sql/README.md
@@ -1,5 +1,13 @@
 ## Configuring SQL store for front50
 
+> **Deprecation notice:** Non-SQL Front50 metadata storage backends (S3, GCS, Redis,
+> Azure, Oracle, Swift) are deprecated and scheduled for removal after Spinnaker
+> **2027.0.0**. SQL is the recommended persistence store and will be required after
+> that release. See the
+> [Front50 SQL setup guide](https://spinnaker.io/docs/setup/productionize/persistence/front50-sql/)
+> for migration steps. S3 plugin-binary storage (`spinnaker.s3.plugin-storage`) and
+> Orca's artifact store are not covered by this deprecation.
+
 #### MySQL:
 
 ```yaml

--- a/front50/front50-swift/src/main/java/com/netflix/spinnaker/front50/config/SwiftConfig.java
+++ b/front50/front50-swift/src/main/java/com/netflix/spinnaker/front50/config/SwiftConfig.java
@@ -28,6 +28,14 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestTemplate;
 
+/**
+ * OpenStack Swift metadata storage configuration.
+ *
+ * @deprecated Front50 is moving to SQL-only persistence. Swift metadata storage remains available
+ *     through Spinnaker 2027.0.0 and is scheduled for removal afterward. Prefer SQL; see {@link
+ *     DeprecatedStorageBackend}.
+ */
+@Deprecated
 @Configuration
 @ConditionalOnExpression("${spinnaker.swift.enabled:false}")
 @EnableConfigurationProperties(SwiftProperties.class)
@@ -38,7 +46,9 @@ public class SwiftConfig {
   private final Logger log = LoggerFactory.getLogger(getClass());
 
   @Bean
+  @SuppressWarnings("deprecation")
   public SwiftStorageService swiftService(SwiftProperties properties) {
+    DeprecatedStorageBackend.warn(log, "Swift");
     return new SwiftStorageService(
         properties.getContainerName(),
         properties.getIdentityEndpoint(),

--- a/front50/front50-swift/src/main/java/com/netflix/spinnaker/front50/model/SwiftStorageService.java
+++ b/front50/front50-swift/src/main/java/com/netflix/spinnaker/front50/model/SwiftStorageService.java
@@ -50,6 +50,13 @@ import org.openstack4j.openstack.OSFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * OpenStack Swift-backed Front50 metadata storage.
+ *
+ * @deprecated Front50 is moving to SQL-only persistence. Remains available through Spinnaker
+ *     2027.0.0; scheduled for removal afterward. Prefer SQL.
+ */
+@Deprecated
 public class SwiftStorageService implements StorageService {
   private static final Logger log = LoggerFactory.getLogger(SwiftStorageService.class);
 


### PR DESCRIPTION
Warn at startup and mark S3/GCS/Redis/Azure/Oracle/Swift metadata storage deprecated so operators can migrate to SQL before removal after Spinnaker 2027.0.0. S3 plugin-binary storage is left alone.

https://spinnaker.io/docs/releases/roadmap/