### PR TITLE
chore(aws): Migrate remaining v1 ELB client usage in ASG atomic operations to SDK v2

### DIFF
--- a/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/AbstractEnableDisableAtomicOperation.groovy
+++ b/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/AbstractEnableDisableAtomicOperation.groovy
@@ -21,15 +21,15 @@ import software.amazon.awssdk.services.ec2.model.DescribeInstancesResponse
 import software.amazon.awssdk.services.ec2.model.Filter
 import software.amazon.awssdk.services.ec2.model.InstanceStateName
 import software.amazon.awssdk.services.ec2.model.Reservation
-import com.amazonaws.services.elasticloadbalancing.model.DeregisterInstancesFromLoadBalancerRequest
-import com.amazonaws.services.elasticloadbalancing.model.Instance
-import com.amazonaws.services.elasticloadbalancing.model.LoadBalancerNotFoundException
-import com.amazonaws.services.elasticloadbalancing.model.RegisterInstancesWithLoadBalancerRequest
-import com.amazonaws.services.elasticloadbalancingv2.model.DeregisterTargetsRequest
-import com.amazonaws.services.elasticloadbalancingv2.model.InvalidTargetException
-import com.amazonaws.services.elasticloadbalancingv2.model.RegisterTargetsRequest
-import com.amazonaws.services.elasticloadbalancingv2.model.TargetDescription
-import com.amazonaws.services.elasticloadbalancingv2.model.TargetGroupNotFoundException
+import software.amazon.awssdk.services.elasticloadbalancing.model.DeregisterInstancesFromLoadBalancerRequest
+import software.amazon.awssdk.services.elasticloadbalancing.model.Instance
+import software.amazon.awssdk.services.elasticloadbalancing.model.LoadBalancerNotFoundException
+import software.amazon.awssdk.services.elasticloadbalancing.model.RegisterInstancesWithLoadBalancerRequest
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.DeregisterTargetsRequest
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.InvalidTargetException
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.RegisterTargetsRequest
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.TargetDescription
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.TargetGroupNotFoundException
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.EnableDisableAsgDescription
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.EnableDisableInstanceDiscoveryDescription
 import com.netflix.spinnaker.clouddriver.aws.deploy.ops.discovery.AwsEurekaSupport
