### PR TITLE
fix(ecs): re-describe task definitions cached in a degraded form

### DIFF
--- a/clouddriver/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskDefinitionCachingAgent.java
+++ b/clouddriver/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskDefinitionCachingAgent.java
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.clouddriver.ecs.provider.agent;
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE;
 import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.TASK_DEFINITIONS;
 
+import com.amazonaws.services.ecs.model.LoadBalancer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.cats.agent.AgentDataType;
@@ -84,23 +85,36 @@ public class TaskDefinitionCachingAgent extends AbstractEcsOnDemandAgent<TaskDef
     Collection<Service> services = serviceCacheClient.getAll(accountName, region);
     log.debug("Found {} ECS services for which to cache task definitions", services.size());
 
-    Set<String> taskDefArns = new HashSet<>();
+    Map<String, Set<Integer>> loadBalancedPortsByTaskDefArn = new HashMap<>();
 
     for (Service service : services) {
-      taskDefArns.add(service.getTaskDefinition());
+      Set<Integer> loadBalancedPorts =
+          loadBalancedPortsByTaskDefArn.computeIfAbsent(
+              service.getTaskDefinition(), arn -> new HashSet<>());
+
+      if (service.getLoadBalancers() == null) {
+        continue;
+      }
+
+      for (LoadBalancer loadBalancer : service.getLoadBalancers()) {
+        if (loadBalancer.getContainerPort() != null) {
+          loadBalancedPorts.add(loadBalancer.getContainerPort());
+        }
+      }
     }
 
     List<TaskDefinition> taskDefinitions = new ArrayList<>();
 
     int newTaskDefs = 0;
 
