### PR TITLE
chore(aws): Lambda migration to AWS SDK v2

### DIFF
--- a/clouddriver/clouddriver-lambda/clouddriver-lambda.gradle
+++ b/clouddriver/clouddriver-lambda/clouddriver-lambda.gradle
@@ -7,7 +7,7 @@ dependencies {
   implementation project(":clouddriver-security")
 
   implementation "commons-io:commons-io"
-  implementation "com.amazonaws:aws-java-sdk"
+  implementation "software.amazon.awssdk:iam-policy-builder"
   implementation "com.github.ben-manes.caffeine:guava"
   implementation "com.netflix.awsobjectmapper:awsobjectmapper"
   implementation "io.spinnaker.kork:kork-artifacts"

--- a/clouddriver/clouddriver-lambda/src/main/java/com/netflix/spinnaker/clouddriver/lambda/deploy/ops/CreateLambdaAtomicOperation.java
+++ b/clouddriver/clouddriver-lambda/src/main/java/com/netflix/spinnaker/clouddriver/lambda/deploy/ops/CreateLambdaAtomicOperation.java
@@ -16,13 +16,6 @@
 
 package com.netflix.spinnaker.clouddriver.lambda.deploy.ops;
 
-import com.amazonaws.services.elasticloadbalancingv2.AmazonElasticLoadBalancing;
-import com.amazonaws.services.elasticloadbalancingv2.model.DescribeTargetGroupsRequest;
-import com.amazonaws.services.elasticloadbalancingv2.model.DescribeTargetGroupsResult;
-import com.amazonaws.services.elasticloadbalancingv2.model.RegisterTargetsRequest;
-import com.amazonaws.services.elasticloadbalancingv2.model.RegisterTargetsResult;
-import com.amazonaws.services.elasticloadbalancingv2.model.TargetDescription;
-import com.amazonaws.services.elasticloadbalancingv2.model.TargetGroup;
 import com.netflix.frigga.Names;
 import com.netflix.spinnaker.clouddriver.lambda.deploy.description.CreateLambdaFunctionDescription;
 import com.netflix.spinnaker.clouddriver.lambda.names.LambdaTagNamer;
@@ -33,6 +26,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.UUID;
+import software.amazon.awssdk.services.elasticloadbalancingv2.ElasticLoadBalancingV2Client;
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.DescribeTargetGroupsRequest;
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.DescribeTargetGroupsResponse;
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.RegisterTargetsRequest;
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.RegisterTargetsResponse;
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.TargetDescription;
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.TargetGroup;
 import software.amazon.awssdk.services.lambda.LambdaClient;
 import software.amazon.awssdk.services.lambda.model.AddPermissionRequest;
 import software.amazon.awssdk.services.lambda.model.CreateFunctionRequest;
@@ -143,16 +143,17 @@ public class CreateLambdaAtomicOperation
     }
   }
 
-  private RegisterTargetsResult registerTargetGroup(String functionArn, LambdaClient lambdaClient) {
+  private RegisterTargetsResponse registerTargetGroup(
+      String functionArn, LambdaClient lambdaClient) {
 
-    AmazonElasticLoadBalancing loadBalancingV2 = getAmazonElasticLoadBalancingClient();
+    ElasticLoadBalancingV2Client loadBalancingV2 = getAmazonElasticLoadBalancingClient();
     TargetGroup targetGroup = retrieveTargetGroup(loadBalancingV2);
 
     AddPermissionRequest addPermissionRequest =
         AddPermissionRequest.builder()
             .functionName(functionArn)
             .action("lambda:InvokeFunction")
-            .sourceArn(targetGroup.getTargetGroupArn())
+            .sourceArn(targetGroup.targetGroupArn())
             .principal("elasticloadbalancing.amazonaws.com")
             .statementId(UUID.randomUUID().toString())
             .build();
@@ -162,31 +163,32 @@ public class CreateLambdaAtomicOperation
     updateTaskStatus(
         String.format(
             "Lambda (%s) invoke permissions added to Target group (%s).",
-            functionArn, targetGroup.getTargetGroupArn()));
+            functionArn, targetGroup.targetGroupArn()));
 