@@ -85,8 +85,8 @@ abstract class AbstractEnableDisableAtomicOperation implements AtomicOperation<V
     def credentials = description.credentials
     try {
       def regionScopedProvider = regionScopedProviderFactory.forRegion(credentials, region)
-      def loadBalancing = regionScopedProvider.amazonElasticLoadBalancing
-      def lbv2 = regionScopedProvider.getAmazonElasticLoadBalancingV2(true)
+      def loadBalancing = regionScopedProvider.amazonElasticLoadBalancingClassicV2
+      def lbv2 = regionScopedProvider.getElasticLoadBalancingV2Client()
 
       def asgService = regionScopedProvider.asgService
       def asg = asgService.getAutoScalingGroup(serverGroupName)
@@ -174,7 +174,7 @@ abstract class AbstractEnableDisableAtomicOperation implements AtomicOperation<V
         changeRegistrationOfInstancesWithLoadBalancer(asg.loadBalancerNames, instanceIds) { String loadBalancerName, List<Instance> instances ->
           try {
             task.updateStatus phaseName, "Deregistering instances from Load Balancers..."
-            loadBalancing.deregisterInstancesFromLoadBalancer(new DeregisterInstancesFromLoadBalancerRequest(loadBalancerName, instances))
+            loadBalancing.deregisterInstancesFromLoadBalancer(DeregisterInstancesFromLoadBalancerRequest.builder().loadBalancerName(loadBalancerName).instances(instances).build())
           } catch (LoadBalancerNotFoundException e) {
             task.updateStatus phaseName, "Unable to deregister instances, ${loadBalancerName} does not exist (${e.message})"
           }
@@ -182,7 +182,7 @@ abstract class AbstractEnableDisableAtomicOperation implements AtomicOperation<V
         changeRegistrationOfInstancesWithTargetGroups(asg.targetGroupARNs, instanceIds) { String targetGroupArn, List<TargetDescription> instances ->
           try {
             task.updateStatus phaseName, "Deregistering instances from Target Groups..."
-            lbv2.deregisterTargets(new DeregisterTargetsRequest().withTargetGroupArn(targetGroupArn).withTargets(instances))
+            lbv2.deregisterTargets(DeregisterTargetsRequest.builder().targetGroupArn(targetGroupArn).targets(instances).build())
           } catch (TargetGroupNotFoundException | InvalidTargetException ex) {
             task.updateStatus phaseName, "Unable to deregister targets, $targetGroupArn invalid ($ex.message)"
           }
@@ -190,11 +190,11 @@ abstract class AbstractEnableDisableAtomicOperation implements AtomicOperation<V
       } else {
         changeRegistrationOfInstancesWithLoadBalancer(asg.loadBalancerNames, instanceIds) { String loadBalancerName, List<Instance> instances ->
           task.updateStatus phaseName, "Registering instances with Load Balancers..."
-          loadBalancing.registerInstancesWithLoadBalancer(new RegisterInstancesWithLoadBalancerRequest(loadBalancerName, instances))
+          loadBalancing.registerInstancesWithLoadBalancer(RegisterInstancesWithLoadBalancerRequest.builder().loadBalancerName(loadBalancerName).instances(instances).build())
         }
         changeRegistrationOfInstancesWithTargetGroups(asg.targetGroupARNs, instanceIds) { String targetGroupArn, List<TargetDescription> targets ->
           task.updateStatus phaseName, "Registering instances with Target Groups..."
-          lbv2.registerTargets(new RegisterTargetsRequest().withTargetGroupArn(targetGroupArn).withTargets(targets))
+          lbv2.registerTargets(RegisterTargetsRequest.builder().targetGroupArn(targetGroupArn).targets(targets).build())
         }
       }
 
@@ -252,11 +252,11 @@ abstract class AbstractEnableDisableAtomicOperation implements AtomicOperation<V
   }
 
   private static void changeRegistrationOfInstancesWithTargetGroups(Collection<String> targetGroupArns, Collection<String> instanceIds, Closure actOnInstancesAndTargetGroup) {
-    handleInstancesWithLoadBalancing(targetGroupArns, instanceIds, { new TargetDescription().withId(it) }, actOnInstancesAndTargetGroup)
+    handleInstancesWithLoadBalancing(targetGroupArns, instanceIds, { TargetDescription.builder().id(it).build() }, actOnInstancesAndTargetGroup)
   }
 
   private static void changeRegistrationOfInstancesWithLoadBalancer(Collection<String> loadBalancerNames, Collection<String> instanceIds, Closure actOnInstancesAndLoadBalancer) {
-    handleInstancesWithLoadBalancing(loadBalancerNames, instanceIds, { new Instance(instanceId: it)}, actOnInstancesAndLoadBalancer)
+    handleInstancesWithLoadBalancing(loadBalancerNames, instanceIds, { Instance.builder().instanceId(it).build() }, actOnInstancesAndLoadBalancer)
   }
 
   private static void handleInstancesWithLoadBalancing(Collection<String> lbIdentifiers, Collection<String> instanceIds, Closure instanceIdTransform, Closure actOnInstancesAndLoadBalancer) {

--- a/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/AbstractInstanceLoadBalancerRegistrationAtomicOperation.groovy
+++ b/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/AbstractInstanceLoadBalancerRegistrationAtomicOperation.groovy
@@ -17,9 +17,9 @@
 package com.netflix.spinnaker.clouddriver.aws.deploy.ops
 
 import software.amazon.awssdk.services.autoscaling.model.AutoScalingGroup
-import com.amazonaws.services.elasticloadbalancing.model.DeregisterInstancesFromLoadBalancerRequest
-import com.amazonaws.services.elasticloadbalancing.model.Instance
-import com.amazonaws.services.elasticloadbalancing.model.RegisterInstancesWithLoadBalancerRequest
+import software.amazon.awssdk.services.elasticloadbalancing.model.DeregisterInstancesFromLoadBalancerRequest
+import software.amazon.awssdk.services.elasticloadbalancing.model.Instance
+import software.amazon.awssdk.services.elasticloadbalancing.model.RegisterInstancesWithLoadBalancerRequest
 import com.google.common.annotations.VisibleForTesting
 import com.netflix.spinnaker.clouddriver.aws.deploy.ops.loadbalancer.LoadBalancerLookupHelper
 import com.netflix.spinnaker.clouddriver.data.task.Task
@@ -88,23 +88,23 @@ abstract class AbstractInstanceLoadBalancerRegistrationAtomicOperation implement
   private void operateOnInstances(RegionScopedProviderFactory.RegionScopedProvider regionScopedProvider, LoadBalancerLookupHelper.LoadBalancerLookupResult loadBalancers, Collection<String> instanceIds, String performingAction) {
     def task = getTask()
     if (loadBalancers.classicLoadBalancers) {
-      def instances = instanceIds.collect { new Instance(instanceId: it) }
+      def instances = instanceIds.collect { Instance.builder().instanceId(it).build() }
 
-      def amazonELB = regionScopedProvider.getAmazonElasticLoadBalancing()
+      def amazonELB = regionScopedProvider.getAmazonElasticLoadBalancingClassicV2()
       loadBalancers.classicLoadBalancers.each {
         task.updateStatus phaseName, "${performingAction} instances ($instanceIds) in ${it}."
         if (getRegistrationAction() == RegistrationAction.REGISTER) {
-          amazonELB.registerInstancesWithLoadBalancer(new RegisterInstancesWithLoadBalancerRequest(
-            it,
-            instances
-          ))
+          amazonELB.registerInstancesWithLoadBalancer(RegisterInstancesWithLoadBalancerRequest.builder()
+            .loadBalancerName(it)
+            .instances(instances)
+            .build())
         } else {
-          amazonELB.deregisterInstancesFromLoadBalancer(new DeregisterInstancesFromLoadBalancerRequest(
-            it,
-            instances
-          ))
+          amazonELB.deregisterInstancesFromLoadBalancer(DeregisterInstancesFromLoadBalancerRequest.builder()
+            .loadBalancerName(it)
+            .instances(instances)
+            .build())
         }
-        task.updateStatus phaseName, "Finished ${performingAction.toLowerCase()} instances (${instances*.instanceId.join(", ")}) in ${it}."
+        task.updateStatus phaseName, "Finished ${performingAction.toLowerCase()} instances (${instances*.instanceId().join(", ")}) in ${it}."
       }
     }
   }

--- a/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/AbstractInstanceTargetGroupRegistrationAtomicOperation.groovy
+++ b/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/AbstractInstanceTargetGroupRegistrationAtomicOperation.groovy
@@ -17,9 +17,9 @@
 package com.netflix.spinnaker.clouddriver.aws.deploy.ops
 
 import software.amazon.awssdk.services.autoscaling.model.AutoScalingGroup
-import com.amazonaws.services.elasticloadbalancingv2.model.DeregisterTargetsRequest
-import com.amazonaws.services.elasticloadbalancingv2.model.RegisterTargetsRequest
-import com.amazonaws.services.elasticloadbalancingv2.model.TargetDescription
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.DeregisterTargetsRequest
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.RegisterTargetsRequest
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.TargetDescription
 import com.google.common.annotations.VisibleForTesting
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.InstanceTargetGroupRegistrationDescription
 import com.netflix.spinnaker.clouddriver.aws.deploy.ops.loadbalancer.TargetGroupLookupHelper
@@ -87,14 +87,14 @@ abstract class AbstractInstanceTargetGroupRegistrationAtomicOperation implements
   private void operateOnInstances(RegionScopedProviderFactory.RegionScopedProvider regionScopedProvider, TargetGroupLookupHelper.TargetGroupLookupResult targetGroups, Collection<String> instanceIds, String performingAction) {
     def task = getTask()
     if (targetGroups.targetGroupARNs) {
-      def targets = instanceIds.collect { new TargetDescription().withId(it) }
-      def elbv2 = regionScopedProvider.getAmazonElasticLoadBalancingV2(true)
+      def targets = instanceIds.collect { TargetDescription.builder().id(it).build() }
+      def elbv2 = regionScopedProvider.getElasticLoadBalancingV2Client()
       targetGroups.targetGroupARNs.each {
         task.updateStatus phaseName, "${performingAction} instances ($instanceIds) in target group $it"
         if (getRegistrationAction() == RegistrationAction.REGISTER) {
-          elbv2.registerTargets(new RegisterTargetsRequest().withTargetGroupArn(it).withTargets(targets))
+          elbv2.registerTargets(RegisterTargetsRequest.builder().targetGroupArn(it).targets(targets).build())
         } else {
-          elbv2.deregisterTargets(new DeregisterTargetsRequest().withTargetGroupArn(it).withTargets(targets))
+          elbv2.deregisterTargets(DeregisterTargetsRequest.builder().targetGroupArn(it).targets(targets).build())
         }
       }
     }

--- a/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/CopyLastAsgAtomicOperation.groovy
+++ b/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/CopyLastAsgAtomicOperation.groovy
@@ -23,7 +23,7 @@ import software.amazon.awssdk.services.autoscaling.model.LaunchTemplateSpecifica
 import software.amazon.awssdk.services.ec2.model.DescribeSubnetsRequest
 import software.amazon.awssdk.services.ec2.model.LaunchTemplateVersion
 import software.amazon.awssdk.services.ec2.model.ResponseLaunchTemplateData
-import com.amazonaws.services.elasticloadbalancingv2.model.DescribeTargetGroupsRequest
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.DescribeTargetGroupsRequest
 import com.netflix.frigga.Names
 import com.netflix.frigga.autoscaling.AutoScalingGroupNameBuilder
 import com.netflix.spinnaker.clouddriver.aws.deploy.asg.AsgConfigHelper
@@ -254,8 +254,8 @@ class CopyLastAsgAtomicOperation implements AtomicOperation<DeploymentResult> {
         newDescription.loadBalancers = description.loadBalancers != null ? description.loadBalancers : ancestorAsg.loadBalancerNames()
         newDescription.targetGroups = description.targetGroups
         if (newDescription.targetGroups == null && ancestorAsg.targetGroupARNs() && ancestorAsg.targetGroupARNs().size() > 0) {
-          def targetGroups = sourceRegionScopedProvider.getAmazonElasticLoadBalancingV2(true).describeTargetGroups(new DescribeTargetGroupsRequest().withTargetGroupArns(ancestorAsg.targetGroupARNs())).targetGroups
-          def targetGroupNames = targetGroups.collect { it.targetGroupName }
+          def targetGroups = sourceRegionScopedProvider.getElasticLoadBalancingV2Client().describeTargetGroups(DescribeTargetGroupsRequest.builder().targetGroupArns(ancestorAsg.targetGroupARNs()).build()).targetGroups()
+          def targetGroupNames = targetGroups.collect { it.targetGroupName() }
           newDescription.targetGroups = targetGroupNames
         }
 

--- a/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/TerminateInstanceAndDecrementAsgAtomicOperation.groovy
+++ b/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/TerminateInstanceAndDecrementAsgAtomicOperation.groovy
@@ -21,8 +21,8 @@ import software.amazon.awssdk.services.autoscaling.model.AutoScalingGroup
 import software.amazon.awssdk.services.autoscaling.model.DescribeAutoScalingGroupsRequest
 import software.amazon.awssdk.services.autoscaling.model.TerminateInstanceInAutoScalingGroupRequest
 import software.amazon.awssdk.services.autoscaling.model.UpdateAutoScalingGroupRequest
-import com.amazonaws.services.elasticloadbalancing.model.DeregisterInstancesFromLoadBalancerRequest
-import com.amazonaws.services.elasticloadbalancing.model.Instance
+import software.amazon.awssdk.services.elasticloadbalancing.model.DeregisterInstancesFromLoadBalancerRequest
+import software.amazon.awssdk.services.elasticloadbalancing.model.Instance
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
@@ -70,9 +70,12 @@ class TerminateInstanceAndDecrementAsgAtomicOperation implements AtomicOperation
         throw new IllegalStateException("Invalid ASG capacity for terminateAndDecrementAsg: min: ${asg.minSize()}, max: ${asg.maxSize()}, desired: ${asg.desiredCapacity()}")
       }
     }
-    def loadBalancing = amazonClientProvider.getAmazonElasticLoadBalancing(description.credentials, description.region, true)
+    def loadBalancing = amazonClientProvider.getAmazonElasticLoadBalancingClassicV2(description.credentials, description.region)
     for (loadBalancer in asg.loadBalancerNames()) {
-      def deregisterRequest = new DeregisterInstancesFromLoadBalancerRequest(loadBalancer, [new Instance(description.instance)])
+      def deregisterRequest = DeregisterInstancesFromLoadBalancerRequest.builder()
+          .loadBalancerName(loadBalancer)
+          .instances(Instance.builder().instanceId(description.instance).build())
+          .build()
       loadBalancing.deregisterInstancesFromLoadBalancer(deregisterRequest)
     }
 

--- a/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/discovery/AbstractEnableDisableInstanceDiscoveryAtomicOperation.groovy
+++ b/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/discovery/AbstractEnableDisableInstanceDiscoveryAtomicOperation.groovy
@@ -17,7 +17,7 @@
 package com.netflix.spinnaker.clouddriver.aws.deploy.ops.discovery
 
 import software.amazon.awssdk.services.autoscaling.model.AutoScalingGroup
-import com.amazonaws.services.elasticloadbalancing.model.Instance
+import software.amazon.awssdk.services.elasticloadbalancing.model.Instance
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.eureka.deploy.ops.AbstractEurekaSupport
@@ -62,7 +62,7 @@ abstract class AbstractEnableDisableInstanceDiscoveryAtomicOperation implements 
       }*.instanceId as Set<String>
       def instancesInAsg = description.instanceIds.findAll {
         asgInstanceIds.contains(it)
-      }.collect { new Instance(it)}
+      }.collect { Instance.builder().instanceId(it).build() }
 
       if (!instancesInAsg) {
         return
@@ -70,7 +70,7 @@ abstract class AbstractEnableDisableInstanceDiscoveryAtomicOperation implements 
 
       def status = isEnable() ? AbstractEurekaSupport.DiscoveryStatus.UP : AbstractEurekaSupport.DiscoveryStatus.OUT_OF_SERVICE
       discoverySupport.updateDiscoveryStatusForInstances(
-          description, task, phaseName, status, instancesInAsg*.instanceId, true
+          description, task, phaseName, status, instancesInAsg*.instanceId(), true
       )
     }
 

