### PR TITLE
chore(aws): Migrate EC2 client and EC2-only caching agents to AWS SDK v2

### DIFF
--- a/clouddriver/clouddriver-aws/clouddriver-aws.gradle
+++ b/clouddriver/clouddriver-aws/clouddriver-aws.gradle
@@ -34,6 +34,7 @@ dependencies {
   api "software.amazon.awssdk:applicationautoscaling"
   api "software.amazon.awssdk:cloudformation"
   api "software.amazon.awssdk:cloudwatch"
+  api "software.amazon.awssdk:ec2"
   api "software.amazon.awssdk:ecr"
   api "software.amazon.awssdk:ecs"
   api "software.amazon.awssdk:elasticloadbalancingv2"

--- a/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonElasticIpCachingAgent.groovy
+++ b/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonElasticIpCachingAgent.groovy
@@ -16,7 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.aws.provider.agent
 
-import com.amazonaws.services.ec2.model.Address
+import software.amazon.awssdk.services.ec2.model.Address
 import com.netflix.spinnaker.cats.agent.AccountAware
 import com.netflix.spinnaker.cats.agent.AgentDataType
 import com.netflix.spinnaker.cats.agent.CacheResult
@@ -82,14 +82,14 @@ class AmazonElasticIpCachingAgent implements CachingAgent, AccountAware, CustomS
   @Override
   CacheResult loadData(ProviderCache providerCache) {
     log.info("Describing items in ${agentType}")
-    def ec2 = amazonClientProvider.getAmazonEC2(account, region)
-    def eips = ec2.describeAddresses().addresses
+    def ec2 = amazonClientProvider.getAmazonEC2V2(account, region)
+    def eips = ec2.describeAddresses().addresses()
 
     List<CacheData> data = eips.collect { Address address ->
-      new DefaultCacheData(Keys.getElasticIpKey(address.publicIp, region, account.name), [
-        address     : address.publicIp,
-        domain      : address.domain,
-        attachedToId: address.instanceId,
+      new DefaultCacheData(Keys.getElasticIpKey(address.publicIp(), region, account.name), [
+        address     : address.publicIp(),
+        domain      : address.domainAsString(),
+        attachedToId: address.instanceId(),
         accountName : account.name,
         region      : region
       ], [:])

--- a/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonKeyPairCachingAgent.groovy
+++ b/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonKeyPairCachingAgent.groovy
@@ -16,7 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.aws.provider.agent
 
-import com.amazonaws.services.ec2.model.KeyPairInfo
+import software.amazon.awssdk.services.ec2.model.KeyPairInfo
 import com.netflix.spinnaker.cats.agent.AccountAware
 import com.netflix.spinnaker.cats.agent.AgentDataType
 import com.netflix.spinnaker.cats.agent.CacheResult
@@ -82,13 +82,13 @@ class AmazonKeyPairCachingAgent implements CachingAgent, AccountAware, CustomSch
   @Override
   CacheResult loadData(ProviderCache providerCache) {
     log.info("Describing items in ${agentType}")
-    def ec2 = amazonClientProvider.getAmazonEC2(account, region)
-    def keyPairs = ec2.describeKeyPairs().keyPairs
+    def ec2 = amazonClientProvider.getAmazonEC2V2(account, region)
+    def keyPairs = ec2.describeKeyPairs().keyPairs()
 
     List<CacheData> data = keyPairs.collect { KeyPairInfo keyPair ->
-      new DefaultCacheData(Keys.getKeyPairKey(keyPair.keyName, region, account.name), [
-        keyName       : keyPair.keyName,
-        keyFingerprint: keyPair.keyFingerprint
+      new DefaultCacheData(Keys.getKeyPairKey(keyPair.keyName(), region, account.name), [
+        keyName       : keyPair.keyName(),
+        keyFingerprint: keyPair.keyFingerprint()
       ], [:])
     }
     log.info("Caching ${data.size()} items in ${agentType}")

--- a/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonSecurityGroupCachingAgent.groovy
+++ b/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonSecurityGroupCachingAgent.groovy
@@ -16,8 +16,8 @@
 
 package com.netflix.spinnaker.clouddriver.aws.provider.agent
 
-import com.amazonaws.services.ec2.AmazonEC2
-import com.amazonaws.services.ec2.model.SecurityGroup
+import software.amazon.awssdk.services.ec2.Ec2Client
+import software.amazon.awssdk.services.ec2.model.SecurityGroup
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.cats.agent.AccountAware
@@ -113,7 +113,7 @@ class AmazonSecurityGroupCachingAgent implements CachingAgent, OnDemandAgent, Ac
 
     Long startTime = null
     def securityGroups = metricsSupport.readData {
-      def ec2 = amazonClientProvider.getAmazonEC2(account, region, true)
+      def ec2 = amazonClientProvider.getAmazonEC2V2(account, region)
       if (account.eddaEnabled && !eddaTimeoutConfig.disabledRegions.contains(region)) {
         startTime = System.currentTimeMillis()
       }
@@ -132,10 +132,13 @@ class AmazonSecurityGroupCachingAgent implements CachingAgent, OnDemandAgent, Ac
 
   @Override
   CacheResult loadData(ProviderCache providerCache) {
-    def ec2 = amazonClientProvider.getAmazonEC2(account, region)
+    def ec2 = amazonClientProvider.getAmazonEC2V2(account, region)
     List<SecurityGroup> securityGroups = getSecurityGroups(ec2)
     def evictions = [:]
     if (account.eddaEnabled && !eddaTimeoutConfig.disabledRegions.contains(region)) {
+      // amazonClientProvider.lastModified is only ever populated by the v1 Edda-intercepting
+      // proxy; v2 clients read directly from AWS, so this is always null here and the
+      // short-circuit-on-unchanged-data optimization below no longer applies for this agent.
       Long startTime = amazonClientProvider.lastModified
       if (startTime) {
         def lastModifiedRecord = providerCache.get(ON_DEMAND.ns, lastModifiedKey)
@@ -169,15 +172,15 @@ class AmazonSecurityGroupCachingAgent implements CachingAgent, OnDemandAgent, Ac
     return []
   }
 
-  private List<SecurityGroup> getSecurityGroups(AmazonEC2 amazonEC2) {
+  private List<SecurityGroup> getSecurityGroups(Ec2Client amazonEC2) {
     log.info("Describing items in ${agentType}")
-    amazonEC2.describeSecurityGroups().securityGroups
+    amazonEC2.describeSecurityGroups().securityGroups()
   }
 
   private CacheResult buildCacheResult(ProviderCache providerCache, List<SecurityGroup> securityGroups, Map<String, List<String>> evictions, Long lastModified) {
     List<CacheData> data = securityGroups.collect { SecurityGroup securityGroup ->
       Map<String, Object> attributes = objectMapper.convertValue(securityGroup, AwsInfrastructureProvider.ATTRIBUTES)
-      new DefaultCacheData(Keys.getSecurityGroupKey(securityGroup.groupName, securityGroup.groupId, region, account.name, securityGroup.vpcId),
+      new DefaultCacheData(Keys.getSecurityGroupKey(securityGroup.groupName(), securityGroup.groupId(), region, account.name, securityGroup.vpcId()),
         attributes,
         [:])
     }

--- a/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonSubnetCachingAgent.groovy
+++ b/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonSubnetCachingAgent.groovy
@@ -16,7 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.aws.provider.agent
 
-import com.amazonaws.services.ec2.model.Subnet
+import software.amazon.awssdk.services.ec2.model.Subnet
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.cats.agent.*
 import com.netflix.spinnaker.cats.cache.CacheData
@@ -76,13 +76,13 @@ class AmazonSubnetCachingAgent implements CachingAgent, AccountAware {
   @Override
   CacheResult loadData(ProviderCache providerCache) {
     log.info("Describing items in ${agentType}")
-    def ec2 = amazonClientProvider.getAmazonEC2(account, region)
-    def subnets = ec2.describeSubnets().subnets
+    def ec2 = amazonClientProvider.getAmazonEC2V2(account, region)
+    def subnets = ec2.describeSubnets().subnets()
 
     List<CacheData> data = subnets.collect { Subnet subnet ->
       Map<String, Object> attributes = amazonObjectMapper.convertValue(subnet, AwsInfrastructureProvider.ATTRIBUTES)
       attributes.putIfAbsent("accountId", account.accountId)
-      new DefaultCacheData(Keys.getSubnetKey(subnet.subnetId, region, account.name),
+      new DefaultCacheData(Keys.getSubnetKey(subnet.subnetId(), region, account.name),
         attributes,
         [:])
     }

--- a/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonVpcCachingAgent.groovy
+++ b/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonVpcCachingAgent.groovy
@@ -16,7 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.aws.provider.agent
 
-import com.amazonaws.services.ec2.model.Vpc
+import software.amazon.awssdk.services.ec2.model.Vpc
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.cats.agent.AccountAware
 import com.netflix.spinnaker.cats.agent.AgentDataType
@@ -81,12 +81,12 @@ class AmazonVpcCachingAgent implements CachingAgent, AccountAware {
   @Override
   CacheResult loadData(ProviderCache providerCache) {
     log.info("Describing items in ${agentType}")
-    def ec2 = amazonClientProvider.getAmazonEC2(account, region)
-    def vpcs = ec2.describeVpcs().vpcs
+    def ec2 = amazonClientProvider.getAmazonEC2V2(account, region)
+    def vpcs = ec2.describeVpcs().vpcs()
 
     List<CacheData> data = vpcs.collect { Vpc vpc ->
       Map<String, Object> attributes = objectMapper.convertValue(vpc, AwsInfrastructureProvider.ATTRIBUTES)
-      new DefaultCacheData(Keys.getVpcKey(vpc.vpcId, region, account.name),
+      new DefaultCacheData(Keys.getVpcKey(vpc.vpcId(), region, account.name),
         attributes,
         [:])
     }

--- a/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ImageCachingAgent.groovy
+++ b/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ImageCachingAgent.groovy
@@ -16,9 +16,9 @@
 
 package com.netflix.spinnaker.clouddriver.aws.provider.agent
 
-import com.amazonaws.services.ec2.model.DescribeImagesRequest
-import com.amazonaws.services.ec2.model.Filter
-import com.amazonaws.services.ec2.model.Image
+import software.amazon.awssdk.services.ec2.model.DescribeImagesRequest
+import software.amazon.awssdk.services.ec2.model.Filter
+import software.amazon.awssdk.services.ec2.model.Image
 import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
@@ -125,48 +125,40 @@ class ImageCachingAgent implements CachingAgent, AccountAware, DriftMetric, Cust
     }
     log.info("Describing items in ${agentType}")
     //we read public images directly from AWS instead of having edda cache them:
-    def amazonEC2 = amazonClientProvider.getAmazonEC2(account, region, includePublicImages)
-    def request = new DescribeImagesRequest()
+    def amazonEC2 = amazonClientProvider.getAmazonEC2V2(account, region)
+    List<Filter> filters = new ArrayList<>()
     if (includePublicImages) {
-      request.withFilters(new Filter('is-public', ['true']))
+      filters.add(Filter.builder().name('is-public').values(['true']).build())
     } else {
-      request.withFilters(new Filter('is-public', ['false']))
+      filters.add(Filter.builder().name('is-public').values(['false']).build())
     }
 
     List<String> imageStates = dynamicConfigService.getConfig(List, "aws.defaults.image-states", List.of());
     if (!imageStates.isEmpty()) {
       log.debug("using image state filter '${imageStates}'")
-      request.withFilters(new Filter('state', imageStates))
+      filters.add(Filter.builder().name('state').values(imageStates).build())
     }
+    def request = DescribeImagesRequest.builder().filters(filters).build()
 
-    List<Image> images = amazonEC2.describeImages(request).images
+    List<Image> images = amazonEC2.describeImages(request).images()
     Long start = null
-    if (account.eddaEnabled) {
-      start = amazonClientProvider.lastModified ?: 0
-      // Edda does not respect filter parameters. Filter here manually instead.
-      if (includePublicImages) {
-        images = images.findAll { it.isPublic() }
-      } else {
-        images = images.findAll { !it.isPublic() }
-      }
-    }
 
     Collection<CacheData> imageCacheData = new ArrayList<>(images.size())
     Map<String, CacheData> namedImageCacheDataMap = new HashMap<>(images.size())
 
     for (Image image : images) {
       Map<String, Object> attributes = objectMapper.convertValue(image, ATTRIBUTES)
-      def imageId = Keys.getImageKey(image.imageId, account.name, region)
-      def namedImageId = Keys.getNamedImageKey(account.name, image.name)
+      def imageId = Keys.getImageKey(image.imageId(), account.name, region)
+      def namedImageId = Keys.getNamedImageKey(account.name, image.name())
       imageCacheData.add(new DefaultCacheData(imageId, attributes, [(NAMED_IMAGES.ns): [namedImageId]]))
 
       CacheData namedImageCacheData = namedImageCacheDataMap.get(namedImageId);
       if (namedImageCacheData == null) {
         namedImageCacheDataMap.put(namedImageId, new DefaultCacheData(namedImageId, [
-          name              : image.name,
-          virtualizationType: image.virtualizationType,
-          architecture      : image.architecture,
-          creationDate      : image.creationDate
+          name              : image.name(),
+          virtualizationType: image.virtualizationType(),
+          architecture      : image.architecture(),
+          creationDate      : image.creationDate()
         ], [(IMAGES.ns): [imageId]]))
       } else {
         // There's already a named image with this name, so add the imageId to

--- a/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/InstanceCachingAgent.groovy
+++ b/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/InstanceCachingAgent.groovy
@@ -16,11 +16,12 @@
 
 package com.netflix.spinnaker.clouddriver.aws.provider.agent
 
-import com.amazonaws.services.ec2.model.DescribeInstancesRequest
-import com.amazonaws.services.ec2.model.Instance
-import com.amazonaws.services.ec2.model.InstanceState
-import com.amazonaws.services.ec2.model.InstanceStateName
-import com.amazonaws.services.ec2.model.StateReason
+import software.amazon.awssdk.services.ec2.model.DescribeInstancesRequest
+import software.amazon.awssdk.services.ec2.model.Instance
+import software.amazon.awssdk.services.ec2.model.InstanceLifecycleType
+import software.amazon.awssdk.services.ec2.model.InstanceState
+import software.amazon.awssdk.services.ec2.model.InstanceStateName
+import software.amazon.awssdk.services.ec2.model.StateReason
 import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
@@ -106,19 +107,16 @@ class InstanceCachingAgent implements CachingAgent, AccountAware, DriftMetric {
   CacheResult loadData(ProviderCache providerCache) {
     log.info("Describing items in ${agentType}")
 
-    def amazonEC2 = amazonClientProvider.getAmazonEC2(account, region)
+    def amazonEC2 = amazonClientProvider.getAmazonEC2V2(account, region)
 
     Long start = null
-    def request = new DescribeInstancesRequest().withMaxResults(500)
+    def request = DescribeInstancesRequest.builder().maxResults(500).build()
     List<Instance> awsInstances = []
     while (true) {
       def resp = amazonEC2.describeInstances(request)
-      if (account.eddaEnabled) {
-        start = amazonClientProvider.lastModified ?: 0
-      }
-      awsInstances.addAll(resp.reservations.collectMany { it.instances })
-      if (resp.nextToken) {
-        request.withNextToken(resp.nextToken)
+      awsInstances.addAll(resp.reservations().collectMany { it.instances() })
+      if (resp.nextToken()) {
+        request = request.toBuilder().nextToken(resp.nextToken()).build()
       } else {
         break
       }
@@ -150,9 +148,9 @@ class InstanceCachingAgent implements CachingAgent, AccountAware, DriftMetric {
         if (data.cache) {
           cacheImage(data, images)
           cacheServerGroup(data, serverGroups)
-          cacheInstance(data, convertedInstancesById.get(data.instance.instanceId), instances)
+          cacheInstance(data, convertedInstancesById.get(data.instance.instanceId()), instances)
         } else {
-          skipIds.add(data.instance.instanceId)
+          skipIds.add(data.instance.instanceId())
         }
       }
     }
@@ -212,26 +210,26 @@ class InstanceCachingAgent implements CachingAgent, AccountAware, DriftMetric {
   }
 
   private Map<String, String>  getAmazonHealth(Instance instance) {
-    InstanceState state = instance.state
-    StateReason stateReason = instance.stateReason
-    HealthState amazonState = state?.name == InstanceStateName.Running.toString() ? HealthState.Unknown : HealthState.Down
+    InstanceState state = instance.state()
+    StateReason stateReason = instance.stateReason()
+    HealthState amazonState = state?.name() == InstanceStateName.RUNNING ? HealthState.Unknown : HealthState.Down
     Map<String, String> awsInstanceHealth = [
       type: 'Amazon',
       healthClass: 'platform',
       state: amazonState.toString()
     ]
     if (stateReason) {
-      awsInstanceHealth.description = stateReason.message
+      awsInstanceHealth.description = stateReason.message()
     }
     awsInstanceHealth
   }
 
   private String getCapacityType(Instance instance) {
-    if (instance.instanceLifecycle == null) {
+    if (instance.instanceLifecycle() == null) {
       return "on-demand"
     }
 
-    if (instance.instanceLifecycle.toString().equalsIgnoreCase("spot")) {
+    if (instance.instanceLifecycle() == InstanceLifecycleType.SPOT) {
       return "spot"
     }
 
@@ -240,8 +238,8 @@ class InstanceCachingAgent implements CachingAgent, AccountAware, DriftMetric {
 
   private static class InstanceData {
     static final String ASG_TAG_NAME = "aws:autoscaling:groupName"
-    static final String SHUTTING_DOWN = InstanceStateName.ShuttingDown.toString()
-    static final String TERMINATED = InstanceStateName.Terminated.toString()
+    static final InstanceStateName SHUTTING_DOWN = InstanceStateName.SHUTTING_DOWN
+    static final InstanceStateName TERMINATED = InstanceStateName.TERMINATED
 
     final Instance instance
     final String instanceId
@@ -251,11 +249,11 @@ class InstanceCachingAgent implements CachingAgent, AccountAware, DriftMetric {
 
     public InstanceData(Instance instance, String account, String region) {
       this.instance = instance
-      cache = !(instance.state.name == SHUTTING_DOWN || instance.state.name == TERMINATED)
-      this.instanceId = Keys.getInstanceKey(instance.instanceId, account, region)
-      String sgTag = instance.tags?.find { it.key == ASG_TAG_NAME }?.value
+      cache = !(instance.state().name() == SHUTTING_DOWN || instance.state().name() == TERMINATED)
+      this.instanceId = Keys.getInstanceKey(instance.instanceId(), account, region)
+      String sgTag = instance.tags()?.find { it.key() == ASG_TAG_NAME }?.value()
       this.serverGroup = sgTag ? Keys.getServerGroupKey(sgTag, account, region) : null
-      this.imageId = Keys.getImageKey(instance.imageId, account, region)
+      this.imageId = Keys.getImageKey(instance.imageId(), account, region)
     }
 
   }

--- a/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ReservationReportCachingAgent.groovy
+++ b/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ReservationReportCachingAgent.groovy
@@ -17,7 +17,7 @@
 package com.netflix.spinnaker.clouddriver.aws.provider.agent
 
 
-import com.amazonaws.services.ec2.model.DescribeInstancesRequest
+import software.amazon.awssdk.services.ec2.model.DescribeInstancesRequest
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.core.JsonGenerator
@@ -272,7 +272,7 @@ class ReservationReportCachingAgent implements CachingAgent, CustomScheduledAgen
         long startTime = System.currentTimeMillis()
 
         try {
-          def amazonEC2 = amazonClientProvider.getAmazonEC2(credentials, region.name)
+          def amazonEC2 = amazonClientProvider.getAmazonEC2V2(credentials, region.name)
           def cacheView = getCacheView()
           def reservedInstances = cacheView.getAll(
             RESERVED_INSTANCES.ns,
@@ -295,37 +295,37 @@ class ReservationReportCachingAgent implements CachingAgent, CustomScheduledAgen
 
           startTime = System.currentTimeMillis()
           def fetchedInstanceCount = 0
-          def describeInstancesRequest = new DescribeInstancesRequest().withMaxResults(500)
+          def describeInstancesRequest = DescribeInstancesRequest.builder().maxResults(500).build()
           def allowedStates = ["pending", "running"] as Set<String>
           while (true) {
             log.debug("Describing instances for ${credentials.name}/${region.name}")
             def result = amazonEC2.describeInstances(describeInstancesRequest)
             log.debug("Described instances for ${credentials.name}/${region.name}")
 
-            result.reservations.each {
-              it.getInstances().each {
-                if (!allowedStates.contains(it.state.name.toLowerCase())) {
+            result.reservations().each {
+              it.instances().each {
+                if (!allowedStates.contains(it.state().nameAsString().toLowerCase())) {
                   return
                 }
 
-                def osTypeName = operatingSystemType(it.platform ? "Windows" : "Linux/UNIX").name
-                def reservation = getReservation(it.placement.availabilityZone[0..-2], it.placement.availabilityZone, osTypeName, it.instanceType)
+                def osTypeName = operatingSystemType(it.platform() ? "Windows" : "Linux/UNIX").name
+                def reservation = getReservation(it.placement().availabilityZone()[0..-2], it.placement().availabilityZone(), osTypeName, it.instanceTypeAsString())
                 reservation.totalUsed.incrementAndGet()
 
-                if (it.vpcId) {
+                if (it.vpcId()) {
                   reservation.getAccount(credentials.name).usedVpc.incrementAndGet()
                 } else {
                   reservation.getAccount(credentials.name).used.incrementAndGet()
                 }
               }
 
-              fetchedInstanceCount += it.getInstances().size()
+              fetchedInstanceCount += it.instances().size()
             }
 
-            log.debug("Fetched ${fetchedInstanceCount} instances in ${credentials.name}/${region.name} (nextToken: ${result.nextToken})")
+            log.debug("Fetched ${fetchedInstanceCount} instances in ${credentials.name}/${region.name} (nextToken: ${result.nextToken()})")
 
-            if (result.nextToken) {
-              describeInstancesRequest.withNextToken(result.nextToken)
+            if (result.nextToken()) {
+              describeInstancesRequest = describeInstancesRequest.toBuilder().nextToken(result.nextToken()).build()
             } else {
               break
             }

--- a/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ReservedInstancesCachingAgent.groovy
+++ b/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ReservedInstancesCachingAgent.groovy
@@ -17,8 +17,8 @@
 
 package com.netflix.spinnaker.clouddriver.aws.provider.agent
 
-import com.amazonaws.services.ec2.model.DescribeReservedInstancesRequest
-import com.amazonaws.services.ec2.model.ReservedInstances
+import software.amazon.awssdk.services.ec2.model.DescribeReservedInstancesRequest
+import software.amazon.awssdk.services.ec2.model.ReservedInstances
 import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
@@ -97,16 +97,16 @@ class ReservedInstancesCachingAgent implements CachingAgent, CustomScheduledAgen
   CacheResult loadData(ProviderCache providerCache) {
     log.info("Describing items in ${agentType}")
 
-    def amazonEC2 = amazonClientProvider.getAmazonEC2(account, region)
+    def amazonEC2 = amazonClientProvider.getAmazonEC2V2(account, region)
 
-    def result = amazonEC2.describeReservedInstances(new DescribeReservedInstancesRequest())
-    List<ReservedInstances> allReservedInstances = result.reservedInstances
+    def result = amazonEC2.describeReservedInstances(DescribeReservedInstancesRequest.builder().build())
+    List<ReservedInstances> allReservedInstances = result.reservedInstances()
 
     Collection<CacheData> reservedInstancesData = allReservedInstances
-      .findAll { it.state.equalsIgnoreCase("active") }
+      .findAll { it.stateAsString().equalsIgnoreCase("active") }
       .collect { ReservedInstances reservedInstances ->
       Map<String, Object> attributes = objectMapper.convertValue(reservedInstances, ATTRIBUTES);
-      new DefaultCacheData(Keys.getReservedInstancesKey(reservedInstances.reservedInstancesId, account.name, region), attributes, [:])
+      new DefaultCacheData(Keys.getReservedInstancesKey(reservedInstances.reservedInstancesId(), account.name, region), attributes, [:])
     }
 
     log.info("Caching ${reservedInstancesData.size()} items in ${agentType}")

--- a/clouddriver/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonInstanceTypeCachingAgent.java
+++ b/clouddriver/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonInstanceTypeCachingAgent.java
@@ -18,12 +18,6 @@ package com.netflix.spinnaker.clouddriver.aws.provider.agent;
 
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE;
 
-import com.amazonaws.services.ec2.AmazonEC2;
-import com.amazonaws.services.ec2.model.DescribeInstanceTypesRequest;
-import com.amazonaws.services.ec2.model.DescribeInstanceTypesResult;
-import com.amazonaws.services.ec2.model.GpuInfo;
-import com.amazonaws.services.ec2.model.InstanceStorageInfo;
-import com.amazonaws.services.ec2.model.InstanceTypeInfo;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spinnaker.cats.agent.AccountAware;
@@ -48,6 +42,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import software.amazon.awssdk.services.ec2.Ec2Client;
+import software.amazon.awssdk.services.ec2.model.DescribeInstanceTypesRequest;
+import software.amazon.awssdk.services.ec2.model.DescribeInstanceTypesResponse;
+import software.amazon.awssdk.services.ec2.model.GpuInfo;
+import software.amazon.awssdk.services.ec2.model.InstanceStorageInfo;
+import software.amazon.awssdk.services.ec2.model.InstanceTypeInfo;
 
 public class AmazonInstanceTypeCachingAgent implements CachingAgent, AccountAware {
 
@@ -80,7 +80,7 @@ public class AmazonInstanceTypeCachingAgent implements CachingAgent, AccountAwar
 
   @Override
   public CacheResult loadData(ProviderCache providerCache) {
-    AmazonEC2 amazonEC2 = amazonClientProvider.getAmazonEC2(this.account, this.region);
+    Ec2Client amazonEC2 = amazonClientProvider.getAmazonEC2V2(this.account, this.region);
     final List<InstanceTypeInfo> instanceTypesInfo = getInstanceTypes(amazonEC2);
 
     Map<String, Collection<CacheData>> cacheResults = new HashMap<>();
@@ -88,7 +88,7 @@ public class AmazonInstanceTypeCachingAgent implements CachingAgent, AccountAwar
     // cache instance types for key "metadata" for backwards compatibility
     Set<String> instanceTypes =
         instanceTypesInfo.stream()
-            .map(InstanceTypeInfo::getInstanceType)
+            .map(InstanceTypeInfo::instanceTypeAsString)
             .collect(Collectors.toSet());
     DefaultCacheData metadata = buildCacheDataForMetadataKey(providerCache, instanceTypes);
     cacheResults.put(getAgentType(), Collections.singleton(metadata));
@@ -105,49 +105,48 @@ public class AmazonInstanceTypeCachingAgent implements CachingAgent, AccountAwar
                   Map<String, Object> attributes = objectMapper.convertValue(i, ATTRIBUTES);
                   attributes.put("account", account.getName());
                   attributes.put("region", region);
-                  attributes.put("name", i.getInstanceType());
-                  attributes.put("defaultVCpus", i.getVCpuInfo().getDefaultVCpus());
-                  attributes.put("memoryInGiB", i.getMemoryInfo().getSizeInMiB() / 1024);
+                  attributes.put("name", i.instanceTypeAsString());
+                  attributes.put("defaultVCpus", i.vCpuInfo().defaultVCpus());
+                  attributes.put("memoryInGiB", i.memoryInfo().sizeInMiB() / 1024);
                   attributes.put(
-                      "supportedArchitectures", i.getProcessorInfo().getSupportedArchitectures());
+                      "supportedArchitectures", i.processorInfo().supportedArchitectures());
 
-                  if (i.getInstanceStorageInfo() != null) {
-                    InstanceStorageInfo info = i.getInstanceStorageInfo();
+                  if (i.instanceStorageInfo() != null) {
+                    InstanceStorageInfo info = i.instanceStorageInfo();
                     Map<String, Object> instanceStorageAttributes = new HashMap<>();
 
-                    instanceStorageAttributes.put("totalSizeInGB", info.getTotalSizeInGB());
-                    if (info.getDisks() != null && info.getDisks().size() > 0) {
+                    instanceStorageAttributes.put("totalSizeInGB", info.totalSizeInGB());
+                    if (info.disks() != null && info.disks().size() > 0) {
                       instanceStorageAttributes.put(
                           "storageTypes",
-                          info.getDisks().stream()
-                              .map(d -> d.getType())
+                          info.disks().stream()
+                              .map(d -> d.typeAsString())
                               .collect(Collectors.joining(",")));
                     }
-                    if (info.getNvmeSupport() != null) {
-                      instanceStorageAttributes.put("nvmeSupport", info.getNvmeSupport());
+                    if (info.nvmeSupport() != null) {
+                      instanceStorageAttributes.put("nvmeSupport", info.nvmeSupportAsString());
                     }
                     attributes.put("instanceStorageInfo", instanceStorageAttributes);
                   }
 
-                  if (i.getGpuInfo() != null) {
-                    GpuInfo info = i.getGpuInfo();
+                  if (i.gpuInfo() != null) {
+                    GpuInfo info = i.gpuInfo();
                     Map<String, Object> gpuInfoAttributes = new HashMap<>();
 
-                    if (info.getTotalGpuMemoryInMiB() != null) {
-                      gpuInfoAttributes.put("totalGpuMemoryInMiB", info.getTotalGpuMemoryInMiB());
+                    if (info.totalGpuMemoryInMiB() != null) {
+                      gpuInfoAttributes.put("totalGpuMemoryInMiB", info.totalGpuMemoryInMiB());
                     }
-                    if (info.getGpus() != null) {
+                    if (info.gpus() != null) {
                       gpuInfoAttributes.put(
                           "gpus",
-                          info.getGpus().stream()
+                          info.gpus().stream()
                               .map(
                                   g -> {
                                     Map<String, Object> gpuDeviceInfo = new HashMap<>();
-                                    gpuDeviceInfo.put("name", g.getName());
-                                    gpuDeviceInfo.put("manufacturer", g.getManufacturer());
-                                    gpuDeviceInfo.put("count", g.getCount());
-                                    gpuDeviceInfo.put(
-                                        "gpuSizeInMiB", g.getMemoryInfo().getSizeInMiB());
+                                    gpuDeviceInfo.put("name", g.name());
+                                    gpuDeviceInfo.put("manufacturer", g.manufacturer());
+                                    gpuDeviceInfo.put("count", g.count());
+                                    gpuDeviceInfo.put("gpuSizeInMiB", g.memoryInfo().sizeInMiB());
                                     return gpuDeviceInfo;
                                   })
                               .collect(Collectors.toList()));
@@ -155,12 +154,12 @@ public class AmazonInstanceTypeCachingAgent implements CachingAgent, AccountAwar
                     attributes.put("gpuInfo", gpuInfoAttributes);
                   }
 
-                  if (i.getNetworkInfo() != null) {
-                    attributes.put("ipv6Supported", i.getNetworkInfo().getIpv6Supported());
+                  if (i.networkInfo() != null) {
+                    attributes.put("ipv6Supported", i.networkInfo().ipv6Supported());
                   }
 
                   return new DefaultCacheData(
-                      Keys.getInstanceTypeKey(i.getInstanceType(), region, account.getName()),
+                      Keys.getInstanceTypeKey(i.instanceTypeAsString(), region, account.getName()),
                       attributes,
                       Collections.emptyMap());
                 })
@@ -191,14 +190,14 @@ public class AmazonInstanceTypeCachingAgent implements CachingAgent, AccountAwar
         Collections.emptyMap());
   }
 
-  private List<InstanceTypeInfo> getInstanceTypes(AmazonEC2 ec2) {
+  private List<InstanceTypeInfo> getInstanceTypes(Ec2Client ec2) {
     final List<InstanceTypeInfo> instanceTypeInfoList = new ArrayList<>();
-    final DescribeInstanceTypesRequest request = new DescribeInstanceTypesRequest();
+    DescribeInstanceTypesRequest request = DescribeInstanceTypesRequest.builder().build();
     while (true) {
-      final DescribeInstanceTypesResult result = ec2.describeInstanceTypes(request);
-      instanceTypeInfoList.addAll(result.getInstanceTypes());
-      if (result.getNextToken() != null) {
-        request.withNextToken(result.getNextToken());
+      final DescribeInstanceTypesResponse result = ec2.describeInstanceTypes(request);
+      instanceTypeInfoList.addAll(result.instanceTypes());
+      if (result.nextToken() != null) {
+        request = request.toBuilder().nextToken(result.nextToken()).build();
       } else {
         break;
       }

--- a/clouddriver/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonLaunchTemplateCachingAgent.java
+++ b/clouddriver/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonLaunchTemplateCachingAgent.java
@@ -21,13 +21,6 @@ import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.IM
 import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.LAUNCH_TEMPLATES;
 import static java.util.stream.Collectors.toSet;
 
-import com.amazonaws.services.ec2.AmazonEC2;
-import com.amazonaws.services.ec2.model.DescribeLaunchTemplateVersionsRequest;
-import com.amazonaws.services.ec2.model.DescribeLaunchTemplateVersionsResult;
-import com.amazonaws.services.ec2.model.DescribeLaunchTemplatesRequest;
-import com.amazonaws.services.ec2.model.DescribeLaunchTemplatesResult;
-import com.amazonaws.services.ec2.model.LaunchTemplate;
-import com.amazonaws.services.ec2.model.LaunchTemplateVersion;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spectator.api.Registry;
@@ -54,6 +47,13 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.ec2.Ec2Client;
+import software.amazon.awssdk.services.ec2.model.DescribeLaunchTemplateVersionsRequest;
+import software.amazon.awssdk.services.ec2.model.DescribeLaunchTemplateVersionsResponse;
+import software.amazon.awssdk.services.ec2.model.DescribeLaunchTemplatesRequest;
+import software.amazon.awssdk.services.ec2.model.DescribeLaunchTemplatesResponse;
+import software.amazon.awssdk.services.ec2.model.LaunchTemplate;
+import software.amazon.awssdk.services.ec2.model.LaunchTemplateVersion;
 
 public class AmazonLaunchTemplateCachingAgent implements CachingAgent, AccountAware {
   private final Logger log = LoggerFactory.getLogger(getClass());
@@ -88,7 +88,7 @@ public class AmazonLaunchTemplateCachingAgent implements CachingAgent, AccountAw
 
   @Override
   public CacheResult loadData(ProviderCache providerCache) {
-    final AmazonEC2 ec2 = amazonClientProvider.getAmazonEC2(account, region);
+    final Ec2Client ec2 = amazonClientProvider.getAmazonEC2V2(account, region);
     final List<LaunchTemplate> launchTemplates = getLaunchTemplates(ec2);
     final List<LaunchTemplateVersion> launchTemplateVersions =
         getLaunchTemplateVersions(ec2, DEFAULT_VERSIONS);
@@ -96,13 +96,13 @@ public class AmazonLaunchTemplateCachingAgent implements CachingAgent, AccountAw
     for (LaunchTemplate launchTemplate : launchTemplates) {
       Set<LaunchTemplateVersion> versions =
           launchTemplateVersions.stream()
-              .filter(t -> t.getLaunchTemplateId().equals(launchTemplate.getLaunchTemplateId()))
+              .filter(t -> t.launchTemplateId().equals(launchTemplate.launchTemplateId()))
               .collect(toSet());
 
       // store the latest template version info
       Optional<LaunchTemplateVersion> latest =
           versions.stream()
-              .filter(v -> v.getVersionNumber().equals(launchTemplate.getLatestVersionNumber()))
+              .filter(v -> v.versionNumber().equals(launchTemplate.latestVersionNumber()))
               .findFirst();
 
       if (latest.isEmpty()) {
@@ -111,8 +111,7 @@ public class AmazonLaunchTemplateCachingAgent implements CachingAgent, AccountAw
       }
 
       String key =
-          Keys.getLaunchTemplateKey(
-              launchTemplate.getLaunchTemplateName(), account.getName(), region);
+          Keys.getLaunchTemplateKey(launchTemplate.launchTemplateName(), account.getName(), region);
       Map<String, Object> attributes = objectMapper.convertValue(launchTemplate, ATTRIBUTES);
 
       attributes.put("application", Keys.parse(key).get("application"));
@@ -125,8 +124,7 @@ public class AmazonLaunchTemplateCachingAgent implements CachingAgent, AccountAw
           versions.stream()
               .map(
                   i ->
-                      Keys.getImageKey(
-                          i.getLaunchTemplateData().getImageId(), account.getName(), region))
+                      Keys.getImageKey(i.launchTemplateData().imageId(), account.getName(), region))
               .collect(Collectors.toSet());
 
       Map<String, Collection<String>> relationships = Collections.singletonMap(IMAGES.ns, images);
@@ -137,14 +135,14 @@ public class AmazonLaunchTemplateCachingAgent implements CachingAgent, AccountAw
   }
 
   /** Gets a list of ec2 Launch templates */
-  private List<LaunchTemplate> getLaunchTemplates(AmazonEC2 ec2) {
+  private List<LaunchTemplate> getLaunchTemplates(Ec2Client ec2) {
     final List<LaunchTemplate> launchTemplates = new ArrayList<>();
-    final DescribeLaunchTemplatesRequest request = new DescribeLaunchTemplatesRequest();
+    DescribeLaunchTemplatesRequest request = DescribeLaunchTemplatesRequest.builder().build();
     while (true) {
-      final DescribeLaunchTemplatesResult result = ec2.describeLaunchTemplates(request);
-      launchTemplates.addAll(result.getLaunchTemplates());
-      if (result.getNextToken() != null) {
-        request.withNextToken(result.getNextToken());
+      final DescribeLaunchTemplatesResponse result = ec2.describeLaunchTemplates(request);
+      launchTemplates.addAll(result.launchTemplates());
+      if (result.nextToken() != null) {
+        request = request.toBuilder().nextToken(result.nextToken()).build();
       } else {
         break;
       }
@@ -154,16 +152,16 @@ public class AmazonLaunchTemplateCachingAgent implements CachingAgent, AccountAw
   }
 
   /** Gets a list of ec2 Launch template versions for a Launch template */
-  private List<LaunchTemplateVersion> getLaunchTemplateVersions(AmazonEC2 ec2, String... versions) {
+  private List<LaunchTemplateVersion> getLaunchTemplateVersions(Ec2Client ec2, String... versions) {
     final List<LaunchTemplateVersion> launchTemplateVersions = new ArrayList<>();
-    final DescribeLaunchTemplateVersionsRequest request =
-        new DescribeLaunchTemplateVersionsRequest().withVersions(versions);
+    DescribeLaunchTemplateVersionsRequest request =
+        DescribeLaunchTemplateVersionsRequest.builder().versions(versions).build();
     while (true) {
-      final DescribeLaunchTemplateVersionsResult result =
+      final DescribeLaunchTemplateVersionsResponse result =
           ec2.describeLaunchTemplateVersions(request);
-      launchTemplateVersions.addAll(result.getLaunchTemplateVersions());
-      if (result.getNextToken() != null) {
-        request.withNextToken(result.getNextToken());
+      launchTemplateVersions.addAll(result.launchTemplateVersions());
+      if (result.nextToken() != null) {
+        request = request.toBuilder().nextToken(result.nextToken()).build();
       } else {
         break;
       }

--- a/clouddriver/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/security/AmazonClientProvider.java
+++ b/clouddriver/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/security/AmazonClientProvider.java
@@ -63,6 +63,7 @@ import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 import software.amazon.awssdk.services.applicationautoscaling.ApplicationAutoScalingClient;
 import software.amazon.awssdk.services.cloudformation.CloudFormationClient;
 import software.amazon.awssdk.services.cloudwatch.CloudWatchClient;
+import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.ecr.EcrClient;
 import software.amazon.awssdk.services.ecs.EcsClient;
 import software.amazon.awssdk.services.elasticloadbalancingv2.ElasticLoadBalancingV2Client;
@@ -650,6 +651,24 @@ public class AmazonClientProvider {
   // provide Edda read-through support (Edda interception is v1-only).
   // They are the building blocks for the clouddriver-ecs → v2 migration.
   // ---------------------------------------------------------------------------
+
+  /**
+   * Returns an AWS SDK v2 {@link Ec2Client} for the given account and region.
+   *
+   * <p>No {@code skipEdda} parameter: Edda interception is v1-only (see {@link #getAmazonEcsV2}).
+   * Note that EC2 is one of the few remaining v1 services that is actually fronted by Edda in
+   * practice (via {@link #getAmazonEC2(NetflixAmazonCredentials, String, boolean)}), so callers
+   * migrating to this method should be aware they are trading Edda read-through for direct AWS API
+   * calls.
+   */
+  public Ec2Client getAmazonEC2V2(NetflixAmazonCredentials amazonCredentials, String region) {
+    return awsSdkV2ClientSupplier.getClient(
+        Ec2Client::builder,
+        Ec2Client.class,
+        amazonCredentials.getV2CredentialsProvider(),
+        region,
+        amazonCredentials.getName());
+  }
 
   /**
    * Returns an AWS SDK v2 {@link EcsClient} for the given account and region.

--- a/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonElasticIpCachingAgentSpec.groovy
+++ b/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonElasticIpCachingAgentSpec.groovy
@@ -16,10 +16,10 @@
 
 package com.netflix.spinnaker.clouddriver.aws.provider.agent
 
-import com.amazonaws.services.ec2.AmazonEC2
-import com.amazonaws.services.ec2.model.Address
-import com.amazonaws.services.ec2.model.DescribeAddressesResult
-import com.amazonaws.services.ec2.model.DomainType
+import software.amazon.awssdk.services.ec2.Ec2Client
+import software.amazon.awssdk.services.ec2.model.Address
+import software.amazon.awssdk.services.ec2.model.DescribeAddressesResponse
+import software.amazon.awssdk.services.ec2.model.DomainType
 import com.netflix.spinnaker.cats.provider.ProviderCache
 import com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
@@ -40,34 +40,34 @@ class AmazonElasticIpCachingAgentSpec extends Specification {
   ProviderCache providerCache = Mock(ProviderCache)
 
   @Shared
-  AmazonEC2 ec2
+  Ec2Client ec2
 
   @Shared
-  Address eipA = new Address().withPublicIp("10.0.0.1").withDomain(DomainType.Standard).withInstanceId("i-123456")
+  Address eipA = Address.builder().publicIp("10.0.0.1").domain(DomainType.STANDARD).instanceId("i-123456").build()
 
   @Shared
-  String eipAKey = Keys.getElasticIpKey(eipA.publicIp, region, account)
+  String eipAKey = Keys.getElasticIpKey(eipA.publicIp(), region, account)
 
   @Shared
-  Address eipB = new Address().withPublicIp("10.0.0.2").withDomain(DomainType.Vpc)
+  Address eipB = Address.builder().publicIp("10.0.0.2").domain(DomainType.VPC).build()
 
   @Shared
-  String eipBKey = Keys.getElasticIpKey(eipB.publicIp, region, account)
+  String eipBKey = Keys.getElasticIpKey(eipB.publicIp(), region, account)
 
   def setup() {
-    ec2 = Mock(AmazonEC2)
+    ec2 = Mock(Ec2Client)
     def creds = Stub(NetflixAmazonCredentials) {
       getName() >> account
     }
     def acp = Stub(AmazonClientProvider) {
-      getAmazonEC2(creds, region) >> ec2
+      getAmazonEC2V2(creds, region) >> ec2
     }
     agent = new AmazonElasticIpCachingAgent(acp, creds, region)
   }
 
   void "should add elastic ips on initial run"() {
     given:
-    def addr = new DescribeAddressesResult().withAddresses([eipA, eipB])
+    def addr = DescribeAddressesResponse.builder().addresses([eipA, eipB]).build()
 
     when:
     def result = agent.loadData(providerCache)
@@ -81,15 +81,11 @@ class AmazonElasticIpCachingAgentSpec extends Specification {
   }
 
   void "should evict elastic ips when not found on subsequent runs"() {
-    given:
-    def result = Mock(DescribeAddressesResult)
-
     when:
     def cache = agent.loadData(providerCache)
 
     then:
-    1 * result.getAddresses() >> [eipA, eipB]
-    1 * ec2.describeAddresses() >> result
+    1 * ec2.describeAddresses() >> DescribeAddressesResponse.builder().addresses([eipA, eipB]).build()
     0 * _
 
     cache.cacheResults[Keys.Namespace.ELASTIC_IPS.ns].find { it.id == eipAKey }
@@ -99,8 +95,7 @@ class AmazonElasticIpCachingAgentSpec extends Specification {
     cache = agent.loadData(providerCache)
 
     then:
-    1 * result.getAddresses() >> [eipA]
-    1 * ec2.describeAddresses() >> result
+    1 * ec2.describeAddresses() >> DescribeAddressesResponse.builder().addresses([eipA]).build()
     0 * _
 
     cache.cacheResults[Keys.Namespace.ELASTIC_IPS.ns].find { it.id == eipAKey }

--- a/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonInstanceTypeCachingAgentSpec.groovy
+++ b/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonInstanceTypeCachingAgentSpec.groovy
@@ -1,25 +1,27 @@
 package com.netflix.spinnaker.clouddriver.aws.provider.agent
 
-import com.amazonaws.services.ec2.AmazonEC2
-import com.amazonaws.services.ec2.model.DescribeInstanceTypesResult
-import com.amazonaws.services.ec2.model.InstanceTypeInfo
-import com.amazonaws.services.ec2.model.ProcessorInfo
-import com.amazonaws.services.ec2.model.VCpuInfo
-import com.amazonaws.services.ec2.model.MemoryInfo
-import com.amazonaws.services.ec2.model.InstanceStorageInfo
-import com.amazonaws.services.ec2.model.EbsInfo
-import com.amazonaws.services.ec2.model.EbsOptimizedInfo
-import com.amazonaws.services.ec2.model.NetworkInfo
-import com.amazonaws.services.ec2.model.GpuInfo
-import com.amazonaws.services.ec2.model.GpuDeviceInfo
-import com.amazonaws.services.ec2.model.GpuDeviceMemoryInfo
-import com.amazonaws.services.ec2.model.DiskInfo
-import com.amazonaws.services.ec2.model.NetworkCardInfo
+import software.amazon.awssdk.services.ec2.Ec2Client
+import software.amazon.awssdk.services.ec2.model.DescribeInstanceTypesResponse
+import software.amazon.awssdk.services.ec2.model.InstanceTypeInfo
+import software.amazon.awssdk.services.ec2.model.ProcessorInfo
+import software.amazon.awssdk.services.ec2.model.VCpuInfo
+import software.amazon.awssdk.services.ec2.model.MemoryInfo
+import software.amazon.awssdk.services.ec2.model.InstanceStorageInfo
+import software.amazon.awssdk.services.ec2.model.EbsInfo
+import software.amazon.awssdk.services.ec2.model.EbsOptimizedInfo
+import software.amazon.awssdk.services.ec2.model.NetworkInfo
+import software.amazon.awssdk.services.ec2.model.GpuInfo
+import software.amazon.awssdk.services.ec2.model.GpuDeviceInfo
+import software.amazon.awssdk.services.ec2.model.GpuDeviceMemoryInfo
+import software.amazon.awssdk.services.ec2.model.DiskInfo
+import software.amazon.awssdk.services.ec2.model.NetworkCardInfo
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.awsobjectmapper.AmazonObjectMapperConfigurer
 import com.netflix.spinnaker.cats.cache.DefaultCacheData
 import com.netflix.spinnaker.cats.provider.ProviderCache
 import com.netflix.spinnaker.clouddriver.aws.cache.Keys
+import com.netflix.spinnaker.clouddriver.aws.jackson.AwsSdkV2Module
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
 import spock.lang.Shared
@@ -28,7 +30,7 @@ import spock.lang.Subject
 
 class AmazonInstanceTypeCachingAgentSpec extends Specification {
   def region = "us-east-1"
-  def objectMapper = new ObjectMapper()
+  def objectMapper = AmazonObjectMapperConfigurer.createConfigured().registerModule(new AwsSdkV2Module())
   def amazonClientProvider = Mock(AmazonClientProvider)
   def account = "test"
   def credentials = Stub(NetflixAmazonCredentials) {
@@ -42,13 +44,13 @@ class AmazonInstanceTypeCachingAgentSpec extends Specification {
   def agent = new AmazonInstanceTypeCachingAgent(region, amazonClientProvider, credentials, objectMapper)
 
   @Shared
-  AmazonEC2 ec2
+  Ec2Client ec2
 
   @Shared
   def it1, it2
 
   def setup() {
-    ec2 = Mock(AmazonEC2)
+    ec2 = Mock(Ec2Client)
     it1 = getInstanceTypeWithEbs()
     it2 = getInstanceTypeWithGpu()
   }
@@ -59,8 +61,8 @@ class AmazonInstanceTypeCachingAgentSpec extends Specification {
     def cache = result.cacheResults
 
     then:
-    1 * amazonClientProvider.getAmazonEC2(credentials, region) >> ec2
-    1 * ec2.describeInstanceTypes(_) >> new DescribeInstanceTypesResult(instanceTypes: [it1, it2])
+    1 * amazonClientProvider.getAmazonEC2V2(credentials, region) >> ec2
+    1 * ec2.describeInstanceTypes(_) >> DescribeInstanceTypesResponse.builder().instanceTypes([it1, it2]).build()
 
     and:
     cache.size() == 2
@@ -75,8 +77,8 @@ class AmazonInstanceTypeCachingAgentSpec extends Specification {
     def cache = result.cacheResults
 
     then:
-    1 * amazonClientProvider.getAmazonEC2(credentials, region) >> ec2
-    1 * ec2.describeInstanceTypes(_) >> new DescribeInstanceTypesResult(instanceTypes: [it1, it2])
+    1 * amazonClientProvider.getAmazonEC2V2(credentials, region) >> ec2
+    1 * ec2.describeInstanceTypes(_) >> DescribeInstanceTypesResponse.builder().instanceTypes([it1, it2]).build()
 
     and:
     def instanceTypesInfo = cache.get(Keys.Namespace.INSTANCE_TYPES.getNs())
@@ -93,8 +95,8 @@ class AmazonInstanceTypeCachingAgentSpec extends Specification {
     def cache = result.cacheResults
 
     then:
-    1 * amazonClientProvider.getAmazonEC2(credentials, region) >> ec2
-    1 * ec2.describeInstanceTypes(_) >> new DescribeInstanceTypesResult(instanceTypes: [it1, it2])
+    1 * amazonClientProvider.getAmazonEC2V2(credentials, region) >> ec2
+    1 * ec2.describeInstanceTypes(_) >> DescribeInstanceTypesResponse.builder().instanceTypes([it1, it2]).build()
 
     and:
     def metadata = cache.get(agent.getAgentType())?.head()
@@ -105,89 +107,85 @@ class AmazonInstanceTypeCachingAgentSpec extends Specification {
   }
 
   InstanceTypeInfo getInstanceTypeWithEbs() {
-    return new InstanceTypeInfo(
-      instanceType: "test.large",
-      currentGeneration: false,
-      supportedUsageClasses: ["on-demand","spot"],
-      supportedRootDeviceTypes: ["ebs","instance-store"],
-      supportedVirtualizationTypes: ["hvm","paravirtual"],
-      bareMetal: false,
-      hypervisor: "xen",
-      processorInfo: new ProcessorInfo(supportedArchitectures: ["i386","x86_64"], sustainedClockSpeedInGhz: 2.8),
-      vCpuInfo: new VCpuInfo(
-        defaultVCpus: 2,
-        defaultCores: 1,
-        defaultThreadsPerCore: 2,
-        validCores: [1],
-        validThreadsPerCore: [1, 2]
-      ),
-      memoryInfo: new MemoryInfo(sizeInMiB: 3840),
-      instanceStorageSupported: true,
-      instanceStorageInfo: new InstanceStorageInfo(
-        totalSizeInGB: 32,
-        disks: [new DiskInfo(sizeInGB: 16, count: 2, type: "ssd")],
-        nvmeSupport: "unsupported"
-      ),
-      ebsInfo: new EbsInfo(
-        ebsOptimizedSupport: "unsupported",
-        encryptionSupport: "supported",
-        nvmeSupport: "unsupported"
-      ),
-      networkInfo: new NetworkInfo(
-        ipv6Supported: true,
-      ),
-      burstablePerformanceSupported: false)
+    return InstanceTypeInfo.builder()
+      .instanceType("test.large")
+      .currentGeneration(false)
+      .supportedUsageClassesWithStrings("on-demand", "spot")
+      .supportedRootDeviceTypesWithStrings("ebs", "instance-store")
+      .supportedVirtualizationTypesWithStrings("hvm", "paravirtual")
+      .bareMetal(false)
+      .hypervisor("xen")
+      .processorInfo(ProcessorInfo.builder().supportedArchitecturesWithStrings("i386", "x86_64").sustainedClockSpeedInGhz(2.8).build())
+      .vCpuInfo(VCpuInfo.builder()
+        .defaultVCpus(2)
+        .defaultCores(1)
+        .defaultThreadsPerCore(2)
+        .validCores(1)
+        .validThreadsPerCore(1, 2)
+        .build())
+      .memoryInfo(MemoryInfo.builder().sizeInMiB(3840).build())
+      .instanceStorageSupported(true)
+      .instanceStorageInfo(InstanceStorageInfo.builder()
+        .totalSizeInGB(32)
+        .disks(DiskInfo.builder().sizeInGB(16).count(2).type("ssd").build())
+        .nvmeSupport("unsupported")
+        .build())
+      .ebsInfo(EbsInfo.builder()
+        .ebsOptimizedSupport("unsupported")
+        .encryptionSupport("supported")
+        .nvmeSupport("unsupported")
+        .build())
+      .networkInfo(NetworkInfo.builder().ipv6Supported(true).build())
+      .burstablePerformanceSupported(false)
+      .build()
   }
 
   InstanceTypeInfo getInstanceTypeWithGpu() {
-    return new InstanceTypeInfo(
-      instanceType: "test.xlarge",
-      currentGeneration: true,
-      supportedUsageClasses: ["on-demand","spot"],
-      supportedRootDeviceTypes: ["ebs"],
-      supportedVirtualizationTypes: ["hvm"],
-      bareMetal: false,
-      hypervisor: "xen",
-      processorInfo: new ProcessorInfo(
-        supportedArchitectures: ["x86_64"],
-        sustainedClockSpeedInGhz: 2.7
-      ),
-      vCpuInfo: new VCpuInfo(
-        defaultVCpus: 32,
-        defaultCores: 16,
-        defaultThreadsPerCore: 2,
-        validCores: [1,2,3],
-        validThreadsPerCore: [1,2]
-      ),
-      memoryInfo: new MemoryInfo(sizeInMiB: 249856),
-      instanceStorageSupported: false,
-      ebsInfo: new EbsInfo(
-        ebsOptimizedSupport: "default",
-        encryptionSupport: "supported",
-        ebsOptimizedInfo: new EbsOptimizedInfo(
-          baselineBandwidthInMbps: 7000,
-          baselineThroughputInMBps: 875.0,
-          baselineIops: 40000,
-          maximumBandwidthInMbps: 7000,
-          maximumThroughputInMBps: 875.0,
-          maximumIops: 40000
-        ),
-        nvmeSupport: "unsupported"
-      ),
-      networkInfo: new NetworkInfo(
-        ipv6Supported: true,
-      ),
-      gpuInfo: new GpuInfo(
-        gpus: [
-          new GpuDeviceInfo(
-            name: "V100",
-            manufacturer: "NVIDIA",
-            count: 4,
-            memoryInfo: new GpuDeviceMemoryInfo(sizeInMiB: 16384))
-        ],
-        totalGpuMemoryInMiB: 65536
-      ),
-      burstablePerformanceSupported: false,
-    )
+    return InstanceTypeInfo.builder()
+      .instanceType("test.xlarge")
+      .currentGeneration(true)
+      .supportedUsageClassesWithStrings("on-demand", "spot")
+      .supportedRootDeviceTypesWithStrings("ebs")
+      .supportedVirtualizationTypesWithStrings("hvm")
+      .bareMetal(false)
+      .hypervisor("xen")
+      .processorInfo(ProcessorInfo.builder()
+        .supportedArchitecturesWithStrings("x86_64")
+        .sustainedClockSpeedInGhz(2.7)
+        .build())
+      .vCpuInfo(VCpuInfo.builder()
+        .defaultVCpus(32)
+        .defaultCores(16)
+        .defaultThreadsPerCore(2)
+        .validCores(1, 2, 3)
+        .validThreadsPerCore(1, 2)
+        .build())
+      .memoryInfo(MemoryInfo.builder().sizeInMiB(249856).build())
+      .instanceStorageSupported(false)
+      .ebsInfo(EbsInfo.builder()
+        .ebsOptimizedSupport("default")
+        .encryptionSupport("supported")
+        .ebsOptimizedInfo(EbsOptimizedInfo.builder()
+          .baselineBandwidthInMbps(7000)
+          .baselineThroughputInMBps(875.0)
+          .baselineIops(40000)
+          .maximumBandwidthInMbps(7000)
+          .maximumThroughputInMBps(875.0)
+          .maximumIops(40000)
+          .build())
+        .nvmeSupport("unsupported")
+        .build())
+      .networkInfo(NetworkInfo.builder().ipv6Supported(true).build())
+      .gpuInfo(GpuInfo.builder()
+        .gpus(GpuDeviceInfo.builder()
+          .name("V100")
+          .manufacturer("NVIDIA")
+          .count(4)
+          .memoryInfo(GpuDeviceMemoryInfo.builder().sizeInMiB(16384).build())
+          .build())
+        .totalGpuMemoryInMiB(65536)
+        .build())
+      .burstablePerformanceSupported(false)
+      .build()
   }
 }

--- a/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonKeyPairCachingAgentSpec.groovy
+++ b/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonKeyPairCachingAgentSpec.groovy
@@ -16,9 +16,9 @@
 
 package com.netflix.spinnaker.clouddriver.aws.provider.agent
 
-import com.amazonaws.services.ec2.AmazonEC2
-import com.amazonaws.services.ec2.model.DescribeKeyPairsResult
-import com.amazonaws.services.ec2.model.KeyPairInfo
+import software.amazon.awssdk.services.ec2.Ec2Client
+import software.amazon.awssdk.services.ec2.model.DescribeKeyPairsResponse
+import software.amazon.awssdk.services.ec2.model.KeyPairInfo
 import com.netflix.spinnaker.cats.cache.CacheData
 import com.netflix.spinnaker.cats.provider.ProviderCache
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
@@ -32,7 +32,7 @@ class AmazonKeyPairCachingAgentSpec extends Specification {
   static final String region = 'us-east-1'
 
 
-  AmazonEC2 ec2 = Mock(AmazonEC2)
+  Ec2Client ec2 = Mock(Ec2Client)
 
   ProviderCache providerCache = Mock(ProviderCache)
 
@@ -41,7 +41,7 @@ class AmazonKeyPairCachingAgentSpec extends Specification {
   }
 
   AmazonClientProvider amazonClientProvider = Stub(AmazonClientProvider) {
-    getAmazonEC2(creds, region) >> ec2
+    getAmazonEC2V2(creds, region) >> ec2
   }
 
   @Subject
@@ -52,10 +52,10 @@ class AmazonKeyPairCachingAgentSpec extends Specification {
     def result = agent.loadData(providerCache)
 
     then:
-    1 * ec2.describeKeyPairs() >> new DescribeKeyPairsResult(keyPairs: [
-      new KeyPairInfo(keyName: 'key1', keyFingerprint: '1'),
-      new KeyPairInfo(keyName: 'key2', keyFingerprint: '2')
-    ])
+    1 * ec2.describeKeyPairs() >> DescribeKeyPairsResponse.builder().keyPairs(
+      KeyPairInfo.builder().keyName('key1').keyFingerprint('1').build(),
+      KeyPairInfo.builder().keyName('key2').keyFingerprint('2').build()
+    ).build()
     with (result.cacheResults.get(Keys.Namespace.KEY_PAIRS.ns)) { List<CacheData> cd ->
       cd.size() == 2
       def k1 = cd.find { it.id == Keys.getKeyPairKey('key1', region, account) }

--- a/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonLaunchTemplateCachingAgentSpec.groovy
+++ b/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonLaunchTemplateCachingAgentSpec.groovy
@@ -16,17 +16,18 @@
 
 package com.netflix.spinnaker.clouddriver.aws.provider.agent
 
-import com.amazonaws.services.ec2.AmazonEC2
-import com.amazonaws.services.ec2.model.DescribeLaunchTemplateVersionsRequest
-import com.amazonaws.services.ec2.model.DescribeLaunchTemplateVersionsResult
-import com.amazonaws.services.ec2.model.DescribeLaunchTemplatesResult
-import com.amazonaws.services.ec2.model.LaunchTemplate
-import com.amazonaws.services.ec2.model.LaunchTemplateVersion
-import com.amazonaws.services.ec2.model.ResponseLaunchTemplateData
+import software.amazon.awssdk.services.ec2.Ec2Client
+import software.amazon.awssdk.services.ec2.model.DescribeLaunchTemplateVersionsResponse
+import software.amazon.awssdk.services.ec2.model.DescribeLaunchTemplatesResponse
+import software.amazon.awssdk.services.ec2.model.LaunchTemplate
+import software.amazon.awssdk.services.ec2.model.LaunchTemplateVersion
+import software.amazon.awssdk.services.ec2.model.ResponseLaunchTemplateData
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.awsobjectmapper.AmazonObjectMapperConfigurer
 import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spinnaker.cats.provider.ProviderCache
 import com.netflix.spinnaker.clouddriver.aws.data.Keys
+import com.netflix.spinnaker.clouddriver.aws.jackson.AwsSdkV2Module
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
 import spock.lang.Shared
@@ -37,7 +38,7 @@ import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.LA
 
 class AmazonLaunchTemplateCachingAgentSpec extends Specification {
   def registry = new NoopRegistry()
-  def objectMapper = new ObjectMapper()
+  def objectMapper = AmazonObjectMapperConfigurer.createConfigured().registerModule(new AwsSdkV2Module())
   def region = "us-east-1"
   def account = "test"
   def amazonClientProvider = Mock(AmazonClientProvider)
@@ -54,48 +55,48 @@ class AmazonLaunchTemplateCachingAgentSpec extends Specification {
 
   def "should load launch templates"() {
     given:
-    def ec2 = Mock(AmazonEC2)
-    def lt1 = new LaunchTemplate(launchTemplateName: "lt-1", launchTemplateId: "lt-1", latestVersionNumber: 1, defaultVersionNumber: 0)
-    def lt2 = new LaunchTemplate(launchTemplateName: "lt-2", launchTemplateId: "lt-2", latestVersionNumber: 0, defaultVersionNumber: 0)
+    def ec2 = Mock(Ec2Client)
+    def lt1 = LaunchTemplate.builder().launchTemplateName("lt-1").launchTemplateId("lt-1").latestVersionNumber(1L).defaultVersionNumber(0L).build()
+    def lt2 = LaunchTemplate.builder().launchTemplateName("lt-2").launchTemplateId("lt-2").latestVersionNumber(0L).defaultVersionNumber(0L).build()
 
-    def lt1Version0 = new LaunchTemplateVersion(
-      launchTemplateId: lt1.launchTemplateId,
-      defaultVersion: true,
-      versionNumber: 0,
-      launchTemplateData: new ResponseLaunchTemplateData(imageId: "ami-10")
-    )
+    def lt1Version0 = LaunchTemplateVersion.builder()
+      .launchTemplateId(lt1.launchTemplateId())
+      .defaultVersion(true)
+      .versionNumber(0L)
+      .launchTemplateData(ResponseLaunchTemplateData.builder().imageId("ami-10").build())
+      .build()
 
-    def lt1Version1 = new LaunchTemplateVersion(
-      launchTemplateId: lt1.launchTemplateId,
-      defaultVersion: false,
-      versionNumber: 1,
-      launchTemplateData: new ResponseLaunchTemplateData(imageId: "ami-11")
-    )
+    def lt1Version1 = LaunchTemplateVersion.builder()
+      .launchTemplateId(lt1.launchTemplateId())
+      .defaultVersion(false)
+      .versionNumber(1L)
+      .launchTemplateData(ResponseLaunchTemplateData.builder().imageId("ami-11").build())
+      .build()
 
-    def lt2Version0 = new LaunchTemplateVersion(
-      launchTemplateId: lt2.launchTemplateId,
-      defaultVersion: true,
-      versionNumber: 0,
-      launchTemplateData: new ResponseLaunchTemplateData(imageId: "ami-20")
-    )
+    def lt2Version0 = LaunchTemplateVersion.builder()
+      .launchTemplateId(lt2.launchTemplateId())
+      .defaultVersion(true)
+      .versionNumber(0L)
+      .launchTemplateData(ResponseLaunchTemplateData.builder().imageId("ami-20").build())
+      .build()
 
     and:
-    amazonClientProvider.getAmazonEC2(credentials, region) >> ec2
+    amazonClientProvider.getAmazonEC2V2(credentials, region) >> ec2
 
     when:
     def result = agent.loadData(providerCache).cacheResults[LAUNCH_TEMPLATES.ns]
 
     then:
-    1 * ec2.describeLaunchTemplates(_) >> new DescribeLaunchTemplatesResult(launchTemplates: [lt1, lt2])
-    1 * ec2.describeLaunchTemplateVersions(_) >> new DescribeLaunchTemplateVersionsResult(launchTemplateVersions: [lt1Version0, lt1Version1, lt2Version0])
+    1 * ec2.describeLaunchTemplates(_) >> DescribeLaunchTemplatesResponse.builder().launchTemplates([lt1, lt2]).build()
+    1 * ec2.describeLaunchTemplateVersions(_) >> DescribeLaunchTemplateVersionsResponse.builder().launchTemplateVersions([lt1Version0, lt1Version1, lt2Version0]).build()
 
     result.size() == 2
-    def lt1Result = result.find { it.attributes.launchTemplateName == lt1.launchTemplateName }
-    def lt1v1Image = Keys.getImageKey(lt1Version1.launchTemplateData.imageId, account, region)
-    def lt1v0Image = Keys.getImageKey(lt1Version0.launchTemplateData.imageId, account, region)
+    def lt1Result = result.find { it.attributes.launchTemplateName == lt1.launchTemplateName() }
+    def lt1v1Image = Keys.getImageKey(lt1Version1.launchTemplateData().imageId(), account, region)
+    def lt1v0Image = Keys.getImageKey(lt1Version0.launchTemplateData().imageId(), account, region)
 
-    def lt2Result = result.find { it.attributes.launchTemplateName == lt2.launchTemplateName }
-    def lt2Image = Keys.getImageKey(lt2Version0.launchTemplateData.imageId, account, region)
+    def lt2Result = result.find { it.attributes.launchTemplateName == lt2.launchTemplateName() }
+    def lt2Image = Keys.getImageKey(lt2Version0.launchTemplateData().imageId(), account, region)
     lt1Result.attributes.versions.size() == 2
     lt1Result.attributes.latestVersion == lt1Version1
     lt1Result.relationships.images == [lt1v0Image, lt1v1Image] as Set

--- a/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonSecurityGroupCachingAgentSpec.groovy
+++ b/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonSecurityGroupCachingAgentSpec.groovy
@@ -16,11 +16,12 @@
 
 package com.netflix.spinnaker.clouddriver.aws.provider.agent
 
-import com.amazonaws.services.ec2.AmazonEC2
-import com.amazonaws.services.ec2.model.DescribeSecurityGroupsResult
-import com.amazonaws.services.ec2.model.SecurityGroup
+import software.amazon.awssdk.services.ec2.Ec2Client
+import software.amazon.awssdk.services.ec2.model.DescribeSecurityGroupsResponse
+import software.amazon.awssdk.services.ec2.model.SecurityGroup
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.awsobjectmapper.AmazonObjectMapperConfigurer
+import com.netflix.spinnaker.clouddriver.aws.jackson.AwsSdkV2Module
 import com.netflix.spectator.api.Spectator
 import com.netflix.spinnaker.cats.cache.CacheData
 import com.netflix.spinnaker.cats.cache.DefaultCacheData
@@ -41,28 +42,28 @@ class AmazonSecurityGroupCachingAgentSpec extends Specification {
   static final String region = 'region'
   static final String account = 'account'
 
-  AmazonEC2 ec2 = Mock(AmazonEC2)
+  Ec2Client ec2 = Mock(Ec2Client)
   NetflixAmazonCredentials creds = Stub(NetflixAmazonCredentials) { getName() >> account }
   AmazonClientProvider amazonClientProvider = Stub(AmazonClientProvider) {
-    getAmazonEC2(_, _) >> ec2
+    getAmazonEC2V2(_, _) >> ec2
     getLastModified() >> 12345L
   }
   ProviderCache providerCache = Mock(ProviderCache)
-  ObjectMapper mapper = new AmazonObjectMapperConfigurer().createConfigured()
+  ObjectMapper mapper = new AmazonObjectMapperConfigurer().createConfigured().registerModule(new AwsSdkV2Module())
   EddaTimeoutConfig eddaTimeoutConfig = new EddaTimeoutConfig.Builder().build()
 
   @Subject AmazonSecurityGroupCachingAgent agent = new AmazonSecurityGroupCachingAgent(
     amazonClientProvider, creds, region, mapper, Spectator.registry(), eddaTimeoutConfig)
 
-  SecurityGroup securityGroupA = new SecurityGroup(groupId: 'id-a', groupName: 'name-a', description: 'a')
-  SecurityGroup securityGroupB = new SecurityGroup(groupId: 'id-b', groupName: 'name-b', description: 'b')
-  String keyGroupA = Keys.getSecurityGroupKey(securityGroupA.groupName, securityGroupA.groupId, region, account, null)
-  String keyGroupB = Keys.getSecurityGroupKey(securityGroupB.groupName, securityGroupB.groupId, region, account, null)
+  SecurityGroup securityGroupA = SecurityGroup.builder().groupId('id-a').groupName('name-a').description('a').build()
+  SecurityGroup securityGroupB = SecurityGroup.builder().groupId('id-b').groupName('name-b').description('b').build()
+  String keyGroupA = Keys.getSecurityGroupKey(securityGroupA.groupName(), securityGroupA.groupId(), region, account, null)
+  String keyGroupB = Keys.getSecurityGroupKey(securityGroupB.groupName(), securityGroupB.groupId(), region, account, null)
 
   void "should add security groups on initial run"() {
     given:
-    DescribeSecurityGroupsResult result = new DescribeSecurityGroupsResult(
-      securityGroups: [securityGroupA, securityGroupB])
+    DescribeSecurityGroupsResponse result = DescribeSecurityGroupsResponse.builder()
+      .securityGroups(securityGroupA, securityGroupB).build()
 
     when:
     def cache = agent.loadData(providerCache)
@@ -78,8 +79,8 @@ class AmazonSecurityGroupCachingAgentSpec extends Specification {
 
   void "should prefer security groups from cache when on_demand record present"() {
     given:
-    DescribeSecurityGroupsResult result = new DescribeSecurityGroupsResult(
-      securityGroups: [securityGroupA, securityGroupB])
+    DescribeSecurityGroupsResponse result = DescribeSecurityGroupsResponse.builder()
+      .securityGroups(securityGroupA, securityGroupB).build()
     def cred = TestCredential.named("test", [edda: "http://foo", eddaEnabled: true])
     def agent = new AmazonSecurityGroupCachingAgent(
       amazonClientProvider, cred, region, mapper, Spectator.registry(), eddaTimeoutConfig)

--- a/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonSubnetCachingAgentSpec.groovy
+++ b/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonSubnetCachingAgentSpec.groovy
@@ -16,12 +16,13 @@
 
 package com.netflix.spinnaker.clouddriver.aws.provider.agent
 
-import com.amazonaws.services.ec2.AmazonEC2
-import com.amazonaws.services.ec2.model.DescribeSubnetsResult
-import com.amazonaws.services.ec2.model.Subnet
+import software.amazon.awssdk.services.ec2.Ec2Client
+import software.amazon.awssdk.services.ec2.model.DescribeSubnetsResponse
+import software.amazon.awssdk.services.ec2.model.Subnet
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.awsobjectmapper.AmazonObjectMapper
 import com.netflix.awsobjectmapper.AmazonObjectMapperConfigurer
+import com.netflix.spinnaker.clouddriver.aws.jackson.AwsSdkV2Module
 import com.netflix.spinnaker.cats.cache.CacheData
 import com.netflix.spinnaker.cats.provider.ProviderCache
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
@@ -35,19 +36,19 @@ class AmazonSubnetCachingAgentSpec extends Specification {
   static final String region = 'us-east-1'
 
 
-  AmazonEC2 ec2 = Mock(AmazonEC2)
+  Ec2Client ec2 = Mock(Ec2Client)
 
   NetflixAmazonCredentials creds = Stub(NetflixAmazonCredentials) {
     getName() >> account
   }
 
   AmazonClientProvider amazonClientProvider = Stub(AmazonClientProvider) {
-    getAmazonEC2(creds, region) >> ec2
+    getAmazonEC2V2(creds, region) >> ec2
   }
 
   ProviderCache providerCache = Mock(ProviderCache)
 
-  ObjectMapper amazonObjectMapper = new AmazonObjectMapperConfigurer().createConfigured()
+  ObjectMapper amazonObjectMapper = new AmazonObjectMapperConfigurer().createConfigured().registerModule(new AwsSdkV2Module())
 
   @Subject
   AmazonSubnetCachingAgent agent = new AmazonSubnetCachingAgent(
@@ -58,10 +59,10 @@ class AmazonSubnetCachingAgentSpec extends Specification {
     def result = agent.loadData(providerCache)
 
     then:
-    1 * ec2.describeSubnets() >> new DescribeSubnetsResult(subnets: [
-      new Subnet(subnetId: 'subnetId1'),
-      new Subnet(subnetId: 'subnetId2')
-    ])
+    1 * ec2.describeSubnets() >> DescribeSubnetsResponse.builder().subnets(
+      Subnet.builder().subnetId('subnetId1').build(),
+      Subnet.builder().subnetId('subnetId2').build()
+    ).build()
     0 * _
 
     with (result.cacheResults.get(Keys.Namespace.SUBNETS.ns)) { List<CacheData> cd ->

--- a/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ImageCachingAgentSpec.groovy
+++ b/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ImageCachingAgentSpec.groovy
@@ -16,18 +16,19 @@
 
 package com.netflix.spinnaker.clouddriver.aws.provider.agent
 
-import com.amazonaws.services.ec2.AmazonEC2
-import com.amazonaws.services.ec2.model.DescribeImagesRequest
-import com.amazonaws.services.ec2.model.DescribeImagesResult
-import com.amazonaws.services.ec2.model.Filter
-import com.amazonaws.services.ec2.model.Image
 import com.netflix.awsobjectmapper.AmazonObjectMapperConfigurer
+import com.netflix.spinnaker.clouddriver.aws.jackson.AwsSdkV2Module
 import com.netflix.spectator.api.Spectator
 import com.netflix.spinnaker.cats.provider.ProviderCache
 import com.netflix.spinnaker.clouddriver.aws.data.Keys
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
+import software.amazon.awssdk.services.ec2.Ec2Client
+import software.amazon.awssdk.services.ec2.model.DescribeImagesRequest
+import software.amazon.awssdk.services.ec2.model.DescribeImagesResponse
+import software.amazon.awssdk.services.ec2.model.Filter
+import software.amazon.awssdk.services.ec2.model.Image
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -64,36 +65,35 @@ class ImageCachingAgentSpec extends Specification {
   NetflixAmazonCredentials creds
 
   @Shared
-  AmazonEC2 ec2
+  Ec2Client ec2
 
   def setup() {
-    ec2 = Mock(AmazonEC2)
-    publicImage = new Image().withImageId('ami-11111111').withName('public').withPublic(true)
-    privateImage = new Image().withImageId('ami-22222222').withName('private').withPublic(false)
-    privateImageKey = Keys.getImageKey(privateImage.getImageId(), accountName, region)
-    publicImageKey = Keys.getImageKey(publicImage.getImageId(), accountName, region)
-    privateNamedImageKey =  Keys.getNamedImageKey(accountName, privateImage.getName())
-    publicNamedImageKey = Keys.getNamedImageKey(accountName, publicImage.getName())
+    ec2 = Mock(Ec2Client)
+    publicImage = Image.builder().imageId('ami-11111111').name('public').publicLaunchPermissions(true).build()
+    privateImage = Image.builder().imageId('ami-22222222').name('private').publicLaunchPermissions(false).build()
+    privateImageKey = Keys.getImageKey(privateImage.imageId(), accountName, region)
+    publicImageKey = Keys.getImageKey(publicImage.imageId(), accountName, region)
+    privateNamedImageKey =  Keys.getNamedImageKey(accountName, privateImage.name())
+    publicNamedImageKey = Keys.getNamedImageKey(accountName, publicImage.name())
   }
 
-  def getAgent(boolean publicImages, boolean eddaEnabled) {
-    getAgent(publicImages, eddaEnabled, List.of())
+  def getAgent(boolean publicImages) {
+    getAgent(publicImages, List.of())
   }
 
-  def getAgent(boolean publicImages, boolean eddaEnabled, List<String> imageStates) {
+  def getAgent(boolean publicImages, List<String> imageStates) {
     def creds = Stub(NetflixAmazonCredentials) {
       getName() >> accountName
       it.getAccountId() >> accountId
-      isEddaEnabled() >> eddaEnabled
     }
     def dcs = Stub(DynamicConfigService) {
       isEnabled(_ as String, true) >> true
       getConfig(List, "aws.defaults.image-states", List.of()) >> imageStates
     }
     def acp = Stub(AmazonClientProvider) {
-      getAmazonEC2(creds, region, _) >> ec2
+      getAmazonEC2V2(creds, region) >> ec2
     }
-    new ImageCachingAgent(acp, creds, region, AmazonObjectMapperConfigurer.createConfigured(), Spectator.globalRegistry(), publicImages, dcs)
+    new ImageCachingAgent(acp, creds, region, AmazonObjectMapperConfigurer.createConfigured().registerModule(new AwsSdkV2Module()), Spectator.globalRegistry(), publicImages, dcs)
   }
 
   void "two images with the same name result in one named image"() {
@@ -101,22 +101,18 @@ class ImageCachingAgentSpec extends Specification {
     // amis have unique ids, but it's possible for two amis with the same name
     // to exist in the same account (and potentially the same region).
     String imageName = 'foo'
-    Image imageOne = new Image().withImageId('ami-1').withName(imageName)
-    Image imageTwo = new Image().withImageId('ami-2').withName(imageName)
-    String imageOneKey = Keys.getNamedImageKey(accountName, imageOne.getName())
-    String imageTwoKey = Keys.getNamedImageKey(accountName, imageTwo.getName())
+    Image imageOne = Image.builder().imageId('ami-1').name(imageName).build()
+    Image imageTwo = Image.builder().imageId('ami-2').name(imageName).build()
 
     and:
-    // arbitrary values for publicImages and eddaEnabled, but the expected
-    // request corresponds to them
-    def agent = getAgent(false, false)
-    def request = new DescribeImagesRequest().withFilters(new Filter('is-public', ['false']))
+    def agent = getAgent(false)
+    def request = DescribeImagesRequest.builder().filters(Filter.builder().name('is-public').values(['false']).build()).build()
 
     when:
     def result = agent.loadData(providerCache)
 
     then: 'the result has one named image'
-    1 * ec2.describeImages(request) >> new DescribeImagesResult(images: [imageOne, imageTwo])
+    1 * ec2.describeImages(request) >> DescribeImagesResponse.builder().images(imageOne, imageTwo).build()
     0 * _
 
     result.cacheResults[NAMED_IMAGES.ns].size() == 1
@@ -130,31 +126,32 @@ class ImageCachingAgentSpec extends Specification {
 
   void "include the filter corresponding to the configured image states"() {
     given:
-    // arbitrary values for publicImages and eddaEnabled, but the expected
-    // request corresponds to them
     def imageStates = ['available', 'failed']
-    def agent = getAgent(false, false, imageStates)
-    def request = new DescribeImagesRequest().withFilters(new Filter('is-public', ['false']), new Filter('state', imageStates))
+    def agent = getAgent(false, imageStates)
+    def request = DescribeImagesRequest.builder().filters(
+      Filter.builder().name('is-public').values(['false']).build(),
+      Filter.builder().name('state').values(imageStates).build()
+    ).build()
 
     when:
     def result = agent.loadData(providerCache)
 
     then:
     // arbitrarily choose the image to return
-    1 * ec2.describeImages(request) >> new DescribeImagesResult(images: [privateImage])
+    1 * ec2.describeImages(request) >> DescribeImagesResponse.builder().images(privateImage).build()
     0 * _
   }
 
   void "should include only private images"() {
     given:
-    def agent = getAgent(false, false)
-    def request = new DescribeImagesRequest().withFilters(new Filter('is-public', ['false']))
+    def agent = getAgent(false)
+    def request = DescribeImagesRequest.builder().filters(Filter.builder().name('is-public').values(['false']).build()).build()
 
     when:
     def result = agent.loadData(providerCache)
 
     then:
-    1 * ec2.describeImages(request) >> new DescribeImagesResult(images: [privateImage])
+    1 * ec2.describeImages(request) >> DescribeImagesResponse.builder().images(privateImage).build()
     0 * _
 
     result.cacheResults[IMAGES.ns].find { it.id == privateImageKey }
@@ -165,50 +162,14 @@ class ImageCachingAgentSpec extends Specification {
 
   void "should include only public images"() {
     given:
-    def agent = getAgent(true, false)
-    def request = new DescribeImagesRequest().withFilters(new Filter('is-public', ['true']))
+    def agent = getAgent(true)
+    def request = DescribeImagesRequest.builder().filters(Filter.builder().name('is-public').values(['true']).build()).build()
 
     when:
     def result = agent.loadData(providerCache)
 
     then:
-    1 * ec2.describeImages(request) >> new DescribeImagesResult(images: [publicImage])
-    0 * _
-
-    result.cacheResults[IMAGES.ns].find { it.id == publicImageKey }
-    result.cacheResults[NAMED_IMAGES.ns].find { it.id == publicNamedImageKey }
-    !result.cacheResults[IMAGES.ns].find { it.id == privateImageKey }
-    !result.cacheResults[NAMED_IMAGES.ns].find { it.id == privateNamedImageKey }
-  }
-
-  void "should manually filter private images from Edda"() {
-    given:
-    def agent = getAgent(false, true)
-    def request = new DescribeImagesRequest().withFilters(new Filter('is-public', ['false']))
-
-    when:
-    def result = agent.loadData(providerCache)
-
-    then:
-    1 * ec2.describeImages(request) >> new DescribeImagesResult(images: [privateImage, publicImage])
-    0 * _
-
-    result.cacheResults[IMAGES.ns].find { it.id == privateImageKey }
-    result.cacheResults[NAMED_IMAGES.ns].find { it.id == privateNamedImageKey }
-    !result.cacheResults[IMAGES.ns].find { it.id == publicImageKey }
-    !result.cacheResults[NAMED_IMAGES.ns].find { it.id == publicNamedImageKey }
-  }
-
-  void "should manually filter public images from Edda"() {
-    given:
-    def agent = getAgent(true, true)
-    def request = new DescribeImagesRequest().withFilters(new Filter('is-public', ['true']))
-
-    when:
-    def result = agent.loadData(providerCache)
-
-    then:
-    1 * ec2.describeImages(request) >> new DescribeImagesResult(images: [privateImage, publicImage])
+    1 * ec2.describeImages(request) >> DescribeImagesResponse.builder().images(publicImage).build()
     0 * _
 
     result.cacheResults[IMAGES.ns].find { it.id == publicImageKey }

--- a/clouddriver/clouddriver-aws/src/test/java/com/netflix/spinnaker/clouddriver/aws/security/AmazonClientProviderV2Test.java
+++ b/clouddriver/clouddriver-aws/src/test/java/com/netflix/spinnaker/clouddriver/aws/security/AmazonClientProviderV2Test.java
@@ -27,6 +27,7 @@ import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.services.applicationautoscaling.ApplicationAutoScalingClient;
 import software.amazon.awssdk.services.cloudwatch.CloudWatchClient;
+import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.ecr.EcrClient;
 import software.amazon.awssdk.services.ecs.EcsClient;
 import software.amazon.awssdk.services.iam.IamClient;
@@ -34,7 +35,7 @@ import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 import software.amazon.awssdk.services.servicediscovery.ServiceDiscoveryClient;
 
 /**
- * Unit tests verifying the seven v2 getter methods on {@link AmazonClientProvider} produce the
+ * Unit tests verifying the eight v2 getter methods on {@link AmazonClientProvider} produce the
  * correct v2 client types and delegate to the v2 supplier correctly.
  */
 class AmazonClientProviderV2Test {
@@ -55,6 +56,12 @@ class AmazonClientProviderV2Test {
     creds = mock(NetflixAmazonCredentials.class);
     when(creds.getV2CredentialsProvider()).thenReturn(dummyCreds());
     when(creds.getName()).thenReturn("test-account");
+  }
+
+  @Test
+  void getAmazonEC2V2ReturnsEc2Client() {
+    Ec2Client client = provider.getAmazonEC2V2(creds, REGION);
+    assertThat(client).isNotNull().isInstanceOf(Ec2Client.class);
   }
 
   @Test


### PR DESCRIPTION
Adds getAmazonEC2V2 to AmazonClientProvider and migrates the 11 provider/agent caching agents that use EC2 exclusively (Image, Instance, SecurityGroup, Subnet, Vpc, KeyPair, ElasticIp, ReservationReport, ReservedInstances, InstanceType, LaunchTemplate). ClusterCachingAgent and LaunchConfigCachingAgent are deferred to a follow-up since they also depend on AutoScaling/CloudWatch v2 clients.

This is PR1 of a multi-PR roadmap to finish moving clouddriver-aws off AWS SDK v1; EC2/AutoScaling/ELB/CloudWatch remain the bulk of what's left after prior SNS/SQS/SWF/Support/CloudFormation/ECS/Lambda/secrets migrations.