-    RegisterTargetsResult result =
+    RegisterTargetsResponse result =
         loadBalancingV2.registerTargets(
-            new RegisterTargetsRequest()
-                .withTargets(new TargetDescription().withId(functionArn))
-                .withTargetGroupArn(targetGroup.getTargetGroupArn()));
+            RegisterTargetsRequest.builder()
+                .targetGroupArn(targetGroup.targetGroupArn())
+                .targets(TargetDescription.builder().id(functionArn).build())
+                .build());
 
     updateTaskStatus(
         String.format(
             "Registered the Lambda (%s) with Target group (%s).",
-            functionArn, targetGroup.getTargetGroupArn()));
+            functionArn, targetGroup.targetGroupArn()));
     return result;
   }
 
-  private TargetGroup retrieveTargetGroup(AmazonElasticLoadBalancing loadBalancingV2) {
+  private TargetGroup retrieveTargetGroup(ElasticLoadBalancingV2Client loadBalancingV2) {
 
     DescribeTargetGroupsRequest request =
-        new DescribeTargetGroupsRequest().withNames(description.getTargetGroups());
-    DescribeTargetGroupsResult describeTargetGroupsResult =
+        DescribeTargetGroupsRequest.builder().names(description.getTargetGroups()).build();
+    DescribeTargetGroupsResponse describeTargetGroupsResult =
         loadBalancingV2.describeTargetGroups(request);
 
-    if (describeTargetGroupsResult.getTargetGroups().size() == 1) {
-      return describeTargetGroupsResult.getTargetGroups().get(0);
-    } else if (describeTargetGroupsResult.getTargetGroups().size() > 1) {
+    if (describeTargetGroupsResult.targetGroups().size() == 1) {
+      return describeTargetGroupsResult.targetGroups().get(0);
+    } else if (describeTargetGroupsResult.targetGroups().size() > 1) {
       throw new IllegalArgumentException(
           "There are multiple target groups with the name " + description.getTargetGroups() + ".");
     } else {
@@ -195,9 +197,9 @@ public class CreateLambdaAtomicOperation
     }
   }
 
-  private AmazonElasticLoadBalancing getAmazonElasticLoadBalancingClient() {
+  private ElasticLoadBalancingV2Client getAmazonElasticLoadBalancingClient() {
 
     return getAmazonClientProvider()
-        .getAmazonElasticLoadBalancingV2(description.getCredentials(), getRegion(), false);
+        .getElasticLoadBalancingV2Client(description.getCredentials(), getRegion());
   }
 }

--- a/clouddriver/clouddriver-lambda/src/main/java/com/netflix/spinnaker/clouddriver/lambda/deploy/ops/UpdateLambdaConfigurationAtomicOperation.java
+++ b/clouddriver/clouddriver-lambda/src/main/java/com/netflix/spinnaker/clouddriver/lambda/deploy/ops/UpdateLambdaConfigurationAtomicOperation.java
@@ -16,15 +16,6 @@
 
 package com.netflix.spinnaker.clouddriver.lambda.deploy.ops;
 
-import com.amazonaws.services.elasticloadbalancingv2.AmazonElasticLoadBalancing;
-import com.amazonaws.services.elasticloadbalancingv2.model.DeregisterTargetsRequest;
-import com.amazonaws.services.elasticloadbalancingv2.model.DeregisterTargetsResult;
-import com.amazonaws.services.elasticloadbalancingv2.model.DescribeTargetGroupsRequest;
-import com.amazonaws.services.elasticloadbalancingv2.model.DescribeTargetGroupsResult;
-import com.amazonaws.services.elasticloadbalancingv2.model.RegisterTargetsRequest;
-import com.amazonaws.services.elasticloadbalancingv2.model.RegisterTargetsResult;
-import com.amazonaws.services.elasticloadbalancingv2.model.TargetDescription;
-import com.amazonaws.services.elasticloadbalancingv2.model.TargetGroup;
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
 import com.netflix.spinnaker.clouddriver.lambda.cache.model.LambdaFunction;
 import com.netflix.spinnaker.clouddriver.lambda.deploy.description.CreateLambdaFunctionConfigurationDescription;
@@ -34,6 +25,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.springframework.util.StringUtils;
+import software.amazon.awssdk.services.elasticloadbalancingv2.ElasticLoadBalancingV2Client;
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.DeregisterTargetsRequest;
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.DescribeTargetGroupsRequest;
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.DescribeTargetGroupsResponse;
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.RegisterTargetsRequest;
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.TargetDescription;
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.TargetGroup;
 import software.amazon.awssdk.services.lambda.LambdaClient;
 import software.amazon.awssdk.services.lambda.model.Environment;
 import software.amazon.awssdk.services.lambda.model.ListTagsRequest;
@@ -134,25 +132,24 @@ public class UpdateLambdaConfigurationAtomicOperation
     updateTaskStatus("Finished Updating of AWS Lambda Function Configuration Operation...");
     if (StringUtils.isEmpty(description.getTargetGroups())) {
       if (cache.getTargetGroups() != null && !cache.getTargetGroups().isEmpty()) {
-        AmazonElasticLoadBalancing loadBalancingV2 = getAmazonElasticLoadBalancingClient();
+        ElasticLoadBalancingV2Client loadBalancingV2 = getAmazonElasticLoadBalancingClient();
         for (String groupName : cache.getTargetGroups()) {
           deregisterTarget(
               loadBalancingV2,
               cache.getFunctionArn(),
-              retrieveTargetGroup(loadBalancingV2, groupName).getTargetGroupArn());
+              retrieveTargetGroup(loadBalancingV2, groupName).targetGroupArn());
           updateTaskStatus("De-registered the target group...");
         }
       }
 
     } else {
-      AmazonElasticLoadBalancing loadBalancingV2 = getAmazonElasticLoadBalancingClient();
+      ElasticLoadBalancingV2Client loadBalancingV2 = getAmazonElasticLoadBalancingClient();
       List<String> cacheTargetGroups = cache.getTargetGroups();
       if (cacheTargetGroups == null || cacheTargetGroups.isEmpty()) {
         registerTarget(
             loadBalancingV2,
             cache.getFunctionArn(),
-            retrieveTargetGroup(loadBalancingV2, description.getTargetGroups())
-                .getTargetGroupArn());
+            retrieveTargetGroup(loadBalancingV2, description.getTargetGroups()).targetGroupArn());
         updateTaskStatus("Registered the target group...");
       } else {
         for (String groupName : cacheTargetGroups) {
@@ -161,7 +158,7 @@ public class UpdateLambdaConfigurationAtomicOperation
                 loadBalancingV2,
                 cache.getFunctionArn(),
                 retrieveTargetGroup(loadBalancingV2, description.getTargetGroups())
-                    .getTargetGroupArn());
+                    .targetGroupArn());
             updateTaskStatus("Registered the target group...");
           }
         }
