### PR TITLE
fix(spin): send Bearer token on all API requests when using oauth2 auth

### DIFF
--- a/spin/cmd/gateclient/client.go
+++ b/spin/cmd/gateclient/client.go
@@ -187,6 +187,25 @@ func NewGateClient(ui output.Ui, gateEndpoint, defaultHeaders, configLocation st
 		// on every API request, rather than relying solely on session cookies.
 		if gateClient.Config.Auth.OAuth2.CachedToken != nil {
 			gateClient.Context = context.WithValue(gateClient.Context, gate.ContextAccessToken, gateClient.Config.Auth.OAuth2.CachedToken.AccessToken)
+
+			// The generated gate client never consumes ContextAccessToken, so
+			// inject the Bearer header at the transport level for requests to
+			// the gate host. Without this, API calls carry no Authorization
+			// header at all and depend on a session cookie that a gate running
+			// Spring Security oauth2Login() never issues to non-browser clients.
+			if gateURL, err := url.Parse(gateClient.GateEndpoint()); err == nil {
+				oauth2Config := gateClient.Config.Auth.OAuth2
+				httpClient.Transport = &bearerAuthTransport{
+					next:     httpClient.Transport,
+					gateHost: gateURL.Host,
+					tokenFn: func() string {
+						if oauth2Config.CachedToken != nil {
+							return oauth2Config.CachedToken.AccessToken
+						}
+						return ""
+					},
+				}
+			}
 		}
 
 		updatedMessage = "Caching oauth2 token."
@@ -309,6 +328,26 @@ func userConfig(gateClient *GatewayClient, configLocation string) error {
 		gateClient.Config = config.Config{}
 	}
 	return nil
+}
+
+// bearerAuthTransport injects the cached OAuth2 access token as a Bearer
+// Authorization header on requests to the gate host that do not already
+// carry one. Scoped to the gate host so the token is not replayed to other
+// hosts on redirects (e.g. the identity provider).
+type bearerAuthTransport struct {
+	next     http.RoundTripper
+	gateHost string
+	tokenFn  func() string
+}
+
+func (b *bearerAuthTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.Header.Get("Authorization") == "" && req.URL.Host == b.gateHost {
+		if token := b.tokenFn(); token != "" {
+			req = req.Clone(req.Context())
+			req.Header.Set("Authorization", "Bearer "+token)
+		}
+	}
+	return b.next.RoundTrip(req)
 }
 
 // InitializeHTTPClient will return an *http.Client configured with

--- a/spin/cmd/gateclient/client_test.go
+++ b/spin/cmd/gateclient/client_test.go
@@ -55,6 +55,66 @@ func TestNewGateClientSendsXSpinnakerTokenHeader(t *testing.T) {
 	}
 }
 
+// TestNewGateClientSendsBearerTokenOnApiRequests verifies that API requests
+// (not just the initial login call) carry the cached OAuth2 access token as
+// an Authorization header. The generated gate client never consumes
+// gate.ContextAccessToken, so without transport-level injection API calls go
+// out with no Authorization header at all and depend on a session cookie
+// that a gate running Spring Security oauth2Login() never issues to
+// non-browser clients. This completes the assertion the test below sets up
+// but never makes: it captures the login request's Authorization header,
+// while this test asserts the header on an actual API request (/version).
+func TestNewGateClientSendsBearerTokenOnApiRequests(t *testing.T) {
+	token := "cached-access-token"
+	versionHeaders := make(chan string, 1)
+
+	mux := http.NewServeMux()
+	mux.Handle("/version", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		versionHeaders <- r.Header.Get("Authorization")
+		payload := map[string]string{"version": "Unknown"}
+		b, _ := json.Marshal(payload)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintln(w, string(b))
+	}))
+	mux.Handle("/login/oauth2/code/test-provider", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	testServer := httptest.NewServer(mux)
+	defer testServer.Close()
+
+	configPath := filepath.Join(t.TempDir(), "config")
+	configContents := "gate:\n" +
+		"  endpoint: " + testServer.URL + "\n" +
+		"auth:\n" +
+		"  enabled: true\n" +
+		"  oauth2:\n" +
+		"    authUrl: " + testServer.URL + "/oauth/authorize\n" +
+		"    tokenUrl: " + testServer.URL + "/oauth/token\n" +
+		"    scopes:\n" +
+		"      - openid\n" +
+		"    provider: test-provider\n" +
+		"    cachedToken:\n" +
+		"      access_token: " + token + "\n" +
+		"      token_type: Bearer\n" +
+		"      expiry: " + time.Now().Add(time.Hour).UTC().Format(time.RFC3339) + "\n"
+
+	if err := os.WriteFile(configPath, []byte(configContents), 0o600); err != nil {
+		t.Fatalf("failed writing test config: %v", err)
+	}
+
+	ui := output.NewUI(true, false, output.MarshalToJson, io.Discard, io.Discard)
+	if _, err := NewGateClient(ui, "", "", configPath, false, false, 0); err != nil {
+		t.Fatalf("NewGateClient returned error: %v", err)
+	}
+
+	got := <-versionHeaders
+	want := "Bearer " + token
+	if got != want {
+		t.Fatalf("Authorization header on /version: got %q, want %q", got, want)
+	}
+}
+
 func TestNewGateClientSetsContextAccessTokenFromOAuth2CachedToken(t *testing.T) {
 	token := "cached-access-token"
 	loginHeaders := make(chan string, 1)


### PR DESCRIPTION
Fixes #7917.

### Summary

With `auth.oauth2` configured, spin sends the Bearer token only on its initial `login()` request; every actual API call goes out with **no Authorization header**, relying on a session cookie that a Gate running the Spring Security `oauth2Login()` stack never issues to non-browser clients. Result: oauth2-configured spin cannot call any protected Gate endpoint (`Could not reach Gate... undefined response type`). Broken in the 2026.2.3 release binary and at current `main` (verified with a header-logging fake Gate - captures in the linked issue).

### Root cause

#7612 stores the token in `gate.ContextAccessToken`, but nothing consumes it:
- Gate's `swagger.json` declares no `securitySchemes`, so openapi-generator emits no auth-injection code in the generated gateapi client (the `ContextAccessToken` constant is only sed-injected into the generated `configuration.go` by `spin/swagger/generate_swagger.sh`).
- The `AddAuthHeaders` helper that would map the context value to a header has no callers.

### Fix

A `bearerAuthTransport` (`http.RoundTripper`) wired into the gate HTTP client when an oauth2 cached token exists:
- **Host-scoped** to the gate host, so the token is not replayed to other hosts on redirects (e.g. the identity provider).
- Skips requests that already carry an Authorization header.
- Reads the token through a closure, so tokens refreshed by `authenticateOAuth2` are picked up.

The existing `ContextAccessToken` line is kept for API parity.

### Test

`TestNewGateClientSendsBearerTokenOnApiRequests` asserts the Authorization header is actually **received** by a fake Gate on an API request (`/version`). This completes the assertion the #7612 test set up but never made (it fills a channel with the login request's Authorization header and never reads it). Verified the new test fails without the fix and passes with it. Also verified end-to-end against a real Okta-backed Gate deployment (oauth2Login() stack): `spin application list` works with only an OIDC bearer token.

### Future work (out of scope)

Declaring `securitySchemes` in Gate's OpenAPI spec would make openapi-generator emit native auth handling in the generated client, removing the need for the sed-injection and this transport. Larger blast radius (full client regeneration), left for a follow-up.