### PR TITLE
fix(ecs): stop dropping fields when reading cached task definitions

### DIFF
--- a/clouddriver/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskDefinitionCachingAgent.java
+++ b/clouddriver/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskDefinitionCachingAgent.java
@@ -29,7 +29,6 @@ import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider;
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
 import com.netflix.spinnaker.clouddriver.ecs.cache.Keys;
 import com.netflix.spinnaker.clouddriver.ecs.cache.client.ServiceCacheClient;
-import com.netflix.spinnaker.clouddriver.ecs.cache.client.TaskDefinitionCacheClient;
 import com.netflix.spinnaker.clouddriver.ecs.cache.model.Service;
 import java.util.*;
 import org.slf4j.Logger;
@@ -123,43 +122,22 @@ public class TaskDefinitionCachingAgent extends AbstractEcsOnDemandAgent<TaskDef
     return taskDefinitions;
   }
 
+  /**
+   * Reads a cached task definition back as the SDK v2 model. The cached attributes are written by
+   * {@link #convertTaskDefinitionToAttributes} and are deserialized as a whole, so every field the
+   * agent caches survives the round trip: rebuilding the model field by field silently dropped
+   * everything not copied (port mappings, health checks, environment), and since task definitions
+   * are never re-described once cached, that loss was permanent.
+   */
   private TaskDefinition retrieveFromCache(String taskDefArn, ProviderCache providerCache) {
-    TaskDefinitionCacheClient taskDefinitionCacheClient =
-        new TaskDefinitionCacheClient(providerCache, objectMapper);
-
     String key = Keys.getTaskDefinitionKey(accountName, region, taskDefArn);
+    CacheData cacheData = providerCache.get(TASK_DEFINITIONS.toString(), key);
 
-    com.amazonaws.services.ecs.model.TaskDefinition cached = taskDefinitionCacheClient.get(key);
-    if (cached == null) {
+    if (cacheData == null) {
       return null;
     }
 
-    // Convert v1 cached TaskDefinition to v2 TaskDefinition
-    TaskDefinition.Builder builder =
-        TaskDefinition.builder()
-            .taskDefinitionArn(cached.getTaskDefinitionArn())
-            .taskRoleArn(cached.getTaskRoleArn())
-            .cpu(cached.getCpu())
-            .memory(cached.getMemory());
-
-    if (cached.getContainerDefinitions() != null) {
-      List<software.amazon.awssdk.services.ecs.model.ContainerDefinition> v2ContainerDefs =
-          new ArrayList<>();
-      for (com.amazonaws.services.ecs.model.ContainerDefinition v1Def :
-          cached.getContainerDefinitions()) {
-        v2ContainerDefs.add(
-            software.amazon.awssdk.services.ecs.model.ContainerDefinition.builder()
-                .name(v1Def.getName())
-                .image(v1Def.getImage())
-                .cpu(v1Def.getCpu())
-                .memory(v1Def.getMemory())
-                .memoryReservation(v1Def.getMemoryReservation())
-                .build());
-      }
-      builder.containerDefinitions(v2ContainerDefs);
-    }
-
-    return builder.build();
+    return objectMapper.convertValue(cacheData.getAttributes(), TaskDefinition.class);
   }
 
   @Override

--- a/clouddriver/clouddriver-ecs/src/test/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskDefinitionCachingAgentTest.java
+++ b/clouddriver/clouddriver-ecs/src/test/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskDefinitionCachingAgentTest.java
@@ -27,16 +27,21 @@ import static org.mockito.Mockito.when;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spinnaker.cats.cache.CacheData;
 import com.netflix.spinnaker.cats.cache.DefaultCacheData;
+import com.netflix.spinnaker.clouddriver.aws.jackson.AwsSdkV2Module;
 import com.netflix.spinnaker.clouddriver.ecs.cache.Keys;
 import java.util.*;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.ecs.model.ContainerDefinition;
 import software.amazon.awssdk.services.ecs.model.DescribeTaskDefinitionRequest;
 import software.amazon.awssdk.services.ecs.model.DescribeTaskDefinitionResponse;
+import software.amazon.awssdk.services.ecs.model.HealthCheck;
+import software.amazon.awssdk.services.ecs.model.KeyValuePair;
+import software.amazon.awssdk.services.ecs.model.PortMapping;
 import software.amazon.awssdk.services.ecs.model.TaskDefinition;
 import spock.lang.Subject;
 
 public class TaskDefinitionCachingAgentTest extends CommonCachingAgent {
-  ObjectMapper mapper = new ObjectMapper();
+  ObjectMapper mapper = new ObjectMapper().registerModule(new AwsSdkV2Module());
 
   @Subject
   private final TaskDefinitionCachingAgent agent =
@@ -135,6 +140,78 @@ public class TaskDefinitionCachingAgentTest extends CommonCachingAgent {
               + " but it was: "
               + taskDef.taskDefinitionArn());
     }
+  }
+
+  @Test
+  public void shouldRetainAllFieldsOfCachedTaskDefinitions() {
+    // Given
+    Map<String, Object> serviceAttr = new HashMap<>();
+    serviceAttr.put("taskDefinition", TASK_DEFINITION_ARN_1);
+    serviceAttr.put("desiredCount", 1);
+    serviceAttr.put("serviceName", SERVICE_NAME_1);
+    serviceAttr.put("maximumPercent", 200);
+    serviceAttr.put("minimumHealthyPercent", 50);
+    serviceAttr.put("createdAt", 8976543L);
+
+    DefaultCacheData serviceCache =
+        new DefaultCacheData("test-service", serviceAttr, Collections.emptyMap());
+    when(providerCache.filterIdentifiers(
+            SERVICES.toString(), "ecs;services;test-account;us-west-2;*"))
+        .thenReturn(Collections.singletonList("test-service"));
+    when(providerCache.getAll(anyString(), any(Set.class)))
+        .thenReturn(Collections.singletonList(serviceCache));
+
+    TaskDefinition cachedTaskDef =
+        TaskDefinition.builder()
+            .taskDefinitionArn(TASK_DEFINITION_ARN_1)
+            .taskRoleArn("task-role-arn")
+            .cpu("256")
+            .memory("512")
+            .containerDefinitions(
+                ContainerDefinition.builder()
+                    .name("test-container")
+                    .image("test-image")
+                    .memoryReservation(256)
+                    .portMappings(PortMapping.builder().containerPort(7007).hostPort(7007).build())
+                    .environment(KeyValuePair.builder().name("ENV_VAR").value("value").build())
+                    .healthCheck(HealthCheck.builder().command("CMD-SHELL", "exit 0").build())
+                    .build())
+            .build();
+
+    // the agent caches attributes through convertTaskDefinitionToAttributes, so the cache entry a
+    // later run reads back is exactly what a previous run wrote
+    Map<String, Object> taskDefAttr =
+        TaskDefinitionCachingAgent.convertTaskDefinitionToAttributes(cachedTaskDef);
+    DefaultCacheData taskDefCache =
+        new DefaultCacheData(TASK_DEFINITION_ARN_1, taskDefAttr, Collections.emptyMap());
+    when(providerCache.get(
+            TASK_DEFINITIONS.toString(),
+            "ecs;taskDefinitions;test-account;us-west-2;" + TASK_DEFINITION_ARN_1))
+        .thenReturn(taskDefCache);
+
+    // When
+    List<TaskDefinition> returnedTaskDefs = agent.getItems(ecs, providerCache);
+
+    // Then no field may be dropped: the loss would be permanent, since a cached task definition is
+    // never described again. (The models are not compared with equals() because the round trip
+    // materializes the SDK's auto-construct collections, e.g. Links=[], as explicitly set empties.)
+    assertEquals(1, returnedTaskDefs.size());
+    TaskDefinition returned = returnedTaskDefs.get(0);
+    assertEquals(TASK_DEFINITION_ARN_1, returned.taskDefinitionArn());
+    assertEquals("task-role-arn", returned.taskRoleArn());
+    assertEquals("256", returned.cpu());
+    assertEquals("512", returned.memory());
+    assertEquals(1, returned.containerDefinitions().size());
+
+    ContainerDefinition returnedContainer = returned.containerDefinitions().get(0);
+    ContainerDefinition cachedContainer = cachedTaskDef.containerDefinitions().get(0);
+    assertEquals(cachedContainer.name(), returnedContainer.name());
+    assertEquals(cachedContainer.image(), returnedContainer.image());
+    assertEquals(cachedContainer.memoryReservation(), returnedContainer.memoryReservation());
+    // port mappings drive load balancer health: without them TaskHealthCachingAgent skips the task
+    assertEquals(cachedContainer.portMappings(), returnedContainer.portMappings());
+    assertEquals(cachedContainer.environment(), returnedContainer.environment());
+    assertEquals(cachedContainer.healthCheck(), returnedContainer.healthCheck());
   }
 
   @Test