@@ -171,16 +168,16 @@ public class UpdateLambdaConfigurationAtomicOperation
   }
 
   private TargetGroup retrieveTargetGroup(
-      AmazonElasticLoadBalancing loadBalancingV2, String targetGroupName) {
+      ElasticLoadBalancingV2Client loadBalancingV2, String targetGroupName) {
 
     DescribeTargetGroupsRequest request =
-        new DescribeTargetGroupsRequest().withNames(targetGroupName);
-    DescribeTargetGroupsResult describeTargetGroupsResult =
+        DescribeTargetGroupsRequest.builder().names(targetGroupName).build();
+    DescribeTargetGroupsResponse describeTargetGroupsResult =
         loadBalancingV2.describeTargetGroups(request);
 
-    if (describeTargetGroupsResult.getTargetGroups().size() == 1) {
-      return describeTargetGroupsResult.getTargetGroups().get(0);
-    } else if (describeTargetGroupsResult.getTargetGroups().size() > 1) {
+    if (describeTargetGroupsResult.targetGroups().size() == 1) {
+      return describeTargetGroupsResult.targetGroups().get(0);
+    } else if (describeTargetGroupsResult.targetGroups().size() > 1) {
       throw new IllegalArgumentException(
           "There are multiple target groups with the name " + targetGroupName + ".");
     } else {
@@ -189,28 +186,28 @@ public class UpdateLambdaConfigurationAtomicOperation
     }
   }
 
-  private AmazonElasticLoadBalancing getAmazonElasticLoadBalancingClient() {
+  private ElasticLoadBalancingV2Client getAmazonElasticLoadBalancingClient() {
     NetflixAmazonCredentials credentialAccount = description.getCredentials();
 
     return getAmazonClientProvider()
-        .getAmazonElasticLoadBalancingV2(credentialAccount, getRegion(), false);
+        .getElasticLoadBalancingV2Client(credentialAccount, getRegion());
   }
 
   private void registerTarget(
-      AmazonElasticLoadBalancing loadBalancingV2, String functionArn, String targetGroupArn) {
-    RegisterTargetsResult result =
-        loadBalancingV2.registerTargets(
-            new RegisterTargetsRequest()
-                .withTargets(new TargetDescription().withId(functionArn))
-                .withTargetGroupArn(targetGroupArn));
+      ElasticLoadBalancingV2Client loadBalancingV2, String functionArn, String targetGroupArn) {
+    loadBalancingV2.registerTargets(
+        RegisterTargetsRequest.builder()
+            .targetGroupArn(targetGroupArn)
+            .targets(TargetDescription.builder().id(functionArn).build())
+            .build());
   }
 
   private void deregisterTarget(
-      AmazonElasticLoadBalancing loadBalancingV2, String functionArn, String targetGroupArn) {
-    DeregisterTargetsResult result =
-        loadBalancingV2.deregisterTargets(
-            new DeregisterTargetsRequest()
-                .withTargetGroupArn(targetGroupArn)
-                .withTargets(new TargetDescription().withId(functionArn)));
+      ElasticLoadBalancingV2Client loadBalancingV2, String functionArn, String targetGroupArn) {
+    loadBalancingV2.deregisterTargets(
+        DeregisterTargetsRequest.builder()
+            .targetGroupArn(targetGroupArn)
+            .targets(TargetDescription.builder().id(functionArn).build())
+            .build());
   }
 }

--- a/clouddriver/clouddriver-lambda/src/main/java/com/netflix/spinnaker/clouddriver/lambda/provider/agent/IamRoleCachingAgent.java
+++ b/clouddriver/clouddriver-lambda/src/main/java/com/netflix/spinnaker/clouddriver/lambda/provider/agent/IamRoleCachingAgent.java
@@ -19,11 +19,6 @@ package com.netflix.spinnaker.clouddriver.lambda.provider.agent;
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE;
 import static com.netflix.spinnaker.clouddriver.lambda.cache.Keys.Namespace.IAM_ROLE;
 
-import com.amazonaws.regions.Regions;
-import com.amazonaws.services.identitymanagement.AmazonIdentityManagement;
-import com.amazonaws.services.identitymanagement.model.ListRolesRequest;
-import com.amazonaws.services.identitymanagement.model.ListRolesResult;
-import com.amazonaws.services.identitymanagement.model.Role;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spinnaker.cats.agent.AgentDataType;
 import com.netflix.spinnaker.cats.agent.CacheResult;
@@ -45,6 +40,11 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.iam.IamClient;
+import software.amazon.awssdk.services.iam.model.ListRolesRequest;
+import software.amazon.awssdk.services.iam.model.ListRolesResponse;
+import software.amazon.awssdk.services.iam.model.Role;
 
 public class IamRoleCachingAgent implements CachingAgent, CustomScheduledAgent {
   private static final long POLL_INTERVAL_MILLIS = TimeUnit.MINUTES.toMillis(30);
@@ -98,8 +98,7 @@ public class IamRoleCachingAgent implements CachingAgent, CustomScheduledAgent {
 
   @Override
   public CacheResult loadData(ProviderCache providerCache) {
-    AmazonIdentityManagement iam =
-        amazonClientProvider.getIam(account, Regions.DEFAULT_REGION.getName(), false);
+    IamClient iam = amazonClientProvider.getIamV2(account, Region.US_EAST_1.id());
 
     Set<IamRole> cacheableRoles = fetchIamRoles(iam, accountName);
     Map<String, Collection<CacheData>> newDataMap = generateFreshData(cacheableRoles);
@@ -165,28 +164,28 @@ public class IamRoleCachingAgent implements CachingAgent, CustomScheduledAgent {
     return newDataMap;
   }
 
-  private Set<IamRole> fetchIamRoles(AmazonIdentityManagement iam, String accountName) {
+  private Set<IamRole> fetchIamRoles(IamClient iam, String accountName) {
     Set<IamRole> cacheableRoles = new HashSet<>();
     String marker = null;
     do {
-      ListRolesRequest request = new ListRolesRequest();
+      ListRolesRequest.Builder requestBuilder = ListRolesRequest.builder();
       if (marker != null) {
-        request.setMarker(marker);
+        requestBuilder.marker(marker);
       }
 
-      ListRolesResult listRolesResult = iam.listRoles(request);
-      List<Role> roles = listRolesResult.getRoles();
+      ListRolesResponse listRolesResult = iam.listRoles(requestBuilder.build());
+      List<Role> roles = listRolesResult.roles();
       for (Role role : roles) {
         cacheableRoles.add(
             new IamRole(
-                role.getArn(),
-                role.getRoleName(),
+                role.arn(),
+                role.roleName(),
                 accountName,
-                getTrustedEntities(role.getAssumeRolePolicyDocument())));
+                getTrustedEntities(role.assumeRolePolicyDocument())));
       }
 
-      if (listRolesResult.isTruncated()) {
-        marker = listRolesResult.getMarker();
+      if (Boolean.TRUE.equals(listRolesResult.isTruncated())) {
+        marker = listRolesResult.marker();
       } else {
         marker = null;
       }

--- a/clouddriver/clouddriver-lambda/src/main/java/com/netflix/spinnaker/clouddriver/lambda/service/LambdaService.java
+++ b/clouddriver/clouddriver-lambda/src/main/java/com/netflix/spinnaker/clouddriver/lambda/service/LambdaService.java
@@ -16,8 +16,6 @@
 
 package com.netflix.spinnaker.clouddriver.lambda.service;
 
-import com.amazonaws.auth.policy.Policy;
-import com.amazonaws.auth.policy.Statement;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spinnaker.clouddriver.aws.data.ArnUtils;
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider;
@@ -29,6 +27,10 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import lombok.extern.log4j.Log4j2;
+import software.amazon.awssdk.policybuilder.iam.IamConditionOperator;
+import software.amazon.awssdk.policybuilder.iam.IamEffect;
+import software.amazon.awssdk.policybuilder.iam.IamPolicy;
+import software.amazon.awssdk.policybuilder.iam.IamStatement;
 import software.amazon.awssdk.services.lambda.LambdaClient;
 import software.amazon.awssdk.services.lambda.model.*;
 import software.amazon.awssdk.services.lambda.paginators.ListFunctionsIterable;
@@ -170,37 +172,35 @@ public class LambdaService extends LambdaClientProvider {
     return null;
   }
 
-  private static final Predicate<Statement> isLambdaInvokeAction =
+  private static final Predicate<IamStatement> isAllowStatement =
+      statement -> IamEffect.ALLOW.equals(statement.effect());
+  private static final Predicate<IamStatement> isLambdaInvokeAction =
       statement ->
-          statement.getActions().stream()
-              .anyMatch(action -> "lambda:InvokeFunction".equals(action.getActionName()));
-  private static final Predicate<Statement> isElbPrincipal =
+          statement.actions().stream()
+              .anyMatch(action -> "lambda:InvokeFunction".equals(action.value()));
+  private static final Predicate<IamStatement> isElbPrincipal =
       statement ->
-          statement.getPrincipals().stream()
-              .anyMatch(
-                  principal -> "elasticloadbalancing.amazonaws.com".equals(principal.getId()));
+          statement.principals().stream()
+              .anyMatch(principal -> "elasticloadbalancing.amazonaws.com".equals(principal.id()));
 
   private List<String> getTargetGroupNames(String functionName) {
     List<String> targetGroupNames = new ArrayList<>();
-    Predicate<Statement> isAllowStatement =
-        statement -> statement.getEffect().toString().equals(Statement.Effect.Allow.toString());
 
     try {
       LambdaClient lambda = getLambdaClient();
       GetPolicyResponse result =
           lambda.getPolicy(GetPolicyRequest.builder().functionName(functionName).build());
-      Policy policy = Policy.fromJson(result.policy());
+      IamPolicy policy = IamPolicy.fromJson(result.policy());
 
       targetGroupNames =
-          policy.getStatements().stream()
+          policy.statements().stream()
               .filter(isAllowStatement.and(isLambdaInvokeAction).and(isElbPrincipal))
-              .flatMap(statement -> statement.getConditions().stream())
+              .flatMap(statement -> statement.conditions().stream())
               .filter(
                   condition ->
-                      "ArnLike".equals(condition.getType())
-                          && "AWS:SourceArn".equals(condition.getConditionKey()))
-              .flatMap(condition -> condition.getValues().stream())
-              .flatMap(value -> ArnUtils.extractTargetGroupName(value).stream())
+                      IamConditionOperator.ARN_LIKE.equals(condition.operator())
+                          && "AWS:SourceArn".equals(condition.key().value()))
+              .flatMap(condition -> ArnUtils.extractTargetGroupName(condition.value()).stream())
               .collect(Collectors.toList());
 
     } catch (NullPointerException | ResourceNotFoundException e) {


### PR DESCRIPTION
PRIMARY worry is if there's any cross-over on the cache system for the LB information.  E.g. often, these pull from the AWS provider for various deps.  That said when I last looked at Lambda, it does NOT cache or integrate with this, so this should move Lambda fully onto AWS V2.  (https://github.com/spinnaker/spinnaker/blob/main/clouddriver/clouddriver-lambda/src/main/java/com/netflix/spinnaker/clouddriver/lambda/cache/Keys.java for reference)