### PR TITLE
fix(sql): qualify GROUP BY columns so getAllByApplication works on Postgres

### DIFF
--- a/clouddriver/cats/cats-sql/src/main/kotlin/com/netflix/spinnaker/cats/sql/cache/SqlCache.kt
+++ b/clouddriver/cats/cats-sql/src/main/kotlin/com/netflix/spinnaker/cats/sql/cache/SqlCache.kt
@@ -1143,10 +1143,13 @@ class SqlCache(
               .innerJoin(table(sqlNames.relTableName(type)).`as`("rel"))
               .on(sql("rel.id=r.id"))
               .where(relWhere)
+              // Columns must be qualified with the `rel` alias: both `r` and `rel` expose an `id`
+              // column, and postgres resolves group by names against input columns before output
+              // aliases, so unqualified names fail with "column reference is ambiguous".
               .groupBy(
-                field("rel_id"),
-                field("id"),
-                field("rel_type")
+                field("rel.rel_id"),
+                field("rel.id"),
+                field("rel.rel_type")
               )
           )
           .fetch()

--- a/clouddriver/cats/cats-sql/src/test/groovy/com/netflix/spinnaker/cats/sql/MySqlProviderCacheSpec.groovy
+++ b/clouddriver/cats/cats-sql/src/test/groovy/com/netflix/spinnaker/cats/sql/MySqlProviderCacheSpec.groovy
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 Harness, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.cats.sql
+
+import com.netflix.spinnaker.kork.sql.test.SqlTestUtil
+import org.jooq.SQLDialect
+import org.testcontainers.DockerClientFactory
+import spock.lang.Requires
+
+@Requires({ DockerClientFactory.instance().isDockerAvailable() })
+class MySqlProviderCacheSpec extends SqlProviderCacheSpec {
+
+  @Override
+  SqlTestUtil.TestDatabase initDatabase() {
+    SqlTestUtil.initTcMysqlDatabase()
+  }
+
+  @Override
+  SQLDialect getDialect() {
+    SQLDialect.MYSQL
+  }
+}

--- a/clouddriver/cats/cats-sql/src/test/groovy/com/netflix/spinnaker/cats/sql/PostgreSqlProviderCacheSpec.groovy
+++ b/clouddriver/cats/cats-sql/src/test/groovy/com/netflix/spinnaker/cats/sql/PostgreSqlProviderCacheSpec.groovy
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 Harness, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.cats.sql
+
+import com.netflix.spinnaker.kork.sql.test.SqlTestUtil
+import org.jooq.SQLDialect
+import org.testcontainers.DockerClientFactory
+import spock.lang.Requires
+
+@Requires({ DockerClientFactory.instance().isDockerAvailable() })
+class PostgreSqlProviderCacheSpec extends SqlProviderCacheSpec {
+
+  @Override
+  SqlTestUtil.TestDatabase initDatabase() {
+    SqlTestUtil.initTcPostgresDatabase()
+  }
+
+  @Override
+  SQLDialect getDialect() {
+    SQLDialect.POSTGRES
+  }
+}

--- a/clouddriver/cats/cats-sql/src/test/groovy/com/netflix/spinnaker/cats/sql/SqlProviderCacheSpec.groovy
+++ b/clouddriver/cats/cats-sql/src/test/groovy/com/netflix/spinnaker/cats/sql/SqlProviderCacheSpec.groovy
@@ -19,9 +19,7 @@ import com.netflix.spinnaker.kork.sql.test.SqlTestUtil
 import com.zaxxer.hikari.HikariDataSource
 import org.jooq.DSLContext
 import org.jooq.SQLDialect
-import org.testcontainers.DockerClientFactory
 import spock.lang.AutoCleanup
-import spock.lang.Requires
 import spock.lang.Shared
 import spock.lang.Unroll
 
@@ -30,8 +28,7 @@ import java.time.Instant
 import java.time.ZoneId
 
 
