### PR TITLE
fix(ecs): read cached task containers with the SDK v2 model

### DIFF
--- a/clouddriver/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/client/TaskCacheClient.java
+++ b/clouddriver/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/client/TaskCacheClient.java
@@ -18,7 +18,6 @@ package com.netflix.spinnaker.clouddriver.ecs.cache.client;
 
 import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.TASKS;
 
-import com.amazonaws.services.ecs.model.Container;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spinnaker.cats.cache.Cache;
 import com.netflix.spinnaker.cats.cache.CacheData;
@@ -29,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.ecs.model.Container;
 
 @Component
 public class TaskCacheClient extends AbstractCacheClient<Task> {

--- a/clouddriver/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/model/Task.java
+++ b/clouddriver/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/model/Task.java
@@ -16,9 +16,9 @@
 
 package com.netflix.spinnaker.clouddriver.ecs.cache.model;
 
-import com.amazonaws.services.ecs.model.Container;
 import java.util.List;
 import lombok.Data;
+import software.amazon.awssdk.services.ecs.model.Container;
 
 @Data
 public class Task {

--- a/clouddriver/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/model/EcsTask.java
+++ b/clouddriver/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/model/EcsTask.java
@@ -16,7 +16,6 @@
 
 package com.netflix.spinnaker.clouddriver.ecs.model;
 
-import com.amazonaws.services.ecs.model.NetworkInterface;
 import com.netflix.spinnaker.clouddriver.ecs.EcsCloudProvider;
 import com.netflix.spinnaker.clouddriver.model.HealthState;
 import com.netflix.spinnaker.clouddriver.model.Instance;
@@ -24,6 +23,7 @@ import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 import lombok.Data;
+import software.amazon.awssdk.services.ecs.model.NetworkInterface;
 
 @Data
 public class EcsTask implements Instance, Serializable {

--- a/clouddriver/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskHealthCachingAgent.java
+++ b/clouddriver/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskHealthCachingAgent.java
@@ -20,11 +20,8 @@ import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITA
 import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.HEALTH;
 import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.TASKS;
 
-import com.amazonaws.services.ecs.model.Container;
 import com.amazonaws.services.ecs.model.ContainerDefinition;
 import com.amazonaws.services.ecs.model.LoadBalancer;
-import com.amazonaws.services.ecs.model.NetworkBinding;
-import com.amazonaws.services.ecs.model.NetworkInterface;
 import com.amazonaws.services.ecs.model.PortMapping;
 import com.amazonaws.services.ecs.model.TaskDefinition;
 import com.amazonaws.services.elasticloadbalancingv2.model.TargetHealthDescription;
@@ -51,6 +48,9 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.ecs.EcsClient;
+import software.amazon.awssdk.services.ecs.model.Container;
+import software.amazon.awssdk.services.ecs.model.NetworkBinding;
+import software.amazon.awssdk.services.ecs.model.NetworkInterface;
 
 public class TaskHealthCachingAgent extends AbstractEcsCachingAgent<TaskHealth>
     implements HealthProvidingCachingAgent {
@@ -200,8 +200,8 @@ public class TaskHealthCachingAgent extends AbstractEcsCachingAgent<TaskHealth>
       NetworkInterface networkInterface = null;
 
       for (Container container : containers) {
-        if (container.getNetworkInterfaces().size() >= 1) {
-          networkInterface = container.getNetworkInterfaces().get(0);
+        if (container.networkInterfaces().size() >= 1) {
+          networkInterface = container.networkInterfaces().get(0);
           break;
         }
       }
@@ -212,7 +212,7 @@ public class TaskHealthCachingAgent extends AbstractEcsCachingAgent<TaskHealth>
               task,
               serviceName,
               loadBalancer.getTargetGroupArn(),
-              networkInterface.getPrivateIpv4Address(),
+              networkInterface.privateIpv4Address(),
               loadBalancer.getContainerPort(),
               overallTaskHealth);
     }
@@ -338,12 +338,12 @@ public class TaskHealthCachingAgent extends AbstractEcsCachingAgent<TaskHealth>
   private Optional<Integer> getHostPort(List<Container> containers, Integer hostPort) {
     if (containers != null && !containers.isEmpty()) {
       for (Container container : containers) {
-        for (NetworkBinding networkBinding : container.getNetworkBindings()) {
-          Integer containerPort = networkBinding.getContainerPort();
+        for (NetworkBinding networkBinding : container.networkBindings()) {
+          Integer containerPort = networkBinding.containerPort();
 
           if (containerPort != null && containerPort.intValue() == hostPort.intValue()) {
             log.debug("Load balanced hostPort: {} found for container.", hostPort);
-            return Optional.of(networkBinding.getHostPort());
+            return Optional.of(networkBinding.hostPort());
           }
         }
       }
@@ -370,9 +370,7 @@ public class TaskHealthCachingAgent extends AbstractEcsCachingAgent<TaskHealth>
     Collection<Container> containers = task.getContainers();
 
     for (Container container : containers) {
-      if (!(container.getNetworkBindings() == null
-          || container.getNetworkBindings().isEmpty()
-          || container.getNetworkBindings().get(0) == null)) {
+      if (!(container.networkBindings().isEmpty() || container.networkBindings().get(0) == null)) {
         return false;
       }
     }
@@ -383,9 +381,8 @@ public class TaskHealthCachingAgent extends AbstractEcsCachingAgent<TaskHealth>
     Collection<Container> containers = task.getContainers();
 
     for (Container container : containers) {
-      if (!(container.getNetworkInterfaces() == null
-          || container.getNetworkInterfaces().isEmpty()
-          || container.getNetworkInterfaces().get(0) == null)) {
+      if (!(container.networkInterfaces().isEmpty()
+          || container.networkInterfaces().get(0) == null)) {
         return false;
       }
     }

--- a/clouddriver/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcsServerClusterProvider.java
+++ b/clouddriver/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcsServerClusterProvider.java
@@ -19,7 +19,6 @@ package com.netflix.spinnaker.clouddriver.ecs.provider.view;
 import com.amazonaws.services.applicationautoscaling.model.ScalableTarget;
 import com.amazonaws.services.ec2.model.GroupIdentifier;
 import com.amazonaws.services.ecs.model.ContainerDefinition;
-import com.amazonaws.services.ecs.model.NetworkInterface;
 import com.google.common.collect.Sets;
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonCredentials;
 import com.netflix.spinnaker.clouddriver.ecs.EcsCloudProvider;
@@ -60,6 +59,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.ecs.model.NetworkInterface;
 
 @Component
 public class EcsServerClusterProvider implements ClusterProvider<EcsServerCluster> {
@@ -225,8 +225,8 @@ public class EcsServerClusterProvider implements ClusterProvider<EcsServerCluste
 
     NetworkInterface networkInterface =
         !task.getContainers().isEmpty()
-                && !task.getContainers().get(0).getNetworkInterfaces().isEmpty()
-            ? task.getContainers().get(0).getNetworkInterfaces().get(0)
+                && !task.getContainers().get(0).networkInterfaces().isEmpty()
+            ? task.getContainers().get(0).networkInterfaces().get(0)
             : null;
 
     return new EcsTask(

--- a/clouddriver/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/services/ContainerInformationService.java
+++ b/clouddriver/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/services/ContainerInformationService.java
@@ -19,7 +19,6 @@ package com.netflix.spinnaker.clouddriver.ecs.services;
 import com.amazonaws.services.ec2.model.Instance;
 import com.amazonaws.services.ecs.model.ContainerDefinition;
 import com.amazonaws.services.ecs.model.LoadBalancer;
-import com.amazonaws.services.ecs.model.NetworkBinding;
 import com.amazonaws.services.ecs.model.TaskDefinition;
 import com.netflix.spinnaker.clouddriver.ecs.cache.Keys;
 import com.netflix.spinnaker.clouddriver.ecs.cache.client.ContainerInstanceCacheClient;
@@ -43,6 +42,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.ecs.model.NetworkBinding;
 
 @Component
 public class ContainerInformationService {
@@ -229,7 +229,7 @@ public class ContainerInformationService {
       hostPort = getAddressHostPortForMultipleContainers(task);
     } else {
       try {
-        hostPort = task.getContainers().get(0).getNetworkBindings().get(0).getHostPort();
+        hostPort = task.getContainers().get(0).networkBindings().get(0).hostPort();
       } catch (Exception e) {
         hostPort = -1;
       }
@@ -300,11 +300,11 @@ public class ContainerInformationService {
     task.getContainers()
         .forEach(
             (c) -> {
-              List<NetworkBinding> networkBindings = c.getNetworkBindings();
+              List<NetworkBinding> networkBindings = c.networkBindings();
               networkBindings.forEach(
                   (b) -> {
-                    if (b.getHostPort() != null) {
-                      hostPorts.add(b.getHostPort());
+                    if (b.hostPort() != null) {
+                      hostPorts.add(b.hostPort());
                     }
                   });
             });

--- a/clouddriver/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/view/EcsInstanceProvider.java
+++ b/clouddriver/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/view/EcsInstanceProvider.java
@@ -16,7 +16,6 @@
 
 package com.netflix.spinnaker.clouddriver.ecs.view;
 
-import com.amazonaws.services.ecs.model.NetworkInterface;
 import com.netflix.spinnaker.clouddriver.ecs.EcsCloudProvider;
 import com.netflix.spinnaker.clouddriver.ecs.cache.Keys;
 import com.netflix.spinnaker.clouddriver.ecs.cache.client.ContainerInstanceCacheClient;
@@ -31,6 +30,7 @@ import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.ecs.model.NetworkInterface;
 
 @Component
 public class EcsInstanceProvider implements InstanceProvider<EcsTask, String> {
@@ -80,8 +80,8 @@ public class EcsInstanceProvider implements InstanceProvider<EcsTask, String> {
     NetworkInterface networkInterface =
         task.getContainers() != null
                 && !task.getContainers().isEmpty()
-                && !task.getContainers().get(0).getNetworkInterfaces().isEmpty()
-            ? task.getContainers().get(0).getNetworkInterfaces().get(0)
+                && !task.getContainers().get(0).networkInterfaces().isEmpty()
+            ? task.getContainers().get(0).networkInterfaces().get(0)
             : null;
 
     Service service = containerInformationService.getService(serviceName, account, region);

--- a/clouddriver/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/cache/TaskCacheClientSpec.groovy
+++ b/clouddriver/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/cache/TaskCacheClientSpec.groovy
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2026 spinnaker.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.ecs.cache
+
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.netflix.spinnaker.cats.cache.Cache
+import com.netflix.spinnaker.cats.cache.DefaultCacheData
+import com.netflix.spinnaker.clouddriver.aws.jackson.AwsSdkV2Module
+import com.netflix.spinnaker.clouddriver.ecs.cache.client.TaskCacheClient
+import com.netflix.spinnaker.clouddriver.ecs.provider.agent.TaskCachingAgent
+import software.amazon.awssdk.services.ecs.model.Container
+import software.amazon.awssdk.services.ecs.model.ManagedAgent
+import software.amazon.awssdk.services.ecs.model.NetworkBinding
+import software.amazon.awssdk.services.ecs.model.NetworkInterface
+import software.amazon.awssdk.services.ecs.model.Task
+import spock.lang.Specification
+import spock.lang.Subject
+
+import java.time.Instant
+
+import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.TASKS
+
+class TaskCacheClientSpec extends Specification {
+  def cacheView = Mock(Cache)
+  // mirrors clouddriver's ObjectMapper: AwsSdkV2Module is registered as a Spring Module bean
+  def objectMapper = new ObjectMapper()
+    .registerModule(new JavaTimeModule())
+    .registerModule(new AwsSdkV2Module())
+    .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+
+  @Subject
+  TaskCacheClient client = new TaskCacheClient(cacheView, objectMapper)
+
+  def 'should convert cache data written by the caching agent back into a task'() {
+    given:
+    def taskArn = 'arn:aws:ecs:us-west-1:123456789012:task/test-cluster/1dc5c17a-422b-4dc4-b493-371970c6c4d6'
+    def key = Keys.getTaskKey('test-account', 'us-west-1', '1dc5c17a-422b-4dc4-b493-371970c6c4d6')
+
+    // a managed agent carries an Instant, the field that broke deserialization while the cache
+    // client still bound to the SDK v1 Container model
+    def givenTask = Task.builder()
+      .taskArn(taskArn)
+      .clusterArn('arn:aws:ecs:us-west-1:123456789012:cluster/test-cluster')
+      .group('service:test-service')
+      .lastStatus('RUNNING')
+      .desiredStatus('RUNNING')
+      .healthStatus('HEALTHY')
+      .startedAt(Instant.ofEpochMilli(1600000000000L))
+      .availabilityZone('us-west-1a')
+      .containers(Container.builder()
+        .name('test-container')
+        .networkBindings(NetworkBinding.builder().containerPort(1338).hostPort(1338).build())
+        .networkInterfaces(NetworkInterface.builder().privateIpv4Address('192.168.0.100').build())
+        .managedAgents(ManagedAgent.builder()
+          .name('ExecuteCommandAgent')
+          .lastStatus('RUNNING')
+          .lastStartedAt(Instant.ofEpochMilli(1600000000000L))
+          .build())
+        .build())
+      .build()
+
+    def attributes = TaskCachingAgent.convertTaskToAttributes(givenTask)
+    def cachedAttributes = objectMapper.readValue(objectMapper.writeValueAsString(attributes), Map)
+    cacheView.get(TASKS.ns, key) >> new DefaultCacheData(key, cachedAttributes, [:])
+
+    when:
+    def retrievedTask = client.get(key)
+
+    then:
+    retrievedTask.taskArn == taskArn
+    retrievedTask.lastStatus == 'RUNNING'
+    retrievedTask.containers.size() == 1
+    retrievedTask.containers[0].networkBindings()[0].hostPort() == 1338
+    retrievedTask.containers[0].networkInterfaces()[0].privateIpv4Address() == '192.168.0.100'
+    retrievedTask.containers[0].managedAgents()[0].lastStartedAt() == Instant.ofEpochMilli(1600000000000L)
+  }
+}

--- a/clouddriver/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskHealthCacheSpec.groovy
+++ b/clouddriver/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskHealthCacheSpec.groovy
@@ -17,10 +17,12 @@
 package com.netflix.spinnaker.clouddriver.ecs.provider.agent
 
 import software.amazon.awssdk.services.ecs.EcsClient
-import com.amazonaws.services.ecs.model.Container
+import com.netflix.spinnaker.clouddriver.aws.jackson.AwsSdkV2Module
+import software.amazon.awssdk.services.ecs.model.Container
+import com.netflix.spinnaker.clouddriver.aws.jackson.AwsSdkV2Module
 import com.amazonaws.services.ecs.model.ContainerDefinition
 import com.amazonaws.services.ecs.model.LoadBalancer
-import com.amazonaws.services.ecs.model.NetworkBinding
+import software.amazon.awssdk.services.ecs.model.NetworkBinding
 import com.amazonaws.services.ecs.model.PortMapping
 import com.amazonaws.services.elasticloadbalancingv2.AmazonElasticLoadBalancing
 import com.amazonaws.services.elasticloadbalancingv2.model.DescribeTargetHealthResult
@@ -46,7 +48,7 @@ class TaskHealthCacheSpec extends Specification {
   def ecs = Mock(EcsClient)
   def clientProvider = Mock(AmazonClientProvider)
   def providerCache = Mock(ProviderCache)
-  ObjectMapper mapper = new ObjectMapper()
+  ObjectMapper mapper = new ObjectMapper().registerModule(new AwsSdkV2Module())
 
   @Subject
   TaskHealthCachingAgent agent = new TaskHealthCachingAgent(CommonCachingAgent.netflixAmazonCredentials, CommonCachingAgent.REGION, clientProvider, mapper)
@@ -66,8 +68,8 @@ class TaskHealthCacheSpec extends Specification {
     def containerInstanceKey = Keys.getContainerInstanceKey(CommonCachingAgent.ACCOUNT, CommonCachingAgent.REGION, CommonCachingAgent.CONTAINER_INSTANCE_ARN_1)
     def targetHealthKey = Keys.getTargetHealthKey(CommonCachingAgent.ACCOUNT, CommonCachingAgent.REGION, targetGroupArn)
 
-    ObjectMapper mapper = new ObjectMapper()
-    Map<String, Object> containerMap = mapper.convertValue(new Container().withNetworkBindings(new NetworkBinding().withContainerPort(1338).withHostPort(1338)), Map.class)
+    ObjectMapper mapper = new ObjectMapper().registerModule(new AwsSdkV2Module())
+    Map<String, Object> containerMap = mapper.convertValue(Container.builder().networkBindings(NetworkBinding.builder().containerPort(1338).hostPort(1338).build()).build(), Map.class)
     Map<String, Object> loadbalancerMap = mapper.convertValue(new LoadBalancer().withTargetGroupArn(targetGroupArn).withContainerPort(1338), Map.class)
     Map<String, Object> targetHealthMap = mapper.convertValue(
       new TargetHealthDescription().withTarget(new TargetDescription().withId(CommonCachingAgent.EC2_INSTANCE_ID_1).withPort(1338)).withTargetHealth(new TargetHealth().withState(TargetHealthStateEnum.Healthy)), Map.class)

--- a/clouddriver/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskHealthCachingAgentSpec.groovy
+++ b/clouddriver/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskHealthCachingAgentSpec.groovy
@@ -17,12 +17,13 @@
 package com.netflix.spinnaker.clouddriver.ecs.provider.agent
 
 import software.amazon.awssdk.services.ecs.EcsClient
-import com.amazonaws.services.ecs.model.Container
 import com.amazonaws.services.ecs.model.ContainerDefinition
 import com.amazonaws.services.ecs.model.LoadBalancer
-import com.amazonaws.services.ecs.model.NetworkBinding
-import com.amazonaws.services.ecs.model.NetworkInterface
 import com.amazonaws.services.ecs.model.PortMapping
+import com.netflix.spinnaker.clouddriver.aws.jackson.AwsSdkV2Module
+import software.amazon.awssdk.services.ecs.model.Container
+import software.amazon.awssdk.services.ecs.model.NetworkBinding
+import software.amazon.awssdk.services.ecs.model.NetworkInterface
 import com.amazonaws.services.elasticloadbalancingv2.model.TargetDescription
 import com.amazonaws.services.elasticloadbalancingv2.model.TargetHealth
 import com.amazonaws.services.elasticloadbalancingv2.model.TargetHealthDescription
@@ -47,7 +48,7 @@ class TaskHealthCachingAgentSpec extends Specification {
   def clientProvider = Mock(AmazonClientProvider)
   def providerCache = Mock(ProviderCache)
   def targetGroupArn = 'arn:aws:elasticloadbalancing:' + CommonCachingAgent.REGION + ':' + CommonCachingAgent.ACCOUNT_ID + ':targetgroup/test-target-group/9e8997b7cff00c62'
-  ObjectMapper mapper = new ObjectMapper()
+  ObjectMapper mapper = new ObjectMapper().registerModule(new AwsSdkV2Module())
 
 
   @Subject
@@ -59,7 +60,7 @@ class TaskHealthCachingAgentSpec extends Specification {
     def containerInstanceKey = Keys.getContainerInstanceKey(CommonCachingAgent.ACCOUNT, CommonCachingAgent.REGION, CommonCachingAgent.CONTAINER_INSTANCE_ARN_1)
     def targetHealthKey = Keys.getTargetHealthKey(CommonCachingAgent.ACCOUNT, CommonCachingAgent.REGION, targetGroupArn)
 
-    ObjectMapper mapper = new ObjectMapper()
+    ObjectMapper mapper = new ObjectMapper().registerModule(new AwsSdkV2Module())
     Map<String, Object> loadbalancerMap = mapper.convertValue(new LoadBalancer().withTargetGroupArn(targetGroupArn).withContainerPort(1338), Map.class)
     Map<String, Object> targetHealthMap = mapper.convertValue(
       new TargetHealthDescription().withTarget(new TargetDescription().withId(CommonCachingAgent.EC2_INSTANCE_ID_1).withPort(1338)).withTargetHealth(new TargetHealth().withState(TargetHealthStateEnum.Healthy)), Map.class)
@@ -100,8 +101,8 @@ class TaskHealthCachingAgentSpec extends Specification {
 
   def 'should get a list of task health'() {
     given:
-    ObjectMapper mapper = new ObjectMapper()
-    Map<String, Object> containerMap = mapper.convertValue(new Container().withNetworkBindings(new NetworkBinding().withContainerPort(1338).withHostPort(1338)), Map.class)
+    ObjectMapper mapper = new ObjectMapper().registerModule(new AwsSdkV2Module())
+    Map<String, Object> containerMap = mapper.convertValue(Container.builder().networkBindings(NetworkBinding.builder().containerPort(1338).hostPort(1338).build()).build(), Map.class)
     def taskAttributes = [
       taskId               : CommonCachingAgent.TASK_ID_1,
       taskArn              : CommonCachingAgent.TASK_ARN_1,
@@ -142,12 +143,10 @@ class TaskHealthCachingAgentSpec extends Specification {
 
   def 'should get a list of task health with host port mapping of 0'() {
     given:
-    ObjectMapper mapper = new ObjectMapper()
+    ObjectMapper mapper = new ObjectMapper().registerModule(new AwsSdkV2Module())
     Map<String, Object> containerMap = mapper.convertValue(
-      new Container().withNetworkBindings(
-        new NetworkBinding()
-          .withContainerPort(1338)
-          .withHostPort(1338)), Map.class)
+      Container.builder().networkBindings(
+        NetworkBinding.builder().containerPort(1338).hostPort(1338).build()).build(), Map.class)
     def taskAttributes = [
       taskId               : CommonCachingAgent.TASK_ID_1,
       taskArn              : CommonCachingAgent.TASK_ARN_1,
@@ -188,11 +187,11 @@ class TaskHealthCachingAgentSpec extends Specification {
 
   def 'should get a list of task health for tasks with multiple network bindings'() {
     given:
-    ObjectMapper mapper = new ObjectMapper()
-    Map<String, Object> containerMap = mapper.convertValue(new Container().withNetworkBindings(
-      new NetworkBinding().withContainerPort(1337).withHostPort(1337),
-      new NetworkBinding().withContainerPort(1338).withHostPort(1338)
-    ), Map.class)
+    ObjectMapper mapper = new ObjectMapper().registerModule(new AwsSdkV2Module())
+    Map<String, Object> containerMap = mapper.convertValue(Container.builder().networkBindings(
+      NetworkBinding.builder().containerPort(1337).hostPort(1337).build(),
+      NetworkBinding.builder().containerPort(1338).hostPort(1338).build()
+    ).build(), Map.class)
     def taskAttributes = [
       taskId              : CommonCachingAgent.TASK_ID_1,
       taskArn             : CommonCachingAgent.TASK_ARN_1,
@@ -233,8 +232,8 @@ class TaskHealthCachingAgentSpec extends Specification {
 
   def 'should skip tasks with a non-cached container instance'() {
     given:
-    ObjectMapper mapper = new ObjectMapper()
-    Map<String, Object> containerMap = mapper.convertValue(new Container().withNetworkBindings(new NetworkBinding().withContainerPort(1337).withHostPort(1337)), Map.class)
+    ObjectMapper mapper = new ObjectMapper().registerModule(new AwsSdkV2Module())
+    Map<String, Object> containerMap = mapper.convertValue(Container.builder().networkBindings(NetworkBinding.builder().containerPort(1337).hostPort(1337).build()).build(), Map.class)
     def taskAttributes = [
       taskId              : CommonCachingAgent.TASK_ID_1,
       taskArn             : CommonCachingAgent.TASK_ARN_1,
@@ -256,9 +255,9 @@ class TaskHealthCachingAgentSpec extends Specification {
 
   def 'should get a list of task health for aws-vpc mode'() {
     given:
-    ObjectMapper mapper = new ObjectMapper()
-    Map<String, Object> containerMap = mapper.convertValue(new Container().withNetworkInterfaces(
-      new NetworkInterface().withPrivateIpv4Address("192.168.0.100")),
+    ObjectMapper mapper = new ObjectMapper().registerModule(new AwsSdkV2Module())
+    Map<String, Object> containerMap = mapper.convertValue(Container.builder().networkInterfaces(
+      NetworkInterface.builder().privateIpv4Address("192.168.0.100").build()).build(),
       Map.class)
     def taskAttributes = [
       taskId               : CommonCachingAgent.TASK_ID_1,
@@ -298,9 +297,9 @@ class TaskHealthCachingAgentSpec extends Specification {
 
   def 'should skip tasks with a non-cached task definition and aws-vpc mode'() {
     given:
-    ObjectMapper mapper = new ObjectMapper()
-    Map<String, Object> containerMap = mapper.convertValue(new Container().withNetworkInterfaces(
-            new NetworkInterface().withPrivateIpv4Address("192.168.0.100")),
+    ObjectMapper mapper = new ObjectMapper().registerModule(new AwsSdkV2Module())
+    Map<String, Object> containerMap = mapper.convertValue(Container.builder().networkInterfaces(
+            NetworkInterface.builder().privateIpv4Address("192.168.0.100").build()).build(),
             Map.class)
     def taskAttributes = [
             taskId               : CommonCachingAgent.TASK_ID_1,
@@ -322,8 +321,8 @@ class TaskHealthCachingAgentSpec extends Specification {
 
   def 'should skip tasks with no networking'() {
     given:
-    ObjectMapper mapper = new ObjectMapper()
-    Map<String, Object> containerMap = mapper.convertValue(new Container(), Map.class)
+    ObjectMapper mapper = new ObjectMapper().registerModule(new AwsSdkV2Module())
+    Map<String, Object> containerMap = mapper.convertValue(Container.builder().build(), Map.class)
     def taskAttributes = [
       taskId               : CommonCachingAgent.TASK_ID_1,
       taskArn              : CommonCachingAgent.TASK_ARN_1,
@@ -352,8 +351,8 @@ class TaskHealthCachingAgentSpec extends Specification {
 
   def 'should skip tasks with null network bindings'() {
     given:
-    ObjectMapper mapper = new ObjectMapper()
-    Map<String, Object> containerMap = mapper.convertValue(new Container().withNetworkBindings(null), Map.class)
+    ObjectMapper mapper = new ObjectMapper().registerModule(new AwsSdkV2Module())
+    Map<String, Object> containerMap = [networkBindings: null]
     def taskAttributes = [
       taskId               : CommonCachingAgent.TASK_ID_1,
       taskArn              : CommonCachingAgent.TASK_ARN_1,
@@ -382,8 +381,8 @@ class TaskHealthCachingAgentSpec extends Specification {
 
   def 'should skip tasks with null network interfaces'() {
     given:
-    ObjectMapper mapper = new ObjectMapper()
-    Map<String, Object> containerMap = mapper.convertValue(new Container().withNetworkInterfaces(null), Map.class)
+    ObjectMapper mapper = new ObjectMapper().registerModule(new AwsSdkV2Module())
+    Map<String, Object> containerMap = [networkInterfaces: null]
     def taskAttributes = [
       taskId               : CommonCachingAgent.TASK_ID_1,
       taskArn              : CommonCachingAgent.TASK_ARN_1,
@@ -412,11 +411,11 @@ class TaskHealthCachingAgentSpec extends Specification {
 
   def 'should get task health for task with some non-networked containers'() {
     given:
-    ObjectMapper mapper = new ObjectMapper()
-    Map<String, Object> containerMap1 = mapper.convertValue(new Container().withName('noports'), Map.class)
-    Map<String, Object> containerMap2 = mapper.convertValue(new Container().withName('withports').withNetworkBindings(
-      new NetworkBinding().withContainerPort(1338).withHostPort(1338)
-    ), Map.class)
+    ObjectMapper mapper = new ObjectMapper().registerModule(new AwsSdkV2Module())
+    Map<String, Object> containerMap1 = mapper.convertValue(Container.builder().name('noports').build(), Map.class)
+    Map<String, Object> containerMap2 = mapper.convertValue(Container.builder().name('withports').networkBindings(
+      NetworkBinding.builder().containerPort(1338).hostPort(1338).build()
+    ).build(), Map.class)
 
     def taskAttributes = [
       taskId              : CommonCachingAgent.TASK_ID_1,

--- a/clouddriver/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/services/ContainerInformationServiceSpec.groovy
+++ b/clouddriver/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/services/ContainerInformationServiceSpec.groovy
@@ -18,11 +18,11 @@ package com.netflix.spinnaker.clouddriver.ecs.services
 
 import com.amazonaws.services.ec2.model.Instance
 import com.amazonaws.services.ec2.model.Placement
-import com.amazonaws.services.ecs.model.Container
+import software.amazon.awssdk.services.ecs.model.Container
 import com.amazonaws.services.ecs.model.ContainerDefinition
 import com.amazonaws.services.ecs.model.HealthCheck
 import com.amazonaws.services.ecs.model.LoadBalancer
-import com.amazonaws.services.ecs.model.NetworkBinding
+import software.amazon.awssdk.services.ecs.model.NetworkBinding
 import com.amazonaws.services.ecs.model.TaskDefinition
 import com.amazonaws.services.elasticloadbalancingv2.model.TargetHealth
 import com.amazonaws.services.elasticloadbalancingv2.model.TargetHealthDescription
@@ -404,13 +404,7 @@ class ContainerInformationServiceSpec extends Specification {
     def task = new Task(
       containerInstanceArn: containerInstanceArn,
       containers: [
-        new Container(
-          networkBindings: [
-            new NetworkBinding(
-              hostPort: port
-            )
-          ]
-        )
+        Container.builder().networkBindings(NetworkBinding.builder().hostPort(port).build()).build()
       ]
     )
 
@@ -437,13 +431,7 @@ class ContainerInformationServiceSpec extends Specification {
     given:
     def task = new Task(
       containers: [
-        new Container(
-          networkBindings: [
-            new NetworkBinding(
-              hostPort: 999999999999
-            )
-          ]
-        )
+        Container.builder().networkBindings(NetworkBinding.builder().hostPort(999999999).build()).build()
       ]
     )
 
@@ -469,13 +457,7 @@ class ContainerInformationServiceSpec extends Specification {
     def task = new Task(
       containerInstanceArn: containerInstanceArn,
       containers: [
-        new Container(
-          networkBindings: [
-            new NetworkBinding(
-              hostPort: port
-            )
-          ]
-        )
+        Container.builder().networkBindings(NetworkBinding.builder().hostPort(port).build()).build()
       ]
     )
 
@@ -501,13 +483,7 @@ class ContainerInformationServiceSpec extends Specification {
     def task = new Task(
       containerInstanceArn: 'container-instance-arn',
       containers: [
-        new Container(
-          networkBindings: [
-            new NetworkBinding(
-              hostPort: 1337
-            )
-          ]
-        )
+        Container.builder().networkBindings(NetworkBinding.builder().hostPort(1337).build()).build()
       ]
     )
 
@@ -525,13 +501,7 @@ class ContainerInformationServiceSpec extends Specification {
     def task = new Task(
       containerInstanceArn: 'container-instance-arn',
       containers: [
-        new Container(
-          networkBindings: [
-            new NetworkBinding(
-              hostPort: 1337
-            )
-          ]
-        )
+        Container.builder().networkBindings(NetworkBinding.builder().hostPort(1337).build()).build()
       ]
     )
 
@@ -568,20 +538,8 @@ class ContainerInformationServiceSpec extends Specification {
     def task = new Task(
       containerInstanceArn: 'container-instance-arn',
       containers: [
-        new Container(
-          networkBindings: [
-            new NetworkBinding(
-              hostPort: 1234
-            )
-          ]
-        ),
-        new Container(
-          networkBindings: [
-            new NetworkBinding(
-              hostPort: 5678
-            )
-          ]
-        )
+        Container.builder().networkBindings(NetworkBinding.builder().hostPort(1234).build()).build(),
+        Container.builder().networkBindings(NetworkBinding.builder().hostPort(5678).build()).build()
       ]
     )
 
@@ -620,14 +578,8 @@ class ContainerInformationServiceSpec extends Specification {
     def task = new Task(
       containerInstanceArn: containerInstanceArn,
       containers: [
-        new Container(
-          networkBindings: [
-            new NetworkBinding(
-              hostPort: port
-            )
-          ]
-        ),
-        new Container()
+        Container.builder().networkBindings(NetworkBinding.builder().hostPort(port).build()).build(),
+        Container.builder().build()
       ]
     )
 
@@ -655,13 +607,7 @@ class ContainerInformationServiceSpec extends Specification {
     def task = new Task(
       containerInstanceArn: 'container-instance-arn',
       containers: [
-        new Container(
-          networkBindings: [
-            new NetworkBinding(
-              hostPort: 1337
-            )
-          ]
-        )
+        Container.builder().networkBindings(NetworkBinding.builder().hostPort(1337).build()).build()
       ]
     )
 


### PR DESCRIPTION
## Problem

Since #7759 migrated the core ECS caching agents to AWS SDK v2, `TaskCachingAgent` writes v2 `software.amazon.awssdk.services.ecs.model` objects into the `TASKS` namespace, but `TaskCacheClient` still deserialized `containers` into the v1 `com.amazonaws.services.ecs.model.Container`.

Where a container reports managed agents (ECS Exec), the cached `managedAgents[].lastStartedAt` is a floating-point epoch, because the v2 model uses `Instant`. The v1 `java.util.Date` binding rejects it:

```
java.lang.IllegalArgumentException: Cannot deserialize value of type `java.util.Date` from
  Floating-point value (token `JsonToken.VALUE_NUMBER_FLOAT`) (through reference chain:
  com.amazonaws.services.ecs.model.Container["managedAgents"]->java.util.ArrayList[0]
  ->com.amazonaws.services.ecs.model.ManagedAgent["lastStartedAt"])
```

Every task conversion throws, which means:

- `GET /applications/{app}/serverGroups` answers `400`, so the Deck cluster view shows no ECS server groups and no task instances
- `TaskHealthCachingAgent` fails on every run

Reproduced on a staging cluster running a build of `main`: the endpoint returns the error above, and the caching pod logs the same stack trace once per agent cycle.

## Fix

Move the task read path to the v2 model: the `Task` cache model, `TaskCacheClient`, and the `Container` / `NetworkBinding` / `NetworkInterface` call sites in `TaskHealthCachingAgent`, `ContainerInformationService`, `EcsServerClusterProvider`, `EcsInstanceProvider` and `EcsTask`.

`ContainerDefinition`, `PortMapping`, `LoadBalancer` and `TaskDefinition` stay on v1, matching the caches that still write them.

No writer changes, so the cached format is untouched and rolling deploys are unaffected in both directions — this only aligns readers with a format that already changed in #7759. The v2 `NetworkInterface` serializes to the same JSON field names, so the `EcsTask` payload Deck receives is unchanged.

## Tests

- New `TaskCacheClientSpec` covers the agent write path, the JSON round trip the cache performs, and a container carrying managed agents (the case that failed).
- The affected specs now use an `ObjectMapper` with `AwsSdkV2Module` registered, as clouddriver does. A bare `new ObjectMapper()` hides this class of bug, since v2 objects only serialize correctly with that module.
- `:clouddriver:clouddriver-ecs:test`, `:integrationTest` and `spotlessCheck` pass.

## Follow-up (not in this PR)

`ServiceCacheClient` (v1 `LoadBalancer`) and `TaskDefinitionCacheClient` (v1 `ContainerDefinition`) also read v2-written attributes. Neither type has a date field, so they round-trip by field name today and do not crash — but they are the same latent mismatch and will break as soon as one of those shapes gains an `Instant` or a differently-serialized enum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)