### PR TITLE
fix(signalfx): Move from signalfx library to standard retrofit to remove an old dep issue.

### DIFF
--- a/kayenta/kayenta-signalfx/kayenta-signalfx.gradle
+++ b/kayenta/kayenta-signalfx/kayenta-signalfx.gradle
@@ -86,9 +86,9 @@ String getRequiredSystemProp(String key) {
 
 //noinspection GroovyAssignabilityCheck
 task integrationTest(type: Test) {
+  useJUnitPlatform()
   doFirst {
     systemProperty("redis.port", startEmbeddedRedis.ext.redisPort)
-    systemProperty("kayenta.signalfx.apiKey", getRequiredSystemProp('kayenta.signalfx.apiKey'))
   }
   systemProperty("spring.application.name", "kayenta")
   systemProperty('spring.config.name', "spinnaker,kayenta")
@@ -114,14 +114,16 @@ configurations {
 dependencies {
   implementation project(":kayenta-core")
 
-  api 'com.signalfx.public:signalfx-java:1.0.49'
-
   testImplementation project(":kayenta-standalone-canary-analysis")
   testImplementation "com.squareup.retrofit2:converter-jackson"
+  testImplementation "com.squareup.okhttp3:mockwebserver"
   // Integration Test dependencies
   integrationTestImplementation sourceSets.main.output
   integrationTestImplementation sourceSets.test.output
   integrationTestImplementation project(':kayenta-web')
+  integrationTestImplementation "com.squareup.okhttp3:mockwebserver"
+  integrationTestRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
+  integrationTestRuntimeOnly "org.junit.platform:junit-platform-launcher"
 
   // Apache 2.0 https://github.com/rest-assured/rest-assured/blob/master/LICENSE
   integrationTestImplementation "io.rest-assured:rest-assured"

--- a/kayenta/kayenta-signalfx/src/integration-test/java/com/netflix/kayenta/config/SignalFxMockServiceReportingConfig.java
+++ b/kayenta/kayenta-signalfx/src/integration-test/java/com/netflix/kayenta/config/SignalFxMockServiceReportingConfig.java
@@ -17,68 +17,58 @@
 
 package com.netflix.kayenta.config;
 
-import static com.netflix.kayenta.signalfx.EndToEndCanaryIntegrationTests.CANARY_WINDOW_IN_MINUTES;
-import static io.restassured.RestAssured.given;
-
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import io.restassured.http.Header;
+import java.io.IOException;
 import java.time.Instant;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
-import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
+import okhttp3.mockwebserver.Dispatcher;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 
 /**
- * Spring Test Config for the SignalFx Integration Tests. Creates
- * NUMBER_OF_INSTANCES_PER_MOCK_CLUSTER number of threads for a mock service with three clusters
- * (control, healthy experiment and a unhealthy experiment) These mock clusters will report metrics
- * in their background threads to SignalFx for the IntegrationTest suite to integrate with.
+ * Spring Test Config for the SignalFx integration tests.
  *
- * <p>The metrics that get sent from this config, should align with what is defined in
- * integration-test-canary-config.json in the integration source set resources dir.
+ * <p>Historically these tests spun up threads that pushed metrics into a real Splunk Observability
+ * account (via {@code ingest.signalfx.com}) and then polled the live SignalFlow API. That required
+ * a valid API key and a network round trip, which made the tests unusable in CI. This replacement
+ * stands up an {@link MockWebServer} (managed statically by the base test class) that speaks the
+ * same SignalFlow SSE wire protocol Kayenta queries, and serves canned data shaped to make each
+ * canary judgment deterministic:
+ *
+ * <ul>
+ *   <li>{@code control} and {@code healthy-experiment}: identical low, low-variance values → the
+ *       judge classifies as {@code Pass}.
+ *   <li>{@code unhealthy-experiment}: elevated values on the metric marked {@code critical} → the
+ *       judge classifies as {@code Fail} with a "High" classification reason.
+ *   <li>Any metric name containing {@code errors} (the two non-existent metrics in the canary
+ *       config): empty data stream, mirroring "no data in SignalFx".
+ * </ul>
  */
 @TestConfiguration
 @Slf4j
 public class SignalFxMockServiceReportingConfig {
 
-  private static final int NUMBER_OF_INSTANCES_PER_MOCK_CLUSTER = 3;
-  private static final String INGEST_ENDPOINT = "https://ingest.signalfx.com/v2/datapoint";
-  private static final int MOCK_SERVICE_REPORTING_INTERVAL_IN_MILLISECONDS = 1000;
-
-  public static final String SIGNAL_FX_SCOPE_IDENTIFYING_DIMENSION_NAME = "canary-scope";
-  public static final String SIGNAL_FX_LOCATION_IDENTIFYING_DIMENSION_NAME = "location";
-  public static final String KAYENTA_INTEGRATION_TEST_CPU_AVG_METRIC_NAME =
-      "kayenta.integration-test.cpu.avg";
-  public static final String KAYENTA_INTEGRATION_TEST_REQUEST_COUNT_METRIC_NAME =
-      "kayenta.integration-test.request.count";
   public static final String CONTROL_SCOPE_NAME = "control";
   public static final String HEALTHY_EXPERIMENT_SCOPE_NAME = "healthy-experiment";
   public static final String UNHEALTHY_EXPERIMENT_SCOPE_NAME = "unhealthy-experiment";
 
-  private final ExecutorService executorService;
-  private final String signalFxApiToken;
+  private static final int POINT_COUNT = 60;
+  private static final long STEP_MS = 1000L;
+  private static final String TS_ID = "AAAAAFOJhJg";
 
-  private String testId;
-  private Instant metricsReportingStartTime;
-
-  public SignalFxMockServiceReportingConfig(
-      @Value("${kayenta.signalfx.api-key}") final String signalFxApiToken) {
-    executorService = Executors.newFixedThreadPool(9);
-    this.signalFxApiToken = signalFxApiToken;
-  }
+  private final String testId = UUID.randomUUID().toString();
+  private final Instant metricsReportingStartTime =
+      Instant.now().minusSeconds(POINT_COUNT * STEP_MS / 1000);
 
   @Bean
   public String testId() {
@@ -90,133 +80,97 @@ public class SignalFxMockServiceReportingConfig {
     return metricsReportingStartTime;
   }
 
-  @PostConstruct
-  public void start() {
-    testId = UUID.randomUUID().toString();
+  /** Starts a MockWebServer that dispatches SignalFlow SSE responses. */
+  public static MockWebServer startMockSignalFlowServer() throws IOException {
+    MockWebServer server = new MockWebServer();
+    server.setDispatcher(new SignalFlowDispatcher());
+    server.start();
+    log.info("Mock SignalFlow server listening at {}", server.url("/"));
+    return server;
+  }
 
-    ImmutableList.of(CONTROL_SCOPE_NAME, HEALTHY_EXPERIMENT_SCOPE_NAME)
-        .forEach(
-            scope -> {
-              for (int i = 0; i < NUMBER_OF_INSTANCES_PER_MOCK_CLUSTER; i++) {
-                executorService.submit(
-                    createMetricReportingMockService(
-                        scope,
-                        ImmutableMap.of(
-                            KAYENTA_INTEGRATION_TEST_CPU_AVG_METRIC_NAME, new Metric(10),
-                            KAYENTA_INTEGRATION_TEST_REQUEST_COUNT_METRIC_NAME,
-                                new Metric(
-                                    0,
-                                    ImmutableMap.of(
-                                        "uri", "/v1/some-endpoint",
-                                        "status_code", "400"))),
-                        UUID.randomUUID().toString()));
-              }
-            });
+  private static final class SignalFlowDispatcher extends Dispatcher {
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
-    ImmutableList.of(UNHEALTHY_EXPERIMENT_SCOPE_NAME)
-        .forEach(
-            scope -> {
-              for (int i = 0; i < NUMBER_OF_INSTANCES_PER_MOCK_CLUSTER; i++) {
-                executorService.submit(
-                    createMetricReportingMockService(
-                        scope,
-                        ImmutableMap.of(
-                            KAYENTA_INTEGRATION_TEST_CPU_AVG_METRIC_NAME, new Metric(12),
-                            KAYENTA_INTEGRATION_TEST_REQUEST_COUNT_METRIC_NAME,
-                                new Metric(
-                                    50,
-                                    ImmutableMap.of(
-                                        "uri", "/v1/some-endpoint",
-                                        "status_code", "400"))),
-                        UUID.randomUUID().toString()));
-              }
-            });
-
-    metricsReportingStartTime = Instant.now();
-
-    if (Boolean.valueOf(System.getProperty("block.for.metrics", "true"))) {
-      // Wait for the mock services to send data, before allowing the tests to run
-      try {
-        long pause =
-            TimeUnit.MINUTES.toMillis(CANARY_WINDOW_IN_MINUTES) + TimeUnit.SECONDS.toMillis(15);
-        log.info(
-            "Waiting for {} milliseconds for mock data to flow through SignalFx, before letting the integration tests run",
-            pause);
-        Thread.sleep(pause);
-      } catch (InterruptedException e) {
-        log.error("Failed to wait to send metrics", e);
-        throw new RuntimeException(e);
+    @NotNull
+    @Override
+    public MockResponse dispatch(@NotNull RecordedRequest request) {
+      String path = request.getPath() != null ? request.getPath() : "";
+      if (!path.startsWith("/v2/signalflow/execute")) {
+        return new MockResponse().setResponseCode(404);
       }
+      String program = request.getBody().readUtf8();
+      String scope = extractScope(program);
+      double base = baselineFor(scope, program);
+      boolean emitData = !program.contains("errors");
+      String metric = program.contains("cpu.avg") ? "cpu" : "req";
+      // Seed by metric only (not scope) so control and healthy-experiment produce identical
+      // noise patterns — the canary judge should classify that as Pass. The unhealthy scope
+      // shifts the baseline, which the judge should classify as Fail.
+      long seed = metric.hashCode();
+      return new MockResponse()
+          .setResponseCode(200)
+          .setHeader("Content-Type", "text/plain")
+          .setBody(buildSseBody(base, emitData, seed));
     }
-  }
 
-  @PreDestroy
-  public void stop() {
-    executorService.shutdownNow();
-  }
-
-  private Runnable createMetricReportingMockService(
-      String scopeName, Map<String, Metric> metrics, String uuid) {
-    return () -> {
-      while (!Thread.currentThread().isInterrupted()) {
-        try {
-          List<Map<String, Object>> signalfxMetrics = new LinkedList<>();
-          metrics.forEach(
-              (metricName, metric) ->
-                  signalfxMetrics.add(
-                      ImmutableMap.of(
-                          "metric",
-                          metricName,
-                          "dimensions",
-                          ImmutableMap.builder()
-                              .putAll(metric.getDimensions())
-                              .put(SIGNAL_FX_SCOPE_IDENTIFYING_DIMENSION_NAME, scopeName)
-                              .put(SIGNAL_FX_LOCATION_IDENTIFYING_DIMENSION_NAME, "us-west-2")
-                              .put("env", "integration")
-                              .put("test-id", testId)
-                              .put("uuid", uuid)
-                              .build(),
-                          "value",
-                          metric.getValue() + new Random().nextInt(6))));
-          Map<String, List<Map<String, Object>>> signalfxRequest =
-              ImmutableMap.of("gauge", signalfxMetrics);
-
-          given()
-              .header(new Header("X-SF-TOKEN", signalFxApiToken))
-              .contentType("application/json")
-              .body(signalfxRequest)
-              .when()
-              .post(INGEST_ENDPOINT)
-              .then()
-              .statusCode(200);
-
-          try {
-            Thread.sleep(MOCK_SERVICE_REPORTING_INTERVAL_IN_MILLISECONDS);
-          } catch (InterruptedException e) {
-            log.debug("Thread interrupted", e);
-          }
-        } catch (Throwable t) {
-          log.error("FAILED TO REPORT METRICS TO SIGNALFX, SHUTTING DOWN JVM", t);
-          System.exit(1);
+    private String extractScope(String program) {
+      for (String candidate :
+          new String[] {
+            UNHEALTHY_EXPERIMENT_SCOPE_NAME, HEALTHY_EXPERIMENT_SCOPE_NAME, CONTROL_SCOPE_NAME
+          }) {
+        if (program.contains("'" + candidate + "'")) {
+          return candidate;
         }
       }
-    };
-  }
-
-  @Data
-  private class Metric {
-
-    public Metric(Integer value, Map<String, String> dimensions) {
-      this.dimensions = dimensions;
-      this.value = value;
+      return CONTROL_SCOPE_NAME;
     }
 
-    public Metric(Integer value) {
-      this.value = value;
-      this.dimensions = new HashMap<>();
+    private double baselineFor(String scope, String program) {
+      boolean cpuMetric = program.contains("cpu.avg");
+      boolean requestMetric = program.contains("request.count");
+      if (UNHEALTHY_EXPERIMENT_SCOPE_NAME.equals(scope)) {
+        if (cpuMetric) return 60.0;
+        if (requestMetric) return 50.0;
+      }
+      if (cpuMetric) return 10.0;
+      if (requestMetric) return 0.0;
+      return 0.0;
     }
 
-    private Map<String, String> dimensions;
-    private Integer value;
+    private String buildSseBody(double base, boolean emitData, long seed) {
+      Random random = new Random(seed);
+      StringBuilder sb = new StringBuilder();
+      appendEvent(
+          sb, "control-message", ImmutableMap.of("event", "STREAM_START", "timestampMs", 0));
+      if (emitData) {
+        long ts = 1_700_000_000_000L;
+        for (int i = 0; i < POINT_COUNT; i++) {
+          double value = base + random.nextInt(3);
+          appendEvent(
+              sb,
+              "data",
+              ImmutableMap.of(
+                  "data",
+                  ImmutableList.of(ImmutableMap.of("tsId", TS_ID, "value", value)),
+                  "logicalTimestampMs",
+                  ts + i * STEP_MS));
+        }
+      }
+      appendEvent(
+          sb, "control-message", ImmutableMap.of("event", "END_OF_CHANNEL", "timestampMs", 0));
+      return sb.toString();
+    }
+
+    private void appendEvent(StringBuilder sb, String eventName, Map<String, ?> payload) {
+      String json;
+      try {
+        json = objectMapper.writeValueAsString(payload);
+      } catch (JsonProcessingException e) {
+        throw new IllegalStateException("Failed to serialize mock SignalFlow payload", e);
+      }
+      sb.append("event: ").append(eventName).append('\n');
+      sb.append("data: ").append(json).append("\n\n");
+    }
   }
 }

--- a/kayenta/kayenta-signalfx/src/integration-test/java/com/netflix/kayenta/signalfx/BaseSignalFxIntegrationTest.java
+++ b/kayenta/kayenta-signalfx/src/integration-test/java/com/netflix/kayenta/signalfx/BaseSignalFxIntegrationTest.java
@@ -19,14 +19,18 @@ package com.netflix.kayenta.signalfx;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.kayenta.Main;
 import com.netflix.kayenta.canary.CanaryConfig;
+import com.netflix.kayenta.config.SignalFxMockServiceReportingConfig;
 import java.io.IOException;
 import java.time.Instant;
 import lombok.extern.slf4j.Slf4j;
+import okhttp3.mockwebserver.MockWebServer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @ExtendWith(SpringExtension.class)
@@ -41,6 +45,26 @@ public abstract class BaseSignalFxIntegrationTest {
   protected static final String TEST_ID = "test-id";
   protected static final String LOCATION = "us-west-2";
 
+  private static final MockWebServer mockSignalFlowServer;
+
+  static {
+    try {
+      mockSignalFlowServer = SignalFxMockServiceReportingConfig.startMockSignalFlowServer();
+      Runtime.getRuntime()
+          .addShutdownHook(
+              new Thread(
+                  () -> {
+                    try {
+                      mockSignalFlowServer.shutdown();
+                    } catch (IOException ignored) {
+                      // best effort at JVM shutdown
+                    }
+                  }));
+    } catch (IOException e) {
+      throw new ExceptionInInitializerError(e);
+    }
+  }
+
   protected CanaryConfig integrationTestCanaryConfig;
 
   @Autowired protected ObjectMapper objectMapper = new ObjectMapper();
@@ -50,6 +74,11 @@ public abstract class BaseSignalFxIntegrationTest {
   @Autowired protected Instant metricsReportingStartTime;
 
   @LocalServerPort protected int serverPort;
+
+  @DynamicPropertySource
+  static void registerSignalFxProperties(DynamicPropertyRegistry registry) {
+    registry.add("kayenta.signalfx.mockEndpoint", () -> mockSignalFlowServer.url("/").toString());
+  }
 
   protected String getUriTemplate() {
     return "http://localhost:" + serverPort + "%s";

--- a/kayenta/kayenta-signalfx/src/integration-test/java/com/netflix/kayenta/signalfx/EndToEndCanaryIntegrationTests.java
+++ b/kayenta/kayenta-signalfx/src/integration-test/java/com/netflix/kayenta/signalfx/EndToEndCanaryIntegrationTests.java
@@ -34,7 +34,6 @@ import io.restassured.response.ValidatableResponse;
 import java.io.IOException;
 import java.time.Instant;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 /** End to end integration tests */
@@ -42,11 +41,6 @@ import org.junit.jupiter.api.Test;
 public class EndToEndCanaryIntegrationTests extends BaseSignalFxIntegrationTest {
 
   public static final int CANARY_WINDOW_IN_MINUTES = 5;
-
-  @BeforeAll
-  public static void beforeClass() {
-    System.setProperty("block.for.metrics", System.getProperty("block.for.metrics", "true"));
-  }
 
   @Test
   public void test_that_signalfx_can_be_used_as_a_data_source_for_a_canary_execution_healthy()

--- a/kayenta/kayenta-signalfx/src/integration-test/java/com/netflix/kayenta/signalfx/EndToEndStandaloneCanaryAnalysisIntegrationTests.java
+++ b/kayenta/kayenta-signalfx/src/integration-test/java/com/netflix/kayenta/signalfx/EndToEndStandaloneCanaryAnalysisIntegrationTests.java
@@ -31,16 +31,10 @@ import com.netflix.kayenta.standalonecanaryanalysis.domain.CanaryAnalysisExecuti
 import com.netflix.kayenta.standalonecanaryanalysis.domain.StageMetadata;
 import io.restassured.response.ValidatableResponse;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 @Slf4j
 public class EndToEndStandaloneCanaryAnalysisIntegrationTests extends BaseSignalFxIntegrationTest {
-
-  @BeforeAll
-  public static void beforeClass() {
-    System.setProperty("block.for.metrics", System.getProperty("block.for.metrics", "false"));
-  }
 
   @Test
   public void test_that_a_canary_analysis_execution_can_be_created_healthy()
@@ -64,8 +58,8 @@ public class EndToEndStandaloneCanaryAnalysisIntegrationTests extends BaseSignal
                         .step(1L)
                         .build()))
             .thresholds(CanaryClassifierThresholdsConfig.builder().marginal(50D).pass(75D).build())
-            .lifetimeDurationMins(5L)
-            .analysisIntervalMins(2L)
+            .lifetimeDurationMins(2L)
+            .analysisIntervalMins(1L)
             .build();
 
     request.setExecutionRequest(executionRequest);
@@ -99,7 +93,7 @@ public class EndToEndStandaloneCanaryAnalysisIntegrationTests extends BaseSignal
                       getUriTemplate(), "/standalone_canary_analysis/" + canaryAnalysisExecutionId))
               .then()
               .statusCode(200);
-      Thread.sleep(5000);
+      Thread.sleep(1000);
       log.info("Stage Status");
       response
           .extract()

--- a/kayenta/kayenta-signalfx/src/integration-test/resources/config/kayenta.yml
+++ b/kayenta/kayenta-signalfx/src/integration-test/resources/config/kayenta.yml
@@ -7,7 +7,9 @@ kayenta:
     enabled: true
     accounts:
     - name: sfx-integration-test-account
-      accessToken: ${kayenta.signalfx.apiKey}
+      accessToken: mock-token
+      endpoint:
+        baseUrl: ${kayenta.signalfx.mockEndpoint:http://localhost:0}
       supportedTypes:
       - METRICS_STORE
       defaultScopeKey: canary-scope

--- a/kayenta/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/metrics/SignalFxMetricsService.java
+++ b/kayenta/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/metrics/SignalFxMetricsService.java
@@ -17,8 +17,8 @@
 
 package com.netflix.kayenta.signalfx.metrics;
 
-import static com.signalfx.signalflow.ChannelMessage.Type.DATA_MESSAGE;
-import static com.signalfx.signalflow.ChannelMessage.Type.ERROR_MESSAGE;
+import static com.netflix.kayenta.signalfx.service.signalflow.SignalFlowMessage.Type.DATA_MESSAGE;
+import static com.netflix.kayenta.signalfx.service.signalflow.SignalFlowMessage.Type.ERROR_MESSAGE;
 
 import com.netflix.kayenta.canary.CanaryConfig;
 import com.netflix.kayenta.canary.CanaryMetricConfig;
@@ -35,8 +35,8 @@ import com.netflix.kayenta.signalfx.service.ErrorResponse;
 import com.netflix.kayenta.signalfx.service.SignalFlowExecutionResult;
 import com.netflix.kayenta.signalfx.service.SignalFxRequestError;
 import com.netflix.kayenta.signalfx.service.SignalFxSignalFlowRemoteService;
+import com.netflix.kayenta.signalfx.service.signalflow.SignalFlowMessage;
 import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerHttpException;
-import com.signalfx.signalflow.ChannelMessage;
 import jakarta.validation.constraints.NotNull;
 import java.time.Duration;
 import java.time.Instant;
@@ -160,13 +160,13 @@ public class SignalFxMetricsService implements MetricsService {
         immediate,
         program);
 
-    LinkedList<ChannelMessage.DataMessage> dataMessages =
+    LinkedList<SignalFlowMessage.DataMessage> dataMessages =
         extractDataMessages(signalFlowExecutionResult);
 
-    ChannelMessage.DataMessage firstDataPoint =
+    SignalFlowMessage.DataMessage firstDataPoint =
         dataMessages.size() > 0 ? dataMessages.getFirst() : null;
 
-    ChannelMessage.DataMessage lastDataPoint =
+    SignalFlowMessage.DataMessage lastDataPoint =
         dataMessages.size() > 0 ? dataMessages.getLast() : null;
 
     // Return a Metric set of the reduced and aggregated data
@@ -211,17 +211,17 @@ public class SignalFxMetricsService implements MetricsService {
    * @param signalFlowExecutionResult The SignalFlow program results.
    * @return An linked list of the data points from the result.
    */
-  private LinkedList<ChannelMessage.DataMessage> extractDataMessages(
+  private LinkedList<SignalFlowMessage.DataMessage> extractDataMessages(
       SignalFlowExecutionResult signalFlowExecutionResult) {
     return signalFlowExecutionResult.getChannelMessages().parallelStream()
         .filter(channelMessage -> channelMessage.getType().equals(DATA_MESSAGE))
-        .map((message) -> (ChannelMessage.DataMessage) message)
+        .map((message) -> (SignalFlowMessage.DataMessage) message)
         .collect(Collectors.toCollection(LinkedList::new));
   }
 
   /** Parses the channel messages and the first error if present. */
   private void validateResults(
-      List<ChannelMessage> channelMessages,
+      List<SignalFlowMessage> channelMessages,
       String account,
       long startEpochMilli,
       long endEpochMilli,
@@ -257,7 +257,7 @@ public class SignalFxMetricsService implements MetricsService {
    * @return The list of values with missing data filled with NaNs
    */
   protected List<Double> getTimeSeriesDataFromDataMessages(
-      List<ChannelMessage.DataMessage> dataMessages) {
+      List<SignalFlowMessage.DataMessage> dataMessages) {
     return dataMessages.stream()
         .map(
             message -> {

--- a/kayenta/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/service/SignalFlowExecutionResult.java
+++ b/kayenta/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/service/SignalFlowExecutionResult.java
@@ -17,7 +17,7 @@
 
 package com.netflix.kayenta.signalfx.service;
 
-import com.signalfx.signalflow.ChannelMessage;
+import com.netflix.kayenta.signalfx.service.signalflow.SignalFlowMessage;
 import java.util.List;
 import lombok.Builder;
 import lombok.Data;
@@ -26,5 +26,5 @@ import lombok.Data;
 @Builder
 public class SignalFlowExecutionResult {
 
-  private List<ChannelMessage> channelMessages;
+  private List<SignalFlowMessage> channelMessages;
 }

--- a/kayenta/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/service/SignalFxConverter.java
+++ b/kayenta/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/service/SignalFxConverter.java
@@ -20,9 +20,8 @@ package com.netflix.kayenta.signalfx.service;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.netflix.kayenta.metrics.ConversionException;
-import com.signalfx.signalflow.ChannelMessage;
-import com.signalfx.signalflow.ServerSentEventsTransport;
-import com.signalfx.signalflow.StreamMessage;
+import com.netflix.kayenta.signalfx.service.signalflow.SignalFlowMessage;
+import com.netflix.kayenta.signalfx.service.signalflow.SignalFlowSseParser;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.LinkedList;
@@ -89,14 +88,10 @@ public class SignalFxConverter extends Converter.Factory {
 
     @Override
     public SignalFlowExecutionResult convert(ResponseBody value) {
-      List<ChannelMessage> messages = new LinkedList<>();
-      try (ServerSentEventsTransport.TransportEventStreamParser parser =
-          new ServerSentEventsTransport.TransportEventStreamParser(value.byteStream())) {
-
+      List<SignalFlowMessage> messages = new LinkedList<>();
+      try (SignalFlowSseParser parser = new SignalFlowSseParser(value.byteStream(), objectMapper)) {
         while (parser.hasNext()) {
-          StreamMessage streamMessage = parser.next();
-          ChannelMessage channelMessage = ChannelMessage.decodeStreamMessage(streamMessage);
-          messages.add(channelMessage);
+          messages.add(parser.next());
         }
       } catch (Exception e) {
         throw new ConversionException("There was an issue parsing the SignalFlow response", e);

--- a/kayenta/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/service/signalflow/SignalFlowMessage.java
+++ b/kayenta/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/service/signalflow/SignalFlowMessage.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2026 Harness, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.kayenta.signalfx.service.signalflow;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import lombok.Getter;
+
+/**
+ * Internal replacement for the {@code ChannelMessage} hierarchy from the archived
+ * com.signalfx.public:signalfx-java library. Only the fields kayenta actually consumes are modeled.
+ */
+@Getter
+public abstract class SignalFlowMessage {
+
+  public enum Type {
+    CONTROL_MESSAGE,
+    METADATA_MESSAGE,
+    DATA_MESSAGE,
+    EVENT_MESSAGE,
+    INFO_MESSAGE,
+    ERROR_MESSAGE,
+    EXPIRED_TSID_MESSAGE,
+    UNKNOWN
+  }
+
+  private final Type type;
+
+  protected SignalFlowMessage(Type type) {
+    this.type = type;
+  }
+
+  /** Maps the SSE {@code event:} name to a message type. */
+  static Type parseEventType(String eventName) {
+    if (eventName == null) {
+      return Type.UNKNOWN;
+    }
+    switch (eventName) {
+      case "control-message":
+        return Type.CONTROL_MESSAGE;
+      case "metadata":
+        return Type.METADATA_MESSAGE;
+      case "data":
+        return Type.DATA_MESSAGE;
+      case "event":
+        return Type.EVENT_MESSAGE;
+      case "message":
+        return Type.INFO_MESSAGE;
+      case "error":
+        return Type.ERROR_MESSAGE;
+      case "expired-tsid":
+        return Type.EXPIRED_TSID_MESSAGE;
+      default:
+        return Type.UNKNOWN;
+    }
+  }
+
+  /** Data point message; kayenta reads only {@link #getLogicalTimestampMs} and {@link #getData}. */
+  @Getter
+  public static class DataMessage extends SignalFlowMessage {
+    private final long logicalTimestampMs;
+    private final Map<String, Number> data;
+
+    DataMessage(long logicalTimestampMs, Map<String, Number> data) {
+      super(Type.DATA_MESSAGE);
+      this.logicalTimestampMs = logicalTimestampMs;
+      this.data = data;
+    }
+  }
+
+  /** Any non-data message we don't need to introspect (control/metadata/info/event/error/etc). */
+  @Getter
+  public static class RawMessage extends SignalFlowMessage {
+    private final JsonNode payload;
+
+    RawMessage(Type type, JsonNode payload) {
+      super(type);
+      this.payload = payload;
+    }
+  }
+
+  static SignalFlowMessage fromJson(Type type, JsonNode payload) {
+    if (type == Type.DATA_MESSAGE) {
+      long logicalTimestampMs =
+          payload.hasNonNull("logicalTimestampMs")
+              ? payload.get("logicalTimestampMs").asLong()
+              : 0L;
+      JsonNode dataArray = payload.get("data");
+      Map<String, Number> data = new LinkedHashMap<>();
+      if (dataArray != null && dataArray.isArray()) {
+        for (JsonNode point : dataArray) {
+          JsonNode tsId = point.get("tsId");
+          JsonNode value = point.get("value");
+          if (tsId != null && value != null) {
+            data.put(tsId.asText(), value.isIntegralNumber() ? value.asLong() : value.asDouble());
+          }
+        }
+      }
+      return new DataMessage(logicalTimestampMs, Collections.unmodifiableMap(data));
+    }
+    return new RawMessage(type, payload);
+  }
+}

--- a/kayenta/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/service/signalflow/SignalFlowSseParser.java
+++ b/kayenta/kayenta-signalfx/src/main/java/com/netflix/kayenta/signalfx/service/signalflow/SignalFlowSseParser.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2026 Harness, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.kayenta.signalfx.service.signalflow;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+/**
+ * Parses a Splunk Observability SignalFlow response stream (text/event-stream) into typed {@link
+ * SignalFlowMessage}s. Replaces {@code
+ * com.signalfx.signalflow.ServerSentEventsTransport.TransportEventStreamParser} from the archived
+ * signalfx-java library.
+ *
+ * <p>The wire format is standard SSE: records separated by blank lines, each record composed of
+ * {@code event: <name>} and one or more {@code data: <line>} fields. The payload of a record is the
+ * concatenation of its data lines joined with {@code \n}, and — for SignalFlow — is JSON. Unknown
+ * event types are surfaced as {@link SignalFlowMessage.RawMessage} with type {@code UNKNOWN} rather
+ * than dropped, so callers can log or ignore them.
+ */
+public class SignalFlowSseParser implements Iterator<SignalFlowMessage>, AutoCloseable {
+
+  private final BufferedReader reader;
+  private final ObjectMapper objectMapper;
+  private SignalFlowMessage next;
+  private boolean eof;
+
+  public SignalFlowSseParser(InputStream inputStream) {
+    this(inputStream, new ObjectMapper());
+  }
+
+  public SignalFlowSseParser(InputStream inputStream, ObjectMapper objectMapper) {
+    this.reader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8));
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  public boolean hasNext() {
+    if (next != null) {
+      return true;
+    }
+    if (eof) {
+      return false;
+    }
+    try {
+      next = readNext();
+    } catch (IOException e) {
+      throw new SignalFlowParseException("Failed reading SignalFlow SSE stream", e);
+    }
+    if (next == null) {
+      eof = true;
+      return false;
+    }
+    return true;
+  }
+
+  @Override
+  public SignalFlowMessage next() {
+    if (!hasNext()) {
+      throw new NoSuchElementException();
+    }
+    SignalFlowMessage result = next;
+    next = null;
+    return result;
+  }
+
+  private SignalFlowMessage readNext() throws IOException {
+    String eventName = null;
+    StringBuilder data = null;
+    String line;
+    while ((line = reader.readLine()) != null) {
+      if (line.isEmpty()) {
+        if (eventName != null && data != null) {
+          return decode(eventName, data.toString());
+        }
+        // stray blank line between records with no fields; keep scanning
+        eventName = null;
+        data = null;
+        continue;
+      }
+      if (line.startsWith(":")) {
+        // SSE comment
+        continue;
+      }
+      int colon = line.indexOf(':');
+      String field;
+      String value;
+      if (colon < 0) {
+        field = line;
+        value = "";
+      } else {
+        field = line.substring(0, colon);
+        value = line.substring(colon + 1);
+        if (!value.isEmpty() && value.charAt(0) == ' ') {
+          value = value.substring(1);
+        }
+      }
+      switch (field) {
+        case "event":
+          eventName = value;
+          break;
+        case "data":
+          if (data == null) {
+            data = new StringBuilder(value);
+          } else {
+            data.append('\n').append(value);
+          }
+          break;
+        default:
+          // ignore id:, retry:, and any unknown fields
+      }
+    }
+    if (eventName != null && data != null) {
+      return decode(eventName, data.toString());
+    }
+    return null;
+  }
+
+  private SignalFlowMessage decode(String eventName, String data) {
+    SignalFlowMessage.Type type = SignalFlowMessage.parseEventType(eventName);
+    JsonNode payload;
+    try {
+      payload = objectMapper.readTree(data);
+    } catch (IOException e) {
+      throw new SignalFlowParseException(
+          "Failed parsing SignalFlow JSON payload for event '" + eventName + "'", e);
+    }
+    return SignalFlowMessage.fromJson(type, payload);
+  }
+
+  @Override
+  public void close() throws IOException {
+    reader.close();
+  }
+
+  public static class SignalFlowParseException extends RuntimeException {
+    public SignalFlowParseException(String message, Throwable cause) {
+      super(message, cause);
+    }
+  }
+}

--- a/kayenta/kayenta-signalfx/src/test/java/com/netflix/kayenta/signalfx/service/signalflow/SignalFlowSseParserTest.java
+++ b/kayenta/kayenta-signalfx/src/test/java/com/netflix/kayenta/signalfx/service/signalflow/SignalFlowSseParserTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2026 Harness, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.kayenta.signalfx.service.signalflow;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class SignalFlowSseParserTest {
+
+  @Test
+  void parses_the_fixture_signalflow_response() throws Exception {
+    try (InputStream response =
+            getClass().getClassLoader().getResourceAsStream("signalfx-signalflow-response.text");
+        SignalFlowSseParser parser = new SignalFlowSseParser(response)) {
+      List<SignalFlowMessage> messages = new ArrayList<>();
+      while (parser.hasNext()) {
+        messages.add(parser.next());
+      }
+      assertThat(messages).hasSizeGreaterThan(1);
+
+      long dataMessageCount =
+          messages.stream().filter(m -> m.getType() == SignalFlowMessage.Type.DATA_MESSAGE).count();
+      assertThat(dataMessageCount).isGreaterThan(0);
+
+      SignalFlowMessage.DataMessage anyDataPoint =
+          messages.stream()
+              .filter(m -> m instanceof SignalFlowMessage.DataMessage)
+              .map(m -> (SignalFlowMessage.DataMessage) m)
+              .filter(dm -> !dm.getData().isEmpty())
+              .findFirst()
+              .orElseThrow();
+      assertThat(anyDataPoint.getLogicalTimestampMs()).isGreaterThan(0);
+      assertThat(anyDataPoint.getData()).containsKey("AAAAAFOJhJg");
+    }
+  }
+
+  @Test
+  void extracts_ts_id_and_value_from_data_frame() {
+    String body =
+        "event: data\n"
+            + "id: data-1\n"
+            + "data: {\n"
+            + "data:   \"data\" : [ { \"tsId\" : \"ABC\", \"value\" : 42.5 } ],\n"
+            + "data:   \"logicalTimestampMs\" : 1000\n"
+            + "data: }\n\n";
+    SignalFlowMessage.DataMessage msg = (SignalFlowMessage.DataMessage) parseOne(body);
+    assertThat(msg.getLogicalTimestampMs()).isEqualTo(1000L);
+    assertThat(msg.getData()).containsEntry("ABC", 42.5);
+  }
+
+  @Test
+  void empty_data_array_yields_empty_map() {
+    String body = "event: data\ndata: {\"data\":[],\"logicalTimestampMs\":10}\n\n";
+    SignalFlowMessage.DataMessage msg = (SignalFlowMessage.DataMessage) parseOne(body);
+    assertThat(msg.getData()).isEmpty();
+    assertThat(msg.getLogicalTimestampMs()).isEqualTo(10L);
+  }
+
+  @Test
+  void unknown_event_types_surface_as_unknown_raw_messages() {
+    String body = "event: nonsense\ndata: {\"foo\":1}\n\n";
+    SignalFlowMessage msg = parseOne(body);
+    assertThat(msg.getType()).isEqualTo(SignalFlowMessage.Type.UNKNOWN);
+    assertThat(msg).isInstanceOf(SignalFlowMessage.RawMessage.class);
+  }
+
+  @Test
+  void terminates_cleanly_on_end_of_channel() {
+    String body =
+        "event: data\ndata: {\"data\":[],\"logicalTimestampMs\":1}\n\n"
+            + "event: control-message\ndata: {\"event\":\"END_OF_CHANNEL\"}\n\n";
+    try (SignalFlowSseParser parser = newParser(body)) {
+      assertThat(parser.hasNext()).isTrue();
+      parser.next();
+      assertThat(parser.hasNext()).isTrue();
+      SignalFlowMessage control = parser.next();
+      assertThat(control.getType()).isEqualTo(SignalFlowMessage.Type.CONTROL_MESSAGE);
+      assertThat(parser.hasNext()).isFalse();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Test
+  void malformed_json_raises_parse_exception() {
+    String body = "event: data\ndata: {not-json}\n\n";
+    assertThatThrownBy(() -> parseOne(body))
+        .isInstanceOf(SignalFlowSseParser.SignalFlowParseException.class);
+  }
+
+  private SignalFlowMessage parseOne(String body) {
+    try (SignalFlowSseParser parser = newParser(body)) {
+      assertThat(parser.hasNext()).isTrue();
+      return parser.next();
+    } catch (Exception e) {
+      if (e instanceof RuntimeException) throw (RuntimeException) e;
+      throw new RuntimeException(e);
+    }
+  }
+
+  private SignalFlowSseParser newParser(String body) {
+    return new SignalFlowSseParser(new ByteArrayInputStream(body.getBytes(StandardCharsets.UTF_8)));
+  }
+}


### PR DESCRIPTION
The signalfx java library is dead with a recommendation to move to OTEL.  HOWEVER... OTEL is for sending metrics, not querying them. Thus this migration which replaces the signalfx-java with simple parsers/converters.  The primary driver for this is that the signalfx-java library includes some CVE code that needs to be removed.  BUT this also further removes external custom deps that can polluate the system AND makes the tests more reliable.  This still does integration with a server but we mock the data vs. needing a real signalfx account to make this work.