### PR DESCRIPTION
## Problem

`TaskDefinitionCachingAgent` never re-describes a task definition it already has cached — task definitions are immutable, so that is a sound optimization:

```java
// TaskDefinitions are immutable, there's no reason to
// make a describe call on existing ones.
TaskDefinition cacheEntry = retrieveFromCache(arn, providerCache);
if (cacheEntry != null) { taskDefinitions.add(cacheEntry); }
```

Before #7759, `retrieveFromCache` returned the cached model verbatim (one line). That PR replaced it with a hand-rolled conversion that copies only `taskDefinitionArn`, `taskRoleArn`, `cpu`, `memory`, and per container `name`, `image`, `cpu`, `memory`, `memoryReservation` — then `generateFreshData` writes that object straight back to the cache.

Everything else is silently dropped, and since the entry is never described again **the loss is permanent**: `portMappings`, `environment`, `healthCheck`, `logConfiguration` and `secrets` vanish from a cached task definition and never come back — not even after rolling back to a release predating the migration, because that release skips the describe for cached entries too.

## Symptom

Load balancer health goes to `Unknown` for every ECS instance in the account. `TaskHealthCachingAgent` looks for a port mapping matching the service's load balanced container port, and with `portMappings` gone it logs:

```
DEBUG LoadBalancerService found 1 load balancers.
DEBUG Container does not contain a port mapping with load balanced container port: 7007.
INFO  Caching 0 task health checks in <account>/<region>/TaskHealthCachingAgent
```

