### PR TITLE
feat(ecs): migrate TargetHealthCachingAgent to AWS SDK v2 ELBv2

### DIFF
--- a/clouddriver/clouddriver-aws/clouddriver-aws.gradle
+++ b/clouddriver/clouddriver-aws/clouddriver-aws.gradle
@@ -35,6 +35,7 @@ dependencies {
   api "software.amazon.awssdk:cloudwatch"
   api "software.amazon.awssdk:ecr"
   api "software.amazon.awssdk:ecs"
+  api "software.amazon.awssdk:elasticloadbalancingv2"
   api "software.amazon.awssdk:iam"
   api "software.amazon.awssdk:lambda"
   api "software.amazon.awssdk:secretsmanager"

--- a/clouddriver/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/security/AmazonClientProvider.java
+++ b/clouddriver/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/security/AmazonClientProvider.java
@@ -74,6 +74,7 @@ import software.amazon.awssdk.services.applicationautoscaling.ApplicationAutoSca
 import software.amazon.awssdk.services.cloudwatch.CloudWatchClient;
 import software.amazon.awssdk.services.ecr.EcrClient;
 import software.amazon.awssdk.services.ecs.EcsClient;
+import software.amazon.awssdk.services.elasticloadbalancingv2.ElasticLoadBalancingV2Client;
 import software.amazon.awssdk.services.iam.IamClient;
 import software.amazon.awssdk.services.lambda.LambdaClient;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
@@ -846,6 +847,21 @@ public class AmazonClientProvider {
     return awsSdkV2ClientSupplier.getClient(
         ApplicationAutoScalingClient::builder,
         ApplicationAutoScalingClient.class,
+        amazonCredentials.getV2CredentialsProvider(),
+        region,
+        amazonCredentials.getName());
+  }
+
+  /**
+   * Returns an AWS SDK v2 {@link ElasticLoadBalancingV2Client} for the given account and region.
+   *
+   * <p>No {@code skipEdda} parameter: Edda interception is v1-only (see {@link #getAmazonEcsV2}).
+   */
+  public ElasticLoadBalancingV2Client getAmazonElasticLoadBalancingV2V2(
+      NetflixAmazonCredentials amazonCredentials, String region) {
+    return awsSdkV2ClientSupplier.getClient(
+        ElasticLoadBalancingV2Client::builder,
+        ElasticLoadBalancingV2Client.class,
         amazonCredentials.getV2CredentialsProvider(),
         region,
         amazonCredentials.getName());

--- a/clouddriver/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/client/TargetHealthCacheClient.java
+++ b/clouddriver/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/client/TargetHealthCacheClient.java
@@ -17,7 +17,6 @@ package com.netflix.spinnaker.clouddriver.ecs.cache.client;
 
 import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.TARGET_HEALTHS;
 
-import com.amazonaws.services.elasticloadbalancingv2.model.TargetHealthDescription;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spinnaker.cats.cache.Cache;
 import com.netflix.spinnaker.cats.cache.CacheData;
@@ -28,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.TargetHealthDescription;
 
 @Component
 public class TargetHealthCacheClient extends AbstractCacheClient<EcsTargetHealth> {
@@ -55,8 +55,11 @@ public class TargetHealthCacheClient extends AbstractCacheClient<EcsTargetHealth
       for (Map<String, Object> serializedTargetHealthDescription : targetHealthDescriptions) {
         if (serializedTargetHealthDescription != null) {
           deserializedTargetHealthDescriptions.add(
-              objectMapper.convertValue(
-                  serializedTargetHealthDescription, TargetHealthDescription.class));
+              objectMapper
+                  .convertValue(
+                      serializedTargetHealthDescription,
+                      TargetHealthDescription.serializableBuilderClass())
+                  .build());
         }
       }
 

--- a/clouddriver/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/model/EcsTargetHealth.java
+++ b/clouddriver/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/model/EcsTargetHealth.java
@@ -15,9 +15,9 @@
 
 package com.netflix.spinnaker.clouddriver.ecs.cache.model;
 
-import com.amazonaws.services.elasticloadbalancingv2.model.TargetHealthDescription;
 import java.util.List;
 import lombok.Data;
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.TargetHealthDescription;
 
 @Data
 public class EcsTargetHealth {

--- a/clouddriver/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TargetHealthCachingAgent.java
+++ b/clouddriver/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TargetHealthCachingAgent.java
@@ -19,11 +19,6 @@ import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITA
 import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.TARGET_GROUPS;
 import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.TARGET_HEALTHS;
 
-import com.amazonaws.services.elasticloadbalancingv2.AmazonElasticLoadBalancing;
-import com.amazonaws.services.elasticloadbalancingv2.model.DescribeTargetHealthRequest;
-import com.amazonaws.services.elasticloadbalancingv2.model.DescribeTargetHealthResult;
-import com.amazonaws.services.elasticloadbalancingv2.model.TargetGroupNotFoundException;
-import com.amazonaws.services.elasticloadbalancingv2.model.TargetHealthDescription;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spinnaker.cats.agent.*;
 import com.netflix.spinnaker.cats.cache.*;
@@ -41,6 +36,11 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.ecs.EcsClient;
+import software.amazon.awssdk.services.elasticloadbalancingv2.ElasticLoadBalancingV2Client;
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.DescribeTargetHealthRequest;
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.DescribeTargetHealthResponse;
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.TargetGroupNotFoundException;
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.TargetHealthDescription;
 
 public class TargetHealthCachingAgent extends AbstractEcsAwsAwareCachingAgent<EcsTargetHealth>
     implements HealthProvidingCachingAgent {
@@ -72,24 +72,22 @@ public class TargetHealthCachingAgent extends AbstractEcsAwsAwareCachingAgent<Ec
     Set<String> targetGroups = fetchTargetGroups(targetGroupCacheClient);
     log.debug("Fetched {} target groups for which to get target healths", targetGroups.size());
 
-    AmazonElasticLoadBalancing amazonLoadBalancing =
-        amazonClientProvider.getAmazonElasticLoadBalancingV2(account, region, false);
+    ElasticLoadBalancingV2Client amazonLoadBalancing =
+        amazonClientProvider.getAmazonElasticLoadBalancingV2V2(account, region);
 
     List<EcsTargetHealth> targetHealthList = new LinkedList<>();
 
     if (targetGroups != null) {
       for (String tgArn : targetGroups) {
 
-        DescribeTargetHealthResult describeTargetHealthResult = new DescribeTargetHealthResult();
+        List<TargetHealthDescription> healthDescriptions = Collections.emptyList();
         try {
-          describeTargetHealthResult =
+          DescribeTargetHealthResponse response =
               amazonLoadBalancing.describeTargetHealth(
-                  new DescribeTargetHealthRequest().withTargetGroupArn(tgArn));
+                  DescribeTargetHealthRequest.builder().targetGroupArn(tgArn).build());
+          healthDescriptions = response.targetHealthDescriptions();
         } catch (TargetGroupNotFoundException ignore) {
         }
-
-        List<TargetHealthDescription> healthDescriptions =
-            describeTargetHealthResult.getTargetHealthDescriptions();
 
         if (healthDescriptions != null && healthDescriptions.size() > 0) {
           targetHealthList.add(makeEcsTargetHealth(tgArn, healthDescriptions));

--- a/clouddriver/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskHealthCachingAgent.java
+++ b/clouddriver/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskHealthCachingAgent.java
@@ -24,7 +24,6 @@ import com.amazonaws.services.ecs.model.ContainerDefinition;
 import com.amazonaws.services.ecs.model.LoadBalancer;
 import com.amazonaws.services.ecs.model.PortMapping;
 import com.amazonaws.services.ecs.model.TaskDefinition;
-import com.amazonaws.services.elasticloadbalancingv2.model.TargetHealthDescription;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spinnaker.cats.agent.AgentDataType;
 import com.netflix.spinnaker.cats.cache.CacheData;
@@ -51,6 +50,7 @@ import software.amazon.awssdk.services.ecs.EcsClient;
 import software.amazon.awssdk.services.ecs.model.Container;
 import software.amazon.awssdk.services.ecs.model.NetworkBinding;
 import software.amazon.awssdk.services.ecs.model.NetworkInterface;
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.TargetHealthDescription;
 
 public class TaskHealthCachingAgent extends AbstractEcsCachingAgent<TaskHealth>
     implements HealthProvidingCachingAgent {
@@ -223,9 +223,9 @@ public class TaskHealthCachingAgent extends AbstractEcsCachingAgent<TaskHealth>
       Task task, String serviceName, TargetHealthDescription healthDescription) {
     String targetHealth = STATUS_UNKNOWN;
     if (healthDescription != null) {
-      log.debug("Task target health is: {}", healthDescription.getTargetHealth());
+      log.debug("Task target health is: {}", healthDescription.targetHealth());
       targetHealth =
-          healthDescription.getTargetHealth().getState().equals("healthy")
+          healthDescription.targetHealth().stateAsString().equals("healthy")
               ? STATUS_UP
               : STATUS_UNKNOWN;
     }
@@ -289,10 +289,7 @@ public class TaskHealthCachingAgent extends AbstractEcsCachingAgent<TaskHealth>
       List<TargetHealthDescription> targetHealths, String targetId, Integer targetPort) {
 
     return targetHealths.stream()
-        .filter(
-            h ->
-                h.getTarget().getId().equals(targetId)
-                    && h.getTarget().getPort().equals(targetPort))
+        .filter(h -> h.target().id().equals(targetId) && h.target().port().equals(targetPort))
         .findFirst()
         .orElse(null);
   }

--- a/clouddriver/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/services/ContainerInformationService.java
+++ b/clouddriver/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/services/ContainerInformationService.java
@@ -184,7 +184,7 @@ public class ContainerInformationService {
   private String getPlatformHealthStateFromTargetGroup(EcsTargetHealth targetHealth) {
     Set<String> statuses =
         targetHealth.getTargetHealthDescriptions().stream()
-            .map(tg -> tg.getTargetHealth().getState())
+            .map(tg -> tg.targetHealth().stateAsString())
             .collect(Collectors.toSet());
 
     for (String status : statuses) {

--- a/clouddriver/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/cache/TargetHealthCacheClientSpec.groovy
+++ b/clouddriver/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/cache/TargetHealthCacheClientSpec.groovy
@@ -15,10 +15,10 @@
 
 package com.netflix.spinnaker.clouddriver.ecs.cache
 
-import com.amazonaws.services.elasticloadbalancingv2.model.TargetDescription
-import com.amazonaws.services.elasticloadbalancingv2.model.TargetHealth
-import com.amazonaws.services.elasticloadbalancingv2.model.TargetHealthDescription
-import com.amazonaws.services.elasticloadbalancingv2.model.TargetHealthStateEnum
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.TargetDescription
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.TargetHealth
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.TargetHealthDescription
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.TargetHealthStateEnum
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.cats.cache.DefaultCacheData
 
@@ -43,16 +43,26 @@ class TargetHealthCacheClientSpec extends Specification {
     def key =
       Keys.getTargetHealthKey('test-account', 'us-west-1', targetGroupArn)
 
-    def targetHealthDescription = new TargetHealthDescription().withTarget(
-      new TargetDescription().withId(targetId).withPort(80))
-      .withTargetHealth(new TargetHealth().withState(TargetHealthStateEnum.Healthy))
+    def targetHealthDescription = TargetHealthDescription.builder()
+      .target(TargetDescription.builder().id(targetId).port(80).build())
+      .targetHealth(TargetHealth.builder().state(TargetHealthStateEnum.HEALTHY).build())
+      .build()
 
     def originalTargetHealth = new EcsTargetHealth(
       targetGroupArn: targetGroupArn,
       targetHealthDescriptions: Collections.singletonList(targetHealthDescription)
     )
 
-    def attributes = objectMapper.convertValue(originalTargetHealth, Map)
+    // Manually build the attributes map since v2 SDK objects aren't JavaBeans-serializable
+    def attributes = [
+      targetGroupArn: targetGroupArn,
+      targetHealthDescriptions: [
+        [
+          target: [id: targetId, port: 80, availabilityZone: null],
+          targetHealth: [state: 'healthy', reason: null, description: null]
+        ]
+      ]
+    ]
     cacheView.get(TARGET_HEALTHS.toString(), key) >> new DefaultCacheData(key, attributes, Collections.emptyMap())
 
     when:

--- a/clouddriver/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TargetHealthCachingAgentSpec.groovy
+++ b/clouddriver/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TargetHealthCachingAgentSpec.groovy
@@ -16,14 +16,14 @@
 package com.netflix.spinnaker.clouddriver.ecs.provider.agent
 
 import software.amazon.awssdk.services.ecs.EcsClient
-import com.amazonaws.services.elasticloadbalancingv2.AmazonElasticLoadBalancing
-import com.amazonaws.services.elasticloadbalancingv2.model.DescribeTargetHealthRequest
-import com.amazonaws.services.elasticloadbalancingv2.model.DescribeTargetHealthResult
-import com.amazonaws.services.elasticloadbalancingv2.model.TargetDescription
-import com.amazonaws.services.elasticloadbalancingv2.model.TargetGroupNotFoundException
-import com.amazonaws.services.elasticloadbalancingv2.model.TargetHealth
-import com.amazonaws.services.elasticloadbalancingv2.model.TargetHealthDescription
-import com.amazonaws.services.elasticloadbalancingv2.model.TargetHealthStateEnum
+import software.amazon.awssdk.services.elasticloadbalancingv2.ElasticLoadBalancingV2Client
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.DescribeTargetHealthRequest
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.DescribeTargetHealthResponse
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.TargetDescription
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.TargetGroupNotFoundException
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.TargetHealth
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.TargetHealthDescription
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.TargetHealthStateEnum
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.cats.cache.DefaultCacheData
 import com.netflix.spinnaker.cats.provider.ProviderCache
@@ -38,7 +38,7 @@ class TargetHealthCachingAgentSpec extends Specification {
   def ecs = Mock(EcsClient)
   def clientProvider = Mock(AmazonClientProvider)
   def awsProviderCache = Mock(ProviderCache)
-  def amazonloadBalancing = Mock(AmazonElasticLoadBalancing)
+  def amazonloadBalancing = Mock(ElasticLoadBalancingV2Client)
   def targetGroupArn = 'arn:aws:elasticloadbalancing:' + CommonCachingAgent.REGION + ':' + CommonCachingAgent.ACCOUNT_ID + ':targetgroup/test-tg/9e8997b7cff00c62'
   ObjectMapper mapper = new ObjectMapper()
 
@@ -47,7 +47,7 @@ class TargetHealthCachingAgentSpec extends Specification {
     new TargetHealthCachingAgent(CommonCachingAgent.netflixAmazonCredentials, CommonCachingAgent.REGION, clientProvider, mapper)
 
   def setup() {
-    clientProvider.getAmazonElasticLoadBalancingV2(_, _, _) >> amazonloadBalancing
+    clientProvider.getAmazonElasticLoadBalancingV2V2(_, _) >> amazonloadBalancing
     awsProviderCache.filterIdentifiers(_, _) >> []
 
     def targetGroupAttributes = [
@@ -75,8 +75,8 @@ class TargetHealthCachingAgentSpec extends Specification {
     then:
     // ELB response contains no TargetHealths
     1 * amazonloadBalancing.describeTargetHealth({ DescribeTargetHealthRequest request ->
-      request.targetGroupArn == targetGroupArn
-    }) >> new DescribeTargetHealthResult()
+      request.targetGroupArn() == targetGroupArn
+    }) >> DescribeTargetHealthResponse.builder().build()
 
     targetHealthList.size() == 0
   }
@@ -87,14 +87,16 @@ class TargetHealthCachingAgentSpec extends Specification {
     def unhealthyTargetId = '10.0.0.14'
 
     TargetHealthDescription targetHealth1 =
-      new TargetHealthDescription().withTarget(
-        new TargetDescription().withId(healthyTargetId).withPort(80))
-      .withTargetHealth(new TargetHealth().withState(TargetHealthStateEnum.Healthy))
+      TargetHealthDescription.builder()
+        .target(TargetDescription.builder().id(healthyTargetId).port(80).build())
+        .targetHealth(TargetHealth.builder().state(TargetHealthStateEnum.HEALTHY).build())
+        .build()
 
     TargetHealthDescription targetHealth2 =
-      new TargetHealthDescription().withTarget(
-        new TargetDescription().withId(unhealthyTargetId).withPort(80))
-      .withTargetHealth(new TargetHealth().withState(TargetHealthStateEnum.Unhealthy))
+      TargetHealthDescription.builder()
+        .target(TargetDescription.builder().id(unhealthyTargetId).port(80).build())
+        .targetHealth(TargetHealth.builder().state(TargetHealthStateEnum.UNHEALTHY).build())
+        .build()
 
     when:
     agent.setAwsCache(awsProviderCache)
@@ -102,18 +104,18 @@ class TargetHealthCachingAgentSpec extends Specification {
 
     then:
     1 * amazonloadBalancing.describeTargetHealth({ DescribeTargetHealthRequest request ->
-      request.targetGroupArn == targetGroupArn
-    }) >> new DescribeTargetHealthResult().withTargetHealthDescriptions(targetHealth1, targetHealth2)
+      request.targetGroupArn() == targetGroupArn
+    }) >> DescribeTargetHealthResponse.builder().targetHealthDescriptions(targetHealth1, targetHealth2).build()
 
     targetHealthList.size() == 1
     EcsTargetHealth targetHealth = targetHealthList.get(0)
     targetHealth.getTargetGroupArn() == targetGroupArn
     for (TargetHealthDescription targetHealthDescription: targetHealth.getTargetHealthDescriptions()) {
-      targetHealthDescription.getTarget().getPort() == 80
-      if (targetHealthDescription.getTarget().getId() == healthyTargetId) {
-        targetHealthDescription.getTargetHealth().getState() == TargetHealthStateEnum.Healthy.toString()
+      targetHealthDescription.target().port() == 80
+      if (targetHealthDescription.target().id() == healthyTargetId) {
+        targetHealthDescription.targetHealth().stateAsString() == TargetHealthStateEnum.HEALTHY.toString()
       } else {
-        targetHealthDescription.getTargetHealth().getState() == TargetHealthStateEnum.Unhealthy.toString()
+        targetHealthDescription.targetHealth().stateAsString() == TargetHealthStateEnum.UNHEALTHY.toString()
       }
     }
   }
@@ -133,8 +135,8 @@ class TargetHealthCachingAgentSpec extends Specification {
 
     then:
     1 * amazonloadBalancing.describeTargetHealth({ DescribeTargetHealthRequest request ->
-      request.targetGroupArn == targetGroupArn
-    }) >> { throw new TargetGroupNotFoundException("The specified target group does not exist.") }
+      request.targetGroupArn() == targetGroupArn
+    }) >> { throw TargetGroupNotFoundException.builder().message("The specified target group does not exist.").build() }
 
     targetHealthList.size() == 0
   }
@@ -174,9 +176,10 @@ class TargetHealthCachingAgentSpec extends Specification {
       new DefaultCacheData(targetGroupKey2, targetGroupAttributes2, relations2)
 
     TargetHealthDescription targetHealth =
-      new TargetHealthDescription().withTarget(
-        new TargetDescription().withId('10.0.0.3').withPort(80))
-        .withTargetHealth(new TargetHealth().withState(TargetHealthStateEnum.Healthy))
+      TargetHealthDescription.builder()
+        .target(TargetDescription.builder().id('10.0.0.3').port(80).build())
+        .targetHealth(TargetHealth.builder().state(TargetHealthStateEnum.HEALTHY).build())
+        .build()
 
     // return cache data for both target groups
     awsProviderCache.getAll(TARGET_GROUPS.getNs(), _, _) >> [targetGroupCacheData, targetGroupCacheData2]
@@ -188,8 +191,8 @@ class TargetHealthCachingAgentSpec extends Specification {
     then:
     // expect one describe call, with correct target group
     1 * amazonloadBalancing.describeTargetHealth({ DescribeTargetHealthRequest request ->
-      request.targetGroupArn == targetGroupArn
-    }) >> new DescribeTargetHealthResult().withTargetHealthDescriptions(targetHealth)
+      request.targetGroupArn() == targetGroupArn
+    }) >> DescribeTargetHealthResponse.builder().targetHealthDescriptions(targetHealth).build()
 
     targetHealthList.size() == 1
     EcsTargetHealth targetHealthDescription = targetHealthList.get(0)

--- a/clouddriver/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/services/ContainerInformationServiceSpec.groovy
+++ b/clouddriver/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/services/ContainerInformationServiceSpec.groovy
@@ -24,8 +24,8 @@ import com.amazonaws.services.ecs.model.HealthCheck
 import com.amazonaws.services.ecs.model.LoadBalancer
 import software.amazon.awssdk.services.ecs.model.NetworkBinding
 import com.amazonaws.services.ecs.model.TaskDefinition
-import com.amazonaws.services.elasticloadbalancingv2.model.TargetHealth
-import com.amazonaws.services.elasticloadbalancingv2.model.TargetHealthDescription
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.TargetHealth
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.TargetHealthDescription
 import com.netflix.spinnaker.clouddriver.ecs.cache.client.*
 import com.netflix.spinnaker.clouddriver.ecs.cache.model.ContainerInstance
 import com.netflix.spinnaker.clouddriver.ecs.cache.model.EcsTargetHealth
@@ -309,7 +309,7 @@ class ContainerInformationServiceSpec extends Specification {
     taskCacheClient.get(_) >> new Task(lastStatus: lastStatus, healthStatus: healthStatus)
     taskDefinitionCacheClient.get(_) >> new TaskDefinition(containerDefinitions:  Lists.newArrayList(new ContainerDefinition(healthCheck: null)))
     targetHealthCacheClient.get(_) >> new EcsTargetHealth(targetHealthDescriptions: List.of(
-      new TargetHealthDescription(targetHealth: new TargetHealth(state: targetHealthStatus))
+      TargetHealthDescription.builder().targetHealth(TargetHealth.builder().state(targetHealthStatus).build()).build()
     ))
 
     def expectedHealthStatus = [
@@ -356,8 +356,8 @@ class ContainerInformationServiceSpec extends Specification {
     taskCacheClient.get(_) >> new Task(lastStatus: lastStatus, healthStatus: healthStatus)
     taskDefinitionCacheClient.get(_) >> new TaskDefinition(containerDefinitions:  Lists.newArrayList(new ContainerDefinition(healthCheck: null)))
     targetHealthCacheClient.get(_) >> new EcsTargetHealth(targetHealthDescriptions: List.of(
-      new TargetHealthDescription(targetHealth: new TargetHealth(state: targetHealthStatus1)),
-      new TargetHealthDescription(targetHealth: new TargetHealth(state: targetHealthStatus2))
+      TargetHealthDescription.builder().targetHealth(TargetHealth.builder().state(targetHealthStatus1).build()).build(),
+      TargetHealthDescription.builder().targetHealth(TargetHealth.builder().state(targetHealthStatus2).build()).build()
     ))
 
     def expectedHealthStatus = [


### PR DESCRIPTION
Migrate TargetHealthCachingAgent from v1 ELBv2 to v2 ElasticLoadBalancingV2Client.

## Changes

- Add `software.amazon.awssdk:elasticloadbalancingv2` as api dep to clouddriver-aws
- Add `getAmazonElasticLoadBalancingV2V2()` factory method to AmazonClientProvider
- Migrate TargetHealthCachingAgent to v2 DescribeTargetHealthRequest/Response
- Update EcsTargetHealth cache model to use v2 TargetHealthDescription
- Update TargetHealthCacheClient to deserialize via serializableBuilderClass()
- Update TaskHealthCachingAgent and ContainerInformationService for v2 accessors
- All related tests migrated

## Cache compatibility

No impact. JSON shape is identical between v1 and v2 TargetHealthDescription serialization.

## What was tested

- All TargetHealth/TaskHealth/ContainerInformation tests pass
- spotlessCheck clean

Part of spinnaker/spinnaker#7699.