-@Requires({ DockerClientFactory.instance().isDockerAvailable() })
-class SqlProviderCacheSpec extends ProviderCacheSpec {
+abstract class SqlProviderCacheSpec extends ProviderCacheSpec {
 
   @Shared
   DSLContext context
@@ -40,6 +37,14 @@ class SqlProviderCacheSpec extends ProviderCacheSpec {
   HikariDataSource dataSource
 
   WriteableCache backingStore
+
+  /**
+   * The database the spec runs against. Implemented per dialect so that the shared test bodies below
+   * are exercised against every SQL backend clouddriver supports.
+   */
+  abstract SqlTestUtil.TestDatabase initDatabase()
+
+  abstract SQLDialect getDialect()
 
   def cleanup() {
     SqlTestUtil.cleanupDb(context)
@@ -60,7 +65,7 @@ class SqlProviderCacheSpec extends ProviderCacheSpec {
       getConfig(_ as Class, _ as String, _) >> 10
     }
 
-    SqlTestUtil.TestDatabase testDatabase = SqlTestUtil.initTcMysqlDatabase()
+    SqlTestUtil.TestDatabase testDatabase = initDatabase()
     context = testDatabase.context
     dataSource = testDatabase.dataSource
 
@@ -74,7 +79,7 @@ class SqlProviderCacheSpec extends ProviderCacheSpec {
       "test",
       sqlMetrics,
       dynamicConfigService,
-      new SqlConstraintsInitializer().getDefaultSqlConstraints(SQLDialect.MYSQL),
+      new SqlConstraintsInitializer().getDefaultSqlConstraints(getDialect()),
       new SqlNamedCacheFactory.DefaultProviderCacheConfiguration()
     )
 
@@ -171,6 +176,27 @@ class SqlProviderCacheSpec extends ProviderCacheSpec {
     then:
     fooData["instances"].collect { it.id }.sort() == instanceIdsForAppFoo
     fooData["serverGroup"].collect { it.id }.sort() == sgIdsForAppFoo
+  }
+
+  @Unroll
+  def 'can retrieve by application with relationships (filter: #filter)'() {
+    setup:
+    populateOne('serverGroup', 'fooSg1', createData('fooSg1', [application: "foo"], [:]))
+    populateOne('serverGroup', 'barSg1', createData('barSg1', [application: "bar"], [:]))
+
+    addInformative('instances', 'fooInst1', createData('fooInst1', [application: "foo"], [serverGroup: ['fooSg1']]))
+
+    when:
+    def fooData = cache.getAllByApplication('serverGroup', 'foo', filter)
+
+    then:
+    fooData['serverGroup'].collect { it.id } == ['fooSg1']
+    fooData['serverGroup'][0].relationships['instances'] == ['fooInst1']
+
+    where:
+    // A null filter resolves to the "ALL" relationship prefix, which is what AmazonClusterProvider
+    // passes for namespaces absent from its filter map. Both variants must fetch relationships.
+    filter << [RelationshipCacheFilter.include('instances'), null]
   }
 
   void addInformative(String type, String id, CacheData cacheData = createData(id)) {


### PR DESCRIPTION
## Problem

With `sql.cache` backed by **PostgreSQL**, `GET /applications/{application}/serverGroups`
returns an empty list. The same request scoped to a cluster works and returns data:

```
GET /applications/myapp/serverGroups                        -> 200 []          # wrong
GET /applications/myapp/serverGroups?clusters=acct:myapp-x  -> 200 [ ... ]     # correct
```
## Root cause

`SqlCache.getDataWithRelationshipsByApp` builds a `UNION ALL` whose second branch joins
the resource table (aliased `r`) to the relationship table (aliased `rel`), then groups by
**unqualified** column names:

```kotlin
.from(table(...).as("r"))
.innerJoin(table(...).as("rel"))
.on(sql("rel.id=r.id"))
.where(relWhere)
.groupBy(field("rel_id"), field("id"), field("rel_type"))   // <-- unqualified
```

Both `r.id` and `rel.id` are in scope, so `group by ... id ...` is ambiguous:

```
ERROR:  column reference "id" is ambiguous
LINE 9:  group by rel_id, id, rel_type;
                          ^
```

The query throws, and the surrounding `catch (e: Exception)` converts the failure into an
**empty result** — so the API returns `200 []` instead of surfacing an error.

### Why only Postgres

The two engines resolve `GROUP BY` names in opposite orders. MySQL prefers the *output*
column aliases (`rel.id as id`), so the query is unambiguous and succeeds. PostgreSQL
resolves against *input* columns first, where `id` matches both joined tables.

This is not a dialect-configuration problem. `field(String)` is jOOQ's plain-SQL overload,
so the fragment is passed through verbatim; rendering the query with `SQLDialect.POSTGRES`
emits the identical `group by rel_id, id, rel_type`. No configuration avoids it.

Unfortunately `getAllByApplication` is only covered by `SqlProviderCacheSpec`, which ran against MySQL
only. All of its existing cases also pass `RelationshipCacheFilter.none()`, which routes to
the simpler `getDataWithoutRelationshipsByApp` query — so even running that spec against
Postgres as written would not have caught this.

## Fix

Qualify the `GROUP BY` columns with the `rel` alias, matching the style already used in the
`SELECT` list immediately above it. Renders identically on both engines; MySQL behaviour is
unchanged.

## Scope

Affects only code paths reaching `ClusterProvider.getClusterDetails()`, and only the AWS
provider (`AmazonClusterProvider` is the sole provider that branches on
`supportsGetAllByApplication()`):

- `GET /applications/{application}/serverGroups` (with and without `expand`)
- `GET /serverGroups?applications=...`

Not affected: `GET /applications/{app}` (uses `getClusterSummaries`, `includeDetails=false`),
all `ClusterController` endpoints, `GET /serverGroups?ids=...`, and non-AWS providers.

## Testing

- `SqlProviderCacheSpec` is now abstract with `initDatabase()`/`getDialect()` hooks; added
  `MySqlProviderCacheSpec` and `PostgreSqlProviderCacheSpec`. All existing test bodies are
  unchanged and now run against both engines. This mirrors the existing
  `SqlCacheSpec` / `MySqlCacheSpec` / `PostgreSqlCacheSpec` split.
- Added `can retrieve by application with relationships`, covering the previously untested
  relationship-bearing branch. Parameterised over `RelationshipCacheFilter.include(...)` and
  `null` — the latter resolves to the `"ALL"` prefix, which is what `AmazonClusterProvider`
  relies on for `CLUSTERS.ns`.

Confirmed the new tests fail without the fix:

```
PostgreSqlProviderCacheSpec > can retrieve by application with relationships FAILED
    fooData['serverGroup'].collect { it.id } == ['fooSg1']
    |      |               |
    |      []              []
    [serverGroup:[]]
```

And pass with it:

| Spec | Tests | Failures |
|---|---|---|
| `MySqlProviderCacheSpec` | 28 | 0 |
| `PostgreSqlProviderCacheSpec` | 28 | 0 |