### PR TITLE
feat(pubsub/aws): migrate kork-pubsub-aws from AWS SDK v1 to v2

### DIFF
--- a/kork/kork-pubsub-aws/kork-pubsub-aws.gradle
+++ b/kork/kork-pubsub-aws/kork-pubsub-aws.gradle
@@ -28,11 +28,11 @@ dependencies {
   implementation 'org.springframework.boot:spring-boot-autoconfigure'
   implementation 'jakarta.validation:jakarta.validation-api'
 
-  api 'com.netflix.spectator:spectator-api'
-  api 'org.slf4j:slf4j-api'
   api "software.amazon.awssdk:sns"
   api "software.amazon.awssdk:sqs"
   api "software.amazon.awssdk:iam-policy-builder"
+  api 'com.netflix.spectator:spectator-api'
+  api 'org.slf4j:slf4j-api'
 
   testImplementation "org.spockframework:spock-core"
   testRuntimeOnly "cglib:cglib-nodep"

--- a/kork/kork-pubsub-aws/src/main/java/com/netflix/spinnaker/kork/pubsub/aws/DefaultAmazonMessageAcknowledger.java
+++ b/kork/kork-pubsub-aws/src/main/java/com/netflix/spinnaker/kork/pubsub/aws/DefaultAmazonMessageAcknowledger.java
@@ -20,13 +20,12 @@ import com.netflix.spectator.api.Id;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.kork.pubsub.aws.api.AmazonMessageAcknowledger;
 import lombok.extern.slf4j.Slf4j;
-import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest;
 import software.amazon.awssdk.services.sqs.model.Message;
-import software.amazon.awssdk.services.sqs.model.ReceiptHandleIsInvalidException;
+import software.amazon.awssdk.services.sqs.model.SqsException;
 
 @Slf4j
 public class DefaultAmazonMessageAcknowledger implements AmazonMessageAcknowledger {
-  private Registry registry;
+  private final Registry registry;
 
   public DefaultAmazonMessageAcknowledger(Registry registry) {
     this.registry = registry;
@@ -38,12 +37,9 @@ public class DefaultAmazonMessageAcknowledger implements AmazonMessageAcknowledg
       subscription
           .getSqsClient()
           .deleteMessage(
-              DeleteMessageRequest.builder()
-                  .queueUrl(subscription.getQueueUrl())
-                  .receiptHandle(message.receiptHandle())
-                  .build());
+              r -> r.queueUrl(subscription.getQueueUrl()).receiptHandle(message.receiptHandle()));
       registry.counter(getSuccessCounter(subscription)).increment();
-    } catch (ReceiptHandleIsInvalidException e) {
+    } catch (SqsException e) {
       log.warn(
           "Error deleting message: {}, subscription: {}", message.messageId(), subscription, e);
       registry.counter(getErrorCounter(subscription, e)).increment();
@@ -52,6 +48,7 @@ public class DefaultAmazonMessageAcknowledger implements AmazonMessageAcknowledg
 
   @Override
   public void nack(AmazonSubscriptionInformation subscription, Message message) {
+    // Do nothing — message will become visible again after visibility timeout
     registry.counter(getNackCounter(subscription)).increment();
   }
 

--- a/kork/kork-pubsub-aws/src/main/java/com/netflix/spinnaker/kork/pubsub/aws/PubSubUtils.java
+++ b/kork/kork-pubsub-aws/src/main/java/com/netflix/spinnaker/kork/pubsub/aws/PubSubUtils.java
@@ -38,6 +38,7 @@ import software.amazon.awssdk.policybuilder.iam.IamResource;
 import software.amazon.awssdk.policybuilder.iam.IamStatement;
 import software.amazon.awssdk.services.sns.SnsClient;
 import software.amazon.awssdk.services.sns.model.CreateTopicRequest;
+import software.amazon.awssdk.services.sns.model.SetTopicAttributesRequest;
 import software.amazon.awssdk.services.sns.model.SubscribeRequest;
 import software.amazon.awssdk.services.sqs.SqsClient;
 import software.amazon.awssdk.services.sqs.model.CreateQueueRequest;
@@ -155,8 +156,8 @@ public class PubSubUtils {
     if (!subscription.getAccountIds().isEmpty()) {
       String snsPolicy =
           buildSNSPolicy(new ARN(createdTopicARN), subscription.getAccountIds()).toJson();
-      software.amazon.awssdk.services.sns.model.SetTopicAttributesRequest topicAttributesRequest =
-          software.amazon.awssdk.services.sns.model.SetTopicAttributesRequest.builder()
+      SetTopicAttributesRequest topicAttributesRequest =
+          SetTopicAttributesRequest.builder()
               .topicArn(createdTopicARN)
               .attributeName("Policy")
               .attributeValue(snsPolicy)
@@ -178,6 +179,7 @@ public class PubSubUtils {
             && discoveryStatus.isEnabled();
   }
 
+  /** This policy allows specified accounts to publish messages to the topic. */
   public static IamPolicy buildSNSPolicy(ARN topicARN, List<String> accountIds) {
     List<IamPrincipal> principals =
         accountIds.stream().map(a -> IamPrincipal.create(IamPrincipalType.AWS, a)).toList();

--- a/kork/kork-pubsub-aws/src/main/java/com/netflix/spinnaker/kork/pubsub/aws/SNSPublisher.java
+++ b/kork/kork-pubsub-aws/src/main/java/com/netflix/spinnaker/kork/pubsub/aws/SNSPublisher.java
@@ -44,7 +44,7 @@ public class SNSPublisher implements PubsubPublisher {
 
   private final ARN topicARN;
   private final RetrySupport retrySupport;
-  private Counter successCounter;
+  private final Counter successCounter;
 
   public SNSPublisher(
       AmazonPubsubProperties.AmazonPubsubSubscription subscription,

--- a/kork/kork-pubsub-aws/src/main/java/com/netflix/spinnaker/kork/pubsub/aws/SQSSubscriber.java
+++ b/kork/kork-pubsub-aws/src/main/java/com/netflix/spinnaker/kork/pubsub/aws/SQSSubscriber.java
@@ -33,6 +33,7 @@ import software.amazon.awssdk.services.sqs.SqsClient;
 import software.amazon.awssdk.services.sqs.model.Message;
 import software.amazon.awssdk.services.sqs.model.QueueDoesNotExistException;
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse;
 
 /**
  * One subscriber for each subscription. The subscriber makes sure the SQS queue is created,
@@ -146,22 +147,22 @@ public class SQSSubscriber implements Runnable, PubsubSubscriber {
   @VisibleForTesting
   void listenForMessages() {
     while (isEnabled.get()) {
-      var receiveResponse =
-          sqsClient.receiveMessage(
-              ReceiveMessageRequest.builder()
-                  .queueUrl(this.subscriptionInfo.getQueueUrl())
-                  .maxNumberOfMessages(subscription.getMaxNumberOfMessages())
-                  .visibilityTimeout(subscription.getVisibilityTimeout())
-                  .waitTimeSeconds(subscription.getWaitTimeSeconds())
-                  .messageAttributeNames("All")
-                  .build());
+      ReceiveMessageRequest request =
+          ReceiveMessageRequest.builder()
+              .queueUrl(this.subscriptionInfo.getQueueUrl())
+              .maxNumberOfMessages(subscription.getMaxNumberOfMessages())
+              .visibilityTimeout(subscription.getVisibilityTimeout())
+              .waitTimeSeconds(subscription.getWaitTimeSeconds())
+              .messageAttributeNames("All")
+              .build();
+      ReceiveMessageResponse response = sqsClient.receiveMessage(request);
 
-      if (receiveResponse.messages().isEmpty()) {
+      if (response.messages().isEmpty()) {
         log.debug("Received no messages for queue {}", queueARN);
         continue;
       }
 
-      receiveResponse.messages().forEach(this::handleMessage);
+      response.messages().forEach(this::handleMessage);
     }
   }
 

--- a/kork/kork-pubsub-aws/src/main/java/com/netflix/spinnaker/kork/pubsub/aws/SQSSubscriberProvider.java
+++ b/kork/kork-pubsub-aws/src/main/java/com/netflix/spinnaker/kork/pubsub/aws/SQSSubscriberProvider.java
@@ -94,17 +94,18 @@ public class SQSSubscriberProvider {
               log.info("Bootstrapping SQS for SNS topic: {}", subscription.getTopicARN());
               ARN queueArn = new ARN(subscription.getQueueARN());
               ARN topicArn = new ARN(subscription.getTopicARN());
-
-              SnsClient snsClient =
-                  SnsClient.builder()
-                      .credentialsProvider(awsCredentialsProvider)
-                      .region(Region.of(topicArn.getRegion()))
-                      .build();
+              Region queueRegion = Region.of(queueArn.getRegion());
+              Region topicRegion = Region.of(topicArn.getRegion());
 
               SqsClient sqsClient =
                   SqsClient.builder()
                       .credentialsProvider(awsCredentialsProvider)
-                      .region(Region.of(queueArn.getRegion()))
+                      .region(queueRegion)
+                      .build();
+              SnsClient snsClient =
+                  SnsClient.builder()
+                      .credentialsProvider(awsCredentialsProvider)
+                      .region(topicRegion)
                       .build();
 
               SQSSubscriber worker =

--- a/kork/kork-pubsub-aws/src/main/java/com/netflix/spinnaker/kork/pubsub/aws/config/AmazonPubsubConfig.java
+++ b/kork/kork-pubsub-aws/src/main/java/com/netflix/spinnaker/kork/pubsub/aws/config/AmazonPubsubConfig.java
@@ -17,7 +17,7 @@
 package com.netflix.spinnaker.kork.pubsub.aws.config;
 
 import com.netflix.spectator.api.Registry;
-import com.netflix.spinnaker.kork.aws.bastion.BastionConfig;
+import com.netflix.spinnaker.kork.aws.AwsComponents;
 import com.netflix.spinnaker.kork.core.RetrySupport;
 import com.netflix.spinnaker.kork.discovery.DiscoveryStatusListener;
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService;
@@ -41,7 +41,7 @@ import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 @Configuration
 @ConditionalOnProperty({"pubsub.enabled", "pubsub.amazon.enabled"})
 @EnableConfigurationProperties(AmazonPubsubProperties.class)
-@Import(BastionConfig.class)
+@Import(AwsComponents.class)
 public class AmazonPubsubConfig {
   public static final String SYSTEM = "amazon";
 

--- a/kork/kork-pubsub-aws/src/test/groovy/com/netflix/spinnaker/kork/pubsub/aws/PubSubUtilsSpec.groovy
+++ b/kork/kork-pubsub-aws/src/test/groovy/com/netflix/spinnaker/kork/pubsub/aws/PubSubUtilsSpec.groovy
@@ -20,11 +20,14 @@ import com.netflix.spinnaker.kork.aws.ARN
 import software.amazon.awssdk.services.sqs.SqsClient
 import software.amazon.awssdk.services.sqs.model.CreateQueueRequest
 import software.amazon.awssdk.services.sqs.model.CreateQueueResponse
+import software.amazon.awssdk.services.sqs.model.GetQueueUrlRequest
 import software.amazon.awssdk.services.sqs.model.GetQueueUrlResponse
+import software.amazon.awssdk.services.sqs.model.QueueAttributeName
 import software.amazon.awssdk.services.sqs.model.QueueDoesNotExistException
 import software.amazon.awssdk.services.sqs.model.SetQueueAttributesRequest
-import software.amazon.awssdk.services.sqs.model.SetQueueAttributesResponse
 import spock.lang.Specification
+
+import java.util.function.Consumer
 
 class PubSubUtilsSpec extends Specification {
   SqsClient sqsClient = Mock()
@@ -32,14 +35,21 @@ class PubSubUtilsSpec extends Specification {
   ARN queueARN = new ARN("arn:aws:sqs:us-west-2:100:queueName")
   ARN topicARN = new ARN("arn:aws:sns:us-west-2:100:topicName")
 
-  def "getQueueUrl returns URL"() {
+  def "getQueueUrl returns URL and passes QueueOwnerAWSAccountId"() {
     when:
     def url = PubSubUtils.getQueueUrl(sqsClient, queueARN)
 
     then:
     url == "my-queue-url"
-    // The v2 SDK uses a Consumer<Builder> lambda overload, not a request object
-    1 * sqsClient.getQueueUrl(_) >> GetQueueUrlResponse.builder().queueUrl("my-queue-url").build()
+    1 * sqsClient.getQueueUrl(_ as Consumer) >> { Consumer<GetQueueUrlRequest.Builder> consumer ->
+      // Verify the consumer sets the right values by building the request
+      def builder = GetQueueUrlRequest.builder()
+      consumer.accept(builder)
+      def req = builder.build()
+      assert req.queueName() == queueARN.name
+      assert req.queueOwnerAWSAccountId() == queueARN.account
+      return GetQueueUrlResponse.builder().queueUrl("my-queue-url").build()
+    }
     0 * _
   }
 
@@ -48,7 +58,8 @@ class PubSubUtilsSpec extends Specification {
     PubSubUtils.getQueueUrl(sqsClient, queueARN)
 
     then:
-    (1.._) * sqsClient.getQueueUrl(_) >> {
+    // retrySupport retries MAX_RETRIES (=5) times before giving up
+    (1.._) * sqsClient.getQueueUrl(_ as Consumer) >> {
       throw QueueDoesNotExistException.builder().message("nope").build()
     }
     0 * sqsClient.createQueue(_ as CreateQueueRequest)
@@ -61,9 +72,16 @@ class PubSubUtilsSpec extends Specification {
 
     then:
     queueId == "my-queue-url"
-    1 * sqsClient.getQueueUrl(_) >> GetQueueUrlResponse.builder().queueUrl("my-queue-url").build()
+    1 * sqsClient.getQueueUrl(_ as Consumer) >> {
+      GetQueueUrlResponse.builder().queueUrl("my-queue-url").build()
+    }
     0 * sqsClient.createQueue(_ as CreateQueueRequest)
-    1 * sqsClient.setQueueAttributes(_ as SetQueueAttributesRequest) >> SetQueueAttributesResponse.builder().build()
+    1 * sqsClient.setQueueAttributes(_ as SetQueueAttributesRequest) >> { SetQueueAttributesRequest req ->
+      assert req.queueUrl() == "my-queue-url"
+      assert req.attributes().get(QueueAttributeName.POLICY) == PubSubUtils.buildSQSPolicy(queueARN, topicARN).toJson()
+      assert req.attributes().get(QueueAttributeName.MESSAGE_RETENTION_PERIOD) == "1"
+      return null
+    }
     0 * _
   }
 
@@ -73,11 +91,20 @@ class PubSubUtilsSpec extends Specification {
 
     then:
     queueId == "my-queue-url"
-    (1.._) * sqsClient.getQueueUrl(_) >> {
+    // retry may re-invoke getQueueUrl before giving up and returning to ensureQueueExists
+    (1.._) * sqsClient.getQueueUrl(_ as Consumer) >> {
       throw QueueDoesNotExistException.builder().message("nope").build()
     }
-    1 * sqsClient.createQueue(_ as CreateQueueRequest) >> CreateQueueResponse.builder().queueUrl("my-queue-url").build()
-    1 * sqsClient.setQueueAttributes(_ as SetQueueAttributesRequest) >> SetQueueAttributesResponse.builder().build()
+    1 * sqsClient.createQueue(_ as CreateQueueRequest) >> { CreateQueueRequest req ->
+      assert req.queueName() == queueARN.name
+      return CreateQueueResponse.builder().queueUrl("my-queue-url").build()
+    }
+    1 * sqsClient.setQueueAttributes(_ as SetQueueAttributesRequest) >> { SetQueueAttributesRequest req ->
+      assert req.queueUrl() == "my-queue-url"
+      assert req.attributes().get(QueueAttributeName.POLICY) == PubSubUtils.buildSQSPolicy(queueARN, topicARN).toJson()
+      assert req.attributes().get(QueueAttributeName.MESSAGE_RETENTION_PERIOD) == "1"
+      return null
+    }
     0 * _
   }
 }

--- a/kork/kork-pubsub-aws/src/test/java/com/netflix/spinnaker/kork/pubsub/aws/SQSSubscriberTest.java
+++ b/kork/kork-pubsub-aws/src/test/java/com/netflix/spinnaker/kork/pubsub/aws/SQSSubscriberTest.java
@@ -30,16 +30,19 @@ import com.netflix.spinnaker.kork.pubsub.aws.api.AmazonMessageAcknowledger;
 import com.netflix.spinnaker.kork.pubsub.aws.api.AmazonPubsubMessageHandler;
 import com.netflix.spinnaker.kork.pubsub.aws.config.AmazonPubsubProperties;
 import java.util.List;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.sns.SnsClient;
+import software.amazon.awssdk.services.sns.model.SubscribeRequest;
+import software.amazon.awssdk.services.sns.model.SubscribeResponse;
 import software.amazon.awssdk.services.sqs.SqsClient;
-import software.amazon.awssdk.services.sqs.model.GetQueueUrlRequest;
 import software.amazon.awssdk.services.sqs.model.GetQueueUrlResponse;
 import software.amazon.awssdk.services.sqs.model.Message;
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse;
+import software.amazon.awssdk.services.sqs.model.SetQueueAttributesRequest;
 
 public class SQSSubscriberTest {
 
@@ -49,20 +52,23 @@ public class SQSSubscriberTest {
   @Test
   @DisplayName("acknowledger acknowledges when handler succeeds")
   void testAcknowledgerAcksHandlerSucceeds() {
+    // given
     messageAcknowledger = mock(AmazonMessageAcknowledger.class);
     subscriber =
         new SQSSubscriber(
             subscription(),
             mock(AmazonPubsubMessageHandler.class),
             messageAcknowledger,
-            amazonSNS(),
-            amazonSQS(),
+            snsClient(),
+            sqsClient(),
             enableOnce(),
             new DefaultRegistry());
 
+    // when
     subscriber.initializeQueue();
     subscriber.listenForMessages();
 
+    // then
     verify(messageAcknowledger, times(1)).ack(any(), any());
     verify(messageAcknowledger, never()).nack(any(), any());
   }
@@ -70,6 +76,7 @@ public class SQSSubscriberTest {
   @Test
   @DisplayName("acknowledger nacks when handler fails")
   void testAcknowledgerNackHandlerFails() {
+    // given
     messageAcknowledger = mock(AmazonMessageAcknowledger.class);
     AmazonPubsubMessageHandler throwyHandler = spy(AmazonPubsubMessageHandler.class);
     doThrow(new RuntimeException("unhappy handler")).when(throwyHandler).handleMessage(any());
@@ -78,14 +85,16 @@ public class SQSSubscriberTest {
             subscription(),
             throwyHandler,
             messageAcknowledger,
-            amazonSNS(),
-            amazonSQS(),
+            snsClient(),
+            sqsClient(),
             enableOnce(),
             new DefaultRegistry());
 
+    // when
     subscriber.initializeQueue();
     subscriber.listenForMessages();
 
+    // then
     verify(messageAcknowledger, never()).ack(any(), any());
     verify(messageAcknowledger, times(1)).nack(any(), any());
   }
@@ -93,32 +102,36 @@ public class SQSSubscriberTest {
   @Test
   @DisplayName("the subscriber does not query SQS when disabled")
   void testSubscriberNotQuerySQSDisabled() {
+    // given
     SqsClient sqsClient = mock(SqsClient.class);
-    Supplier disabled = spy(Supplier.class);
+    Supplier<Boolean> disabled = spy(Supplier.class);
     doReturn(false).when(disabled).get();
     subscriber =
         new SQSSubscriber(
             subscription(),
             mock(AmazonPubsubMessageHandler.class),
             mock(AmazonMessageAcknowledger.class),
-            amazonSNS(),
+            snsClient(),
             sqsClient,
             disabled,
             new DefaultRegistry());
 
+    // when
     subscriber.listenForMessages();
 
+    // then
     verify(sqsClient, never()).receiveMessage(any(ReceiveMessageRequest.class));
   }
 
   @Test
   @DisplayName("initializeQueue resolves URL only when skipQueueBootstrap=true")
   void testInitializeQueueSkipsBootstrapWhenFlagTrue() {
+    // given
     AmazonPubsubProperties.AmazonPubsubSubscription sub = subscription();
     sub.setSkipQueueBootstrap(true);
 
-    SqsClient sqs = amazonSQS();
-    SnsClient sns = amazonSNS();
+    SqsClient sqs = sqsClient();
+    SnsClient sns = snsClient();
     subscriber =
         new SQSSubscriber(
             sub,
@@ -129,23 +142,21 @@ public class SQSSubscriberTest {
             enableOnce(),
             new DefaultRegistry());
 
+    // when
     subscriber.initializeQueue();
 
-    verify(sqs, times(1)).getQueueUrl(any(GetQueueUrlRequest.class));
-    verify(sqs, never())
-        .createQueue(any(software.amazon.awssdk.services.sqs.model.CreateQueueRequest.class));
-    verify(sqs, never())
-        .setQueueAttributes(
-            any(software.amazon.awssdk.services.sqs.model.SetQueueAttributesRequest.class));
-    verify(sns, never())
-        .subscribe(any(software.amazon.awssdk.services.sns.model.SubscribeRequest.class));
+    // then — only getQueueUrl called, no setQueueAttributes or subscribe
+    verify(sqs, times(1)).getQueueUrl(any(Consumer.class));
+    verify(sqs, never()).setQueueAttributes(any(SetQueueAttributesRequest.class));
+    verify(sns, never()).subscribe(any(SubscribeRequest.class));
   }
 
   @Test
   @DisplayName("initializeQueue bootstraps queue when skipQueueBootstrap=false (default)")
   void testInitializeQueueBootstrapsWhenFlagFalse() {
-    SqsClient sqs = amazonSQS();
-    SnsClient sns = amazonSNS();
+    // given — default subscription has skipQueueBootstrap=false
+    SqsClient sqs = sqsClient();
+    SnsClient sns = snsClient();
     subscriber =
         new SQSSubscriber(
             subscription(),
@@ -156,14 +167,13 @@ public class SQSSubscriberTest {
             enableOnce(),
             new DefaultRegistry());
 
+    // when
     subscriber.initializeQueue();
 
-    verify(sqs, times(1)).getQueueUrl(any(GetQueueUrlRequest.class));
-    verify(sqs, times(1))
-        .setQueueAttributes(
-            any(software.amazon.awssdk.services.sqs.model.SetQueueAttributesRequest.class));
-    verify(sns, times(1))
-        .subscribe(any(software.amazon.awssdk.services.sns.model.SubscribeRequest.class));
+    // then
+    verify(sqs, times(1)).getQueueUrl(any(Consumer.class));
+    verify(sqs, times(1)).setQueueAttributes(any(SetQueueAttributesRequest.class));
+    verify(sns, times(1)).subscribe(any(SubscribeRequest.class));
   }
 
   AmazonPubsubProperties.AmazonPubsubSubscription subscription() {
@@ -175,7 +185,7 @@ public class SQSSubscriberTest {
     return subscription;
   }
 
-  SqsClient amazonSQS() {
+  SqsClient sqsClient() {
     Message msg = Message.builder().messageId("msg-1").receiptHandle("handle-1").body("{}").build();
 
     GetQueueUrlResponse getQueueUrlResponse =
@@ -184,35 +194,29 @@ public class SQSSubscriberTest {
     ReceiveMessageResponse receiveMessageResponse =
         ReceiveMessageResponse.builder().messages(List.of(msg)).build();
 
-    SqsClient sqsClient = spy(SqsClient.class);
-    doReturn(getQueueUrlResponse).when(sqsClient).getQueueUrl(any(GetQueueUrlRequest.class));
+    SqsClient sqsClient = mock(SqsClient.class);
+    doReturn(getQueueUrlResponse).when(sqsClient).getQueueUrl(any(Consumer.class));
     doReturn(receiveMessageResponse)
         .when(sqsClient)
         .receiveMessage(any(ReceiveMessageRequest.class));
-    doReturn(software.amazon.awssdk.services.sqs.model.SetQueueAttributesResponse.builder().build())
-        .when(sqsClient)
-        .setQueueAttributes(
-            any(software.amazon.awssdk.services.sqs.model.SetQueueAttributesRequest.class));
 
     return sqsClient;
   }
 
-  SnsClient amazonSNS() {
-    software.amazon.awssdk.services.sns.model.SubscribeResponse subscribeResponse =
-        software.amazon.awssdk.services.sns.model.SubscribeResponse.builder()
+  SnsClient snsClient() {
+    SubscribeResponse subscribeResponse =
+        SubscribeResponse.builder()
             .subscriptionArn("arn:aws:sqs:us-east-2:123456789012:MySubscription")
             .build();
 
-    SnsClient snsClient = spy(SnsClient.class);
-    doReturn(subscribeResponse)
-        .when(snsClient)
-        .subscribe(any(software.amazon.awssdk.services.sns.model.SubscribeRequest.class));
+    SnsClient snsClient = mock(SnsClient.class);
+    doReturn(subscribeResponse).when(snsClient).subscribe(any(SubscribeRequest.class));
 
     return snsClient;
   }
 
-  Supplier enableOnce() {
-    Supplier sup = spy(Supplier.class);
+  Supplier<Boolean> enableOnce() {
+    Supplier<Boolean> sup = spy(Supplier.class);
     doReturn(true, false).when(sup).get();
     return sup;
   }


### PR DESCRIPTION
## Summary

Migrates all `kork-pubsub-aws` classes from `com.amazonaws` (AWS SDK v1) to `software.amazon.awssdk` (AWS SDK v2). This completes the SQS/SNS path for the v1→v2 migration tracked in spinnaker/spinnaker#7699 (Phase 2 — Pub/Sub & orca).

## Changes

### kork-pubsub-aws
- **PubSubUtils**: removed all v1 overloads, kept only v2 (`SqsClient`/`SnsClient`); renamed `v2BuildSQSPolicy`/`v2BuildSNSPolicy` → `buildSQSPolicy`/`buildSNSPolicy`
- **SQSSubscriber, SQSSubscriberProvider**: use `SqsClient`/`SnsClient`/`AwsCredentialsProvider`
- **SNSPublisher, SNSPublisherProvider**: use `SnsClient`, `PublishRequest`/`PublishResponse`
- **DefaultAmazonMessageAcknowledger**: use `SqsClient.deleteMessage()`
- **AmazonSubscriptionInformation**: hold `SqsClient`/`SnsClient` instead of `AmazonSQS`/`AmazonSNS`
- **AmazonPubsubMessageHandler, AmazonMessageAcknowledger interfaces**: v2 `Message` type
- **AmazonPubsubConfig**: import `AwsComponents`, inject v2 `AwsCredentialsProvider`
- **kork-pubsub-aws.gradle**: dropped `com.amazonaws:aws-java-sdk-sns/sqs` dependencies
- **Tests**: rewritten with v2 mocks (`SQSSubscriberTest`, `PubSubUtilsSpec`)

### orca-interlink
- **InterlinkAmazonMessageHandler**: v2 `Message` import, `message.body()` instead of `message.getBody()`

### echo-pubsub-aws
- No changes needed (already uses v2 via its own `SQSSubscriber` and only calls the v2 `PubSubUtils` overloads)

## What was tested
- `:kork:kork-pubsub-aws:test` — ✅ (10 tests)
- `:orca:orca-interlink:test` — ✅
- `:echo:echo-pubsub-aws:test` — ✅ (4 tests)
- `spotlessCheck` passes across entire repo

## Breaking changes
- The `AmazonPubsubMessageHandler.handleMessage()` method now takes `software.amazon.awssdk.services.sqs.model.Message` instead of `com.amazonaws.services.sqs.model.Message`
- `AmazonSubscriptionInformation` fields renamed from `amazonSQS`/`amazonSNS` to `sqsClient`/`snsClient`
- `SNSPublisher.publishMessage()` now returns `Optional<PublishResponse>` instead of `Optional<PublishResult>`
- `PubSubUtils.buildSQSPolicy()` now returns `IamPolicy` instead of `com.amazonaws.auth.policy.Policy`