### PR TITLE
chore(ecs): Migrate remaining v1 EC2 SDK model type usage to SDK v2

### DIFF
--- a/clouddriver/clouddriver-ecs/clouddriver-ecs.gradle
+++ b/clouddriver/clouddriver-ecs/clouddriver-ecs.gradle
@@ -20,6 +20,9 @@ dependencies {
   implementation project(":clouddriver-security")
 
   implementation "com.amazonaws:aws-java-sdk"
+  // TODO: redundant once clouddriver-aws's SDKv2 EC2 migration merges (it declares this as `api`,
+  // exposing it here transitively). Harmless in the meantime; safe to remove at that point.
+  implementation "software.amazon.awssdk:ec2"
   implementation "com.github.ben-manes.caffeine:guava"
   implementation "com.netflix.awsobjectmapper:awsobjectmapper"
   implementation "com.netflix.frigga:frigga"

--- a/clouddriver/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/client/EcsInstanceCacheClient.java
+++ b/clouddriver/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/client/EcsInstanceCacheClient.java
@@ -18,7 +18,6 @@ package com.netflix.spinnaker.clouddriver.ecs.cache.client;
 
 import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.INSTANCES;
 
-import com.amazonaws.services.ec2.model.Instance;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spinnaker.cats.cache.Cache;
 import com.netflix.spinnaker.clouddriver.aws.data.Keys;
@@ -26,6 +25,7 @@ import java.util.Collection;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.ec2.model.Instance;
 
 @Component
 public class EcsInstanceCacheClient {

--- a/clouddriver/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcsServerClusterProvider.java
+++ b/clouddriver/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcsServerClusterProvider.java
@@ -16,7 +16,6 @@
 
 package com.netflix.spinnaker.clouddriver.ecs.provider.view;
 
-import com.amazonaws.services.ec2.model.GroupIdentifier;
 import com.google.common.collect.Sets;
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonCredentials;
 import com.netflix.spinnaker.clouddriver.ecs.EcsCloudProvider;
@@ -58,6 +57,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import software.amazon.awssdk.services.applicationautoscaling.model.ScalableTarget;
+import software.amazon.awssdk.services.ec2.model.GroupIdentifier;
 import software.amazon.awssdk.services.ecs.model.ContainerDefinition;
 import software.amazon.awssdk.services.ecs.model.NetworkInterface;
 
@@ -355,16 +355,16 @@ public class EcsServerClusterProvider implements ClusterProvider<EcsServerCluste
           Task task = taskCacheClient.get(taskKey);
 
           if (task != null) {
-            com.amazonaws.services.ec2.model.Instance ec2Instance =
+            software.amazon.awssdk.services.ec2.model.Instance ec2Instance =
                 containerInformationService.getEc2Instance(account, region, task);
             if (ec2Instance != null) {
-              if (ec2Instance.getVpcId() != null && !ec2Instance.getVpcId().isEmpty()) {
-                vpcId = ec2Instance.getVpcId();
+              if (ec2Instance.vpcId() != null && !ec2Instance.vpcId().isEmpty()) {
+                vpcId = ec2Instance.vpcId();
               }
-              if (ec2Instance.getSecurityGroups() != null) {
+              if (ec2Instance.securityGroups() != null) {
                 securityGroups =
-                    ec2Instance.getSecurityGroups().stream()
-                        .map(GroupIdentifier::getGroupId)
+                    ec2Instance.securityGroups().stream()
+                        .map(GroupIdentifier::groupId)
                         .collect(Collectors.toSet());
               }
               break;

--- a/clouddriver/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/services/ContainerInformationService.java
+++ b/clouddriver/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/services/ContainerInformationService.java
@@ -16,7 +16,6 @@
 
 package com.netflix.spinnaker.clouddriver.ecs.services;
 
-import com.amazonaws.services.ec2.model.Instance;
 import com.netflix.spinnaker.clouddriver.ecs.cache.Keys;
 import com.netflix.spinnaker.clouddriver.ecs.cache.client.ContainerInstanceCacheClient;
 import com.netflix.spinnaker.clouddriver.ecs.cache.client.EcsInstanceCacheClient;
@@ -39,6 +38,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.ec2.model.Instance;
 import software.amazon.awssdk.services.ecs.model.ContainerDefinition;
 import software.amazon.awssdk.services.ecs.model.LoadBalancer;
 import software.amazon.awssdk.services.ecs.model.NetworkBinding;
@@ -244,7 +244,7 @@ public class ContainerInformationService {
       return null;
     }
 
-    String hostPrivateIpAddress = instance.getPrivateIpAddress();
+    String hostPrivateIpAddress = instance.privateIpAddress();
     if (hostPrivateIpAddress == null || hostPrivateIpAddress.isEmpty()) {
       return null;
     }
@@ -254,8 +254,8 @@ public class ContainerInformationService {
 
   public String getTaskZone(String accountName, String region, Task task) {
     Instance ec2Instance = getEc2Instance(accountName, region, task);
-    if (ec2Instance != null && ec2Instance.getPlacement() != null) {
-      return ec2Instance.getPlacement().getAvailabilityZone();
+    if (ec2Instance != null && ec2Instance.placement() != null) {
+      return ec2Instance.placement().availabilityZone();
     }
 
     // TODO for tasks not placed on an instance (e.g. Fargate), determine the zone from the network

--- a/clouddriver/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/cache/EcsInstanceCacheClientSpec.groovy
+++ b/clouddriver/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/cache/EcsInstanceCacheClientSpec.groovy
@@ -16,15 +16,19 @@
 
 package com.netflix.spinnaker.clouddriver.ecs.cache
 
-import com.amazonaws.services.ec2.model.Instance
+import software.amazon.awssdk.services.ec2.model.Instance
 import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.netflix.spinnaker.cats.cache.Cache
 import com.netflix.spinnaker.cats.cache.DefaultCacheData
 import com.netflix.spinnaker.clouddriver.aws.data.Keys
+import com.netflix.spinnaker.clouddriver.aws.jackson.AwsSdkV2Module
 import com.netflix.spinnaker.clouddriver.ecs.cache.client.EcsInstanceCacheClient
 import spock.lang.Specification
 import spock.lang.Subject
+
+import java.time.Instant
 
 import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.INSTANCES
 
@@ -32,6 +36,8 @@ class EcsInstanceCacheClientSpec extends Specification {
   def cacheView = Mock(Cache)
   def objectMapper = new ObjectMapper()
                           .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                          .registerModule(new AwsSdkV2Module())
+                          .registerModule(new JavaTimeModule())
 
   @Subject
   def client = new EcsInstanceCacheClient(cacheView, objectMapper)
@@ -40,12 +46,12 @@ class EcsInstanceCacheClientSpec extends Specification {
     given:
     def instanceId = 'instance-id'
     def key = Keys.getInstanceKey(instanceId, 'test-account', 'us-west-1')
-    def givenInstance = new Instance(
-      instanceId: instanceId,
-      privateIpAddress: '127.0.0.1',
-      publicDnsName: 'localhost',
-      launchTime: new Date()
-    )
+    def givenInstance = Instance.builder()
+      .instanceId(instanceId)
+      .privateIpAddress('127.0.0.1')
+      .publicDnsName('localhost')
+      .launchTime(Instant.now())
+      .build()
 
     def attributes = objectMapper.convertValue(givenInstance, Map)
     def instanceCache = new DefaultCacheData(key, attributes, [:])
@@ -57,7 +63,16 @@ class EcsInstanceCacheClientSpec extends Specification {
     def foundInstances = client.findAll()
 
     then:
+    // Full-object equality isn't used here: round-tripping through the generic SdkPojo
+    // serializer/deserializer materializes AWS SDK v2's "unset" collection fields (e.g.
+    // blockDeviceMappings) as real empty lists rather than the internal auto-construct sentinel
+    // the builder leaves them as, so the two instances differ in those fields' identity even
+    // though the actual data is equivalent. Compare only the fields this test actually cares about.
     foundInstances.size() == 1
-    foundInstances[0] == givenInstance
+    def foundInstance = foundInstances[0]
+    foundInstance.instanceId() == givenInstance.instanceId()
+    foundInstance.privateIpAddress() == givenInstance.privateIpAddress()
+    foundInstance.publicDnsName() == givenInstance.publicDnsName()
+    foundInstance.launchTime() == givenInstance.launchTime()
   }
 }

--- a/clouddriver/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcsServerClusterProviderSpec.groovy
+++ b/clouddriver/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcsServerClusterProviderSpec.groovy
@@ -17,9 +17,9 @@
 package com.netflix.spinnaker.clouddriver.ecs.provider.view
 
 import software.amazon.awssdk.services.applicationautoscaling.model.ScalableTarget
-import com.amazonaws.services.ec2.model.GroupIdentifier
-import com.amazonaws.services.ec2.model.Instance
-import com.amazonaws.services.ec2.model.Placement
+import software.amazon.awssdk.services.ec2.model.GroupIdentifier
+import software.amazon.awssdk.services.ec2.model.Instance
+import software.amazon.awssdk.services.ec2.model.Placement
 import software.amazon.awssdk.services.ecs.model.AwsVpcConfiguration
 import software.amazon.awssdk.services.ecs.model.DeploymentConfiguration
 import software.amazon.awssdk.services.ecs.model.NetworkConfiguration
@@ -136,15 +136,11 @@ class EcsServerClusterProviderSpec extends Specification {
       type      : 'loadbalancer'
     ]
 
-    ec2Instance = new Instance(
-      placement: new Placement(
-        availabilityZone: availabilityZone
-      ),
-      vpcId: 'vpc-1234',
-      securityGroups: [new GroupIdentifier (
-        groupId: 'sg-1234'
-      )]
-    )
+    ec2Instance = Instance.builder()
+      .placement(Placement.builder().availabilityZone(availabilityZone).build())
+      .vpcId('vpc-1234')
+      .securityGroups(GroupIdentifier.builder().groupId('sg-1234').build())
+      .build()
 
     cachedTaskDefinition = TaskDefinition.builder()
       .containerDefinitions(
@@ -234,8 +230,14 @@ class EcsServerClusterProviderSpec extends Specification {
     def serviceAttributes = TestServiceCachingAgentFactory.create(creds, creds.getRegions()[0].getName()).convertServiceToAttributes(serviceWithVpc)
     def serviceCacheData = new DefaultCacheData('', serviceAttributes, [:])
 
-    ec2Instance.vpcId = 'vpc-wrong'
-    ec2Instance.securityGroups = [new GroupIdentifier (groupId: 'sg-wrong')]
+    ec2Instance = ec2Instance.toBuilder()
+      .vpcId('vpc-wrong')
+      .securityGroups(GroupIdentifier.builder().groupId('sg-wrong').build())
+      .build()
+    // setup() already stubbed getEc2Instance with the pre-rebuild instance; v2 objects are
+    // immutable (unlike v1, mutating the shared field in place no longer updates what the mock
+    // returns), so re-stub with the rebuilt instance.
+    containerInformationService.getEc2Instance(_, _, _) >> ec2Instance
 
     when:
     def retrievedCluster = provider.getCluster("myapp", CREDS_NAME, FAMILY_NAME)
@@ -381,7 +383,7 @@ class EcsServerClusterProviderSpec extends Specification {
     def retrievedCluster = provider.getCluster("myapp", CREDS_NAME, FAMILY_NAME)
 
     then:
-    containerInformationService.getEc2Instance(_, _, _) >> new Instance()
+    containerInformationService.getEc2Instance(_, _, _) >> Instance.builder().build()
     retrievedCluster == expectedCluster
   }
 

--- a/clouddriver/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/services/ContainerInformationServiceSpec.groovy
+++ b/clouddriver/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/services/ContainerInformationServiceSpec.groovy
@@ -16,8 +16,8 @@
 
 package com.netflix.spinnaker.clouddriver.ecs.services
 
-import com.amazonaws.services.ec2.model.Instance
-import com.amazonaws.services.ec2.model.Placement
+import software.amazon.awssdk.services.ec2.model.Instance
+import software.amazon.awssdk.services.ec2.model.Placement
 import software.amazon.awssdk.services.ecs.model.Container
 import software.amazon.awssdk.services.ecs.model.ContainerDefinition
 import software.amazon.awssdk.services.ecs.model.HealthCheck
@@ -412,9 +412,9 @@ class ContainerInformationServiceSpec extends Specification {
       ec2InstanceId: 'i-deadbeef'
     )
 
-    def instance = new Instance(
-      privateIpAddress: ip
-    )
+    def instance = Instance.builder()
+      .privateIpAddress(ip)
+      .build()
 
     containerInstanceCacheClient.get(_) >> containerInstance
     ecsInstanceCacheClient.find(_, _, _) >> [instance]
@@ -465,7 +465,7 @@ class ContainerInformationServiceSpec extends Specification {
       ec2InstanceId: 'i-deadbeef'
     )
 
-    def instance = new Instance()
+    def instance = Instance.builder().build()
 
     containerInstanceCacheClient.get(_) >> containerInstance
     ecsInstanceCacheClient.find(_, _, _) >> [instance]
@@ -547,9 +547,9 @@ class ContainerInformationServiceSpec extends Specification {
       ec2InstanceId: 'i-deadbeef'
     )
 
-    def instance = new Instance(
-      privateIpAddress: '127.0.0.1'
-    )
+    def instance = Instance.builder()
+      .privateIpAddress('127.0.0.1')
+      .build()
 
     containerInstanceCacheClient.get(_) >> containerInstance
     ecsInstanceCacheClient.find(_, _, _) >> [instance]
@@ -587,9 +587,9 @@ class ContainerInformationServiceSpec extends Specification {
       ec2InstanceId: 'i-deadbeef'
     )
 
-    def instance = new Instance(
-      privateIpAddress: ip
-    )
+    def instance = Instance.builder()
+      .privateIpAddress(ip)
+      .build()
 
     containerInstanceCacheClient.get(_) >> containerInstance
     ecsInstanceCacheClient.find(_, _, _) >> [instance]
@@ -622,8 +622,8 @@ class ContainerInformationServiceSpec extends Specification {
 
     containerInstanceCacheClient.get(_) >> containerInstance
     ecsInstanceCacheClient.find(_, _, _) >> [
-      new Instance(instanceId: "id-1"),
-      new Instance(instanceId: "id-2")
+      Instance.builder().instanceId("id-1").build(),
+      Instance.builder().instanceId("id-2").build()
     ]
     ecsCredentialsConfig.getAccounts() >> [ecsAccount]
 
@@ -643,12 +643,12 @@ class ContainerInformationServiceSpec extends Specification {
       name: 'ecs-account',
       awsAccount: 'aws-test-account'
     )
-    def givenInstance = new Instance(
-      instanceId: 'i-deadbeef',
-      privateIpAddress: '0.0.0.0',
-      publicIpAddress: '127.0.0.1',
-      placement: new Placement(availabilityZone: 'us-west-1a')
-    )
+    def givenInstance = Instance.builder()
+      .instanceId('i-deadbeef')
+      .privateIpAddress('0.0.0.0')
+      .publicIpAddress('127.0.0.1')
+      .placement(Placement.builder().availabilityZone('us-west-1a').build())
+      .build()
 
     containerInstanceCacheClient.get(_) >> containerInstance
     ecsCredentialsConfig.getAccounts() >> [ecsAccount]
@@ -684,11 +684,11 @@ class ContainerInformationServiceSpec extends Specification {
       name: 'ecs-account',
       awsAccount: 'aws-test-account'
     )
-    def givenInstance = new Instance(
-      instanceId: 'i-deadbeef',
-      privateIpAddress: '0.0.0.0',
-      publicIpAddress: '127.0.0.1'
-    )
+    def givenInstance = Instance.builder()
+      .instanceId('i-deadbeef')
+      .privateIpAddress('0.0.0.0')
+      .publicIpAddress('127.0.0.1')
+      .build()
 
     containerInstanceCacheClient.get(_) >> containerInstance
     ecsCredentialsConfig.getAccounts() >> [ecsAccount]
@@ -743,11 +743,11 @@ class ContainerInformationServiceSpec extends Specification {
       name: 'ecs-account',
       awsAccount: 'aws-test-account'
     )
-    def givenInstance = new Instance(
-      instanceId: 'i-deadbeef',
-      privateIpAddress: '0.0.0.0',
-      publicIpAddress: '127.0.0.1'
-    )
+    def givenInstance = Instance.builder()
+      .instanceId('i-deadbeef')
+      .privateIpAddress('0.0.0.0')
+      .publicIpAddress('127.0.0.1')
+      .build()
 
     containerInstanceCacheClient.get(_) >> containerInstance
     ecsCredentialsConfig.getAccounts() >> [ecsAccount]
@@ -805,11 +805,11 @@ class ContainerInformationServiceSpec extends Specification {
     )
     def givenInstances = []
     0.upto(4, {
-      givenInstances << new Instance(
-        instanceId: "i-deadbee${it}",
-        privateIpAddress: '0.0.0.0',
-        publicIpAddress: '127.0.0.1'
-      )
+      givenInstances << Instance.builder()
+        .instanceId("i-deadbee${it}")
+        .privateIpAddress('0.0.0.0')
+        .publicIpAddress('127.0.0.1')
+        .build()
     })
 
     containerInstanceCacheClient.get(_) >> containerInstance


### PR DESCRIPTION
EcsInstanceCacheClient, ContainerInformationService, and EcsServerClusterProvider deserialize cached EC2 Instance/GroupIdentifier data via ObjectMapper.convertValue rather than through AmazonClientProvider, so this only needed the v1 model types swapped for v2 equivalents plus adding software.amazon.awssdk:ec2 directly to clouddriver-ecs.gradle (redundant but harmless once clouddriver-aws's EC2 SDKv2 migration merges, since it exposes the same dependency transitively via `api`).

Fully independent of the clouddriver-aws EC2/AutoScaling SDKv2 PRs — branched off main directly, no stacking needed. Also fixes a test (EcsInstanceCacheClientSpec) that relied on a bare `new ObjectMapper()` without AwsSdkV2Module/JavaTimeModule registered, and a full-object equality assertion that doesn't hold across v2 SdkPojo serialize/deserialize round-trips (unset collection fields become real empty lists instead of the SDK's internal auto-construct sentinel) — same class of test gotcha hit during the EC2 PR.