-    for (String arn : taskDefArns) {
+    for (Map.Entry<String, Set<Integer>> taskDefArn : loadBalancedPortsByTaskDefArn.entrySet()) {
+      String arn = taskDefArn.getKey();
 
-      // TaskDefinitions are immutable, there's no reason to
-      // make a describe call on existing ones.
+      // TaskDefinitions are immutable, so there's no reason to make a describe call on an existing
+      // one, as long as what is cached is still complete.
       TaskDefinition cacheEntry = retrieveFromCache(arn, providerCache);
 
-      if (cacheEntry != null) {
+      if (cacheEntry != null && isCacheEntryComplete(cacheEntry, taskDefArn.getValue())) {
         taskDefinitions.add(cacheEntry);
       } else {
         DescribeTaskDefinitionResponse response =
@@ -120,6 +134,45 @@ public class TaskDefinitionCachingAgent extends AbstractEcsOnDemandAgent<TaskDef
         taskDefinitions.size() - newTaskDefs);
 
     return taskDefinitions;
+  }
+
+  /**
+   * A cached task definition is only reused while it still carries what the ECS provider reads from
+   * it, so an entry cached in a degraded form is described again rather than kept indefinitely. A
+   * cached entry is otherwise never described again, which is what made an earlier serialization
+   * bug permanent: entries lost their port mappings, {@link TaskHealthCachingAgent} then skipped
+   * every task, and load balancer health stayed unknown until the entries were evicted by hand.
+   *
+   * @param loadBalancedContainerPorts the container ports the services using this task definition
+   *     load balance on, each of which needs a matching port mapping for task health to resolve
+   */
+  private boolean isCacheEntryComplete(
+      TaskDefinition taskDefinition, Set<Integer> loadBalancedContainerPorts) {
+    if (taskDefinition.containerDefinitions().isEmpty()) {
+      log.debug(
+          "Cached task definition '{}' has no container definitions. Describing it again.",
+          taskDefinition.taskDefinitionArn());
+      return false;
+    }
+
+    for (Integer containerPort : loadBalancedContainerPorts) {
+      if (!isContainerPortPresent(taskDefinition, containerPort)) {
+        log.debug(
+            "Cached task definition '{}' has no port mapping for load balanced container port {}. Describing it again.",
+            taskDefinition.taskDefinitionArn(),
+            containerPort);
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  private static boolean isContainerPortPresent(
+      TaskDefinition taskDefinition, Integer containerPort) {
+    return taskDefinition.containerDefinitions().stream()
+        .flatMap(containerDefinition -> containerDefinition.portMappings().stream())
+        .anyMatch(portMapping -> Objects.equals(portMapping.containerPort(), containerPort));
   }
 
   /**

--- a/clouddriver/clouddriver-ecs/src/test/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskDefinitionCachingAgentTest.java
+++ b/clouddriver/clouddriver-ecs/src/test/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskDefinitionCachingAgentTest.java
@@ -41,6 +41,12 @@ import software.amazon.awssdk.services.ecs.model.TaskDefinition;
 import spock.lang.Subject;
 
 public class TaskDefinitionCachingAgentTest extends CommonCachingAgent {
+  // a described task definition is distinguishable from a cached one, so that reusing the cache can
+  // be told apart from making a describe call
+  private static final String CACHED_IMAGE = "cached-image";
+  private static final String DESCRIBED_IMAGE = "described-image";
+  private static final int LOAD_BALANCED_CONTAINER_PORT = 7007;
+
   ObjectMapper mapper = new ObjectMapper().registerModule(new AwsSdkV2Module());
 
   @Subject
@@ -97,31 +103,9 @@ public class TaskDefinitionCachingAgentTest extends CommonCachingAgent {
   @Test
   public void shouldRetainCachedTaskDefinitions() {
     // Given
-    Map<String, Object> serviceAttr = new HashMap<>();
-    serviceAttr.put("taskDefinition", TASK_DEFINITION_ARN_1);
-    serviceAttr.put("desiredCount", 1);
-    serviceAttr.put("serviceName", SERVICE_NAME_1);
-    serviceAttr.put("maximumPercent", 200);
-    serviceAttr.put("minimumHealthyPercent", 50);
-    serviceAttr.put("createdAt", 8976543L);
-
-    DefaultCacheData serviceCache =
-        new DefaultCacheData("test-service", serviceAttr, Collections.emptyMap());
-    when(providerCache.filterIdentifiers(
-            SERVICES.toString(), "ecs;services;test-account;us-west-2;*"))
-        .thenReturn(Collections.singletonList("test-service"));
-    when(providerCache.getAll(anyString(), any(Set.class)))
-        .thenReturn(Collections.singletonList(serviceCache));
-
-    Map<String, Object> taskDefAttr = new HashMap<>();
-    taskDefAttr.put("taskDefinitionArn", TASK_DEFINITION_ARN_1);
-
-    DefaultCacheData taskDefCache =
-        new DefaultCacheData(TASK_DEFINITION_ARN_1, taskDefAttr, Collections.emptyMap());
-    when(providerCache.get(
-            TASK_DEFINITIONS.toString(),
-            "ecs;taskDefinitions;test-account;us-west-2;" + TASK_DEFINITION_ARN_1))
-        .thenReturn(taskDefCache);
+    givenServiceCache(null);
+    givenCachedTaskDefinition(taskDefinition(CACHED_IMAGE));
+    givenDescribedTaskDefinition(taskDefinition(DESCRIBED_IMAGE));
 
     // When
     List<TaskDefinition> returnedTaskDefs = agent.getItems(ecs, providerCache);
@@ -139,7 +123,147 @@ public class TaskDefinitionCachingAgentTest extends CommonCachingAgent {
               + TASK_DEFINITION_ARN_1
               + " but it was: "
               + taskDef.taskDefinitionArn());
+      assertEquals(
+          CACHED_IMAGE,
+          taskDef.containerDefinitions().get(0).image(),
+          "Expected the cached task definition to be reused rather than described again");
     }
+  }
+
+  @Test
+  public void shouldDescribeCachedTaskDefinitionWithoutContainerDefinitions() {
+    // Given
+    givenServiceCache(null);
+
+    // an entry cached without container definitions carries nothing the ECS provider can read
+    Map<String, Object> taskDefAttr = new HashMap<>();
+    taskDefAttr.put("taskDefinitionArn", TASK_DEFINITION_ARN_1);
+    when(providerCache.get(
+            TASK_DEFINITIONS.toString(),
+            "ecs;taskDefinitions;test-account;us-west-2;" + TASK_DEFINITION_ARN_1))
+        .thenReturn(
+            new DefaultCacheData(TASK_DEFINITION_ARN_1, taskDefAttr, Collections.emptyMap()));
+    givenDescribedTaskDefinition(taskDefinition(DESCRIBED_IMAGE));
+
+    // When
+    List<TaskDefinition> returnedTaskDefs = agent.getItems(ecs, providerCache);
+
+    // Then
+    assertEquals(1, returnedTaskDefs.size());
+    assertEquals(
+        DESCRIBED_IMAGE,
+        returnedTaskDefs.get(0).containerDefinitions().get(0).image(),
+        "Expected an incomplete cache entry to be described again");
+  }
+
+  @Test
+  public void shouldDescribeCachedTaskDefinitionMissingLoadBalancedPortMapping() {
+    // Given
+    givenServiceCache(LOAD_BALANCED_CONTAINER_PORT);
+
+    // without the load balanced port mapping, TaskHealthCachingAgent cannot resolve task health, so
+    // reusing this entry would keep load balancer health unknown for as long as it stays cached
+    givenCachedTaskDefinition(taskDefinition(CACHED_IMAGE));
+    givenDescribedTaskDefinition(taskDefinition(DESCRIBED_IMAGE, LOAD_BALANCED_CONTAINER_PORT));
+
+    // When
+    List<TaskDefinition> returnedTaskDefs = agent.getItems(ecs, providerCache);
+
+    // Then
+    assertEquals(1, returnedTaskDefs.size());
+    assertEquals(
+        DESCRIBED_IMAGE,
+        returnedTaskDefs.get(0).containerDefinitions().get(0).image(),
+        "Expected a cache entry missing the load balanced port mapping to be described again");
+    assertEquals(
+        LOAD_BALANCED_CONTAINER_PORT,
+        returnedTaskDefs
+            .get(0)
+            .containerDefinitions()
+            .get(0)
+            .portMappings()
+            .get(0)
+            .containerPort());
+  }
+
+  @Test
+  public void shouldRetainCachedTaskDefinitionWithLoadBalancedPortMapping() {
+    // Given
+    givenServiceCache(LOAD_BALANCED_CONTAINER_PORT);
+    givenCachedTaskDefinition(taskDefinition(CACHED_IMAGE, LOAD_BALANCED_CONTAINER_PORT));
+    givenDescribedTaskDefinition(taskDefinition(DESCRIBED_IMAGE, LOAD_BALANCED_CONTAINER_PORT));
+
+    // When
+    List<TaskDefinition> returnedTaskDefs = agent.getItems(ecs, providerCache);
+
+    // Then
+    assertEquals(1, returnedTaskDefs.size());
+    assertEquals(
+        CACHED_IMAGE,
+        returnedTaskDefs.get(0).containerDefinitions().get(0).image(),
+        "Expected a complete cache entry to be reused rather than described again");
+  }
+
+  private static TaskDefinition taskDefinition(String image, int... containerPorts) {
+    List<PortMapping> portMappings = new ArrayList<>();
+    for (int containerPort : containerPorts) {
+      portMappings.add(PortMapping.builder().containerPort(containerPort).build());
+    }
+
+    return TaskDefinition.builder()
+        .taskDefinitionArn(TASK_DEFINITION_ARN_1)
+        .containerDefinitions(
+            ContainerDefinition.builder()
+                .name("test-container")
+                .image(image)
+                .portMappings(portMappings)
+                .build())
+        .build();
+  }
+
+  private void givenServiceCache(Integer loadBalancedContainerPort) {
+    Map<String, Object> serviceAttr = new HashMap<>();
+    serviceAttr.put("taskDefinition", TASK_DEFINITION_ARN_1);
+    serviceAttr.put("desiredCount", 1);
+    serviceAttr.put("serviceName", SERVICE_NAME_1);
+    serviceAttr.put("maximumPercent", 200);
+    serviceAttr.put("minimumHealthyPercent", 50);
+    serviceAttr.put("createdAt", 8976543L);
+
+    if (loadBalancedContainerPort != null) {
+      Map<String, Object> loadBalancer = new HashMap<>();
+      loadBalancer.put("containerPort", loadBalancedContainerPort);
+      loadBalancer.put("containerName", "test-container");
+      loadBalancer.put("targetGroupArn", "arn:aws:elasticloadbalancing:targetgroup/test");
+      serviceAttr.put("loadBalancers", Collections.singletonList(loadBalancer));
+    }
+
+    DefaultCacheData serviceCache =
+        new DefaultCacheData("test-service", serviceAttr, Collections.emptyMap());
+    when(providerCache.filterIdentifiers(
+            SERVICES.toString(), "ecs;services;test-account;us-west-2;*"))
+        .thenReturn(Collections.singletonList("test-service"));
+    when(providerCache.getAll(anyString(), any(Set.class)))
+        .thenReturn(Collections.singletonList(serviceCache));
+  }
+
+  private void givenCachedTaskDefinition(TaskDefinition taskDefinition) {
+    // the agent caches through convertTaskDefinitionToAttributes, so the entry a later run reads
+    // back is exactly what an earlier run wrote
+    when(providerCache.get(
+            TASK_DEFINITIONS.toString(),
+            "ecs;taskDefinitions;test-account;us-west-2;" + TASK_DEFINITION_ARN_1))
+        .thenReturn(
+            new DefaultCacheData(
+                TASK_DEFINITION_ARN_1,
+                TaskDefinitionCachingAgent.convertTaskDefinitionToAttributes(taskDefinition),
+                Collections.emptyMap()));
+  }
+
+  private void givenDescribedTaskDefinition(TaskDefinition taskDefinition) {
+    when(ecs.describeTaskDefinition(any(DescribeTaskDefinitionRequest.class)))
+        .thenReturn(
+            DescribeTaskDefinitionResponse.builder().taskDefinition(taskDefinition).build());
   }
 
   @Test


### PR DESCRIPTION
Follow-up to #7899, and an answer to the operational caveat that PR left behind:

> Cached entries already stripped by an affected build stay stripped after this fix, since they are still never re-described. Those cache entries need to be evicted once for the data to come back.

## Problem

`TaskDefinitionCachingAgent` skips `describeTaskDefinition` whenever an entry is already cached. That is sound on its own — task definitions are immutable — but it means a cached entry is *never* described again, so an entry cached in a degraded form stays that way indefinitely. #7899 fixed a read path that dropped `portMappings`, `environment` and `healthCheck`; entries already written by an affected build keep those gaps, and rolling back does not repair them either, because the reuse shortcut exists in every version.

Today the only remedy is deleting the affected records straight from the cache backend. Nothing in cats can prompt a re-fetch:

- the hash/delta write path only compares freshly computed data against what is stored, to skip redundant writes — and here the computed data *is* the degraded data, so there is no delta to notice;
- a forced refresh via `POST /cache/ecs/serverGroups` reaches the agent (it is an `AbstractEcsOnDemandAgent`) but re-enters this same `getItems`, so it takes the reuse branch as well;
- there is no TTL on these records and no evict endpoint.

Concretely, on a staging instance every cached task definition had `"portMappings":[]` and no `containerPort` or `healthCheck` keys at all. `TaskHealthCachingAgent` logged `Container does not contain a port mapping with load balanced container port: 7007` and cached 0 health entries per cycle, so Deck showed `Unknown` for load balancer health on every ECS instance in the account. Deleting the rows was the only thing that brought it back.

## Change

Make the reuse conditional on the cached entry still carrying what the ECS provider reads from it. An entry is reused when:

- it has container definitions, and
- for each container port the services using it load balance on, it has a matching port mapping — exactly what `TaskHealthCachingAgent` needs to resolve task health.

Anything else is described again, so degraded entries repair themselves on the next caching cycle with no operator action.

Notes on cost and edge cases:

- The load balanced ports come from the services the agent already reads to collect task definition ARNs, so this adds no API calls.
- A task definition whose services have no load balancer is only checked for container definitions.
- If a task definition genuinely never satisfies the check, the cost is one describe per caching cycle for that one task definition — and describing it is the correct behaviour regardless.

## Tests

Three new cases in `TaskDefinitionCachingAgentTest`: a cache entry missing the load balanced port mapping is described again, an entry without container definitions is described again, and a complete entry with the load balanced port mapping is still reused. The two "described again" cases fail against `main` and pass with this change.

`shouldRetainCachedTaskDefinitions` previously cached nothing but an ARN, which no longer counts as complete, so its fixture now caches a container definition to keep expressing reuse.

All the tests here distinguish reuse from a describe call by the image they assert on, rather than by verifying against the `EcsClient` mock — that mock is `static` in `CommonCachingAgent` and therefore shared across tests, so stubs leak between them and `verify()` counts accumulate. Worth flagging separately; not touched here.

`:clouddriver-ecs:test` and `spotlessCheck` pass. `integrationTest` passes; `CreateServerGroupWithAppAutoScalingSpec` is intermittently flaky on `main` independently of this change (reproduced on the unmodified base, roughly 1 run in 3).

## Alternative considered

Versioning the cache key instead — following `CachingSchema` in the Titus provider and the `kubernetes.v2` key prefix — would let existing eviction logic clear outdated records automatically, and would generalise to future serialization changes. It also changes the key format everywhere task definition keys are built or parsed (Titus needed a `removeSchemaVersion` helper at API boundaries), so I went with the narrower fix here. Happy to switch approach if you would prefer the general mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)