### PR TITLE
chore(titus): Migrate remaining v1 AWS SDK model type usage to SDK v2

### DIFF
--- a/clouddriver/clouddriver-titus/clouddriver-titus.gradle
+++ b/clouddriver/clouddriver-titus/clouddriver-titus.gradle
@@ -21,6 +21,9 @@ dependencies {
 
   implementation "jakarta.inject:jakarta.inject-api:2.0.1"
   implementation "com.amazonaws:aws-java-sdk"
+  // TODO: redundant once clouddriver-aws's SDKv2 AutoScaling migration merges (it declares this as
+  // `api`, exposing it here transitively). Harmless in the meantime; safe to remove at that point.
+  implementation "software.amazon.awssdk:autoscaling"
   implementation "com.google.protobuf:protobuf-java"
   implementation "com.google.protobuf:protobuf-java-util"
   implementation "com.netflix.frigga:frigga"

--- a/clouddriver/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/description/UpsertTitusScalingPolicyDescription.groovy
+++ b/clouddriver/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/description/UpsertTitusScalingPolicyDescription.groovy
@@ -16,11 +16,11 @@
 
 package com.netflix.spinnaker.clouddriver.titus.deploy.description
 
-import com.amazonaws.services.applicationautoscaling.model.CustomizedMetricSpecification as AwsCustomizedMetricSpecification
-import com.amazonaws.services.applicationautoscaling.model.MetricDimension as AwsMetricDimension
-import com.amazonaws.services.applicationautoscaling.model.PredefinedMetricSpecification as AwsPredefinedMetricSpecification
-import com.amazonaws.services.applicationautoscaling.model.StepAdjustment as AwsStepAdjustment
-import com.amazonaws.services.autoscaling.model.StepAdjustment
+import software.amazon.awssdk.services.applicationautoscaling.model.CustomizedMetricSpecification as AwsCustomizedMetricSpecification
+import software.amazon.awssdk.services.applicationautoscaling.model.MetricDimension as AwsMetricDimension
+import software.amazon.awssdk.services.applicationautoscaling.model.PredefinedMetricSpecification as AwsPredefinedMetricSpecification
+import software.amazon.awssdk.services.applicationautoscaling.model.StepAdjustment as AwsStepAdjustment
+import software.amazon.awssdk.services.autoscaling.model.StepAdjustment
 import com.google.protobuf.BoolValue
 import com.google.protobuf.DoubleValue
 import com.google.protobuf.Int32Value
@@ -87,8 +87,8 @@ class UpsertTitusScalingPolicyDescription extends AbstractTitusCredentialsDescri
       if (targetTrackingConfiguration.predefinedMetricSpecification) {
         ttpBuilder.setPredefinedMetricSpecification(
           PredefinedMetricSpecification.newBuilder()
-            .setPredefinedMetricType(targetTrackingConfiguration.predefinedMetricSpecification.predefinedMetricType)
-            .setResourceLabel(targetTrackingConfiguration.predefinedMetricSpecification.resourceLabel)
+            .setPredefinedMetricType(targetTrackingConfiguration.predefinedMetricSpecification.predefinedMetricTypeAsString())
+            .setResourceLabel(targetTrackingConfiguration.predefinedMetricSpecification.resourceLabel())
         )
       }
 
@@ -96,19 +96,19 @@ class UpsertTitusScalingPolicyDescription extends AbstractTitusCredentialsDescri
         def metricSpecification = targetTrackingConfiguration.customizedMetricSpecification
         CustomizedMetricSpecification.Builder metricBuilder = CustomizedMetricSpecification.newBuilder()
         metricBuilder
-          .setMetricName(metricSpecification.metricName)
-          .setNamespace(metricSpecification.namespace)
-          .setStatistic(Statistic.valueOf(metricSpecification.statistic))
+          .setMetricName(metricSpecification.metricName())
+          .setNamespace(metricSpecification.namespace())
+          .setStatistic(Statistic.valueOf(metricSpecification.statisticAsString()))
 
-        if (metricSpecification.unit) {
-          metricBuilder.setUnit(metricSpecification.unit)
+        if (metricSpecification.unit()) {
+          metricBuilder.setUnit(metricSpecification.unit())
         }
 
-        metricSpecification.dimensions.each {
+        metricSpecification.dimensions().each {
           metricBuilder.addDimensions(
             MetricDimension.newBuilder()
-              .setName(it.name)
-              .setValue(it.value)
+              .setName(it.name())
+              .setValue(it.value())
           )
         }
         ttpBuilder.setCustomizedMetricSpecification(metricBuilder)
@@ -126,13 +126,13 @@ class UpsertTitusScalingPolicyDescription extends AbstractTitusCredentialsDescri
       }
       step.stepAdjustments.each { adjustment ->
         StepAdjustments.Builder adjustmentBuilder = StepAdjustments.newBuilder()
-        if (adjustment.metricIntervalLowerBound != null) {
-          adjustmentBuilder.setMetricIntervalLowerBound(DoubleValue.of(adjustment.metricIntervalLowerBound))
+        if (adjustment.metricIntervalLowerBound() != null) {
+          adjustmentBuilder.setMetricIntervalLowerBound(DoubleValue.of(adjustment.metricIntervalLowerBound()))
         }
-        if (adjustment.metricIntervalUpperBound != null) {
-          adjustmentBuilder.setMetricIntervalUpperBound(DoubleValue.of(adjustment.metricIntervalUpperBound))
+        if (adjustment.metricIntervalUpperBound() != null) {
+          adjustmentBuilder.setMetricIntervalUpperBound(DoubleValue.of(adjustment.metricIntervalUpperBound()))
         }
-        adjustmentBuilder.setScalingAdjustment(Int32Value.of(adjustment.scalingAdjustment))
+        adjustmentBuilder.setScalingAdjustment(Int32Value.of(adjustment.scalingAdjustment()))
         stepBuilder.addStepAdjustments(adjustmentBuilder)
       }
 
@@ -171,15 +171,14 @@ class UpsertTitusScalingPolicyDescription extends AbstractTitusCredentialsDescri
       step.metricAggregationType = stepPolicy.metricAggregationType
       step.stepAdjustments = []
       stepPolicy.stepAdjustmentsList?.each {
-        com.amazonaws.services.applicationautoscaling.model.StepAdjustment adjustment = new AwsStepAdjustment()
-        adjustment.scalingAdjustment = it.scalingAdjustment.value
+        def adjustmentBuilder = AwsStepAdjustment.builder().scalingAdjustment(it.scalingAdjustment.value)
         if (it.hasMetricIntervalLowerBound()) {
-          adjustment.metricIntervalLowerBound = it.metricIntervalLowerBound?.value
+          adjustmentBuilder.metricIntervalLowerBound(it.metricIntervalLowerBound?.value)
         }
         if (it.hasMetricIntervalUpperBound()) {
-          adjustment.metricIntervalUpperBound = it.metricIntervalUpperBound?.value
+          adjustmentBuilder.metricIntervalUpperBound(it.metricIntervalUpperBound?.value)
         }
-        step.stepAdjustments << adjustment
+        step.stepAdjustments << adjustmentBuilder.build()
       }
       AlarmConfiguration alarmConfig = stepDescriptor.alarmConfig
       UpsertAlarmDescription alarm = new UpsertAlarmDescription()
@@ -207,16 +206,15 @@ class UpsertTitusScalingPolicyDescription extends AbstractTitusCredentialsDescri
       targetTrackingConfiguration.targetValue = targetDescriptor.targetValue.value
 
       CustomizedMetricSpecification sourceMetricSpecification = targetDescriptor.customizedMetricSpecification
-      AwsCustomizedMetricSpecification customizedMetricSpecification = new AwsCustomizedMetricSpecification()
-      targetTrackingConfiguration.customizedMetricSpecification = customizedMetricSpecification
-      customizedMetricSpecification.withMetricName(sourceMetricSpecification.metricName)
-        .withNamespace(sourceMetricSpecification.namespace)
-        .withStatistic(sourceMetricSpecification.statistic.name())
-        .withUnit(sourceMetricSpecification.unit)
-        .withDimensions(sourceMetricSpecification.dimensionsList.collect { dimension ->
+      targetTrackingConfiguration.customizedMetricSpecification = AwsCustomizedMetricSpecification.builder()
+        .metricName(sourceMetricSpecification.metricName)
+        .namespace(sourceMetricSpecification.namespace)
+        .statistic(sourceMetricSpecification.statistic.name())
+        .unit(sourceMetricSpecification.unit)
+        .dimensions(sourceMetricSpecification.dimensionsList.collect { dimension ->
         String value = dimension.name == "AutoScalingGroupName" ? serverGroupName : dimension.value
-        new AwsMetricDimension().withName(dimension.name).withValue(value)
-      })
+        AwsMetricDimension.builder().name(dimension.name).value(value).build()
+      }).build()
     }
     log.info("UpsertTitusScalingPolicyDescription for ${serverGroupName} description: ${ JsonOutput.toJson(description) }")
     description

--- a/clouddriver/clouddriver-titus/src/main/java/com/netflix/spinnaker/clouddriver/titus/caching/agents/TitusStreamingUpdateAgent.java
+++ b/clouddriver/clouddriver-titus/src/main/java/com/netflix/spinnaker/clouddriver/titus/caching/agents/TitusStreamingUpdateAgent.java
@@ -34,7 +34,6 @@ import static java.util.Collections.singletonList;
 import static java.util.Collections.unmodifiableSet;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
-import com.amazonaws.services.elasticloadbalancingv2.model.TargetTypeEnum;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -101,6 +100,7 @@ import java.util.stream.Stream;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.TargetTypeEnum;
 
 public class TitusStreamingUpdateAgent implements CustomScheduledAgent, CachingAgent {
 
@@ -999,7 +999,7 @@ public class TitusStreamingUpdateAgent implements CustomScheduledAgent, CachingA
                           it,
                           getAwsAccountName(account, region),
                           region,
-                          TargetTypeEnum.Ip.toString(),
+                          TargetTypeEnum.IP.toString(),
                           getAwsVpcId(account, region)))
               .collect(Collectors.toSet());
     }


### PR DESCRIPTION
TitusStreamingUpdateAgent only used the v1 elasticloadbalancingv2 TargetTypeEnum (already transitively available via clouddriver-aws's existing api dependency, no gradle change needed there).

UpsertTitusScalingPolicyDescription used v1 ApplicationAutoScaling and plain AutoScaling model types (StepAdjustment, CustomizedMetricSpecification, PredefinedMetricSpecification, MetricDimension) purely as local field/DTO types, not through AmazonClientProvider, so migrating them was a mechanical swap to v2 builders. Added software.amazon.awssdk:autoscaling directly to clouddriver-titus.gradle since that dependency doesn't exist on main yet (only in the unmerged clouddriver-aws AutoScaling PR) — redundant but harmless once that merges.

Two lines in the same file (comparisonOperator/statistic on UpsertAlarmDescription) are deliberately left on v1 CloudWatch types: UpsertAlarmDescription itself (in clouddriver-aws) still declares those fields as v1 types, and migrating them here without also migrating that shared description class would be a real type mismatch, not just a style inconsistency. That class is out of scope for this PR — it belongs to the CloudWatch alarms migration.