Observed on a staging cluster against a build of `main`, comparing the same task definition revision cached by two Spinnakers reading the same AWS account:

| | affected build | unaffected build |
|---|---|---|
| `taskName` | `backstage-production-web:231` | `backstage-production-web:231` |
| `containerImage` | identical | identical |
| `containerPort` | **0** | **7007** |

`taskHasHealthCheck()` in `ContainerInformationService` and the environment variables shown in ECS server group details are degraded the same way.

## Fix

Deserialize the cached attributes into the model rather than rebuilding it field by field. The attributes are written by `convertTaskDefinitionToAttributes`, and `AwsSdkV2Module` is registered on clouddriver's `ObjectMapper`, so the round trip preserves every field the agent caches — and cannot rot as the SDK model gains fields:

```java
return objectMapper.convertValue(cacheData.getAttributes(), TaskDefinition.class);
```

This removes ~25 lines of field copying.

## Tests

The existing `shouldRetainCachedTaskDefinitions` passed throughout because it asserted only on `taskDefinitionArn`. The new `shouldRetainAllFieldsOfCachedTaskDefinitions` exercises a full round trip through the agent's own write path and asserts on port mappings, environment and health check; it fails against the previous implementation and passes with this one. The test `ObjectMapper` now registers `AwsSdkV2Module`, matching how clouddriver builds its own — a bare `ObjectMapper` cannot serialize SDK v2 models and hides this class of bug.

`:clouddriver-ecs:test` and `spotlessCheck` pass. `:integrationTest` passes; note `CreateServerGroupWithAppAutoScalingSpec` is intermittently flaky on `main` independently of this change (reproduced on the unmodified base, 1 of 3 runs).

## Operational note

Cached entries already stripped by an affected build stay stripped after this fix, since they are still never re-described. Those cache entries need to be evicted once for the data to come back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)