--- a/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/loadbalancer/LoadBalancerLookupHelper.groovy
+++ b/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/loadbalancer/LoadBalancerLookupHelper.groovy
@@ -17,8 +17,8 @@
 package com.netflix.spinnaker.clouddriver.aws.deploy.ops.loadbalancer
 
 import software.amazon.awssdk.services.autoscaling.model.AutoScalingGroup
-import com.amazonaws.services.elasticloadbalancing.model.DescribeLoadBalancersRequest
-import com.amazonaws.services.elasticloadbalancing.model.LoadBalancerNotFoundException
+import software.amazon.awssdk.services.elasticloadbalancing.model.DescribeLoadBalancersRequest
+import software.amazon.awssdk.services.elasticloadbalancing.model.LoadBalancerNotFoundException
 import com.netflix.spinnaker.clouddriver.aws.services.RegionScopedProviderFactory
 
 class LoadBalancerLookupHelper {
@@ -43,10 +43,10 @@ class LoadBalancerLookupHelper {
     if (!allLoadBalancers) {
       return result
     }
-    def elbClassic = rsp.getAmazonElasticLoadBalancing()
+    def elbClassic = rsp.getAmazonElasticLoadBalancingClassicV2()
     for (String lbName : allLoadBalancers) {
       try {
-        def foo = elbClassic.describeLoadBalancers(new DescribeLoadBalancersRequest().withLoadBalancerNames(lbName))
+        def foo = elbClassic.describeLoadBalancers(DescribeLoadBalancersRequest.builder().loadBalancerNames(lbName).build())
         result.classicLoadBalancers.add(lbName)
       } catch (LoadBalancerNotFoundException loadBalancerNotFoundException) {
         // ignore

--- a/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/loadbalancer/TargetGroupLookupHelper.groovy
+++ b/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/loadbalancer/TargetGroupLookupHelper.groovy
@@ -16,15 +16,11 @@
 
 package com.netflix.spinnaker.clouddriver.aws.deploy.ops.loadbalancer
 
-import com.amazonaws.AmazonServiceException
 import software.amazon.awssdk.services.autoscaling.model.AutoScalingGroup
-import com.amazonaws.services.elasticloadbalancingv2.model.DescribeTargetGroupsRequest
-import com.amazonaws.services.elasticloadbalancingv2.model.LoadBalancerNotFoundException
-import com.amazonaws.services.elasticloadbalancingv2.model.TargetGroupNotFoundException
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.DescribeTargetGroupsRequest
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.LoadBalancerNotFoundException
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.TargetGroupNotFoundException
 import com.netflix.spinnaker.clouddriver.aws.services.RegionScopedProviderFactory
-
-import java.lang.reflect.InvocationTargetException
-import java.lang.reflect.UndeclaredThrowableException
 
 class TargetGroupLookupHelper {
 
@@ -48,40 +44,17 @@ class TargetGroupLookupHelper {
     if (!allTargetGroups) {
       return result
     }
-    def lbv2 = rsp.getAmazonElasticLoadBalancingV2(false)
+    def lbv2 = rsp.getElasticLoadBalancingV2Client()
     Set<String> targetGroups = []
     for (String targetGroupName : allTargetGroups) {
       try {
-        def targetGroup = lbv2.describeTargetGroups(new DescribeTargetGroupsRequest().withNames(targetGroupName)).targetGroups.first()
+        def targetGroup = lbv2.describeTargetGroups(DescribeTargetGroupsRequest.builder().names(targetGroupName).build()).targetGroups().first()
         targetGroups.add(targetGroupName)
-        result.targetGroupARNs.add(targetGroup.targetGroupArn)
+        result.targetGroupARNs.add(targetGroup.targetGroupArn())
       } catch (LoadBalancerNotFoundException ignore) {
         // ignore
       } catch (TargetGroupNotFoundException ignore) {
         // ignore
-      } catch (UndeclaredThrowableException e) {
-        // There are edda calls hidden behind an .invoke from Aws SDK. Exceptions from
-        // those methods show up wrapped in UndeclaredThrowable and/or InvocationTarget
-        // If it is a legitimate failure, makes sense to throw the actual error
-        boolean rethrow = true
-        Throwable toRethrow = e.undeclaredThrowable
-
-        if (e.undeclaredThrowable instanceof InvocationTargetException) {
-          InvocationTargetException ite = (InvocationTargetException)e.undeclaredThrowable
-
-          toRethrow = ite.targetException
-          if (ite.targetException instanceof AmazonServiceException) {
-            AmazonServiceException ase = (AmazonServiceException)ite.targetException
-
-            if (ase.statusCode == 404) {
-              rethrow = false
-            }
-          }
-        }
-
-        if (rethrow) {
-          throw toRethrow
-        }
       }
     }
 

--- a/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/services/RegionScopedProviderFactory.groovy
+++ b/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/services/RegionScopedProviderFactory.groovy
@@ -84,17 +84,6 @@ class RegionScopedProviderFactory {
       amazonClientProvider.getAutoScalingV2(amazonCredentials, region)
     }
 
-    com.amazonaws.services.elasticloadbalancingv2.AmazonElasticLoadBalancing getAmazonElasticLoadBalancingV2(boolean skipEdda) {
-      amazonClientProvider.getAmazonElasticLoadBalancingV2(amazonCredentials, region, skipEdda)
-    }
-
-    com.amazonaws.services.elasticloadbalancing.AmazonElasticLoadBalancing getAmazonElasticLoadBalancing() {
-      amazonClientProvider.getAmazonElasticLoadBalancing(amazonCredentials, region, true)
-    }
-
-    // AWS SDK v2 equivalents. No skipEdda parameter: Edda read-through is v1-only. Kept alongside
-    // the v1 methods above (not replacing them) since some consumers of this class still depend on
-    // the v1 EC2/AutoScaling methods elsewhere in RegionScopedProvider and haven't migrated yet.
     software.amazon.awssdk.services.elasticloadbalancingv2.ElasticLoadBalancingV2Client getElasticLoadBalancingV2Client() {
       amazonClientProvider.getElasticLoadBalancingV2Client(amazonCredentials, region)
     }

--- a/clouddriver/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/security/AmazonClientProvider.java
+++ b/clouddriver/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/security/AmazonClientProvider.java
@@ -490,21 +490,6 @@ public class AmazonClientProvider {
   }
 
   public AmazonElasticLoadBalancing getAmazonElasticLoadBalancing(
-      NetflixAmazonCredentials amazonCredentials, String region) {
-    return getAmazonElasticLoadBalancing(amazonCredentials, region, false);
-  }
-
-  public AmazonElasticLoadBalancing getAmazonElasticLoadBalancing(
-      NetflixAmazonCredentials amazonCredentials, String region, boolean skipEdda) {
-    return proxyHandlerBuilder.getProxyHandler(
-        AmazonElasticLoadBalancing.class,
-        AmazonElasticLoadBalancingClientBuilder.class,
-        amazonCredentials,
-        region,
-        skipEdda);
-  }
-
-  public AmazonElasticLoadBalancing getAmazonElasticLoadBalancing(
       String accountName, AWSCredentialsProvider awsCredentialsProvider, String region) {
     return awsSdkClientSupplier.getClient(
         AmazonElasticLoadBalancingClientBuilder.class,
@@ -512,22 +497,6 @@ public class AmazonClientProvider {
         accountName,
         awsCredentialsProvider,
         region);
-  }
-
-  public com.amazonaws.services.elasticloadbalancingv2.AmazonElasticLoadBalancing
-      getAmazonElasticLoadBalancingV2(NetflixAmazonCredentials amazonCredentials, String region) {
-    return getAmazonElasticLoadBalancingV2(amazonCredentials, region, false);
-  }
-
-  public com.amazonaws.services.elasticloadbalancingv2.AmazonElasticLoadBalancing
-      getAmazonElasticLoadBalancingV2(
-          NetflixAmazonCredentials amazonCredentials, String region, boolean skipEdda) {
-    return proxyHandlerBuilder.getProxyHandler(
-        com.amazonaws.services.elasticloadbalancingv2.AmazonElasticLoadBalancing.class,
-        com.amazonaws.services.elasticloadbalancingv2.AmazonElasticLoadBalancingClientBuilder.class,
-        amazonCredentials,
-        region,
-        skipEdda);
   }
 
   public com.amazonaws.services.elasticloadbalancingv2.AmazonElasticLoadBalancing

--- a/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandlerUnitSpec.groovy
+++ b/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandlerUnitSpec.groovy
@@ -38,14 +38,14 @@ import software.amazon.awssdk.services.ec2.model.LaunchTemplateVersion
 import software.amazon.awssdk.services.ec2.model.ProcessorInfo
 import software.amazon.awssdk.services.ec2.model.ResponseLaunchTemplateData
 import software.amazon.awssdk.services.ec2.model.VpcClassicLink
-import com.amazonaws.services.elasticloadbalancing.AmazonElasticLoadBalancing as AmazonELBV1
-import com.amazonaws.services.elasticloadbalancing.model.DescribeLoadBalancersResult
-import com.amazonaws.services.elasticloadbalancing.model.LoadBalancerDescription
-import com.amazonaws.services.elasticloadbalancing.model.LoadBalancerNotFoundException as LBNFEV1
-import com.amazonaws.services.elasticloadbalancingv2.AmazonElasticLoadBalancing
-import com.amazonaws.services.elasticloadbalancingv2.model.DescribeTargetGroupsRequest
-import com.amazonaws.services.elasticloadbalancingv2.model.DescribeTargetGroupsResult
-import com.amazonaws.services.elasticloadbalancingv2.model.TargetGroup
+import software.amazon.awssdk.services.elasticloadbalancing.ElasticLoadBalancingClient
+import software.amazon.awssdk.services.elasticloadbalancing.model.DescribeLoadBalancersResponse
+import software.amazon.awssdk.services.elasticloadbalancing.model.LoadBalancerDescription
+import software.amazon.awssdk.services.elasticloadbalancing.model.LoadBalancerNotFoundException as LBNFEV1
+import software.amazon.awssdk.services.elasticloadbalancingv2.ElasticLoadBalancingV2Client
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.DescribeTargetGroupsRequest
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.DescribeTargetGroupsResponse
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.TargetGroup
 import com.netflix.spinnaker.clouddriver.aws.deploy.asg.LaunchTemplateRollOutConfig
 import com.netflix.spinnaker.clouddriver.aws.services.LaunchTemplateService
 import com.netflix.spinnaker.clouddriver.deploy.DeploymentResult
@@ -99,8 +99,8 @@ class BasicAmazonDeployHandlerUnitSpec extends Specification {
   Task task = Mock(Task)
 
   Ec2Client amazonEC2 = Mock(Ec2Client)
-  AmazonElasticLoadBalancing elbV2 = Mock(AmazonElasticLoadBalancing)
-  AmazonELBV1 elbV1 = Mock(AmazonELBV1)
+  ElasticLoadBalancingV2Client elbV2 = Mock(ElasticLoadBalancingV2Client)
+  ElasticLoadBalancingClient elbV1 = Mock(ElasticLoadBalancingClient)
   AwsConfiguration.AmazonServerGroupProvider amazonServerGroupProvider = Mock(AwsConfiguration.AmazonServerGroupProvider)
 
   String instanceType
@@ -120,8 +120,8 @@ class BasicAmazonDeployHandlerUnitSpec extends Specification {
       forRegion(_, _) >> Stub(RegionScopedProviderFactory.RegionScopedProvider) {
         getAutoScaling() >> Stub(AutoScalingClient)
         getAmazonEC2() >> amazonEC2
-        getAmazonElasticLoadBalancingV2(_) >> elbV2
-        getAmazonElasticLoadBalancing() >> elbV1
+        getElasticLoadBalancingV2Client() >> elbV2
+        getAmazonElasticLoadBalancingClassicV2() >> elbV1
       }
     }
     def defaults = new AwsConfiguration.DeployDefaults(iamRole: 'IamRole')
@@ -195,7 +195,7 @@ class BasicAmazonDeployHandlerUnitSpec extends Specification {
     then:
     setlbCalls
     classicLbs == ['lb']
-    1 * elbV1.describeLoadBalancers(_) >> new DescribeLoadBalancersResult().withLoadBalancerDescriptions(new LoadBalancerDescription().withLoadBalancerName("lb"))
+    1 * elbV1.describeLoadBalancers(_) >> DescribeLoadBalancersResponse.builder().loadBalancerDescriptions(LoadBalancerDescription.builder().loadBalancerName("lb").build()).build()
     1 * amazonEC2.describeVpcClassicLink() >> DescribeVpcClassicLinkResponse.builder().build()
   }
 
@@ -213,7 +213,7 @@ class BasicAmazonDeployHandlerUnitSpec extends Specification {
     handler.handle(description, [])
 
     then:
-    1 * elbV1.describeLoadBalancers(_) >> new DescribeLoadBalancersResult().withLoadBalancerDescriptions(new LoadBalancerDescription().withLoadBalancerName("lb"))
+    1 * elbV1.describeLoadBalancers(_) >> DescribeLoadBalancersResponse.builder().loadBalancerDescriptions(LoadBalancerDescription.builder().loadBalancerName("lb").build()).build()
     1 * amazonEC2.describeVpcClassicLink() >> DescribeVpcClassicLinkResponse.builder().build()
 
     classicLbs == ['lb']
@@ -254,7 +254,7 @@ class BasicAmazonDeployHandlerUnitSpec extends Specification {
     handler.handle(description, [])
 
     then:
-    1 * elbV2.describeTargetGroups(new DescribeTargetGroupsRequest().withNames("tg")) >> new DescribeTargetGroupsResult().withTargetGroups(new TargetGroup().withTargetGroupArn("arn:lb:targetGroup1"))
+    1 * elbV2.describeTargetGroups(DescribeTargetGroupsRequest.builder().names("tg").build()) >> DescribeTargetGroupsResponse.builder().targetGroups(TargetGroup.builder().targetGroupArn("arn:lb:targetGroup1").build()).build()
     1 * amazonEC2.describeVpcClassicLink() >> DescribeVpcClassicLinkResponse.builder().build()
 
     targetGroupARNs == ['arn:lb:targetGroup1']
@@ -269,7 +269,7 @@ class BasicAmazonDeployHandlerUnitSpec extends Specification {
     handler.handle(description, [])
 
     then:
-    1 * elbV1.describeLoadBalancers(_) >> { throw new LBNFEV1("not found") }
+    1 * elbV1.describeLoadBalancers(_) >> { throw LBNFEV1.builder().message("not found").build() }
 
     thrown(IllegalStateException)
 

--- a/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/DeregisterInstancesFromLoadBalancerAtomicOperationUnitSpec.groovy
+++ b/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/DeregisterInstancesFromLoadBalancerAtomicOperationUnitSpec.groovy
@@ -18,10 +18,10 @@ package com.netflix.spinnaker.clouddriver.aws.deploy.ops
 
 import software.amazon.awssdk.services.autoscaling.model.AutoScalingGroup
 import software.amazon.awssdk.services.autoscaling.model.Instance
-import com.amazonaws.services.elasticloadbalancing.model.DeregisterInstancesFromLoadBalancerRequest
-import com.amazonaws.services.elasticloadbalancing.model.DescribeLoadBalancersRequest
-import com.amazonaws.services.elasticloadbalancing.model.DescribeLoadBalancersResult
-import com.amazonaws.services.elasticloadbalancing.model.LoadBalancerDescription
+import software.amazon.awssdk.services.elasticloadbalancing.model.DeregisterInstancesFromLoadBalancerRequest
+import software.amazon.awssdk.services.elasticloadbalancing.model.DescribeLoadBalancersRequest
+import software.amazon.awssdk.services.elasticloadbalancing.model.DescribeLoadBalancersResponse
+import software.amazon.awssdk.services.elasticloadbalancing.model.LoadBalancerDescription
 import com.netflix.spinnaker.clouddriver.aws.deploy.ops.loadbalancer.LoadBalancerLookupHelper
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
@@ -57,8 +57,8 @@ class DeregisterInstancesFromLoadBalancerAtomicOperationUnitSpec extends Instanc
     then:
     1 * asgService.getAutoScalingGroup(description.asgName) >> asg
     1 * loadBalancing.deregisterInstancesFromLoadBalancer(_) >> { DeregisterInstancesFromLoadBalancerRequest req ->
-      assert req.instances*.instanceId == description.instanceIds
-      assert req.loadBalancerName == "lb1"
+      assert req.instances()*.instanceId() == description.instanceIds
+      assert req.loadBalancerName() == "lb1"
     }
   }
 
@@ -88,10 +88,10 @@ class DeregisterInstancesFromLoadBalancerAtomicOperationUnitSpec extends Instanc
 
     then:
     0 * asgService.getAutoScalingGroup(_)
-    2 * loadBalancing.describeLoadBalancers(_) >> { DescribeLoadBalancersRequest req -> new DescribeLoadBalancersResult().withLoadBalancerDescriptions(new LoadBalancerDescription().withLoadBalancerName(req.loadBalancerNames[0]))}
+    2 * loadBalancing.describeLoadBalancers(_) >> { DescribeLoadBalancersRequest req -> DescribeLoadBalancersResponse.builder().loadBalancerDescriptions(LoadBalancerDescription.builder().loadBalancerName(req.loadBalancerNames()[0]).build()).build()}
     2 * loadBalancing.deregisterInstancesFromLoadBalancer(_) >> { DeregisterInstancesFromLoadBalancerRequest req ->
-      assert req.instances*.instanceId == description.instanceIds
-      assert description.loadBalancerNames.contains(req.loadBalancerName)
+      assert req.instances()*.instanceId() == description.instanceIds
+      assert description.loadBalancerNames.contains(req.loadBalancerName())
     }
   }
 

--- a/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/DeregisterInstancesFromTargetGroupsAtomicOperationUnitSpec.groovy
+++ b/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/DeregisterInstancesFromTargetGroupsAtomicOperationUnitSpec.groovy
@@ -18,10 +18,10 @@ package com.netflix.spinnaker.clouddriver.aws.deploy.ops
 
 import software.amazon.awssdk.services.autoscaling.model.AutoScalingGroup
 import software.amazon.awssdk.services.autoscaling.model.Instance
-import com.amazonaws.services.elasticloadbalancingv2.model.DeregisterTargetsRequest
-import com.amazonaws.services.elasticloadbalancingv2.model.DescribeTargetGroupsRequest
-import com.amazonaws.services.elasticloadbalancingv2.model.DescribeTargetGroupsResult
-import com.amazonaws.services.elasticloadbalancingv2.model.TargetGroup
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.DeregisterTargetsRequest
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.DescribeTargetGroupsRequest
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.DescribeTargetGroupsResponse
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.TargetGroup
 import com.netflix.spinnaker.clouddriver.aws.TestCredential
 import com.netflix.spinnaker.clouddriver.aws.deploy.ops.loadbalancer.TargetGroupLookupHelper
 import com.netflix.spinnaker.clouddriver.data.task.Task
@@ -57,8 +57,8 @@ class DeregisterInstancesFromTargetGroupsAtomicOperationUnitSpec extends Instanc
     then:
     1 * asgService.getAutoScalingGroup(description.asgName) >> asg
     1 * loadBalancingV2.deregisterTargets(_) >> { DeregisterTargetsRequest req ->
-      assert req.targets*.id == description.instanceIds
-      assert req.targetGroupArn == "tg1"
+      assert req.targets()*.id() == description.instanceIds
+      assert req.targetGroupArn() == "tg1"
     }
   }
 
@@ -88,10 +88,10 @@ class DeregisterInstancesFromTargetGroupsAtomicOperationUnitSpec extends Instanc
 
     then:
     0 * asgService.getAutoScalingGroup(_)
-    2 * loadBalancingV2.describeTargetGroups(_) >> { DescribeTargetGroupsRequest req -> new DescribeTargetGroupsResult().withTargetGroups(new TargetGroup().withTargetGroupName(req.getNames()[0]).withTargetGroupArn(req.getNames()[0]))}
+    2 * loadBalancingV2.describeTargetGroups(_) >> { DescribeTargetGroupsRequest req -> DescribeTargetGroupsResponse.builder().targetGroups(TargetGroup.builder().targetGroupName(req.names()[0]).targetGroupArn(req.names()[0]).build()).build()}
     2 * loadBalancingV2.deregisterTargets(_) >> { DeregisterTargetsRequest req ->
-      assert req.targets*.id == description.instanceIds
-      assert description.targetGroupNames.contains(req.targetGroupArn)
+      assert req.targets()*.id() == description.instanceIds
+      assert description.targetGroupNames.contains(req.targetGroupArn())
     }
   }
 

--- a/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/DisableAsgAtomicOperationUnitSpec.groovy
+++ b/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/DisableAsgAtomicOperationUnitSpec.groovy
@@ -21,8 +21,8 @@ import software.amazon.awssdk.services.ec2.model.Instance
 import software.amazon.awssdk.services.ec2.model.InstanceState
 import software.amazon.awssdk.services.ec2.model.InstanceStateName
 import software.amazon.awssdk.services.ec2.model.Reservation
-import com.amazonaws.services.elasticloadbalancing.model.DeregisterInstancesFromLoadBalancerRequest
-import com.amazonaws.services.elasticloadbalancing.model.LoadBalancerNotFoundException
+import software.amazon.awssdk.services.elasticloadbalancing.model.DeregisterInstancesFromLoadBalancerRequest
+import software.amazon.awssdk.services.elasticloadbalancing.model.LoadBalancerNotFoundException
 import com.netflix.spinnaker.clouddriver.aws.TestCredential
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.EnableDisableAsgDescription
 import com.netflix.spinnaker.clouddriver.aws.deploy.ops.discovery.AwsEurekaSupport
@@ -65,8 +65,8 @@ class DisableAsgAtomicOperationUnitSpec extends EnableDisableAtomicOperationUnit
     1 * asgService.getAutoScalingGroup(_) >> asg
     1 * asgService.suspendProcesses(_, AutoScalingProcessType.getDisableProcesses())
     1 * loadBalancing.deregisterInstancesFromLoadBalancer(_) >> { DeregisterInstancesFromLoadBalancerRequest req ->
-      assert req.instances[0].instanceId == "i1"
-      assert req.loadBalancerName == "lb1"
+      assert req.instances()[0].instanceId() == "i1"
+      assert req.loadBalancerName() == "lb1"
     }
   }
 
@@ -90,7 +90,7 @@ class DisableAsgAtomicOperationUnitSpec extends EnableDisableAtomicOperationUnit
     1 * asgService.getAutoScalingGroup(_) >> asg
     1 * asgService.suspendProcesses(_, AutoScalingProcessType.getDisableProcesses())
     1 * loadBalancing.deregisterInstancesFromLoadBalancer(_) >> {
-      throw new LoadBalancerNotFoundException("Does not exist")
+      throw LoadBalancerNotFoundException.builder().message("Does not exist").build()
     }
     1 * eureka.getInstanceInfo('i1') >>
       Calls.response([

--- a/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/EnableAsgAtomicOperationUnitSpec.groovy
+++ b/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/EnableAsgAtomicOperationUnitSpec.groovy
@@ -20,7 +20,7 @@ import software.amazon.awssdk.services.ec2.model.Instance
 import software.amazon.awssdk.services.ec2.model.InstanceState
 import software.amazon.awssdk.services.ec2.model.InstanceStateName
 import software.amazon.awssdk.services.ec2.model.Reservation
-import com.amazonaws.services.elasticloadbalancing.model.RegisterInstancesWithLoadBalancerRequest
+import software.amazon.awssdk.services.elasticloadbalancing.model.RegisterInstancesWithLoadBalancerRequest
 import com.netflix.spinnaker.clouddriver.aws.TestCredential
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.EnableDisableAsgDescription
 import com.netflix.spinnaker.clouddriver.aws.model.AutoScalingProcessType
@@ -58,8 +58,8 @@ class EnableAsgAtomicOperationUnitSpec extends EnableDisableAtomicOperationUnitS
     1 * asgService.getAutoScalingGroup(_) >> asg
     1 * asgService.resumeProcesses(_, AutoScalingProcessType.getDisableProcesses())
     1 * loadBalancing.registerInstancesWithLoadBalancer(_) >> { RegisterInstancesWithLoadBalancerRequest req ->
-      assert req.instances[0].instanceId == "i1"
-      assert req.loadBalancerName == "lb1"
+      assert req.instances()[0].instanceId() == "i1"
+      assert req.loadBalancerName() == "lb1"
     }
   }
 

--- a/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/EnableDisableAtomicOperationUnitSpecSupport.groovy
+++ b/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/EnableDisableAtomicOperationUnitSpecSupport.groovy
@@ -17,8 +17,8 @@
 package com.netflix.spinnaker.clouddriver.aws.deploy.ops
 
 import software.amazon.awssdk.services.ec2.Ec2Client
-import com.amazonaws.services.elasticloadbalancing.AmazonElasticLoadBalancing
-import com.amazonaws.services.elasticloadbalancingv2.AmazonElasticLoadBalancing as AmazonElasticLoadBalancingV2
+import software.amazon.awssdk.services.elasticloadbalancing.ElasticLoadBalancingClient
+import software.amazon.awssdk.services.elasticloadbalancingv2.ElasticLoadBalancingV2Client
 import com.netflix.spinnaker.clouddriver.aws.TestCredential
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.EnableDisableAsgDescription
 import com.netflix.spinnaker.clouddriver.aws.deploy.ops.discovery.AwsEurekaSupport
@@ -54,10 +54,10 @@ abstract class EnableDisableAtomicOperationUnitSpecSupport extends Specification
   Eureka eureka
 
   @Shared
-  AmazonElasticLoadBalancing loadBalancing
+  ElasticLoadBalancingClient loadBalancing
 
   @Shared
-  AmazonElasticLoadBalancingV2 loadBalancingV2
+  ElasticLoadBalancingV2Client loadBalancingV2
 
   @Shared
   Ec2Client amazonEc2
@@ -67,8 +67,8 @@ abstract class EnableDisableAtomicOperationUnitSpecSupport extends Specification
     TaskRepository.threadLocalTask.set(task)
     eureka = Mock(Eureka)
     asgService = Mock(AsgService)
-    loadBalancing = Mock(AmazonElasticLoadBalancing)
-    loadBalancingV2 = Mock(AmazonElasticLoadBalancingV2)
+    loadBalancing = Mock(ElasticLoadBalancingClient)
+    loadBalancingV2 = Mock(ElasticLoadBalancingV2Client)
     amazonEc2 = Mock(Ec2Client)
     wireOpMocks(op)
   }
@@ -78,8 +78,8 @@ abstract class EnableDisableAtomicOperationUnitSpecSupport extends Specification
       forRegion(_, _) >> {
         return Stub(RegionScopedProviderFactory.RegionScopedProvider) {
           getAsgService() >> asgService
-          getAmazonElasticLoadBalancing() >> loadBalancing
-          getAmazonElasticLoadBalancingV2() >> loadBalancingV2
+          getAmazonElasticLoadBalancingClassicV2() >> loadBalancing
+          getElasticLoadBalancingV2Client() >> loadBalancingV2
           getEureka() >> eureka
           getAmazonEC2() >> amazonEc2
         }

--- a/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/InstanceLoadBalancerRegistrationUnitSpecSupport.groovy
+++ b/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/InstanceLoadBalancerRegistrationUnitSpecSupport.groovy
@@ -16,7 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.aws.deploy.ops
 
-import com.amazonaws.services.elasticloadbalancing.AmazonElasticLoadBalancing
+import software.amazon.awssdk.services.elasticloadbalancing.ElasticLoadBalancingClient
 import com.netflix.spinnaker.clouddriver.aws.TestCredential
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.InstanceLoadBalancerRegistrationDescription
 import com.netflix.spinnaker.clouddriver.aws.services.AsgService
@@ -39,18 +39,18 @@ class InstanceLoadBalancerRegistrationUnitSpecSupport extends Specification {
   AsgService asgService
 
   @Shared
-  AmazonElasticLoadBalancing loadBalancing
+  ElasticLoadBalancingClient loadBalancing
 
   def setup() {
     asgService = Mock(AsgService)
-    loadBalancing = Mock(AmazonElasticLoadBalancing)
+    loadBalancing = Mock(ElasticLoadBalancingClient)
     wireOpMocks(op)
   }
 
   def wireOpMocks(AbstractInstanceLoadBalancerRegistrationAtomicOperation op) {
     def rsp = Stub(RegionScopedProviderFactory.RegionScopedProvider)
     rsp.getAsgService() >> asgService
-    rsp.getAmazonElasticLoadBalancing() >> loadBalancing
+    rsp.getAmazonElasticLoadBalancingClassicV2() >> loadBalancing
 
     def rspf = Mock(RegionScopedProviderFactory)
     rspf.forRegion(_, _) >> rsp

--- a/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/InstanceTargetGroupRegistrationUnitSpecSupport.groovy
+++ b/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/InstanceTargetGroupRegistrationUnitSpecSupport.groovy
@@ -16,8 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.aws.deploy.ops
 
-import com.amazonaws.services.elasticloadbalancing.AmazonElasticLoadBalancing
-import com.amazonaws.services.elasticloadbalancingv2.AmazonElasticLoadBalancing as AmazonElasticLoadBalancingV2
+import software.amazon.awssdk.services.elasticloadbalancingv2.ElasticLoadBalancingV2Client
 import com.netflix.spinnaker.clouddriver.aws.TestCredential
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.InstanceLoadBalancerRegistrationDescription
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.InstanceTargetGroupRegistrationDescription
@@ -41,18 +40,18 @@ class InstanceTargetGroupRegistrationUnitSpecSupport extends Specification {
   AsgService asgService
 
   @Shared
-  AmazonElasticLoadBalancingV2 loadBalancingV2
+  ElasticLoadBalancingV2Client loadBalancingV2
 
   def setup() {
     asgService = Mock(AsgService)
-    loadBalancingV2 = Mock(AmazonElasticLoadBalancingV2)
+    loadBalancingV2 = Mock(ElasticLoadBalancingV2Client)
     wireOpMocks(op)
   }
 
   def wireOpMocks(AbstractInstanceTargetGroupRegistrationAtomicOperation op) {
     def rsp = Stub(RegionScopedProviderFactory.RegionScopedProvider)
     rsp.getAsgService() >> asgService
-    rsp.getAmazonElasticLoadBalancingV2(_) >> loadBalancingV2
+    rsp.getElasticLoadBalancingV2Client() >> loadBalancingV2
 
     def rspf = Mock(RegionScopedProviderFactory)
     rspf.forRegion(_, _) >> rsp

--- a/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/RegisterInstancesWithLoadBalancerAtomicOperationUnitSpec.groovy
+++ b/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/RegisterInstancesWithLoadBalancerAtomicOperationUnitSpec.groovy
@@ -18,10 +18,10 @@ package com.netflix.spinnaker.clouddriver.aws.deploy.ops
 
 import software.amazon.awssdk.services.autoscaling.model.AutoScalingGroup
 import software.amazon.awssdk.services.autoscaling.model.Instance
-import com.amazonaws.services.elasticloadbalancing.model.DescribeLoadBalancersRequest
-import com.amazonaws.services.elasticloadbalancing.model.DescribeLoadBalancersResult
-import com.amazonaws.services.elasticloadbalancing.model.LoadBalancerDescription
-import com.amazonaws.services.elasticloadbalancing.model.RegisterInstancesWithLoadBalancerRequest
+import software.amazon.awssdk.services.elasticloadbalancing.model.DescribeLoadBalancersRequest
+import software.amazon.awssdk.services.elasticloadbalancing.model.DescribeLoadBalancersResponse
+import software.amazon.awssdk.services.elasticloadbalancing.model.LoadBalancerDescription
+import software.amazon.awssdk.services.elasticloadbalancing.model.RegisterInstancesWithLoadBalancerRequest
 import com.netflix.spinnaker.clouddriver.aws.deploy.ops.loadbalancer.LoadBalancerLookupHelper
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
@@ -55,8 +55,8 @@ class RegisterInstancesWithLoadBalancerAtomicOperationUnitSpec extends InstanceL
     then:
     1 * asgService.getAutoScalingGroup(description.asgName) >> asg
     1 * loadBalancing.registerInstancesWithLoadBalancer(_) >> { RegisterInstancesWithLoadBalancerRequest req ->
-      assert req.instances*.instanceId == description.instanceIds
-      assert req.loadBalancerName == "lb1"
+      assert req.instances()*.instanceId() == description.instanceIds
+      assert req.loadBalancerName() == "lb1"
     }
   }
 
@@ -91,10 +91,10 @@ class RegisterInstancesWithLoadBalancerAtomicOperationUnitSpec extends InstanceL
 
     then:
     0 * asgService.getAutoScalingGroup(_)
-    2 * loadBalancing.describeLoadBalancers(_) >> { DescribeLoadBalancersRequest r -> new DescribeLoadBalancersResult().withLoadBalancerDescriptions(new LoadBalancerDescription().withLoadBalancerName(r.loadBalancerNames[0]))}
+    2 * loadBalancing.describeLoadBalancers(_) >> { DescribeLoadBalancersRequest r -> DescribeLoadBalancersResponse.builder().loadBalancerDescriptions(LoadBalancerDescription.builder().loadBalancerName(r.loadBalancerNames()[0]).build()).build()}
     2 * loadBalancing.registerInstancesWithLoadBalancer(_) >> { RegisterInstancesWithLoadBalancerRequest req ->
-      assert req.instances*.instanceId == description.instanceIds
-      assert description.loadBalancerNames.contains(req.loadBalancerName)
+      assert req.instances()*.instanceId() == description.instanceIds
+      assert description.loadBalancerNames.contains(req.loadBalancerName())
     }
   }
 

--- a/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/RegisterInstancesWithTargetGroupsAtomicOperationUnitSpec.groovy
+++ b/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/RegisterInstancesWithTargetGroupsAtomicOperationUnitSpec.groovy
@@ -18,14 +18,10 @@ package com.netflix.spinnaker.clouddriver.aws.deploy.ops
 
 import software.amazon.awssdk.services.autoscaling.model.AutoScalingGroup
 import software.amazon.awssdk.services.autoscaling.model.Instance
-import com.amazonaws.services.elasticloadbalancing.model.DescribeLoadBalancersRequest
-import com.amazonaws.services.elasticloadbalancing.model.DescribeLoadBalancersResult
-import com.amazonaws.services.elasticloadbalancing.model.LoadBalancerDescription
-import com.amazonaws.services.elasticloadbalancing.model.RegisterInstancesWithLoadBalancerRequest
-import com.amazonaws.services.elasticloadbalancingv2.model.DescribeTargetGroupsRequest
-import com.amazonaws.services.elasticloadbalancingv2.model.DescribeTargetGroupsResult
-import com.amazonaws.services.elasticloadbalancingv2.model.RegisterTargetsRequest
-import com.amazonaws.services.elasticloadbalancingv2.model.TargetGroup
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.DescribeTargetGroupsRequest
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.DescribeTargetGroupsResponse
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.RegisterTargetsRequest
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.TargetGroup
 import com.netflix.spinnaker.clouddriver.aws.TestCredential
 import com.netflix.spinnaker.clouddriver.aws.deploy.ops.loadbalancer.LoadBalancerLookupHelper
 import com.netflix.spinnaker.clouddriver.aws.deploy.ops.loadbalancer.TargetGroupLookupHelper
@@ -60,8 +56,8 @@ class RegisterInstancesWithTargetGroupsAtomicOperationUnitSpec extends InstanceT
     then:
     1 * asgService.getAutoScalingGroup(description.asgName) >> asg
     1 * loadBalancingV2.registerTargets(_) >> { RegisterTargetsRequest req ->
-      assert req.targets*.id == description.instanceIds
-      assert req.targetGroupArn == "tg1"
+      assert req.targets()*.id() == description.instanceIds
+      assert req.targetGroupArn() == "tg1"
     }
   }
 
@@ -96,10 +92,10 @@ class RegisterInstancesWithTargetGroupsAtomicOperationUnitSpec extends InstanceT
 
     then:
     0 * asgService.getAutoScalingGroup(_)
-    2 * loadBalancingV2.describeTargetGroups(_) >> { DescribeTargetGroupsRequest req -> new DescribeTargetGroupsResult().withTargetGroups(new TargetGroup().withTargetGroupName(req.getNames()[0]).withTargetGroupArn(req.getNames()[0]))}
+    2 * loadBalancingV2.describeTargetGroups(_) >> { DescribeTargetGroupsRequest req -> DescribeTargetGroupsResponse.builder().targetGroups(TargetGroup.builder().targetGroupName(req.names()[0]).targetGroupArn(req.names()[0]).build()).build()}
     2 * loadBalancingV2.registerTargets(_) >> { RegisterTargetsRequest req ->
-      assert req.targets*.id == description.instanceIds
-      assert description.targetGroupNames.contains(req.targetGroupArn)
+      assert req.targets()*.id() == description.instanceIds
+      assert description.targetGroupNames.contains(req.targetGroupArn())
     }
   }
 

--- a/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/TerminateInstanceAndDecrementAsgAtomicOperationUnitSpec.groovy
+++ b/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/TerminateInstanceAndDecrementAsgAtomicOperationUnitSpec.groovy
@@ -22,9 +22,9 @@ import software.amazon.awssdk.services.autoscaling.model.DescribeAutoScalingGrou
 import software.amazon.awssdk.services.autoscaling.model.DescribeAutoScalingGroupsResponse
 import software.amazon.awssdk.services.autoscaling.model.TerminateInstanceInAutoScalingGroupRequest
 import software.amazon.awssdk.services.autoscaling.model.UpdateAutoScalingGroupRequest
-import com.amazonaws.services.elasticloadbalancing.AmazonElasticLoadBalancing
-import com.amazonaws.services.elasticloadbalancing.model.DeregisterInstancesFromLoadBalancerRequest
-import com.amazonaws.services.elasticloadbalancing.model.Instance
+import software.amazon.awssdk.services.elasticloadbalancing.ElasticLoadBalancingClient
+import software.amazon.awssdk.services.elasticloadbalancing.model.DeregisterInstancesFromLoadBalancerRequest
+import software.amazon.awssdk.services.elasticloadbalancing.model.Instance
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
@@ -72,10 +72,10 @@ class TerminateInstanceAndDecrementAsgAtomicOperationUnitSpec extends Specificat
   void "operation deregisters instances from load balancers"() {
     setup:
     def mockAutoScaling = Mock(AutoScalingClient)
-    def mockLoadBalancing = Mock(AmazonElasticLoadBalancing)
+    def mockLoadBalancing = Mock(ElasticLoadBalancingClient)
     def mockAmazonClientProvider = Stub(AmazonClientProvider) {
       getAutoScalingV2(_, _) >> mockAutoScaling
-      getAmazonElasticLoadBalancing(_, _, true) >> mockLoadBalancing
+      getAmazonElasticLoadBalancingClassicV2(_, _) >> mockLoadBalancing
     }
     def description = new TerminateInstanceAndDecrementAsgDescription(asgName: "myasg-stack-v000", region: "us-west-1", instance: "i-123456")
     description.credentials = TestCredential.named('baz')
@@ -98,8 +98,8 @@ class TerminateInstanceAndDecrementAsgAtomicOperationUnitSpec extends Specificat
       DescribeAutoScalingGroupsResponse.builder().autoScalingGroups(asg).build()
     }
     1 * mockLoadBalancing.deregisterInstancesFromLoadBalancer(_) >> { DeregisterInstancesFromLoadBalancerRequest request ->
-      assert request.instances == [new Instance('i-123456')]
-      assert request.loadBalancerName == 'myasg--frontend'
+      assert request.instances() == [Instance.builder().instanceId('i-123456').build()]
+      assert request.loadBalancerName() == 'myasg--frontend'
     }
     1 * mockAutoScaling.terminateInstanceInAutoScalingGroup(_) >> { TerminateInstanceInAutoScalingGroupRequest request ->
       assert request.instanceId == "i-123456"


### PR DESCRIPTION
## Summary
- Closes out leftover AWS SDK v1 ELB classic/ELBv2 client usage in ASG enable/disable, instance/target-group (de)registration, ASG copy, terminate-and-decrement, and instance-discovery operations.
- The v2 client accessors already existed (`getAmazonElasticLoadBalancingClassicV2`/`getElasticLoadBalancingV2Client`); this converts the remaining callers to use them and deletes the now-dead v1 `skipEdda`-flavored accessors once nothing calls them.
- Part 1 of a follow-up cleanup roadmap after the AWS SDK v1→v2 migration (PR1–PR11, all merged) — CloudWatch alarms/scaling-policies, S3, Route53, and Edda removal are separate, independent follow-up PRs.

## Test plan
- [x] `./gradlew :clouddriver:clouddriver-aws:compileJava :clouddriver:clouddriver-aws:compileGroovy :clouddriver:clouddriver-aws:compileTestGroovy :clouddriver:clouddriver-aws:compileTestJava` — clean
- [x] `./gradlew :clouddriver:clouddriver-aws:test` — 1473/1473 passing
- [x] `./gradlew :clouddriver:clouddriver-aws:integrationTest` — 30/30 passing
- [x] `./gradlew :clouddriver:clouddriver-aws:spotlessApply` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)