### PR TITLE
chore(aws): Migrate CloudWatch alarms and AutoScaling scaling policies to AWS SDK v2

### DIFF
--- a/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/agent/CleanupAlarmsAgent.groovy
+++ b/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/agent/CleanupAlarmsAgent.groovy
@@ -16,12 +16,12 @@
 
 package com.netflix.spinnaker.clouddriver.aws.agent
 
-import com.amazonaws.services.autoscaling.AmazonAutoScaling
-import com.amazonaws.services.cloudwatch.model.DeleteAlarmsRequest
-import com.amazonaws.services.cloudwatch.model.DescribeAlarmsRequest
-import com.amazonaws.services.cloudwatch.model.MetricAlarm
-import com.amazonaws.services.cloudwatch.model.StateValue
-import com.amazonaws.services.gamelift.model.DescribeScalingPoliciesRequest
+import software.amazon.awssdk.services.autoscaling.AutoScalingClient
+import software.amazon.awssdk.services.autoscaling.model.DescribePoliciesRequest
+import software.amazon.awssdk.services.cloudwatch.model.DeleteAlarmsRequest
+import software.amazon.awssdk.services.cloudwatch.model.DescribeAlarmsRequest
+import software.amazon.awssdk.services.cloudwatch.model.MetricAlarm
+import software.amazon.awssdk.services.cloudwatch.model.StateValue
 import com.netflix.spinnaker.cats.agent.RunnableAgent
 import com.netflix.spinnaker.clouddriver.aws.provider.AwsCleanupProvider
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
@@ -87,31 +87,32 @@ class CleanupAlarmsAgent implements RunnableAgent, CustomScheduledAgent {
       credentials.regions.each { AmazonCredentials.AWSRegion region ->
         log.info("Looking for alarms to delete")
         try {
-          def cloudWatch = amazonClientProvider.getCloudWatch(credentials, region.name)
-          Set<String> attachedAlarms = getAttachedAlarms(amazonClientProvider.getAutoScaling(credentials, region.name))
-          def describeAlarmsRequest = new DescribeAlarmsRequest().withStateValue(StateValue.INSUFFICIENT_DATA)
+          def cloudWatch = amazonClientProvider.getAmazonCloudWatchV2(credentials, region.name)
+          Set<String> attachedAlarms = getAttachedAlarms(amazonClientProvider.getAutoScalingV2(credentials, region.name))
+          def describeAlarmsRequest = DescribeAlarmsRequest.builder().stateValue(StateValue.INSUFFICIENT_DATA).build()
+          def cutoff = DateTime.now().minusDays(daysToLeave).toDate().toInstant()
 
           while (true) {
             def result = cloudWatch.describeAlarms(describeAlarmsRequest)
 
-            List<MetricAlarm> alarmsToDelete = result.metricAlarms.findAll {
-              it.stateUpdatedTimestamp.before(DateTime.now().minusDays(daysToLeave).toDate()) &&
-                !attachedAlarms.contains(it.alarmName) &&
-                ALARM_NAME_PATTERN.matcher(it.alarmName).matches()
+            List<MetricAlarm> alarmsToDelete = result.metricAlarms().findAll {
+              it.stateUpdatedTimestamp().isBefore(cutoff) &&
+                !attachedAlarms.contains(it.alarmName()) &&
+                ALARM_NAME_PATTERN.matcher(it.alarmName()).matches()
             }
 
             if (alarmsToDelete) {
               // terminate up to 20 alarms at a time (avoids any AWS limits on # of concurrent deletes)
-              alarmsToDelete.collate(20).each {
+              alarmsToDelete.collect { it.alarmName() }.collate(20).each {
                 log.info("Deleting ${it.size()} alarms in ${credentials.name}/${region.name} " +
-                  "(alarms: ${it.alarmName.join(", ")})")
-                cloudWatch.deleteAlarms(new DeleteAlarmsRequest().withAlarmNames(it.alarmName))
+                  "(alarms: ${it.join(", ")})")
+                cloudWatch.deleteAlarms(DeleteAlarmsRequest.builder().alarmNames(it).build())
                 Thread.sleep(500)
               }
             }
 
-            if (result.nextToken) {
-              describeAlarmsRequest.withNextToken(result.nextToken)
+            if (result.nextToken()) {
+              describeAlarmsRequest = describeAlarmsRequest.toBuilder().nextToken(result.nextToken()).build()
             } else {
               break
             }
@@ -127,15 +128,15 @@ class CleanupAlarmsAgent implements RunnableAgent, CustomScheduledAgent {
     return credentialsRepository.getAll()
   }
 
-  private static Set<String> getAttachedAlarms(AmazonAutoScaling autoScaling) {
+  private static Set<String> getAttachedAlarms(AutoScalingClient autoScaling) {
     Set<String> alarms = []
-    def request = new DescribeScalingPoliciesRequest()
+    def request = DescribePoliciesRequest.builder().build()
     while (true) {
-      def result = autoScaling.describePolicies()
-      alarms.addAll(result.scalingPolicies.alarms.alarmName.flatten())
+      def result = autoScaling.describePolicies(request)
+      alarms.addAll(result.scalingPolicies().collectMany { it.alarms() }*.alarmName())
 
-      if (result.nextToken) {
-        request.withNextToken(result.nextToken)
+      if (result.nextToken()) {
+        request = request.toBuilder().nextToken(result.nextToken()).build()
       } else {
         break
       }

--- a/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/DeleteAlarmDescription.groovy
+++ b/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/DeleteAlarmDescription.groovy
@@ -16,11 +16,6 @@
 
 package com.netflix.spinnaker.clouddriver.aws.deploy.description
 
-import com.amazonaws.services.cloudwatch.model.ComparisonOperator
-import com.amazonaws.services.cloudwatch.model.Dimension
-import com.amazonaws.services.cloudwatch.model.StandardUnit
-import com.amazonaws.services.cloudwatch.model.Statistic
-
 class DeleteAlarmDescription extends AbstractAmazonCredentialsDescription {
   Collection<String> names
   String region

--- a/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/UpsertAlarmDescription.groovy
+++ b/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/UpsertAlarmDescription.groovy
@@ -16,11 +16,8 @@
 
 package com.netflix.spinnaker.clouddriver.aws.deploy.description
 
-import software.amazon.awssdk.services.cloudwatch.model.ComparisonOperator
 import software.amazon.awssdk.services.cloudwatch.model.Dimension
 import software.amazon.awssdk.services.cloudwatch.model.PutMetricAlarmRequest
-import software.amazon.awssdk.services.cloudwatch.model.StandardUnit
-import software.amazon.awssdk.services.cloudwatch.model.Statistic
 import com.netflix.spinnaker.clouddriver.security.resources.ServerGroupsNameable
 
 class UpsertAlarmDescription extends AbstractAmazonCredentialsDescription implements ServerGroupsNameable {
@@ -31,7 +28,7 @@ class UpsertAlarmDescription extends AbstractAmazonCredentialsDescription implem
   Boolean actionsEnabled = true
 
   String alarmDescription
-  ComparisonOperator comparisonOperator
+  String comparisonOperator
 
   Collection<Dimension> dimensions
 
@@ -42,9 +39,9 @@ class UpsertAlarmDescription extends AbstractAmazonCredentialsDescription implem
   String namespace
   String metricName
 
-  Statistic statistic
+  String statistic
 
-  StandardUnit unit
+  String unit
 
   Collection<String> alarmActionArns
   Collection<String> insufficientDataActionArns

--- a/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/UpsertAlarmDescription.groovy
+++ b/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/UpsertAlarmDescription.groovy
@@ -16,11 +16,11 @@
 
 package com.netflix.spinnaker.clouddriver.aws.deploy.description
 
-import com.amazonaws.services.cloudwatch.model.ComparisonOperator
-import com.amazonaws.services.cloudwatch.model.Dimension
-import com.amazonaws.services.cloudwatch.model.PutMetricAlarmRequest
-import com.amazonaws.services.cloudwatch.model.StandardUnit
-import com.amazonaws.services.cloudwatch.model.Statistic
+import software.amazon.awssdk.services.cloudwatch.model.ComparisonOperator
+import software.amazon.awssdk.services.cloudwatch.model.Dimension
+import software.amazon.awssdk.services.cloudwatch.model.PutMetricAlarmRequest
+import software.amazon.awssdk.services.cloudwatch.model.StandardUnit
+import software.amazon.awssdk.services.cloudwatch.model.Statistic
 import com.netflix.spinnaker.clouddriver.security.resources.ServerGroupsNameable
 
 class UpsertAlarmDescription extends AbstractAmazonCredentialsDescription implements ServerGroupsNameable {
@@ -51,23 +51,23 @@ class UpsertAlarmDescription extends AbstractAmazonCredentialsDescription implem
   Collection<String> okActionArns
 
   PutMetricAlarmRequest buildRequest() {
-    new PutMetricAlarmRequest(
-        alarmName: name,
-        actionsEnabled: actionsEnabled,
-        alarmDescription: alarmDescription,
-        comparisonOperator: comparisonOperator,
-        evaluationPeriods: evaluationPeriods,
-        period: period,
-        threshold: threshold,
-        namespace: namespace,
-        metricName: metricName,
-        statistic: statistic,
-        unit: unit,
-        dimensions: dimensions,
-        alarmActions: alarmActionArns,
-        insufficientDataActions: insufficientDataActionArns,
-        oKActions: okActionArns
-    )
+    PutMetricAlarmRequest.builder()
+        .alarmName(name)
+        .actionsEnabled(actionsEnabled)
+        .alarmDescription(alarmDescription)
+        .comparisonOperator(comparisonOperator)
+        .evaluationPeriods(evaluationPeriods)
+        .period(period)
+        .threshold(threshold)
+        .namespace(namespace)
+        .metricName(metricName)
+        .statistic(statistic)
+        .unit(unit)
+        .dimensions(dimensions)
+        .alarmActions(alarmActionArns)
+        .insufficientDataActions(insufficientDataActionArns)
+        .okActions(okActionArns)
+        .build()
   }
 
   @Override

--- a/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/UpsertScalingPolicyDescription.groovy
+++ b/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/UpsertScalingPolicyDescription.groovy
@@ -16,8 +16,8 @@
 
 package com.netflix.spinnaker.clouddriver.aws.deploy.description
 
-import com.amazonaws.services.autoscaling.model.StepAdjustment
-import com.amazonaws.services.autoscaling.model.TargetTrackingConfiguration
+import software.amazon.awssdk.services.autoscaling.model.StepAdjustment
+import software.amazon.awssdk.services.autoscaling.model.TargetTrackingConfiguration
 import com.netflix.spinnaker.clouddriver.security.resources.ServerGroupsNameable
 
 class UpsertScalingPolicyDescription extends AbstractAmazonCredentialsDescription implements ServerGroupsNameable {

--- a/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/DeleteAlarmAtomicOperation.groovy
+++ b/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/DeleteAlarmAtomicOperation.groovy
@@ -15,7 +15,7 @@
  */
 package com.netflix.spinnaker.clouddriver.aws.deploy.ops
 
-import com.amazonaws.services.cloudwatch.model.DeleteAlarmsRequest
+import software.amazon.awssdk.services.cloudwatch.model.DeleteAlarmsRequest
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.DeleteAlarmDescription
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.data.task.Task
@@ -43,12 +43,12 @@ class DeleteAlarmAtomicOperation implements AtomicOperation<Void> {
     @Override
     Void operate(List priorOutputs) {
       task.updateStatus BASE_PHASE, "Initializing Delete Alarm Operation..."
-      def cloudWatch = amazonClientProvider.getCloudWatch(description.credentials, description.region, true)
+      def cloudWatch = amazonClientProvider.getAmazonCloudWatchV2(description.credentials, description.region)
       String alarmDescription = "${description.names.join(", ")} in ${description.region} for ${description.credentials.name}"
       task.updateStatus BASE_PHASE, "Deleting ${alarmDescription}."
-      cloudWatch.deleteAlarms(new DeleteAlarmsRequest(
-        alarmNames: description.names
-      ))
+      cloudWatch.deleteAlarms(DeleteAlarmsRequest.builder()
+        .alarmNames(description.names)
+        .build())
       task.updateStatus BASE_PHASE, "Done deleting ${alarmDescription}."
       null
     }

--- a/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/DeleteScalingPolicyAtomicOperation.groovy
+++ b/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/DeleteScalingPolicyAtomicOperation.groovy
@@ -15,11 +15,11 @@
  */
 package com.netflix.spinnaker.clouddriver.aws.deploy.ops
 
-import com.amazonaws.services.autoscaling.model.Alarm
-import com.amazonaws.services.autoscaling.model.DeletePolicyRequest
-import com.amazonaws.services.autoscaling.model.DescribePoliciesRequest
-import com.amazonaws.services.cloudwatch.model.DeleteAlarmsRequest
-import com.amazonaws.services.cloudwatch.model.DescribeAlarmsRequest
+import software.amazon.awssdk.services.autoscaling.model.Alarm
+import software.amazon.awssdk.services.autoscaling.model.DeletePolicyRequest
+import software.amazon.awssdk.services.autoscaling.model.DescribePoliciesRequest
+import software.amazon.awssdk.services.cloudwatch.model.DeleteAlarmsRequest
+import software.amazon.awssdk.services.cloudwatch.model.DescribeAlarmsRequest
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.DeleteScalingPolicyDescription
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.data.task.Task
@@ -47,32 +47,33 @@ class DeleteScalingPolicyAtomicOperation implements AtomicOperation<Void> {
     @Override
     Void operate(List priorOutputs) {
       task.updateStatus BASE_PHASE, "Initializing Delete Scaling Policy Operation..."
-      def autoScaling = amazonClientProvider.getAutoScaling(description.credentials, description.region, true)
+      def autoScaling = amazonClientProvider.getAutoScalingV2(description.credentials, description.region)
       String policyDescription = "${description.policyName} in ${description.region} for ${description.credentials.name}"
       task.updateStatus BASE_PHASE, "Looking up policy..."
-      def policyMatches = autoScaling.describePolicies(new DescribePoliciesRequest()
-          .withPolicyNames(description.policyName)
-          .withAutoScalingGroupName(description.serverGroupName)
-      ).scalingPolicies
+      def policyMatches = autoScaling.describePolicies(DescribePoliciesRequest.builder()
+          .policyNames(description.policyName)
+          .autoScalingGroupName(description.serverGroupName)
+          .build()
+      ).scalingPolicies()
 
       task.updateStatus BASE_PHASE, "Deleting ${policyDescription}."
-      autoScaling.deletePolicy(new DeletePolicyRequest(
-        autoScalingGroupName: description.serverGroupName,
-        policyName: description.policyName
-      ))
+      autoScaling.deletePolicy(DeletePolicyRequest.builder()
+        .autoScalingGroupName(description.serverGroupName)
+        .policyName(description.policyName)
+        .build())
       task.updateStatus BASE_PHASE, "Done deleting ${policyDescription}."
       if (policyMatches.size() == 1) {
-        def cloudWatch = amazonClientProvider.getCloudWatch(description.credentials, description.region, true)
-        policyMatches[0].alarms.each { Alarm alarm ->
-          def metricAlarms = cloudWatch.describeAlarms(new DescribeAlarmsRequest()
-              .withAlarmNames(alarm.alarmName)).metricAlarms
+        def cloudWatch = amazonClientProvider.getAmazonCloudWatchV2(description.credentials, description.region)
+        policyMatches[0].alarms().each { Alarm alarm ->
+          def metricAlarms = cloudWatch.describeAlarms(DescribeAlarmsRequest.builder()
+              .alarmNames(alarm.alarmName()).build()).metricAlarms()
           metricAlarms.each {
-            if (it.alarmActions.isEmpty() ||
-                (it.alarmActions.size() == 1 && it.alarmActions[0] == policyMatches[0].policyARN)) {
-              task.updateStatus BASE_PHASE, "Deleting orphaned alarm ${alarm.alarmName}"
-              cloudWatch.deleteAlarms(new DeleteAlarmsRequest()
-                  .withAlarmNames(alarm.alarmName))
-              task.updateStatus BASE_PHASE, "Done deleting orphaned alarm ${alarm.alarmName}"
+            if (it.alarmActions().isEmpty() ||
+                (it.alarmActions().size() == 1 && it.alarmActions()[0] == policyMatches[0].policyARN())) {
+              task.updateStatus BASE_PHASE, "Deleting orphaned alarm ${alarm.alarmName()}"
+              cloudWatch.deleteAlarms(DeleteAlarmsRequest.builder()
+                  .alarmNames(alarm.alarmName()).build())
+              task.updateStatus BASE_PHASE, "Done deleting orphaned alarm ${alarm.alarmName()}"
             }
           }
         }

--- a/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/UpsertAlarmAtomicOperation.groovy
+++ b/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/UpsertAlarmAtomicOperation.groovy
@@ -16,8 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.aws.deploy.ops
 
-import com.amazonaws.services.cloudwatch.model.Dimension
-import com.amazonaws.services.cloudwatch.model.PutMetricAlarmRequest
+import software.amazon.awssdk.services.cloudwatch.model.Dimension
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.UpsertAlarmDescription
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.aws.services.IdGenerator
@@ -44,7 +43,7 @@ class UpsertAlarmAtomicOperation implements AtomicOperation<Map<String, String>>
 
     if (description.asgName) {
       description.dimensions = description.dimensions ?: []
-      description.dimensions.add(new Dimension(name: "AutoScalingGroupName", value: description.asgName))
+      description.dimensions.add(Dimension.builder().name("AutoScalingGroupName").value(description.asgName).build())
     }
 
     final previousUpsertScalingPolicyResult = (UpsertScalingPolicyResult) priorOutputs.reverse().find {
@@ -56,7 +55,7 @@ class UpsertAlarmAtomicOperation implements AtomicOperation<Map<String, String>>
     }
 
     def request = description.buildRequest()
-    def cloudWatch = amazonClientProvider.getCloudWatch(description.credentials, description.region, true)
+    def cloudWatch = amazonClientProvider.getAmazonCloudWatchV2(description.credentials, description.region)
     cloudWatch.putMetricAlarm(request)
 
     [alarmName: description.name.toString()]

--- a/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/UpsertScalingPolicyAtomicOperation.groovy
+++ b/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/UpsertScalingPolicyAtomicOperation.groovy
@@ -16,8 +16,8 @@
 
 package com.netflix.spinnaker.clouddriver.aws.deploy.ops
 
-import com.amazonaws.services.autoscaling.model.PutScalingPolicyRequest
-import com.amazonaws.services.autoscaling.model.PutScalingPolicyResult
+import software.amazon.awssdk.services.autoscaling.model.PutScalingPolicyRequest
+import software.amazon.awssdk.services.autoscaling.model.PutScalingPolicyResponse
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.aws.services.IdGenerator
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
@@ -40,57 +40,57 @@ class UpsertScalingPolicyAtomicOperation implements AtomicOperation<UpsertScalin
   @Override
   UpsertScalingPolicyResult operate(List priorOutputs) {
     final policyName = description.name ?: "${description.serverGroupName}-policy-${idGenerator.nextId()}"
-    final request = new PutScalingPolicyRequest(
-      policyName: policyName,
-      autoScalingGroupName: description.serverGroupName,
-    )
+    final requestBuilder = PutScalingPolicyRequest.builder()
+      .policyName(policyName)
+      .autoScalingGroupName(description.serverGroupName)
+
     if (description.targetTrackingConfiguration) {
-      request.withTargetTrackingConfiguration(description.targetTrackingConfiguration)
-        .withEstimatedInstanceWarmup(description.estimatedInstanceWarmup)
-        .withPolicyType(PolicyType.TargetTrackingScaling.toString())
+      requestBuilder.targetTrackingConfiguration(description.targetTrackingConfiguration)
+        .estimatedInstanceWarmup(description.estimatedInstanceWarmup)
+        .policyType(PolicyType.TargetTrackingScaling.toString())
     } else {
-      request.withAdjustmentType(description.adjustmentType.toString())
-        .withMinAdjustmentMagnitude(description.minAdjustmentMagnitude)
+      requestBuilder.adjustmentType(description.adjustmentType.toString())
+        .minAdjustmentMagnitude(description.minAdjustmentMagnitude)
 
       if (description.step) {
-        request.withPolicyType(PolicyType.StepScaling.toString()).
-          withEstimatedInstanceWarmup(description.step.estimatedInstanceWarmup).
-          withStepAdjustments(description.step.stepAdjustments).
-          withMetricAggregationType(description.step.metricAggregationType.toString())
+        requestBuilder.policyType(PolicyType.StepScaling.toString())
+          .estimatedInstanceWarmup(description.step.estimatedInstanceWarmup)
+          .stepAdjustments(description.step.stepAdjustments)
+          .metricAggregationType(description.step.metricAggregationType.toString())
       } else {
-        request.withPolicyType(PolicyType.SimpleScaling.toString()).
-          withCooldown(description.simple.cooldown).
-          withScalingAdjustment(description.simple.scalingAdjustment)
+        requestBuilder.policyType(PolicyType.SimpleScaling.toString())
+          .cooldown(description.simple.cooldown)
+          .scalingAdjustment(description.simple.scalingAdjustment)
       }
     }
 
-    final autoScaling = amazonClientProvider.getAutoScaling(description.credentials, description.region, true)
-    PutScalingPolicyResult scalingPolicyResult = autoScaling.putScalingPolicy(request)
+    final autoScaling = amazonClientProvider.getAutoScalingV2(description.credentials, description.region)
+    PutScalingPolicyResponse scalingPolicyResult = autoScaling.putScalingPolicy(requestBuilder.build())
 
     if (description.alarm && !description.targetTrackingConfiguration) {
       addAlarm(scalingPolicyResult)
       new UpsertScalingPolicyResult(
           policyName: policyName.toString(),
-          policyArn: scalingPolicyResult?.policyARN,
+          policyArn: scalingPolicyResult?.policyARN(),
           alarmName: description.alarm.name
       )
     } else {
       new UpsertScalingPolicyResult(
           policyName: policyName.toString(),
-          policyArn: scalingPolicyResult?.policyARN
+          policyArn: scalingPolicyResult?.policyARN()
       )
     }
   }
 
-  private void addAlarm(PutScalingPolicyResult scalingPolicyResult) {
+  private void addAlarm(PutScalingPolicyResponse scalingPolicyResult) {
     def alarm = description.alarm
     alarm.name = alarm.name ?: "${description.serverGroupName}-alarm-${description.alarm.metricName}-${idGenerator.nextId()}"
     alarm.alarmActionArns = alarm.alarmActionArns ?: []
-    if (!alarm.alarmActionArns.contains(scalingPolicyResult.policyARN)) {
-      alarm.alarmActionArns.add(scalingPolicyResult.policyARN)
+    if (!alarm.alarmActionArns.contains(scalingPolicyResult.policyARN())) {
+      alarm.alarmActionArns.add(scalingPolicyResult.policyARN())
     }
     def request = description.alarm.buildRequest()
-    def cloudWatch = amazonClientProvider.getCloudWatch(description.credentials, description.region, true)
+    def cloudWatch = amazonClientProvider.getAmazonCloudWatchV2(description.credentials, description.region)
     cloudWatch.putMetricAlarm(request)
   }
 

--- a/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/scalingpolicy/DefaultScalingPolicyCopier.groovy
+++ b/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/scalingpolicy/DefaultScalingPolicyCopier.groovy
@@ -16,17 +16,19 @@
 
 package com.netflix.spinnaker.clouddriver.aws.deploy.scalingpolicy
 
-import com.amazonaws.services.autoscaling.AmazonAutoScaling
-import com.amazonaws.services.autoscaling.model.DescribePoliciesRequest
-import com.amazonaws.services.autoscaling.model.DescribePoliciesResult
-import com.amazonaws.services.autoscaling.model.PutScalingPolicyRequest
-import com.amazonaws.services.autoscaling.model.ScalingPolicy
-import com.amazonaws.services.cloudwatch.AmazonCloudWatch
-import com.amazonaws.services.cloudwatch.model.DescribeAlarmsRequest
-import com.amazonaws.services.cloudwatch.model.DescribeAlarmsResult
-import com.amazonaws.services.cloudwatch.model.Dimension
-import com.amazonaws.services.cloudwatch.model.MetricAlarm
-import com.amazonaws.services.cloudwatch.model.PutMetricAlarmRequest
+import software.amazon.awssdk.services.autoscaling.AutoScalingClient
+import software.amazon.awssdk.services.autoscaling.model.DescribePoliciesRequest
+import software.amazon.awssdk.services.autoscaling.model.DescribePoliciesResponse
+import software.amazon.awssdk.services.autoscaling.model.MetricDimension
+import software.amazon.awssdk.services.autoscaling.model.PutScalingPolicyRequest
+import software.amazon.awssdk.services.autoscaling.model.ScalingPolicy
+import software.amazon.awssdk.services.autoscaling.model.TargetTrackingConfiguration
+import software.amazon.awssdk.services.cloudwatch.CloudWatchClient
+import software.amazon.awssdk.services.cloudwatch.model.DescribeAlarmsRequest
+import software.amazon.awssdk.services.cloudwatch.model.DescribeAlarmsResponse
+import software.amazon.awssdk.services.cloudwatch.model.Dimension
+import software.amazon.awssdk.services.cloudwatch.model.MetricAlarm
+import software.amazon.awssdk.services.cloudwatch.model.PutMetricAlarmRequest
 import com.google.common.collect.Lists
 import com.netflix.spinnaker.clouddriver.aws.model.AwsResultsRetriever
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
@@ -69,9 +71,9 @@ class DefaultScalingPolicyCopier implements ScalingPolicyCopier {
                            NetflixAmazonCredentials targetCredentials,
                            String sourceRegion,
                            String targetRegion) {
-    AmazonAutoScaling sourceAutoScaling = amazonClientProvider.getAutoScaling(sourceCredentials, sourceRegion, true)
-    AmazonAutoScaling targetAutoScaling = amazonClientProvider.getAutoScaling(targetCredentials, targetRegion, true)
-    List<ScalingPolicy> sourceAsgScalingPolicies = new ScalingPolicyRetriever(sourceAutoScaling).retrieve(new DescribePoliciesRequest(autoScalingGroupName: sourceAsgName))
+    AutoScalingClient sourceAutoScaling = amazonClientProvider.getAutoScalingV2(sourceCredentials, sourceRegion)
+    AutoScalingClient targetAutoScaling = amazonClientProvider.getAutoScalingV2(targetCredentials, targetRegion)
+    List<ScalingPolicy> sourceAsgScalingPolicies = new ScalingPolicyRetriever(sourceAutoScaling).retrieve(DescribePoliciesRequest.builder().autoScalingGroupName(sourceAsgName).build())
 
     log.info("Copying scaling policies for $sourceAsgName to $targetAsgName: $sourceAsgScalingPolicies")
 
@@ -82,45 +84,47 @@ class DefaultScalingPolicyCopier implements ScalingPolicyCopier {
       task.updateStatus "AWS_DEPLOY", "Creating scaling policy (${policyRequest}) on ${targetRegion}/${targetAsgName} from ${sourceRegion}/${sourceAsgName}..."
 
       def result = targetAutoScaling.putScalingPolicy(policyRequest)
-      sourcePolicyArnToTargetPolicyArn[sourceAsgScalingPolicy.policyARN] = result.policyARN
+      sourcePolicyArnToTargetPolicyArn[sourceAsgScalingPolicy.policyARN()] = result.policyARN()
 
       task.updateStatus "AWS_DEPLOY", "Created scaling policy (${policyRequest}) on ${targetRegion}/${targetAsgName} from ${sourceRegion}/${sourceAsgName}..."
     }
-    Collection<String> allSourceAlarmNames = sourceAsgScalingPolicies*.alarms*.alarmName.flatten().unique()
+    Collection<String> allSourceAlarmNames = sourceAsgScalingPolicies.collectMany { it.alarms() }*.alarmName().unique()
     if (allSourceAlarmNames) {
       copyAlarmsForAsg(targetAsgName, allSourceAlarmNames, sourcePolicyArnToTargetPolicyArn, sourceCredentials, targetCredentials, sourceRegion, targetRegion)
     }
   }
 
   protected PutScalingPolicyRequest buildNewPolicyRequest(String newPolicyName, ScalingPolicy sourceAsgScalingPolicy, String targetAsgName) {
-    if (sourceAsgScalingPolicy.targetTrackingConfiguration) {
-      if (sourceAsgScalingPolicy.targetTrackingConfiguration.customizedMetricSpecification) {
+    TargetTrackingConfiguration targetTrackingConfiguration = sourceAsgScalingPolicy.targetTrackingConfiguration()
+    if (targetTrackingConfiguration) {
+      if (targetTrackingConfiguration.customizedMetricSpecification()) {
         // update target tracking policies to point to the new ASG
         // this will cause grief if a target tracking policy is configured against a *different* ASG, but we are doing
         // the same thing with simple and step policies and have not had any issues thus far
-        sourceAsgScalingPolicy.targetTrackingConfiguration.customizedMetricSpecification.dimensions
-          .findAll { d ->
-            d.name == DIMENSION_NAME_FOR_ASG
-          }
-          .each { d ->
-            d.value = targetAsgName
-          }
+        List<MetricDimension> newDimensions = targetTrackingConfiguration.customizedMetricSpecification().dimensions().collect { d ->
+          d.name() == DIMENSION_NAME_FOR_ASG ? d.toBuilder().value(targetAsgName).build() : d
+        }
+        targetTrackingConfiguration = targetTrackingConfiguration.toBuilder()
+          .customizedMetricSpecification(targetTrackingConfiguration.customizedMetricSpecification().toBuilder()
+            .dimensions(newDimensions)
+            .build())
+          .build()
       }
     }
-    return new PutScalingPolicyRequest(
-      autoScalingGroupName: targetAsgName,
-      policyName: newPolicyName,
-      policyType: sourceAsgScalingPolicy.policyType,
-      scalingAdjustment: sourceAsgScalingPolicy.scalingAdjustment,
-      adjustmentType: sourceAsgScalingPolicy.adjustmentType,
-      cooldown: sourceAsgScalingPolicy.cooldown,
-      minAdjustmentStep: sourceAsgScalingPolicy.minAdjustmentStep,
-      minAdjustmentMagnitude: sourceAsgScalingPolicy.minAdjustmentMagnitude,
-      metricAggregationType: sourceAsgScalingPolicy.metricAggregationType,
-      stepAdjustments: sourceAsgScalingPolicy.stepAdjustments,
-      estimatedInstanceWarmup: sourceAsgScalingPolicy.estimatedInstanceWarmup,
-      targetTrackingConfiguration: sourceAsgScalingPolicy.targetTrackingConfiguration
-    )
+    return PutScalingPolicyRequest.builder()
+      .autoScalingGroupName(targetAsgName)
+      .policyName(newPolicyName)
+      .policyType(sourceAsgScalingPolicy.policyType())
+      .scalingAdjustment(sourceAsgScalingPolicy.scalingAdjustment())
+      .adjustmentType(sourceAsgScalingPolicy.adjustmentType())
+      .cooldown(sourceAsgScalingPolicy.cooldown())
+      .minAdjustmentStep(sourceAsgScalingPolicy.minAdjustmentStep())
+      .minAdjustmentMagnitude(sourceAsgScalingPolicy.minAdjustmentMagnitude())
+      .metricAggregationType(sourceAsgScalingPolicy.metricAggregationType())
+      .stepAdjustments(sourceAsgScalingPolicy.stepAdjustments())
+      .estimatedInstanceWarmup(sourceAsgScalingPolicy.estimatedInstanceWarmup())
+      .targetTrackingConfiguration((TargetTrackingConfiguration) targetTrackingConfiguration)
+      .build()
   }
 
   Collection<String> replacePolicyArnActions(String sourceRegion,
@@ -151,74 +155,94 @@ class DefaultScalingPolicyCopier implements ScalingPolicyCopier {
                                 NetflixAmazonCredentials targetCredentials,
                                 String sourceRegion,
                                 String targetRegion) {
-    AmazonCloudWatch sourceCloudWatch = amazonClientProvider.getCloudWatch(sourceCredentials, sourceRegion, true)
-    AmazonCloudWatch targetCloudWatch = amazonClientProvider.getCloudWatch(targetCredentials, targetRegion, true)
-    List<MetricAlarm> sourceAlarms = new AlarmRetriever(sourceCloudWatch).retrieve(new DescribeAlarmsRequest(alarmNames: sourceAlarmNames))
+    CloudWatchClient sourceCloudWatch = amazonClientProvider.getAmazonCloudWatchV2(sourceCredentials, sourceRegion)
+    CloudWatchClient targetCloudWatch = amazonClientProvider.getAmazonCloudWatchV2(targetCredentials, targetRegion)
+    List<MetricAlarm> sourceAlarms = new AlarmRetriever(sourceCloudWatch).retrieve(DescribeAlarmsRequest.builder().alarmNames(sourceAlarmNames).build())
 
     log.info("Copying scaling policy alarms for $newAutoScalingGroupName: $sourceAlarms")
 
     sourceAlarms.findAll { shouldCopySourceAlarm(it) }.each { alarm ->
-      List<Dimension> newDimensions = Lists.newArrayList(alarm.dimensions)
-      Dimension asgDimension = newDimensions.find { it.name == DIMENSION_NAME_FOR_ASG }
+      List<Dimension> newDimensions = Lists.newArrayList(alarm.dimensions())
+      Dimension asgDimension = newDimensions.find { it.name() == DIMENSION_NAME_FOR_ASG }
       if (asgDimension) {
         newDimensions.remove(asgDimension)
-        newDimensions.add(new Dimension(name: DIMENSION_NAME_FOR_ASG, value: newAutoScalingGroupName))
+        newDimensions.add(Dimension.builder().name(DIMENSION_NAME_FOR_ASG).value(newAutoScalingGroupName).build())
       }
       String newAlarmName = [newAutoScalingGroupName, 'alarm', idGenerator.nextId()].join('-')
-      def request = new PutMetricAlarmRequest(
-        alarmName: newAlarmName,
-        alarmDescription: alarm.alarmDescription,
-        actionsEnabled: alarm.actionsEnabled,
-        oKActions: replacePolicyArnActions(sourceRegion, targetRegion, sourceCredentials, targetCredentials, sourcePolicyArnToTargetPolicyArn, alarm.oKActions),
-        alarmActions: replacePolicyArnActions(sourceRegion, targetRegion, sourceCredentials, targetCredentials, sourcePolicyArnToTargetPolicyArn, alarm.alarmActions),
-        insufficientDataActions: replacePolicyArnActions(sourceRegion, targetRegion, sourceCredentials, targetCredentials, sourcePolicyArnToTargetPolicyArn, alarm.insufficientDataActions),
-        metricName: alarm.metricName,
-        namespace: alarm.namespace,
-        statistic: alarm.statistic,
-        extendedStatistic: alarm.extendedStatistic,
-        dimensions: newDimensions,
-        period: alarm.period,
-        unit: alarm.unit,
-        evaluationPeriods: alarm.evaluationPeriods,
-        threshold: alarm.threshold,
-        comparisonOperator: alarm.comparisonOperator
-      )
+      def request = PutMetricAlarmRequest.builder()
+        .alarmName(newAlarmName)
+        .alarmDescription(alarm.alarmDescription())
+        .actionsEnabled(alarm.actionsEnabled())
+        .okActions(replacePolicyArnActions(sourceRegion, targetRegion, sourceCredentials, targetCredentials, sourcePolicyArnToTargetPolicyArn, alarm.okActions()))
+        .alarmActions(replacePolicyArnActions(sourceRegion, targetRegion, sourceCredentials, targetCredentials, sourcePolicyArnToTargetPolicyArn, alarm.alarmActions()))
+        .insufficientDataActions(replacePolicyArnActions(sourceRegion, targetRegion, sourceCredentials, targetCredentials, sourcePolicyArnToTargetPolicyArn, alarm.insufficientDataActions()))
+        .metricName(alarm.metricName())
+        .namespace(alarm.namespace())
+        .statistic(alarm.statisticAsString())
+        .extendedStatistic(alarm.extendedStatistic())
+        .dimensions(newDimensions)
+        .period(alarm.period())
+        .unit(alarm.unitAsString())
+        .evaluationPeriods(alarm.evaluationPeriods())
+        .threshold(alarm.threshold())
+        .comparisonOperator(alarm.comparisonOperatorAsString())
+        .build()
       targetCloudWatch.putMetricAlarm(request)
     }
   }
 
   protected boolean shouldCopySourceAlarm(MetricAlarm metricAlarm) {
     // AWS auto-creates TargetTracking alarms, so we don't want to copy them (otherwise, we'll have duplicates)
-    return !metricAlarm.alarmName.startsWith("TargetTracking-")
+    return !metricAlarm.alarmName().startsWith("TargetTracking-")
   }
 
   @Canonical
-  static class ScalingPolicyRetriever extends AwsResultsRetriever<ScalingPolicy, DescribePoliciesRequest, DescribePoliciesResult> {
-    final AmazonAutoScaling autoScaling
+  static class ScalingPolicyRetriever extends AwsResultsRetriever<ScalingPolicy, DescribePoliciesRequest, DescribePoliciesResponse> {
+    final AutoScalingClient autoScaling
 
     @Override
-    protected DescribePoliciesResult makeRequest(DescribePoliciesRequest request) {
+    protected DescribePoliciesResponse makeRequest(DescribePoliciesRequest request) {
       autoScaling.describePolicies(request)
     }
 
     @Override
-    protected List<ScalingPolicy> accessResult(DescribePoliciesResult result) {
-      result.scalingPolicies
+    protected List<ScalingPolicy> accessResult(DescribePoliciesResponse result) {
+      result.scalingPolicies()
+    }
+
+    @Override
+    protected DescribePoliciesRequest setNextToken(DescribePoliciesRequest request, String nextToken) {
+      request.toBuilder().nextToken(nextToken).build()
+    }
+
+    @Override
+    protected String getNextToken(DescribePoliciesResponse result) {
+      result.nextToken()
     }
   }
 
   @Canonical
-  static class AlarmRetriever extends AwsResultsRetriever<MetricAlarm, DescribeAlarmsRequest, DescribeAlarmsResult> {
-    final AmazonCloudWatch cloudWatch
+  static class AlarmRetriever extends AwsResultsRetriever<MetricAlarm, DescribeAlarmsRequest, DescribeAlarmsResponse> {
+    final CloudWatchClient cloudWatch
 
     @Override
-    protected DescribeAlarmsResult makeRequest(DescribeAlarmsRequest request) {
+    protected DescribeAlarmsResponse makeRequest(DescribeAlarmsRequest request) {
       cloudWatch.describeAlarms(request)
     }
 
     @Override
-    protected List<MetricAlarm> accessResult(DescribeAlarmsResult result) {
-      result.metricAlarms
+    protected List<MetricAlarm> accessResult(DescribeAlarmsResponse result) {
+      result.metricAlarms()
+    }
+
+    @Override
+    protected DescribeAlarmsRequest setNextToken(DescribeAlarmsRequest request, String nextToken) {
+      request.toBuilder().nextToken(nextToken).build()
+    }
+
+    @Override
+    protected String getNextToken(DescribeAlarmsResponse result) {
+      result.nextToken()
     }
   }
 
@@ -233,16 +257,16 @@ class DefaultScalingPolicyCopier implements ScalingPolicyCopier {
     }
 
     String generateScalingPolicyName(NetflixAmazonCredentials sourceCredentials, String sourceRegion, String sourceAsgName, String targetAsgName, ScalingPolicy policy) {
-      policy.policyName.replaceAll(sourceAsgName, targetAsgName)
-      String fallback = policy.policyName.contains(sourceAsgName) ?
-        policy.policyName.replaceAll(sourceAsgName, targetAsgName) :
-        [policy.policyName, 'no-alarm', idGenerator.nextId()].join('-')
+      policy.policyName().replaceAll(sourceAsgName, targetAsgName)
+      String fallback = policy.policyName().contains(sourceAsgName) ?
+        policy.policyName().replaceAll(sourceAsgName, targetAsgName) :
+        [policy.policyName(), 'no-alarm', idGenerator.nextId()].join('-')
 
-      if (policy.alarms.isEmpty()) {
+      if (policy.alarms().isEmpty()) {
         return fallback
       }
-      AmazonCloudWatch sourceCloudWatch = amazonClientProvider.getCloudWatch(sourceCredentials, sourceRegion, true)
-      List<MetricAlarm> sourceAlarms = new AlarmRetriever(sourceCloudWatch).retrieve(new DescribeAlarmsRequest(alarmNames: [policy.alarms[0].alarmName]))
+      CloudWatchClient sourceCloudWatch = amazonClientProvider.getAmazonCloudWatchV2(sourceCredentials, sourceRegion)
+      List<MetricAlarm> sourceAlarms = new AlarmRetriever(sourceCloudWatch).retrieve(DescribeAlarmsRequest.builder().alarmNames([policy.alarms()[0].alarmName()]).build())
       if (sourceAlarms.isEmpty()) {
         return fallback
       }
@@ -250,12 +274,12 @@ class DefaultScalingPolicyCopier implements ScalingPolicyCopier {
       // 'PolicyName' cannot contain a ':' character but it is a valid character in Cloudwatch Namespace and Metric names.
       return [
         targetAsgName,
-        alarm.namespace,
-        alarm.metricName,
-        alarm.comparisonOperator,
-        alarm.threshold,
-        alarm.evaluationPeriods,
-        alarm.period,
+        alarm.namespace(),
+        alarm.metricName(),
+        alarm.comparisonOperatorAsString(),
+        alarm.threshold(),
+        alarm.evaluationPeriods(),
+        alarm.period(),
         new Date().getTime()
       ].join('-').replace(':', '-')
     }

--- a/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonMetricDescriptor.groovy
+++ b/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonMetricDescriptor.groovy
@@ -16,8 +16,8 @@
 
 package com.netflix.spinnaker.clouddriver.aws.model
 
-import com.amazonaws.services.cloudwatch.model.Dimension
-import com.amazonaws.services.cloudwatch.model.Metric
+import software.amazon.awssdk.services.cloudwatch.model.Dimension
+import software.amazon.awssdk.services.cloudwatch.model.Metric
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.netflix.spinnaker.clouddriver.model.CloudMetricDescriptor
 
@@ -35,7 +35,7 @@ class AmazonMetricDescriptor implements CloudMetricDescriptor {
     this.dimensions = dimensions
   }
   static AmazonMetricDescriptor from(Metric metric) {
-    new AmazonMetricDescriptor('aws', metric.namespace, metric.metricName, metric.dimensions)
+    new AmazonMetricDescriptor('aws', metric.namespace(), metric.metricName(), metric.dimensions())
   }
 
 }

--- a/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonMetricStatistics.groovy
+++ b/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonMetricStatistics.groovy
@@ -16,7 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.aws.model
 
-import com.amazonaws.services.cloudwatch.model.GetMetricStatisticsResult
+import software.amazon.awssdk.services.cloudwatch.model.GetMetricStatisticsResponse
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.netflix.spinnaker.clouddriver.model.CloudMetricStatistics
 import groovy.transform.Immutable
@@ -28,13 +28,12 @@ class AmazonMetricStatistics implements CloudMetricStatistics<AmazonMetricDatapo
   String unit
   List<AmazonMetricDatapoint> datapoints
 
-  static AmazonMetricStatistics from(GetMetricStatisticsResult result) {
-    def datapoints = result.datapoints
-        .sort { a, b -> a.timestamp <=> b.timestamp }
-        .findResults {
-          new AmazonMetricDatapoint(it.timestamp, it.average, it.sum, it.sampleCount, it.minimum, it.maximum)
+  static AmazonMetricStatistics from(GetMetricStatisticsResponse result) {
+    def sortedRawDatapoints = result.datapoints().sort(false) { a, b -> a.timestamp() <=> b.timestamp() }
+    def datapoints = sortedRawDatapoints.findResults {
+          new AmazonMetricDatapoint(Date.from(it.timestamp()), it.average(), it.sum(), it.sampleCount(), it.minimum(), it.maximum())
         } as List
-    def unit = result.datapoints ? result.datapoints[0].unit : null
+    def unit = sortedRawDatapoints ? sortedRawDatapoints[0].unitAsString() : null
 
     new AmazonMetricStatistics(unit, datapoints)
   }

--- a/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonCloudMetricProvider.groovy
+++ b/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonCloudMetricProvider.groovy
@@ -16,8 +16,12 @@
 
 package com.netflix.spinnaker.clouddriver.aws.provider.view
 
-import com.amazonaws.services.cloudwatch.AmazonCloudWatch
-import com.amazonaws.services.cloudwatch.model.*
+import software.amazon.awssdk.services.cloudwatch.CloudWatchClient
+import software.amazon.awssdk.services.cloudwatch.model.Dimension
+import software.amazon.awssdk.services.cloudwatch.model.DimensionFilter
+import software.amazon.awssdk.services.cloudwatch.model.GetMetricStatisticsRequest
+import software.amazon.awssdk.services.cloudwatch.model.GetMetricStatisticsResponse
+import software.amazon.awssdk.services.cloudwatch.model.ListMetricsRequest
 import com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider
 import com.netflix.spinnaker.clouddriver.aws.model.AmazonMetricDescriptor
 import com.netflix.spinnaker.clouddriver.aws.model.AmazonMetricStatistics
@@ -52,10 +56,11 @@ class AmazonCloudMetricProvider implements CloudMetricProvider<AmazonMetricDescr
   @Override
   AmazonMetricDescriptor getMetricDescriptor(String account, String region, Map<String, String> filters) {
     def cloudWatch = getCloudWatch(account, region)
-    def request = new ListMetricsRequest()
-        .withNamespace(filters.namespace)
-        .withMetricName(filters.metricName)
-    def results = cloudWatch.listMetrics(request).metrics
+    def request = ListMetricsRequest.builder()
+        .namespace(filters.namespace)
+        .metricName(filters.metricName)
+        .build()
+    def results = cloudWatch.listMetrics(request).metrics()
     if (!results) {
       return null
     }
@@ -68,22 +73,22 @@ class AmazonCloudMetricProvider implements CloudMetricProvider<AmazonMetricDescr
   @Override
   List<AmazonMetricDescriptor> findMetricDescriptors(String account, String region, Map<String, String> filters) {
     def cloudWatch = getCloudWatch(account, region)
-    def request = new ListMetricsRequest()
+    def requestBuilder = ListMetricsRequest.builder()
     if (filters.namespace) {
-      request.withNamespace(filters.namespace)
+      requestBuilder.namespace(filters.namespace)
     }
     if (filters.name) {
-      request.withMetricName(filters.name)
+      requestBuilder.metricName(filters.name)
     }
 
-    request.withDimensions(filters.findResults {
+    requestBuilder.dimensions(filters.findResults {
       if (it.key != "namespace" && it.key != "name") {
-        new DimensionFilter().withName(it.key).withValue(it.value)
+        DimensionFilter.builder().name(it.key).value(it.value).build()
       } else {
         null
       }
     })
-    def results = cloudWatch.listMetrics(request).metrics
+    def results = cloudWatch.listMetrics(requestBuilder.build()).metrics()
     return results.findResults { AmazonMetricDescriptor.from(it) }
   }
 
@@ -95,30 +100,31 @@ class AmazonCloudMetricProvider implements CloudMetricProvider<AmazonMetricDescr
     if (!filters || !requiredFilters.every({ filters.containsKey(it)})) {
       throw new IllegalArgumentException("Not all required filters (${requiredFilters.join(', ')}) are present")
     }
-    AmazonCloudWatch cloudWatch = getCloudWatch(account, region)
-    GetMetricStatisticsRequest request = new GetMetricStatisticsRequest()
-      .withNamespace(filters.namespace)
-      .withMetricName(metricName)
-      .withStartTime(new Date(startTime))
-      .withEndTime(new Date(endTime))
-      .withStatistics(filters.statistics ? filters.statistics.split(",") : "Average")
-      .withPeriod(filters.period ? Integer.parseInt(filters.period) : 600)
-      .withDimensions(filters.findResults {
+    CloudWatchClient cloudWatch = getCloudWatch(account, region)
+    GetMetricStatisticsRequest request = GetMetricStatisticsRequest.builder()
+      .namespace(filters.namespace)
+      .metricName(metricName)
+      .startTime(new Date(startTime).toInstant())
+      .endTime(new Date(endTime).toInstant())
+      .statisticsWithStrings(filters.statistics ? filters.statistics.split(",") as List : ["Average"])
+      .period(filters.period ? Integer.parseInt(filters.period) : 600)
+      .dimensions(filters.findResults {
         if (!requiredFilters.contains(it.key) && !optionalFilters.contains(it.key)) {
-          new Dimension().withName(it.key).withValue(it.value)
+          Dimension.builder().name(it.key).value(it.value).build()
         } else {
           null
         }
       })
-    GetMetricStatisticsResult results = cloudWatch.getMetricStatistics(request)
+      .build()
+    GetMetricStatisticsResponse results = cloudWatch.getMetricStatistics(request)
     return AmazonMetricStatistics.from(results)
   }
 
-  private AmazonCloudWatch getCloudWatch(String account, String region) {
+  private CloudWatchClient getCloudWatch(String account, String region) {
     def credentials = credentialsRepository.getOne(account)
     if (!(credentials instanceof NetflixAmazonCredentials)) {
       throw new IllegalArgumentException("Invalid credentials: ${account}:${region}")
     }
-    amazonClientProvider.getCloudWatch(credentials, region)
+    amazonClientProvider.getAmazonCloudWatchV2(credentials, region)
   }
 }

--- a/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/agent/CleanupAlarmsAgentSpec.groovy
+++ b/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/agent/CleanupAlarmsAgentSpec.groovy
@@ -16,13 +16,14 @@
 
 package com.netflix.spinnaker.clouddriver.aws.agent
 
-import com.amazonaws.services.autoscaling.AmazonAutoScaling
-import com.amazonaws.services.autoscaling.model.DescribePoliciesResult
-import com.amazonaws.services.autoscaling.model.ScalingPolicy
-import com.amazonaws.services.cloudwatch.AmazonCloudWatch
-import com.amazonaws.services.cloudwatch.model.DeleteAlarmsRequest
-import com.amazonaws.services.cloudwatch.model.DescribeAlarmsResult
-import com.amazonaws.services.cloudwatch.model.MetricAlarm
+import software.amazon.awssdk.services.autoscaling.AutoScalingClient
+import software.amazon.awssdk.services.autoscaling.model.Alarm
+import software.amazon.awssdk.services.autoscaling.model.DescribePoliciesResponse
+import software.amazon.awssdk.services.autoscaling.model.ScalingPolicy
+import software.amazon.awssdk.services.cloudwatch.CloudWatchClient
+import software.amazon.awssdk.services.cloudwatch.model.DeleteAlarmsRequest
+import software.amazon.awssdk.services.cloudwatch.model.DescribeAlarmsResponse
+import software.amazon.awssdk.services.cloudwatch.model.MetricAlarm
 import com.netflix.spinnaker.clouddriver.aws.TestCredential
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.credentials.CredentialsRepository
@@ -35,10 +36,10 @@ class CleanupAlarmsAgentSpec extends Specification {
   @Shared
   def test = TestCredential.named('test')
 
-  AmazonAutoScaling autoScalingUSW
-  AmazonAutoScaling autoScalingUSE
-  AmazonCloudWatch cloudWatchUSW
-  AmazonCloudWatch cloudWatchUSE
+  AutoScalingClient autoScalingUSW
+  AutoScalingClient autoScalingUSE
+  CloudWatchClient cloudWatchUSW
+  CloudWatchClient cloudWatchUSE
   AmazonClientProvider amazonClientProvider
   CredentialsRepository credentialsRepository
   CleanupAlarmsAgent agent
@@ -46,16 +47,16 @@ class CleanupAlarmsAgentSpec extends Specification {
   String deletableAlarmName = "clouddriver-test-v123-alarm-" + validUuid
 
   void setup() {
-    autoScalingUSW = Mock(AmazonAutoScaling)
-    autoScalingUSE = Mock(AmazonAutoScaling)
-    cloudWatchUSW = Mock(AmazonCloudWatch)
-    cloudWatchUSE = Mock(AmazonCloudWatch)
+    autoScalingUSW = Mock(AutoScalingClient)
+    autoScalingUSE = Mock(AutoScalingClient)
+    cloudWatchUSW = Mock(CloudWatchClient)
+    cloudWatchUSE = Mock(CloudWatchClient)
 
     amazonClientProvider = Mock(AmazonClientProvider) {
-      1 * getAutoScaling(test, "us-west-1") >> autoScalingUSW
-      1 * getAutoScaling(test, "us-east-1") >> autoScalingUSE
-      1 * getCloudWatch(test, "us-west-1") >> cloudWatchUSW
-      1 * getCloudWatch(test, "us-east-1") >> cloudWatchUSE
+      1 * getAutoScalingV2(test, "us-west-1") >> autoScalingUSW
+      1 * getAutoScalingV2(test, "us-east-1") >> autoScalingUSE
+      1 * getAmazonCloudWatchV2(test, "us-west-1") >> cloudWatchUSW
+      1 * getAmazonCloudWatchV2(test, "us-east-1") >> cloudWatchUSE
       0 * _
     }
 
@@ -72,12 +73,12 @@ class CleanupAlarmsAgentSpec extends Specification {
     agent.run()
 
     then:
-    1 * autoScalingUSW.describePolicies() >> new DescribePoliciesResult()
-    1 * autoScalingUSE.describePolicies() >> new DescribePoliciesResult()
-    1 * cloudWatchUSE.describeAlarms(_) >> new DescribeAlarmsResult().withMetricAlarms([buildAlarm(deletableAlarmName, 92)])
-    1 * cloudWatchUSW.describeAlarms(_) >> new DescribeAlarmsResult().withMetricAlarms([buildAlarm(deletableAlarmName, 92)])
-    1 * cloudWatchUSE.deleteAlarms({ DeleteAlarmsRequest r -> r.alarmNames == [deletableAlarmName]} as DeleteAlarmsRequest)
-    1 * cloudWatchUSW.deleteAlarms({ DeleteAlarmsRequest r -> r.alarmNames == [deletableAlarmName]} as DeleteAlarmsRequest)
+    1 * autoScalingUSW.describePolicies(_) >> DescribePoliciesResponse.builder().build()
+    1 * autoScalingUSE.describePolicies(_) >> DescribePoliciesResponse.builder().build()
+    1 * cloudWatchUSE.describeAlarms(_) >> DescribeAlarmsResponse.builder().metricAlarms([buildAlarm(deletableAlarmName, 92)]).build()
+    1 * cloudWatchUSW.describeAlarms(_) >> DescribeAlarmsResponse.builder().metricAlarms([buildAlarm(deletableAlarmName, 92)]).build()
+    1 * cloudWatchUSE.deleteAlarms({ DeleteAlarmsRequest r -> r.alarmNames() == [deletableAlarmName]} as DeleteAlarmsRequest)
+    1 * cloudWatchUSW.deleteAlarms({ DeleteAlarmsRequest r -> r.alarmNames() == [deletableAlarmName]} as DeleteAlarmsRequest)
   }
 
   void "should not delete alarms that are newer than threshold"() {
@@ -85,11 +86,11 @@ class CleanupAlarmsAgentSpec extends Specification {
     agent.run()
 
     then:
-    1 * autoScalingUSW.describePolicies() >> new DescribePoliciesResult()
-    1 * autoScalingUSE.describePolicies() >> new DescribePoliciesResult()
-    1 * cloudWatchUSE.describeAlarms(_) >> new DescribeAlarmsResult().withMetricAlarms([buildAlarm(deletableAlarmName, 88)])
-    1 * cloudWatchUSW.describeAlarms(_) >> new DescribeAlarmsResult().withMetricAlarms([buildAlarm(deletableAlarmName, 92)])
-    1 * cloudWatchUSW.deleteAlarms({ DeleteAlarmsRequest r -> r.alarmNames == [deletableAlarmName]} as DeleteAlarmsRequest)
+    1 * autoScalingUSW.describePolicies(_) >> DescribePoliciesResponse.builder().build()
+    1 * autoScalingUSE.describePolicies(_) >> DescribePoliciesResponse.builder().build()
+    1 * cloudWatchUSE.describeAlarms(_) >> DescribeAlarmsResponse.builder().metricAlarms([buildAlarm(deletableAlarmName, 88)]).build()
+    1 * cloudWatchUSW.describeAlarms(_) >> DescribeAlarmsResponse.builder().metricAlarms([buildAlarm(deletableAlarmName, 92)]).build()
+    1 * cloudWatchUSW.deleteAlarms({ DeleteAlarmsRequest r -> r.alarmNames() == [deletableAlarmName]} as DeleteAlarmsRequest)
     0 * cloudWatchUSE.deleteAlarms(_)
   }
 
@@ -97,17 +98,17 @@ class CleanupAlarmsAgentSpec extends Specification {
     given:
     MetricAlarm alarmA = buildAlarm(deletableAlarmName, 99)
     MetricAlarm alarmB = buildAlarm(deletableAlarmName, 99)
-    ScalingPolicy policyA = new ScalingPolicy(alarms: [alarmA])
+    ScalingPolicy policyA = ScalingPolicy.builder().alarms([Alarm.builder().alarmName(alarmA.alarmName()).build()]).build()
 
     when:
     agent.run()
 
     then:
-    1 * autoScalingUSW.describePolicies() >> new DescribePoliciesResult()
-    1 * autoScalingUSE.describePolicies() >> new DescribePoliciesResult().withScalingPolicies([policyA])
-    1 * cloudWatchUSE.describeAlarms(_) >> new DescribeAlarmsResult().withMetricAlarms([alarmA])
-    1 * cloudWatchUSW.describeAlarms(_) >> new DescribeAlarmsResult().withMetricAlarms([alarmB])
-    1 * cloudWatchUSW.deleteAlarms({ DeleteAlarmsRequest r -> r.alarmNames == [deletableAlarmName]} as DeleteAlarmsRequest)
+    1 * autoScalingUSW.describePolicies(_) >> DescribePoliciesResponse.builder().build()
+    1 * autoScalingUSE.describePolicies(_) >> DescribePoliciesResponse.builder().scalingPolicies([policyA]).build()
+    1 * cloudWatchUSE.describeAlarms(_) >> DescribeAlarmsResponse.builder().metricAlarms([alarmA]).build()
+    1 * cloudWatchUSW.describeAlarms(_) >> DescribeAlarmsResponse.builder().metricAlarms([alarmB]).build()
+    1 * cloudWatchUSW.deleteAlarms({ DeleteAlarmsRequest r -> r.alarmNames() == [deletableAlarmName]} as DeleteAlarmsRequest)
     0 * cloudWatchUSE.deleteAlarms(_)
   }
 
@@ -120,10 +121,10 @@ class CleanupAlarmsAgentSpec extends Specification {
     agent.run()
 
     then:
-    1 * autoScalingUSE.describePolicies() >> new DescribePoliciesResult()
-    1 * cloudWatchUSE.describeAlarms(_) >> new DescribeAlarmsResult()
-    1 * autoScalingUSW.describePolicies() >> new DescribePoliciesResult()
-    1 * cloudWatchUSW.describeAlarms(_) >> new DescribeAlarmsResult().withMetricAlarms([alarmA, alarmB])
+    1 * autoScalingUSE.describePolicies(_) >> DescribePoliciesResponse.builder().build()
+    1 * cloudWatchUSE.describeAlarms(_) >> DescribeAlarmsResponse.builder().build()
+    1 * autoScalingUSW.describePolicies(_) >> DescribePoliciesResponse.builder().build()
+    1 * cloudWatchUSW.describeAlarms(_) >> DescribeAlarmsResponse.builder().metricAlarms([alarmA, alarmB]).build()
     0 * cloudWatchUSW.deleteAlarms(_)
 
   }
@@ -139,15 +140,15 @@ class CleanupAlarmsAgentSpec extends Specification {
     agent.run()
 
     then:
-    1 * autoScalingUSE.describePolicies() >> new DescribePoliciesResult()
-    1 * cloudWatchUSE.describeAlarms(_) >> new DescribeAlarmsResult()
-    1 * autoScalingUSW.describePolicies() >> new DescribePoliciesResult()
-    1 * cloudWatchUSW.describeAlarms(_) >> new DescribeAlarmsResult().withMetricAlarms([alarmA, alarmB])
+    1 * autoScalingUSE.describePolicies(_) >> DescribePoliciesResponse.builder().build()
+    1 * cloudWatchUSE.describeAlarms(_) >> DescribeAlarmsResponse.builder().build()
+    1 * autoScalingUSW.describePolicies(_) >> DescribePoliciesResponse.builder().build()
+    1 * cloudWatchUSW.describeAlarms(_) >> DescribeAlarmsResponse.builder().metricAlarms([alarmA, alarmB]).build()
     1 * cloudWatchUSW.deleteAlarms({ DeleteAlarmsRequest request ->
-      request.alarmNames == ["some-other-v000-CustomAlarm-${validUuid}"]
+      request.alarmNames() == ["some-other-v000-CustomAlarm-${validUuid}"]
     })
     0 * cloudWatchUSW.deleteAlarms({ DeleteAlarmsRequest request ->
-      request.alarmNames == ["some-other-alarm-v000-${validUuid}"]
+      request.alarmNames() == ["some-other-alarm-v000-${validUuid}"]
     })
   }
 
@@ -163,17 +164,17 @@ class CleanupAlarmsAgentSpec extends Specification {
     agent.run()
 
     then:
-    1 * autoScalingUSE.describePolicies() >> new DescribePoliciesResult()
-    1 * cloudWatchUSE.describeAlarms(_) >> new DescribeAlarmsResult()
-    1 * autoScalingUSW.describePolicies() >> new DescribePoliciesResult()
-    1 * cloudWatchUSW.describeAlarms(_) >> new DescribeAlarmsResult().withMetricAlarms([alarmA, alarmB])
+    1 * autoScalingUSE.describePolicies(_) >> DescribePoliciesResponse.builder().build()
+    1 * cloudWatchUSE.describeAlarms(_) >> DescribeAlarmsResponse.builder().build()
+    1 * autoScalingUSW.describePolicies(_) >> DescribePoliciesResponse.builder().build()
+    1 * cloudWatchUSW.describeAlarms(_) >> DescribeAlarmsResponse.builder().metricAlarms([alarmA, alarmB]).build()
     1 * cloudWatchUSW.deleteAlarms({ DeleteAlarmsRequest request ->
-      request.alarmNames == ["some-other-v000-CustomAlarm-${validUuid}", "some-other-alarm-v000-${validUuid}"]
+      request.alarmNames() == ["some-other-v000-CustomAlarm-${validUuid}", "some-other-alarm-v000-${validUuid}"]
     })
   }
 
   private static MetricAlarm buildAlarm(String name, int dataDays) {
-    new MetricAlarm(alarmName: name, stateUpdatedTimestamp: DateTime.now().minusDays(dataDays).toDate())
+    MetricAlarm.builder().alarmName(name).stateUpdatedTimestamp(DateTime.now().minusDays(dataDays).toDate().toInstant()).build()
   }
 
 

--- a/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/converters/UpsertAlarmDescriptionAtomicOperationConverterUnitSpec.groovy
+++ b/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/converters/UpsertAlarmDescriptionAtomicOperationConverterUnitSpec.groovy
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2026 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.deploy.converters
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.UpsertAlarmDescription
+import com.netflix.spinnaker.clouddriver.aws.deploy.ops.UpsertAlarmAtomicOperation
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
+import software.amazon.awssdk.services.cloudwatch.model.ComparisonOperator
+import software.amazon.awssdk.services.cloudwatch.model.StandardUnit
+import software.amazon.awssdk.services.cloudwatch.model.Statistic
+import spock.lang.Shared
+import spock.lang.Specification
+
+class UpsertAlarmDescriptionAtomicOperationConverterUnitSpec extends Specification {
+  @Shared
+  ObjectMapper mapper = new ObjectMapper()
+
+  @Shared
+  UpsertAlarmDescriptionAtomicOperationConverter converter
+
+  def setupSpec() {
+    this.converter = new UpsertAlarmDescriptionAtomicOperationConverter(objectMapper: mapper)
+    def accountCredentialsProvider = Mock(AccountCredentialsProvider)
+    def mockCredentials = Mock(NetflixAmazonCredentials)
+    accountCredentialsProvider.getCredentials(_) >> mockCredentials
+    converter.accountCredentialsProvider = accountCredentialsProvider
+  }
+
+  void "deserializes wire-format enum strings from a real request body without error"() {
+    // Deck/Orca send the CloudWatch wire-format names (e.g. "GreaterThanThreshold"), not the AWS
+    // SDK v2 enum constant names (e.g. GREATER_THAN_THRESHOLD). If these fields were typed as the
+    // raw v2 enums, Jackson's default enum deserializer would reject this input outright.
+    setup:
+    def input = [
+        region            : "us-west-1",
+        name              : "myAlarm",
+        alarmDescription  : "a test alarm",
+        comparisonOperator: "GreaterThanThreshold",
+        evaluationPeriods : 1,
+        period            : 60,
+        threshold         : 10.5,
+        namespace         : "AWS/EC2",
+        metricName        : "CPUUtilization",
+        statistic         : "SampleCount",
+        unit              : "Percent",
+        credentials       : "test",
+    ]
+
+    when:
+    UpsertAlarmDescription description = converter.convertDescription(input)
+
+    then:
+    description instanceof UpsertAlarmDescription
+    description.comparisonOperator == "GreaterThanThreshold"
+    description.statistic == "SampleCount"
+    description.unit == "Percent"
+
+    when:
+    def operation = converter.convertOperation(input)
+
+    then:
+    operation instanceof UpsertAlarmAtomicOperation
+
+    when: "the description builds the actual AWS request"
+    def request = description.buildRequest()
+
+    then: "the wire-format strings resolve to the correct typed v2 enum constants"
+    request.comparisonOperator() == ComparisonOperator.GREATER_THAN_THRESHOLD
+    request.statistic() == Statistic.SAMPLE_COUNT
+    request.unit() == StandardUnit.PERCENT
+  }
+}

--- a/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/DeleteAlarmOperationUnitSpec.groovy
+++ b/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/DeleteAlarmOperationUnitSpec.groovy
@@ -16,8 +16,8 @@
 
 package com.netflix.spinnaker.clouddriver.aws.deploy.ops
 
-import com.amazonaws.services.cloudwatch.AmazonCloudWatch
-import com.amazonaws.services.cloudwatch.model.*
+import software.amazon.awssdk.services.cloudwatch.CloudWatchClient
+import software.amazon.awssdk.services.cloudwatch.model.DeleteAlarmsRequest
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.DeleteAlarmDescription
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
@@ -43,9 +43,9 @@ class DeleteAlarmOperationUnitSpec extends Specification {
     credentials: credz
   )
 
-  def cloudWatch = Mock(AmazonCloudWatch)
+  def cloudWatch = Mock(CloudWatchClient)
   def amazonClientProvider = Stub(AmazonClientProvider) {
-    getCloudWatch(credz, "us-west-1", true) >> cloudWatch
+    getAmazonCloudWatchV2(credz, "us-west-1") >> cloudWatch
   }
 
   @Subject def op = new DeleteAlarmAtomicOperation(description)
@@ -60,9 +60,9 @@ class DeleteAlarmOperationUnitSpec extends Specification {
     op.operate([])
 
     then:
-    1 * cloudWatch.deleteAlarms(new DeleteAlarmsRequest(
-      alarmNames: ["alarm1", "alarm2"]
-    ))
+    1 * cloudWatch.deleteAlarms(DeleteAlarmsRequest.builder()
+      .alarmNames(["alarm1", "alarm2"])
+      .build())
   }
 
 }

--- a/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/DeleteScalingPolicyAtomicOperationUnitSpec.groovy
+++ b/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/DeleteScalingPolicyAtomicOperationUnitSpec.groovy
@@ -16,17 +16,17 @@
 
 package com.netflix.spinnaker.clouddriver.aws.deploy.ops
 
-import com.amazonaws.services.autoscaling.AmazonAutoScaling
-import com.amazonaws.services.autoscaling.model.Alarm
-import com.amazonaws.services.autoscaling.model.DeletePolicyRequest
-import com.amazonaws.services.autoscaling.model.DescribePoliciesRequest
-import com.amazonaws.services.autoscaling.model.DescribePoliciesResult
-import com.amazonaws.services.autoscaling.model.ScalingPolicy
-import com.amazonaws.services.cloudwatch.AmazonCloudWatch
-import com.amazonaws.services.cloudwatch.model.DeleteAlarmsRequest
-import com.amazonaws.services.cloudwatch.model.DescribeAlarmsRequest
-import com.amazonaws.services.cloudwatch.model.DescribeAlarmsResult
-import com.amazonaws.services.cloudwatch.model.MetricAlarm
+import software.amazon.awssdk.services.autoscaling.AutoScalingClient
+import software.amazon.awssdk.services.autoscaling.model.Alarm
+import software.amazon.awssdk.services.autoscaling.model.DeletePolicyRequest
+import software.amazon.awssdk.services.autoscaling.model.DescribePoliciesRequest
+import software.amazon.awssdk.services.autoscaling.model.DescribePoliciesResponse
+import software.amazon.awssdk.services.autoscaling.model.ScalingPolicy
+import software.amazon.awssdk.services.cloudwatch.CloudWatchClient
+import software.amazon.awssdk.services.cloudwatch.model.DeleteAlarmsRequest
+import software.amazon.awssdk.services.cloudwatch.model.DescribeAlarmsRequest
+import software.amazon.awssdk.services.cloudwatch.model.DescribeAlarmsResponse
+import software.amazon.awssdk.services.cloudwatch.model.MetricAlarm
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.DeleteScalingPolicyDescription
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
@@ -54,11 +54,11 @@ class DeleteScalingPolicyAtomicOperationUnitSpec extends Specification {
     credentials: credz
   )
 
-  def autoScaling = Mock(AmazonAutoScaling)
-  def cloudWatch = Mock(AmazonCloudWatch)
+  def autoScaling = Mock(AutoScalingClient)
+  def cloudWatch = Mock(CloudWatchClient)
   def amazonClientProvider = Stub(AmazonClientProvider) {
-    getAutoScaling(credz, "us-west-1", true) >> autoScaling
-    getCloudWatch(credz, "us-west-1", true) >> cloudWatch
+    getAutoScalingV2(credz, "us-west-1") >> autoScaling
+    getAmazonCloudWatchV2(credz, "us-west-1") >> cloudWatch
   }
 
   @Subject def op = new DeleteScalingPolicyAtomicOperation(description)
@@ -73,38 +73,40 @@ class DeleteScalingPolicyAtomicOperationUnitSpec extends Specification {
     op.operate([])
 
     then:
-    1 * autoScaling.deletePolicy(new DeletePolicyRequest(
-      policyName: "scalingPolicy1",
-      autoScalingGroupName: "kato-main-v000"
-    ))
-    1 * autoScaling.describePolicies(new DescribePoliciesRequest()
-        .withPolicyNames(description.policyName)
-        .withAutoScalingGroupName(description.serverGroupName)) >> new DescribePoliciesResult()
+    1 * autoScaling.deletePolicy(DeletePolicyRequest.builder()
+      .policyName("scalingPolicy1")
+      .autoScalingGroupName("kato-main-v000")
+      .build())
+    1 * autoScaling.describePolicies(DescribePoliciesRequest.builder()
+        .policyNames(description.policyName)
+        .autoScalingGroupName(description.serverGroupName)
+        .build()) >> DescribePoliciesResponse.builder().build()
   }
 
   @Unroll
   void "deletes alarm if no actions or just the policy we deleted are assigned to it"() {
 
     given:
-    def alarm = new Alarm().withAlarmARN("alarm:arn").withAlarmName("the-alarm")
-    def policy = new ScalingPolicy().withAlarms(alarm).withPolicyARN("policy:arn")
-    def policyResponse = new DescribePoliciesResult().withScalingPolicies(policy)
-    def metricAlarm = new MetricAlarm().withAlarmActions(arns)
-    def alarmsResponse = new DescribeAlarmsResult().withMetricAlarms(metricAlarm)
+    def alarm = Alarm.builder().alarmARN("alarm:arn").alarmName("the-alarm").build()
+    def policy = ScalingPolicy.builder().alarms(alarm).policyARN("policy:arn").build()
+    def policyResponse = DescribePoliciesResponse.builder().scalingPolicies(policy).build()
+    def metricAlarm = MetricAlarm.builder().alarmActions(arns).build()
+    def alarmsResponse = DescribeAlarmsResponse.builder().metricAlarms(metricAlarm).build()
 
     when:
     op.operate([])
 
     then:
-    1 * autoScaling.deletePolicy(new DeletePolicyRequest(
-        policyName: "scalingPolicy1",
-        autoScalingGroupName: "kato-main-v000"
-    ))
-    1 * autoScaling.describePolicies(new DescribePoliciesRequest()
-        .withPolicyNames(description.policyName)
-        .withAutoScalingGroupName(description.serverGroupName)) >> policyResponse
-    1 * cloudWatch.describeAlarms(new DescribeAlarmsRequest().withAlarmNames("the-alarm")) >> alarmsResponse
-    1 * cloudWatch.deleteAlarms(new DeleteAlarmsRequest().withAlarmNames("the-alarm"))
+    1 * autoScaling.deletePolicy(DeletePolicyRequest.builder()
+        .policyName("scalingPolicy1")
+        .autoScalingGroupName("kato-main-v000")
+        .build())
+    1 * autoScaling.describePolicies(DescribePoliciesRequest.builder()
+        .policyNames(description.policyName)
+        .autoScalingGroupName(description.serverGroupName)
+        .build()) >> policyResponse
+    1 * cloudWatch.describeAlarms(DescribeAlarmsRequest.builder().alarmNames("the-alarm").build()) >> alarmsResponse
+    1 * cloudWatch.deleteAlarms(DeleteAlarmsRequest.builder().alarmNames("the-alarm").build())
     0 * _
 
     where:
@@ -115,24 +117,25 @@ class DeleteScalingPolicyAtomicOperationUnitSpec extends Specification {
   void "does not delete the alarm if other actions are assigned to it"() {
 
     given:
-    def alarm = new Alarm().withAlarmARN("alarm:arn").withAlarmName("the-alarm")
-    def policy = new ScalingPolicy().withAlarms(alarm).withPolicyARN("policy:arn")
-    def policyResponse = new DescribePoliciesResult().withScalingPolicies(policy)
-    def metricAlarm = new MetricAlarm().withAlarmActions(arns)
-    def alarmsResponse = new DescribeAlarmsResult().withMetricAlarms(metricAlarm)
+    def alarm = Alarm.builder().alarmARN("alarm:arn").alarmName("the-alarm").build()
+    def policy = ScalingPolicy.builder().alarms(alarm).policyARN("policy:arn").build()
+    def policyResponse = DescribePoliciesResponse.builder().scalingPolicies(policy).build()
+    def metricAlarm = MetricAlarm.builder().alarmActions(arns).build()
+    def alarmsResponse = DescribeAlarmsResponse.builder().metricAlarms(metricAlarm).build()
 
     when:
     op.operate([])
 
     then:
-    1 * autoScaling.deletePolicy(new DeletePolicyRequest(
-        policyName: "scalingPolicy1",
-        autoScalingGroupName: "kato-main-v000"
-    ))
-    1 * autoScaling.describePolicies(new DescribePoliciesRequest()
-        .withPolicyNames(description.policyName)
-        .withAutoScalingGroupName(description.serverGroupName)) >> policyResponse
-    1 * cloudWatch.describeAlarms(new DescribeAlarmsRequest().withAlarmNames("the-alarm")) >> alarmsResponse
+    1 * autoScaling.deletePolicy(DeletePolicyRequest.builder()
+        .policyName("scalingPolicy1")
+        .autoScalingGroupName("kato-main-v000")
+        .build())
+    1 * autoScaling.describePolicies(DescribePoliciesRequest.builder()
+        .policyNames(description.policyName)
+        .autoScalingGroupName(description.serverGroupName)
+        .build()) >> policyResponse
+    1 * cloudWatch.describeAlarms(DescribeAlarmsRequest.builder().alarmNames("the-alarm").build()) >> alarmsResponse
     0 * _
 
     where:

--- a/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/UpsertAlarmOperationUnitSpec.groovy
+++ b/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/UpsertAlarmOperationUnitSpec.groovy
@@ -16,18 +16,12 @@
 
 package com.netflix.spinnaker.clouddriver.aws.deploy.ops
 
-import com.amazonaws.services.autoscaling.AmazonAutoScaling
-import com.amazonaws.services.autoscaling.model.PutScalingPolicyRequest
-import com.amazonaws.services.autoscaling.model.PutScalingPolicyResult
-import com.amazonaws.services.cloudwatch.AmazonCloudWatch
-import com.amazonaws.services.cloudwatch.model.ComparisonOperator
-import com.amazonaws.services.cloudwatch.model.Dimension
-import com.amazonaws.services.cloudwatch.model.PutMetricAlarmRequest
-import com.amazonaws.services.cloudwatch.model.StandardUnit
-import com.amazonaws.services.cloudwatch.model.Statistic
-import com.amazonaws.services.sns.AmazonSNS
-import com.amazonaws.services.sns.model.ListTopicsResult
-import com.amazonaws.services.sns.model.Topic
+import software.amazon.awssdk.services.cloudwatch.CloudWatchClient
+import software.amazon.awssdk.services.cloudwatch.model.ComparisonOperator
+import software.amazon.awssdk.services.cloudwatch.model.Dimension
+import software.amazon.awssdk.services.cloudwatch.model.PutMetricAlarmRequest
+import software.amazon.awssdk.services.cloudwatch.model.StandardUnit
+import software.amazon.awssdk.services.cloudwatch.model.Statistic
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.UpsertAlarmDescription
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.UpsertScalingPolicyDescription
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
@@ -46,19 +40,19 @@ class UpsertAlarmOperationUnitSpec extends Specification {
   def description = new UpsertAlarmDescription(
     region: "us-west-1",
     alarmDescription: "annoying alarm",
-    comparisonOperator: ComparisonOperator.GreaterThanThreshold,
+    comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
     evaluationPeriods: 1,
     period: 2,
     threshold: 10.5,
     namespace: "AWS/EC2",
     metricName: "CPUUtilization",
-    statistic: Statistic.SampleCount,
-    unit: StandardUnit.Percent,
+    statistic: Statistic.SAMPLE_COUNT,
+    unit: StandardUnit.PERCENT,
   )
 
-  def cloudWatch = Mock(AmazonCloudWatch)
+  def cloudWatch = Mock(CloudWatchClient)
   def amazonClientProvider = Stub(AmazonClientProvider) {
-    getCloudWatch(_, _, true) >> cloudWatch
+    getAmazonCloudWatchV2(_, _) >> cloudWatch
   }
 
   @Subject def op = new UpsertAlarmAtomicOperation(description)
@@ -79,19 +73,19 @@ class UpsertAlarmOperationUnitSpec extends Specification {
     op.operate([])
 
     then:
-    1 * cloudWatch.putMetricAlarm(new PutMetricAlarmRequest(
-      alarmName: "alarm-1",
-      actionsEnabled: true,
-      alarmDescription: "annoying alarm",
-      comparisonOperator: "GreaterThanThreshold",
-      evaluationPeriods: 1,
-      period: 2,
-      threshold: 10.5,
-      namespace: "AWS/EC2",
-      metricName: "CPUUtilization",
-      statistic: "SampleCount",
-      unit: "Percent"
-    ))
+    1 * cloudWatch.putMetricAlarm(PutMetricAlarmRequest.builder()
+      .alarmName("alarm-1")
+      .actionsEnabled(true)
+      .alarmDescription("annoying alarm")
+      .comparisonOperator("GreaterThanThreshold")
+      .evaluationPeriods(1)
+      .period(2)
+      .threshold(10.5)
+      .namespace("AWS/EC2")
+      .metricName("CPUUtilization")
+      .statistic("SampleCount")
+      .unit("Percent")
+      .build())
   }
 
   void "updates named alarm"() {
@@ -101,19 +95,19 @@ class UpsertAlarmOperationUnitSpec extends Specification {
     op.operate([])
 
     then:
-    1 * cloudWatch.putMetricAlarm(new PutMetricAlarmRequest(
-      alarmName: "myAlarm",
-      actionsEnabled: true,
-      alarmDescription: "annoying alarm",
-      comparisonOperator: "GreaterThanThreshold",
-      evaluationPeriods: 1,
-      period: 2,
-      threshold: 10.5,
-      namespace: "AWS/EC2",
-      metricName: "CPUUtilization",
-      statistic: "SampleCount",
-      unit: "Percent"
-    ))
+    1 * cloudWatch.putMetricAlarm(PutMetricAlarmRequest.builder()
+      .alarmName("myAlarm")
+      .actionsEnabled(true)
+      .alarmDescription("annoying alarm")
+      .comparisonOperator("GreaterThanThreshold")
+      .evaluationPeriods(1)
+      .period(2)
+      .threshold(10.5)
+      .namespace("AWS/EC2")
+      .metricName("CPUUtilization")
+      .statistic("SampleCount")
+      .unit("Percent")
+      .build())
   }
 
 
@@ -124,22 +118,22 @@ class UpsertAlarmOperationUnitSpec extends Specification {
     op.operate([])
 
     then:
-    1 * cloudWatch.putMetricAlarm(new PutMetricAlarmRequest(
-      alarmName: "kato-main-v000-alarm-1",
-      actionsEnabled: true,
-      alarmDescription: "annoying alarm",
-      comparisonOperator: "GreaterThanThreshold",
-      evaluationPeriods: 1,
-      period: 2,
-      threshold: 10.5,
-      namespace: "AWS/EC2",
-      metricName: "CPUUtilization",
-      statistic: "SampleCount",
-      unit: "Percent",
-      dimensions: [
-              new Dimension(name: "AutoScalingGroupName", value: "kato-main-v000")
-      ]
-    ))
+    1 * cloudWatch.putMetricAlarm(PutMetricAlarmRequest.builder()
+      .alarmName("kato-main-v000-alarm-1")
+      .actionsEnabled(true)
+      .alarmDescription("annoying alarm")
+      .comparisonOperator("GreaterThanThreshold")
+      .evaluationPeriods(1)
+      .period(2)
+      .threshold(10.5)
+      .namespace("AWS/EC2")
+      .metricName("CPUUtilization")
+      .statistic("SampleCount")
+      .unit("Percent")
+      .dimensions([
+              Dimension.builder().name("AutoScalingGroupName").value("kato-main-v000").build()
+      ])
+      .build())
   }
 
 
@@ -150,75 +144,75 @@ class UpsertAlarmOperationUnitSpec extends Specification {
     op.operate([])
 
     then:
-    1 * cloudWatch.putMetricAlarm(new PutMetricAlarmRequest(
-      alarmName: "alarm-1",
-      actionsEnabled: false,
-      alarmDescription: "annoying alarm",
-      comparisonOperator: "GreaterThanThreshold",
-      evaluationPeriods: 1,
-      period: 2,
-      threshold: 10.5,
-      namespace: "AWS/EC2",
-      metricName: "CPUUtilization",
-      statistic: "SampleCount",
-      unit: "Percent"
-    ))
+    1 * cloudWatch.putMetricAlarm(PutMetricAlarmRequest.builder()
+      .alarmName("alarm-1")
+      .actionsEnabled(false)
+      .alarmDescription("annoying alarm")
+      .comparisonOperator("GreaterThanThreshold")
+      .evaluationPeriods(1)
+      .period(2)
+      .threshold(10.5)
+      .namespace("AWS/EC2")
+      .metricName("CPUUtilization")
+      .statistic("SampleCount")
+      .unit("Percent")
+      .build())
   }
 
   void "creates alarm with dimensions"() {
     description.dimensions = [
-            new Dimension(name: "a", value: "1")
+            Dimension.builder().name("a").value("1").build()
     ]
 
     when:
     op.operate([])
 
     then:
-    1 * cloudWatch.putMetricAlarm(new PutMetricAlarmRequest(
-      alarmName: "alarm-1",
-      actionsEnabled: true,
-      alarmDescription: "annoying alarm",
-      comparisonOperator: "GreaterThanThreshold",
-      evaluationPeriods: 1,
-      period: 2,
-      threshold: 10.5,
-      namespace: "AWS/EC2",
-      metricName: "CPUUtilization",
-      statistic: "SampleCount",
-      unit: "Percent",
-      dimensions: [
-        new Dimension(name: "a", value: "1")
-      ]
-    ))
+    1 * cloudWatch.putMetricAlarm(PutMetricAlarmRequest.builder()
+      .alarmName("alarm-1")
+      .actionsEnabled(true)
+      .alarmDescription("annoying alarm")
+      .comparisonOperator("GreaterThanThreshold")
+      .evaluationPeriods(1)
+      .period(2)
+      .threshold(10.5)
+      .namespace("AWS/EC2")
+      .metricName("CPUUtilization")
+      .statistic("SampleCount")
+      .unit("Percent")
+      .dimensions([
+        Dimension.builder().name("a").value("1").build()
+      ])
+      .build())
   }
 
   void "creates alarm with dimensions for ASG"() {
     description.asgName = "kato-main-v000"
     description.dimensions = [
-      new Dimension(name: "a", value: "1")
+      Dimension.builder().name("a").value("1").build()
     ]
 
     when:
     op.operate([])
 
     then:
-    1 * cloudWatch.putMetricAlarm(new PutMetricAlarmRequest(
-      alarmName: "kato-main-v000-alarm-1",
-      actionsEnabled: true,
-      alarmDescription: "annoying alarm",
-      comparisonOperator: "GreaterThanThreshold",
-      evaluationPeriods: 1,
-      period: 2,
-      threshold: 10.5,
-      namespace: "AWS/EC2",
-      metricName: "CPUUtilization",
-      statistic: "SampleCount",
-      unit: "Percent",
-      dimensions: [
-        new Dimension(name: "a", value: "1"),
-        new Dimension(name: "AutoScalingGroupName", value: "kato-main-v000")
-      ],
-    ))
+    1 * cloudWatch.putMetricAlarm(PutMetricAlarmRequest.builder()
+      .alarmName("kato-main-v000-alarm-1")
+      .actionsEnabled(true)
+      .alarmDescription("annoying alarm")
+      .comparisonOperator("GreaterThanThreshold")
+      .evaluationPeriods(1)
+      .period(2)
+      .threshold(10.5)
+      .namespace("AWS/EC2")
+      .metricName("CPUUtilization")
+      .statistic("SampleCount")
+      .unit("Percent")
+      .dimensions([
+        Dimension.builder().name("a").value("1").build(),
+        Dimension.builder().name("AutoScalingGroupName").value("kato-main-v000").build()
+      ])
+      .build())
   }
 
   void "creates alarm with actions"() {
@@ -230,22 +224,22 @@ class UpsertAlarmOperationUnitSpec extends Specification {
     op.operate([])
 
     then:
-    1 * cloudWatch.putMetricAlarm(new PutMetricAlarmRequest(
-      alarmName: "alarm-1",
-      actionsEnabled: true,
-      alarmDescription: "annoying alarm",
-      comparisonOperator: "GreaterThanThreshold",
-      evaluationPeriods: 1,
-      period: 2,
-      threshold: 10.5,
-      namespace: "AWS/EC2",
-      metricName: "CPUUtilization",
-      statistic: "SampleCount",
-      unit: "Percent",
-      alarmActions: ["arn1"],
-      insufficientDataActions: ["arn2", "arn3"],
-      oKActions: ["arn4"]
-    ))
+    1 * cloudWatch.putMetricAlarm(PutMetricAlarmRequest.builder()
+      .alarmName("alarm-1")
+      .actionsEnabled(true)
+      .alarmDescription("annoying alarm")
+      .comparisonOperator("GreaterThanThreshold")
+      .evaluationPeriods(1)
+      .period(2)
+      .threshold(10.5)
+      .namespace("AWS/EC2")
+      .metricName("CPUUtilization")
+      .statistic("SampleCount")
+      .unit("Percent")
+      .alarmActions(["arn1"])
+      .insufficientDataActions(["arn2", "arn3"])
+      .okActions(["arn4"])
+      .build())
   }
 
   void "creates alarm with associated scaling policy in prior output"() {
@@ -256,22 +250,22 @@ class UpsertAlarmOperationUnitSpec extends Specification {
     ])
 
     then:
-    1 * cloudWatch.putMetricAlarm(new PutMetricAlarmRequest(
-      alarmName: "alarm-1",
-      actionsEnabled: true,
-      alarmDescription: "annoying alarm",
-      comparisonOperator: "GreaterThanThreshold",
-      evaluationPeriods: 1,
-      period: 2,
-      threshold: 10.5,
-      namespace: "AWS/EC2",
-      metricName: "CPUUtilization",
-      statistic: "SampleCount",
-      unit: "Percent",
-      alarmActions: [
+    1 * cloudWatch.putMetricAlarm(PutMetricAlarmRequest.builder()
+      .alarmName("alarm-1")
+      .actionsEnabled(true)
+      .alarmDescription("annoying alarm")
+      .comparisonOperator("GreaterThanThreshold")
+      .evaluationPeriods(1)
+      .period(2)
+      .threshold(10.5)
+      .namespace("AWS/EC2")
+      .metricName("CPUUtilization")
+      .statistic("SampleCount")
+      .unit("Percent")
+      .alarmActions([
               "arn"
-      ]
-    ))
+      ])
+      .build())
   }
 
 }

--- a/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/UpsertScalingPolicyAtomicOperationUnitSpec.groovy
+++ b/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/UpsertScalingPolicyAtomicOperationUnitSpec.groovy
@@ -16,11 +16,11 @@
 
 package com.netflix.spinnaker.clouddriver.aws.deploy.ops
 
-import com.amazonaws.services.autoscaling.AmazonAutoScaling
-import com.amazonaws.services.autoscaling.model.PutScalingPolicyRequest
-import com.amazonaws.services.autoscaling.model.PutScalingPolicyResult
-import com.amazonaws.services.autoscaling.model.StepAdjustment
-import com.amazonaws.services.cloudwatch.AmazonCloudWatch
+import software.amazon.awssdk.services.autoscaling.AutoScalingClient
+import software.amazon.awssdk.services.autoscaling.model.PutScalingPolicyRequest
+import software.amazon.awssdk.services.autoscaling.model.PutScalingPolicyResponse
+import software.amazon.awssdk.services.autoscaling.model.StepAdjustment
+import software.amazon.awssdk.services.cloudwatch.CloudWatchClient
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.AdjustmentType
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.MetricAggregationType
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.UpsertAlarmDescription
@@ -48,11 +48,11 @@ class UpsertScalingPolicyAtomicOperationUnitSpec extends Specification {
     )
   )
 
-  def autoScaling = Mock(AmazonAutoScaling)
-  def cloudWatch = Mock(AmazonCloudWatch)
+  def autoScaling = Mock(AutoScalingClient)
+  def cloudWatch = Mock(CloudWatchClient)
   def amazonClientProvider = Stub(AmazonClientProvider) {
-    getAutoScaling(_, _, true) >> autoScaling
-    getCloudWatch(_, _, true) >> cloudWatch
+    getAutoScalingV2(_, _) >> autoScaling
+    getAmazonCloudWatchV2(_, _) >> cloudWatch
   }
 
   @Subject def op = new UpsertScalingPolicyAtomicOperation(description)
@@ -73,16 +73,16 @@ class UpsertScalingPolicyAtomicOperationUnitSpec extends Specification {
     final result = op.operate([])
 
     then:
-    1 * autoScaling.putScalingPolicy(new PutScalingPolicyRequest(
-      policyName: "kato-main-v000-policy-1",
-      autoScalingGroupName: "kato-main-v000",
-      adjustmentType: "PercentChangeInCapacity",
-      cooldown: 1,
-      minAdjustmentMagnitude: 3,
-      scalingAdjustment: 5,
-      policyType: "SimpleScaling"
-    )) >> {
-      new PutScalingPolicyResult(policyARN: "arn", )
+    1 * autoScaling.putScalingPolicy(PutScalingPolicyRequest.builder()
+      .policyName("kato-main-v000-policy-1")
+      .autoScalingGroupName("kato-main-v000")
+      .adjustmentType("PercentChangeInCapacity")
+      .cooldown(1)
+      .minAdjustmentMagnitude(3)
+      .scalingAdjustment(5)
+      .policyType("SimpleScaling")
+      .build()) >> {
+      PutScalingPolicyResponse.builder().policyARN("arn").build()
     }
 
     result == new UpsertScalingPolicyResult(policyArn: "arn", policyName: "kato-main-v000-policy-1")
@@ -94,7 +94,7 @@ class UpsertScalingPolicyAtomicOperationUnitSpec extends Specification {
       estimatedInstanceWarmup: 2,
       metricAggregationType: MetricAggregationType.Average,
       stepAdjustments: [
-            new StepAdjustment(metricIntervalLowerBound: 100, metricIntervalUpperBound: 200, scalingAdjustment: 30)
+            StepAdjustment.builder().metricIntervalLowerBound(100).metricIntervalUpperBound(200).scalingAdjustment(30).build()
       ]
     )
 
@@ -102,19 +102,19 @@ class UpsertScalingPolicyAtomicOperationUnitSpec extends Specification {
     final result = op.operate([])
 
     then:
-    1 * autoScaling.putScalingPolicy(new PutScalingPolicyRequest(
-      policyName: "kato-main-v000-policy-1",
-      autoScalingGroupName: "kato-main-v000",
-      adjustmentType: "PercentChangeInCapacity",
-      estimatedInstanceWarmup: 2,
-      minAdjustmentMagnitude: 3,
-      stepAdjustments: [
-        new StepAdjustment(metricIntervalLowerBound: 100, metricIntervalUpperBound: 200, scalingAdjustment: 30)
-      ],
-      metricAggregationType: "Average",
-      policyType: "StepScaling"
-    )) >> {
-      new PutScalingPolicyResult(policyARN: "arn")
+    1 * autoScaling.putScalingPolicy(PutScalingPolicyRequest.builder()
+      .policyName("kato-main-v000-policy-1")
+      .autoScalingGroupName("kato-main-v000")
+      .adjustmentType("PercentChangeInCapacity")
+      .estimatedInstanceWarmup(2)
+      .minAdjustmentMagnitude(3)
+      .stepAdjustments([
+        StepAdjustment.builder().metricIntervalLowerBound(100).metricIntervalUpperBound(200).scalingAdjustment(30).build()
+      ])
+      .metricAggregationType("Average")
+      .policyType("StepScaling")
+      .build()) >> {
+      PutScalingPolicyResponse.builder().policyARN("arn").build()
     }
 
     result == new UpsertScalingPolicyResult(policyArn: "arn", policyName: "kato-main-v000-policy-1")
@@ -129,16 +129,16 @@ class UpsertScalingPolicyAtomicOperationUnitSpec extends Specification {
     final result = op.operate([])
 
     then:
-    1 * autoScaling.putScalingPolicy(new PutScalingPolicyRequest(
-      policyName: "existingPolicy",
-      autoScalingGroupName: "kato-main-v000",
-      adjustmentType: "PercentChangeInCapacity",
-      cooldown: 1,
-      minAdjustmentMagnitude: 3,
-      scalingAdjustment: 5,
-      policyType: "SimpleScaling"
-    )) >> {
-      new PutScalingPolicyResult(policyARN: "arn")
+    1 * autoScaling.putScalingPolicy(PutScalingPolicyRequest.builder()
+      .policyName("existingPolicy")
+      .autoScalingGroupName("kato-main-v000")
+      .adjustmentType("PercentChangeInCapacity")
+      .cooldown(1)
+      .minAdjustmentMagnitude(3)
+      .scalingAdjustment(5)
+      .policyType("SimpleScaling")
+      .build()) >> {
+      PutScalingPolicyResponse.builder().policyARN("arn").build()
     }
 
     result == new UpsertScalingPolicyResult(policyArn: "arn", policyName: "existingPolicy")
@@ -154,16 +154,16 @@ class UpsertScalingPolicyAtomicOperationUnitSpec extends Specification {
     final result = op.operate([])
 
     then:
-    1 * autoScaling.putScalingPolicy(new PutScalingPolicyRequest(
-        policyName: "existingPolicy",
-        autoScalingGroupName: "kato-main-v000",
-        adjustmentType: "PercentChangeInCapacity",
-        cooldown: 1,
-        minAdjustmentMagnitude: 3,
-        scalingAdjustment: 5,
-        policyType: "SimpleScaling",
-    )) >> {
-      new PutScalingPolicyResult(policyARN: "arn")
+    1 * autoScaling.putScalingPolicy(PutScalingPolicyRequest.builder()
+      .policyName("existingPolicy")
+      .autoScalingGroupName("kato-main-v000")
+      .adjustmentType("PercentChangeInCapacity")
+      .cooldown(1)
+      .minAdjustmentMagnitude(3)
+      .scalingAdjustment(5)
+      .policyType("SimpleScaling")
+      .build()) >> {
+      PutScalingPolicyResponse.builder().policyARN("arn").build()
     }
 
     1 * cloudWatch.putMetricAlarm(alarm.buildRequest())
@@ -183,16 +183,16 @@ class UpsertScalingPolicyAtomicOperationUnitSpec extends Specification {
     final result = op.operate([])
 
     then:
-    1 * autoScaling.putScalingPolicy(new PutScalingPolicyRequest(
-        policyName: "existingPolicy",
-        autoScalingGroupName: "kato-main-v000",
-        adjustmentType: "PercentChangeInCapacity",
-        cooldown: 1,
-        minAdjustmentMagnitude: 3,
-        scalingAdjustment: 5,
-        policyType: "SimpleScaling",
-    )) >> {
-      new PutScalingPolicyResult(policyARN: "arn")
+    1 * autoScaling.putScalingPolicy(PutScalingPolicyRequest.builder()
+      .policyName("existingPolicy")
+      .autoScalingGroupName("kato-main-v000")
+      .adjustmentType("PercentChangeInCapacity")
+      .cooldown(1)
+      .minAdjustmentMagnitude(3)
+      .scalingAdjustment(5)
+      .policyType("SimpleScaling")
+      .build()) >> {
+      PutScalingPolicyResponse.builder().policyARN("arn").build()
     }
 
     1 * cloudWatch.putMetricAlarm(_)

--- a/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/scalingpolicy/DefaultScalingPolicyCopierSpec.groovy
+++ b/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/scalingpolicy/DefaultScalingPolicyCopierSpec.groovy
@@ -16,20 +16,20 @@
 
 package com.netflix.spinnaker.clouddriver.aws.deploy.scalingpolicy
 
-import com.amazonaws.services.autoscaling.AmazonAutoScaling
-import com.amazonaws.services.autoscaling.model.Alarm
-import com.amazonaws.services.autoscaling.model.DescribePoliciesRequest
-import com.amazonaws.services.autoscaling.model.DescribePoliciesResult
-import com.amazonaws.services.autoscaling.model.PutScalingPolicyRequest
-import com.amazonaws.services.autoscaling.model.PutScalingPolicyResult
-import com.amazonaws.services.autoscaling.model.ScalingPolicy
-import com.amazonaws.services.autoscaling.model.StepAdjustment
-import com.amazonaws.services.cloudwatch.AmazonCloudWatch
-import com.amazonaws.services.cloudwatch.model.DescribeAlarmsRequest
-import com.amazonaws.services.cloudwatch.model.DescribeAlarmsResult
-import com.amazonaws.services.cloudwatch.model.Dimension
-import com.amazonaws.services.cloudwatch.model.MetricAlarm
-import com.amazonaws.services.cloudwatch.model.PutMetricAlarmRequest
+import software.amazon.awssdk.services.autoscaling.AutoScalingClient
+import software.amazon.awssdk.services.autoscaling.model.Alarm
+import software.amazon.awssdk.services.autoscaling.model.DescribePoliciesRequest
+import software.amazon.awssdk.services.autoscaling.model.DescribePoliciesResponse
+import software.amazon.awssdk.services.autoscaling.model.PutScalingPolicyRequest
+import software.amazon.awssdk.services.autoscaling.model.PutScalingPolicyResponse
+import software.amazon.awssdk.services.autoscaling.model.ScalingPolicy
+import software.amazon.awssdk.services.autoscaling.model.StepAdjustment
+import software.amazon.awssdk.services.cloudwatch.CloudWatchClient
+import software.amazon.awssdk.services.cloudwatch.model.DescribeAlarmsRequest
+import software.amazon.awssdk.services.cloudwatch.model.DescribeAlarmsResponse
+import software.amazon.awssdk.services.cloudwatch.model.Dimension
+import software.amazon.awssdk.services.cloudwatch.model.MetricAlarm
+import software.amazon.awssdk.services.cloudwatch.model.PutMetricAlarmRequest
 import com.netflix.spinnaker.clouddriver.aws.deploy.asg.AsgReferenceCopier
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
@@ -40,21 +40,21 @@ import spock.lang.Subject
 
 class DefaultScalingPolicyCopierSpec extends Specification {
 
-  def sourceAutoScaling = Mock(AmazonAutoScaling)
-  def targetAutoScaling = Mock(AmazonAutoScaling)
+  def sourceAutoScaling = Mock(AutoScalingClient)
+  def targetAutoScaling = Mock(AutoScalingClient)
   def sourceCredentials = Stub(NetflixAmazonCredentials) {
     getAccountId() >> 'abc'
   }
   def targetCredentials = Stub(NetflixAmazonCredentials) {
     getAccountId() >> 'def'
   }
-  def sourceCloudWatch = Mock(AmazonCloudWatch)
-  def targetCloudWatch = Mock(AmazonCloudWatch)
+  def sourceCloudWatch = Mock(CloudWatchClient)
+  def targetCloudWatch = Mock(CloudWatchClient)
   def amazonClientProvider = Stub(AmazonClientProvider) {
-    getAutoScaling(_, 'us-east-1', true) >> sourceAutoScaling
-    getAutoScaling(_, 'us-west-1', true) >> targetAutoScaling
-    getCloudWatch(_, 'us-east-1', true) >> sourceCloudWatch
-    getCloudWatch(_, 'us-west-1', true) >> targetCloudWatch
+    getAutoScalingV2(_, 'us-east-1') >> sourceAutoScaling
+    getAutoScalingV2(_, 'us-west-1') >> targetAutoScaling
+    getAmazonCloudWatchV2(_, 'us-east-1') >> sourceCloudWatch
+    getAmazonCloudWatchV2(_, 'us-west-1') >> targetCloudWatch
   }
   String newPolicyName = 'new_policy_name'
 
@@ -80,8 +80,8 @@ class DefaultScalingPolicyCopierSpec extends Specification {
     scalingPolicyCopier.copyScalingPolicies(Mock(Task), 'asgard-v000', 'asgard-v001', sourceCredentials, targetCredentials, 'us-east-1', 'us-west-1')
 
     then:
-    1 * sourceAutoScaling.describePolicies(new DescribePoliciesRequest(autoScalingGroupName: 'asgard-v000')) >>
-      new DescribePoliciesResult(scalingPolicies: [])
+    1 * sourceAutoScaling.describePolicies(DescribePoliciesRequest.builder().autoScalingGroupName('asgard-v000').build()) >>
+      DescribePoliciesResponse.builder().scalingPolicies([]).build()
     0 * targetAutoScaling.putScalingPolicy(_)
     0 * sourceCloudWatch.describeAlarms(_)
     0 * targetCloudWatch.putMetricAlarm(_)
@@ -101,35 +101,10 @@ class DefaultScalingPolicyCopierSpec extends Specification {
 
   void 'generates a semantically meaningful alarm name'() {
     given:
-    ScalingPolicy policy = new ScalingPolicy(
-      policyARN: 'oldPolicyARN1',
-      autoScalingGroupName: 'asgard-v000',
-      policyName: 'policy1',
-      scalingAdjustment: 5,
-      adjustmentType: 'ChangeInCapacity',
-      cooldown: 100,
-      minAdjustmentStep: 2,
-      alarms: [new Alarm(alarmName: 'alarm1')]
-    )
-    MetricAlarm alarm = new MetricAlarm(
-        alarmName: 'alarm1',
-        alarmDescription: 'alarm 1 description',
-        actionsEnabled: true,
-        oKActions: [],
-        alarmActions: ['oldPolicyARN1'],
-        insufficientDataActions: [],
-        metricName: 'metric1',
-        namespace: 'namespace1',
-        statistic: 'statistic1',
-        dimensions: [
-          new Dimension(name: AsgReferenceCopier.DIMENSION_NAME_FOR_ASG, value: 'asgard-v000')
-        ],
-        period: 1,
-        unit: 'unit1',
-        evaluationPeriods: 2,
-        threshold: 4.2,
-        comparisonOperator: 'GreaterThanOrEqualToThreshold'
-      )
+    ScalingPolicy policy = ScalingPolicy.builder().policyARN('oldPolicyARN1').autoScalingGroupName('asgard-v000').policyName('policy1').scalingAdjustment(5).adjustmentType('ChangeInCapacity').cooldown(100).minAdjustmentStep(2).alarms([Alarm.builder().alarmName('alarm1').build()]).build()
+    MetricAlarm alarm = MetricAlarm.builder().alarmName('alarm1').alarmDescription('alarm 1 description').actionsEnabled(true).okActions([]).alarmActions(['oldPolicyARN1']).insufficientDataActions([]).metricName('metric1').namespace('namespace1').statistic('statistic1').dimensions([
+          Dimension.builder().name(AsgReferenceCopier.DIMENSION_NAME_FOR_ASG).value('asgard-v000').build()
+        ]).period(1).unit('unit1').evaluationPeriods(2).threshold(4.2).comparisonOperator('GreaterThanOrEqualToThreshold').build()
 
     DefaultScalingPolicyCopier.PolicyNameGenerator generator = new DefaultScalingPolicyCopier.PolicyNameGenerator(idGenerator, amazonClientProvider)
 
@@ -138,42 +113,17 @@ class DefaultScalingPolicyCopierSpec extends Specification {
 
     then:
     result.startsWith('asgard-v011-namespace1-metric1-GreaterThanOrEqualToThreshold-4.2-2-1-')
-    1 * sourceCloudWatch.describeAlarms(new DescribeAlarmsRequest(alarmNames: ['alarm1'])) >> new DescribeAlarmsResult(metricAlarms: [
+    1 * sourceCloudWatch.describeAlarms(DescribeAlarmsRequest.builder().alarmNames(['alarm1']).build()) >> DescribeAlarmsResponse.builder().metricAlarms([
       alarm
-    ])
+    ]).build()
   }
 
   void 'generates a valid Scaling Policy Name'() {
     given:
-    ScalingPolicy policy = new ScalingPolicy(
-      policyARN: 'oldPolicyARN1',
-      autoScalingGroupName: 'asgard-v000',
-      policyName: 'policy1',
-      scalingAdjustment: 5,
-      adjustmentType: 'ChangeInCapacity',
-      cooldown: 100,
-      minAdjustmentStep: 2,
-      alarms: [new Alarm(alarmName: 'alarm1')]
-    )
-    MetricAlarm alarm = new MetricAlarm(
-        alarmName: 'alarm1',
-        alarmDescription: 'alarm 1 description',
-        actionsEnabled: true,
-        oKActions: [],
-        alarmActions: ['oldPolicyARN1'],
-        insufficientDataActions: [],
-        metricName: 'Metric1.with-all_acceptable/special#chars:defined',
-        namespace: 'Namespace1.with-all_acceptable/special#chars:defined',
-        statistic: 'statistic1',
-        dimensions: [
-          new Dimension(name: AsgReferenceCopier.DIMENSION_NAME_FOR_ASG, value: 'asgard-v000')
-        ],
-        period: 1,
-        unit: 'unit1',
-        evaluationPeriods: 2,
-        threshold: 4.2,
-        comparisonOperator: 'GreaterThanOrEqualToThreshold'
-      )
+    ScalingPolicy policy = ScalingPolicy.builder().policyARN('oldPolicyARN1').autoScalingGroupName('asgard-v000').policyName('policy1').scalingAdjustment(5).adjustmentType('ChangeInCapacity').cooldown(100).minAdjustmentStep(2).alarms([Alarm.builder().alarmName('alarm1').build()]).build()
+    MetricAlarm alarm = MetricAlarm.builder().alarmName('alarm1').alarmDescription('alarm 1 description').actionsEnabled(true).okActions([]).alarmActions(['oldPolicyARN1']).insufficientDataActions([]).metricName('Metric1.with-all_acceptable/special#chars:defined').namespace('Namespace1.with-all_acceptable/special#chars:defined').statistic('statistic1').dimensions([
+          Dimension.builder().name(AsgReferenceCopier.DIMENSION_NAME_FOR_ASG).value('asgard-v000').build()
+        ]).period(1).unit('unit1').evaluationPeriods(2).threshold(4.2).comparisonOperator('GreaterThanOrEqualToThreshold').build()
 
     DefaultScalingPolicyCopier.PolicyNameGenerator generator = new DefaultScalingPolicyCopier.PolicyNameGenerator(idGenerator, amazonClientProvider)
 
@@ -182,23 +132,14 @@ class DefaultScalingPolicyCopierSpec extends Specification {
 
     then:
     result.startsWith('asgard-v011-Namespace1.with-all_acceptable/special#chars-defined-Metric1.with-all_acceptable/special#chars-defined-GreaterThanOrEqualToThreshold-4.2-2-1-')
-    1 * sourceCloudWatch.describeAlarms(new DescribeAlarmsRequest(alarmNames: ['alarm1'])) >> new DescribeAlarmsResult(metricAlarms: [
+    1 * sourceCloudWatch.describeAlarms(DescribeAlarmsRequest.builder().alarmNames(['alarm1']).build()) >> DescribeAlarmsResponse.builder().metricAlarms([
       alarm
-    ])
+    ]).build()
   }
 
   void 'falls back to asg name replacement when no alarms found'() {
     given:
-    ScalingPolicy policy = new ScalingPolicy(
-      policyARN: 'oldPolicyARN1',
-      autoScalingGroupName: 'asgard-v000',
-      policyName: 'asgard-v010-blah-blah-blah',
-      scalingAdjustment: 5,
-      adjustmentType: 'ChangeInCapacity',
-      cooldown: 100,
-      minAdjustmentStep: 2,
-      alarms: []
-    )
+    ScalingPolicy policy = ScalingPolicy.builder().policyARN('oldPolicyARN1').autoScalingGroupName('asgard-v000').policyName('asgard-v010-blah-blah-blah').scalingAdjustment(5).adjustmentType('ChangeInCapacity').cooldown(100).minAdjustmentStep(2).alarms([]).build()
     DefaultScalingPolicyCopier.PolicyNameGenerator generator = new DefaultScalingPolicyCopier.PolicyNameGenerator(idGenerator, amazonClientProvider)
 
     when:
@@ -213,182 +154,35 @@ class DefaultScalingPolicyCopierSpec extends Specification {
     scalingPolicyCopier.copyScalingPolicies(Mock(Task), 'asgard-v000', 'asgard-v001', sourceCredentials, targetCredentials, 'us-east-1', 'us-west-1')
 
     then:
-    1 * sourceAutoScaling.describePolicies(new DescribePoliciesRequest(autoScalingGroupName: 'asgard-v000')) >>
-      new DescribePoliciesResult(scalingPolicies: [
-        new ScalingPolicy(
-          policyARN: 'oldPolicyARN1',
-          autoScalingGroupName: 'asgard-v000',
-          policyName: 'policy1',
-          scalingAdjustment: 5,
-          adjustmentType: 'ChangeInCapacity',
-          cooldown: 100,
-          minAdjustmentStep: 2,
-          alarms: ['alarm1', 'alarm2'].collect { new Alarm(alarmName: it) }
-        ),
-        new ScalingPolicy(
-          policyARN: 'oldPolicyARN2',
-          autoScalingGroupName: 'asgard-v000',
-          policyName: 'policy2',
-          scalingAdjustment: 10,
-          adjustmentType: 'PercentChangeInCapacity',
-          cooldown: 200,
-          minAdjustmentStep: 3,
-          minAdjustmentMagnitude: 20,
-          metricAggregationType: "Average",
-          estimatedInstanceWarmup: 30,
-          stepAdjustments: [
-            new StepAdjustment(
-              metricIntervalLowerBound: 10.5,
-              metricIntervalUpperBound: 11.5,
-              scalingAdjustment: 90,
-            )
-          ],
-          policyType: "StepScaling",
-          alarms: ['alarm2', 'alarm3'].collect { new Alarm(alarmName: it) }
-        )
-      ]
-      )
-    1 * targetAutoScaling.putScalingPolicy(new PutScalingPolicyRequest(
-      autoScalingGroupName: 'asgard-v001',
-      policyName: newPolicyName,
-      scalingAdjustment: 5,
-      adjustmentType: 'ChangeInCapacity',
-      cooldown: 100,
-      minAdjustmentStep: 2
-    )) >> new PutScalingPolicyResult(policyARN: 'newPolicyARN1')
-    1 * targetAutoScaling.putScalingPolicy(new PutScalingPolicyRequest(
-      autoScalingGroupName: 'asgard-v001',
-      policyName: newPolicyName,
-      scalingAdjustment: 10,
-      adjustmentType: 'PercentChangeInCapacity',
-      cooldown: 200,
-      minAdjustmentStep: 3,
-      minAdjustmentMagnitude: 20,
-      metricAggregationType: "Average",
-      estimatedInstanceWarmup: 30,
-      stepAdjustments: [
-        new StepAdjustment(
-          metricIntervalLowerBound: 10.5,
-          metricIntervalUpperBound: 11.5,
-          scalingAdjustment: 90,
-        )
-      ],
-      policyType: "StepScaling",
-    )) >> new PutScalingPolicyResult(policyARN: 'newPolicyARN2')
+    1 * sourceAutoScaling.describePolicies(DescribePoliciesRequest.builder().autoScalingGroupName('asgard-v000').build()) >>
+      DescribePoliciesResponse.builder().scalingPolicies([
+        ScalingPolicy.builder().policyARN('oldPolicyARN1').autoScalingGroupName('asgard-v000').policyName('policy1').scalingAdjustment(5).adjustmentType('ChangeInCapacity').cooldown(100).minAdjustmentStep(2).alarms(['alarm1', 'alarm2'].collect { Alarm.builder().alarmName(it).build() }).build(),
+        ScalingPolicy.builder().policyARN('oldPolicyARN2').autoScalingGroupName('asgard-v000').policyName('policy2').scalingAdjustment(10).adjustmentType('PercentChangeInCapacity').cooldown(200).minAdjustmentStep(3).minAdjustmentMagnitude(20).metricAggregationType("Average").estimatedInstanceWarmup(30).stepAdjustments([
+            StepAdjustment.builder().metricIntervalLowerBound(10.5).metricIntervalUpperBound(11.5).scalingAdjustment(90).build()
+          ]).policyType("StepScaling").alarms(['alarm2', 'alarm3'].collect { Alarm.builder().alarmName(it).build() }).build()
+      ]).build()
+    1 * targetAutoScaling.putScalingPolicy(PutScalingPolicyRequest.builder().autoScalingGroupName('asgard-v001').policyName(newPolicyName).scalingAdjustment(5).adjustmentType('ChangeInCapacity').cooldown(100).minAdjustmentStep(2).build()) >> PutScalingPolicyResponse.builder().policyARN('newPolicyARN1').build()
+    1 * targetAutoScaling.putScalingPolicy(PutScalingPolicyRequest.builder().autoScalingGroupName('asgard-v001').policyName(newPolicyName).scalingAdjustment(10).adjustmentType('PercentChangeInCapacity').cooldown(200).minAdjustmentStep(3).minAdjustmentMagnitude(20).metricAggregationType("Average").estimatedInstanceWarmup(30).stepAdjustments([
+        StepAdjustment.builder().metricIntervalLowerBound(10.5).metricIntervalUpperBound(11.5).scalingAdjustment(90).build()
+      ]).policyType("StepScaling").build()) >> PutScalingPolicyResponse.builder().policyARN('newPolicyARN2').build()
 
-    1 * sourceCloudWatch.describeAlarms(new DescribeAlarmsRequest(alarmNames: ['alarm1', 'alarm2', 'alarm3'])) >> new DescribeAlarmsResult(metricAlarms: [
-      new MetricAlarm(
-        alarmName: 'alarm1',
-        alarmDescription: 'alarm 1 description',
-        actionsEnabled: true,
-        oKActions: [],
-        alarmActions: ['oldPolicyARN1'],
-        insufficientDataActions: [],
-        metricName: 'metric1',
-        namespace: 'namespace1',
-        statistic: 'statistic1',
-        dimensions: [
-          new Dimension(name: AsgReferenceCopier.DIMENSION_NAME_FOR_ASG, value: 'asgard-v000')
-        ],
-        period: 1,
-        unit: 'unit1',
-        evaluationPeriods: 2,
-        threshold: 4.2,
-        comparisonOperator: 'GreaterThanOrEqualToThreshold'
-      ),
-      new MetricAlarm(
-        alarmName: 'alarm2',
-        alarmDescription: 'alarm 2 description',
-        actionsEnabled: true,
-        oKActions: [],
-        alarmActions: ['oldPolicyARN1', 'oldPolicyARN2', 'action1'],
-        insufficientDataActions: [],
-        metricName: 'metric2',
-        namespace: 'namespace2',
-        statistic: 'statistic2',
-        dimensions: [
-          new Dimension(name: AsgReferenceCopier.DIMENSION_NAME_FOR_ASG, value: 'asgard-v000'),
-          new Dimension(name: 'other', value: 'dimension1')
-        ],
-        period: 10,
-        unit: 'unit2',
-        evaluationPeriods: 20,
-        threshold: 40.2,
-        comparisonOperator: 'LessThanOrEqualToThreshold'
-      ),
-      new MetricAlarm(
-        alarmName: 'alarm3',
-        alarmDescription: 'alarm 3 description',
-        actionsEnabled: false,
-        oKActions: [],
-        alarmActions: [],
-        insufficientDataActions: ['oldPolicyARN2'],
-        metricName: 'metric3',
-        namespace: 'namespace3',
-        statistic: 'statistic3',
-        dimensions: [],
-        period: 31,
-        unit: 'unit3',
-        evaluationPeriods: 32,
-        threshold: 34,
-        comparisonOperator: 'GreaterThanThreshold'
-      ),
-    ])
-    1 * targetCloudWatch.putMetricAlarm(new PutMetricAlarmRequest(
-      alarmName: 'asgard-v001-alarm-1',
-      alarmDescription: 'alarm 1 description',
-      actionsEnabled: true,
-      oKActions: [],
-      alarmActions: ['newPolicyARN1'],
-      insufficientDataActions: [],
-      metricName: 'metric1',
-      namespace: 'namespace1',
-      statistic: 'statistic1',
-      dimensions: [
-        new Dimension(name: AsgReferenceCopier.DIMENSION_NAME_FOR_ASG, value: 'asgard-v001')
-      ],
-      period: 1,
-      unit: 'unit1',
-      evaluationPeriods: 2,
-      threshold: 4.2,
-      comparisonOperator: 'GreaterThanOrEqualToThreshold'
-    ))
-    1 * targetCloudWatch.putMetricAlarm(new PutMetricAlarmRequest(
-      alarmName: 'asgard-v001-alarm-2',
-      alarmDescription: 'alarm 2 description',
-      actionsEnabled: true,
-      oKActions: [],
-      alarmActions: ['action1', 'newPolicyARN1', 'newPolicyARN2'],
-      insufficientDataActions: [],
-      metricName: 'metric2',
-      namespace: 'namespace2',
-      statistic: 'statistic2',
-      dimensions: [
-        new Dimension(name: 'other', value: 'dimension1'),
-        new Dimension(name: AsgReferenceCopier.DIMENSION_NAME_FOR_ASG, value: 'asgard-v001')
-      ],
-      period: 10,
-      unit: 'unit2',
-      evaluationPeriods: 20,
-      threshold: 40.2,
-      comparisonOperator: 'LessThanOrEqualToThreshold'
-    ))
-    1 * targetCloudWatch.putMetricAlarm(new PutMetricAlarmRequest(
-      alarmName: 'asgard-v001-alarm-3',
-      alarmDescription: 'alarm 3 description',
-      actionsEnabled: false,
-      oKActions: [],
-      alarmActions: [],
-      insufficientDataActions: ['newPolicyARN2'],
-      metricName: 'metric3',
-      namespace: 'namespace3',
-      statistic: 'statistic3',
-      dimensions: [],
-      period: 31,
-      unit: 'unit3',
-      evaluationPeriods: 32,
-      threshold: 34,
-      comparisonOperator: 'GreaterThanThreshold'
-    ))
+    1 * sourceCloudWatch.describeAlarms(DescribeAlarmsRequest.builder().alarmNames(['alarm1', 'alarm2', 'alarm3']).build()) >> DescribeAlarmsResponse.builder().metricAlarms([
+      MetricAlarm.builder().alarmName('alarm1').alarmDescription('alarm 1 description').actionsEnabled(true).okActions([]).alarmActions(['oldPolicyARN1']).insufficientDataActions([]).metricName('metric1').namespace('namespace1').statistic('statistic1').dimensions([
+          Dimension.builder().name(AsgReferenceCopier.DIMENSION_NAME_FOR_ASG).value('asgard-v000').build()
+        ]).period(1).unit('unit1').evaluationPeriods(2).threshold(4.2).comparisonOperator('GreaterThanOrEqualToThreshold').build(),
+      MetricAlarm.builder().alarmName('alarm2').alarmDescription('alarm 2 description').actionsEnabled(true).okActions([]).alarmActions(['oldPolicyARN1', 'oldPolicyARN2', 'action1']).insufficientDataActions([]).metricName('metric2').namespace('namespace2').statistic('statistic2').dimensions([
+          Dimension.builder().name(AsgReferenceCopier.DIMENSION_NAME_FOR_ASG).value('asgard-v000').build(),
+          Dimension.builder().name('other').value('dimension1').build()
+        ]).period(10).unit('unit2').evaluationPeriods(20).threshold(40.2).comparisonOperator('LessThanOrEqualToThreshold').build(),
+      MetricAlarm.builder().alarmName('alarm3').alarmDescription('alarm 3 description').actionsEnabled(false).okActions([]).alarmActions([]).insufficientDataActions(['oldPolicyARN2']).metricName('metric3').namespace('namespace3').statistic('statistic3').dimensions([]).period(31).unit('unit3').evaluationPeriods(32).threshold(34).comparisonOperator('GreaterThanThreshold').build(),
+    ]).build()
+    1 * targetCloudWatch.putMetricAlarm(PutMetricAlarmRequest.builder().alarmName('asgard-v001-alarm-1').alarmDescription('alarm 1 description').actionsEnabled(true).okActions([]).alarmActions(['newPolicyARN1']).insufficientDataActions([]).metricName('metric1').namespace('namespace1').statistic('statistic1').dimensions([
+        Dimension.builder().name(AsgReferenceCopier.DIMENSION_NAME_FOR_ASG).value('asgard-v001').build()
+      ]).period(1).unit('unit1').evaluationPeriods(2).threshold(4.2).comparisonOperator('GreaterThanOrEqualToThreshold').build())
+    1 * targetCloudWatch.putMetricAlarm(PutMetricAlarmRequest.builder().alarmName('asgard-v001-alarm-2').alarmDescription('alarm 2 description').actionsEnabled(true).okActions([]).alarmActions(['action1', 'newPolicyARN1', 'newPolicyARN2']).insufficientDataActions([]).metricName('metric2').namespace('namespace2').statistic('statistic2').dimensions([
+        Dimension.builder().name('other').value('dimension1').build(),
+        Dimension.builder().name(AsgReferenceCopier.DIMENSION_NAME_FOR_ASG).value('asgard-v001').build()
+      ]).period(10).unit('unit2').evaluationPeriods(20).threshold(40.2).comparisonOperator('LessThanOrEqualToThreshold').build())
+    1 * targetCloudWatch.putMetricAlarm(PutMetricAlarmRequest.builder().alarmName('asgard-v001-alarm-3').alarmDescription('alarm 3 description').actionsEnabled(false).okActions([]).alarmActions([]).insufficientDataActions(['newPolicyARN2']).metricName('metric3').namespace('namespace3').statistic('statistic3').dimensions([]).period(31).unit('unit3').evaluationPeriods(32).threshold(34).comparisonOperator('GreaterThanThreshold').build())
   }
 }

--- a/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonMetricStatisticsSpec.groovy
+++ b/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonMetricStatisticsSpec.groovy
@@ -16,21 +16,21 @@
 
 package com.netflix.spinnaker.clouddriver.aws.model
 
-import com.amazonaws.services.cloudwatch.model.Datapoint
-import com.amazonaws.services.cloudwatch.model.GetMetricStatisticsResult
+import software.amazon.awssdk.services.cloudwatch.model.Datapoint
+import software.amazon.awssdk.services.cloudwatch.model.GetMetricStatisticsResponse
 import spock.lang.Specification
 
 class AmazonMetricStatisticsSpec extends Specification {
 
   void "should sort metrics by timestamp"() {
     given:
-    GetMetricStatisticsResult amazonResult = new GetMetricStatisticsResult()
-    .withDatapoints(
-        new Datapoint().withTimestamp(new Date(4)).withAverage(3.0),
-        new Datapoint().withTimestamp(new Date(0)).withAverage(1.0),
-        new Datapoint().withTimestamp(new Date(1)).withAverage(2.0),
-        new Datapoint().withTimestamp(new Date(3)).withAverage(1.0)
-    )
+    GetMetricStatisticsResponse amazonResult = GetMetricStatisticsResponse.builder()
+    .datapoints(
+        Datapoint.builder().timestamp(new Date(4).toInstant()).average(3.0).build(),
+        Datapoint.builder().timestamp(new Date(0).toInstant()).average(1.0).build(),
+        Datapoint.builder().timestamp(new Date(1).toInstant()).average(2.0).build(),
+        Datapoint.builder().timestamp(new Date(3).toInstant()).average(1.0).build()
+    ).build()
     when:
     AmazonMetricStatistics result = AmazonMetricStatistics.from(amazonResult)
 
@@ -41,14 +41,14 @@ class AmazonMetricStatisticsSpec extends Specification {
 
   void "should add any statistics provided by datapoints"() {
     given:
-    GetMetricStatisticsResult amazonResult = new GetMetricStatisticsResult()
-        .withDatapoints(
-        new Datapoint().withTimestamp(new Date(0)).withAverage(3.0),
-        new Datapoint().withTimestamp(new Date(1)).withMaximum(1.0),
-        new Datapoint().withTimestamp(new Date(2)).withMinimum(2.0),
-        new Datapoint().withTimestamp(new Date(3)).withSampleCount(1.0),
-        new Datapoint().withTimestamp(new Date(3)).withSum(6.0)
-    )
+    GetMetricStatisticsResponse amazonResult = GetMetricStatisticsResponse.builder()
+        .datapoints(
+        Datapoint.builder().timestamp(new Date(0).toInstant()).average(3.0).build(),
+        Datapoint.builder().timestamp(new Date(1).toInstant()).maximum(1.0).build(),
+        Datapoint.builder().timestamp(new Date(2).toInstant()).minimum(2.0).build(),
+        Datapoint.builder().timestamp(new Date(3).toInstant()).sampleCount(1.0).build(),
+        Datapoint.builder().timestamp(new Date(3).toInstant()).sum(6.0).build()
+    ).build()
     when:
     AmazonMetricStatistics result = AmazonMetricStatistics.from(amazonResult)
 
@@ -62,13 +62,13 @@ class AmazonMetricStatisticsSpec extends Specification {
 
   void "should add unit from first datapoint"() {
     given:
-    GetMetricStatisticsResult amazonResult = new GetMetricStatisticsResult()
-        .withDatapoints(
-        new Datapoint().withTimestamp(new Date(4)).withAverage(3.0).withUnit("hectares"),
-        new Datapoint().withTimestamp(new Date(0)).withAverage(1.0).withUnit("stone"),
-        new Datapoint().withTimestamp(new Date(1)).withAverage(2.0).withUnit("siriometers"),
-        new Datapoint().withTimestamp(new Date(3)).withAverage(1.0).withUnit("metric ounces")
-    )
+    GetMetricStatisticsResponse amazonResult = GetMetricStatisticsResponse.builder()
+        .datapoints(
+        Datapoint.builder().timestamp(new Date(4).toInstant()).average(3.0).unit("hectares").build(),
+        Datapoint.builder().timestamp(new Date(0).toInstant()).average(1.0).unit("stone").build(),
+        Datapoint.builder().timestamp(new Date(1).toInstant()).average(2.0).unit("siriometers").build(),
+        Datapoint.builder().timestamp(new Date(3).toInstant()).average(1.0).unit("metric ounces").build()
+    ).build()
     when:
     AmazonMetricStatistics result = AmazonMetricStatistics.from(amazonResult)
 

--- a/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonCloudMetricProviderSpec.groovy
+++ b/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonCloudMetricProviderSpec.groovy
@@ -16,8 +16,12 @@
 
 package com.netflix.spinnaker.clouddriver.aws.provider.view
 
-import com.amazonaws.services.cloudwatch.AmazonCloudWatch
-import com.amazonaws.services.cloudwatch.model.*
+import software.amazon.awssdk.services.cloudwatch.CloudWatchClient
+import software.amazon.awssdk.services.cloudwatch.model.Dimension
+import software.amazon.awssdk.services.cloudwatch.model.GetMetricStatisticsRequest
+import software.amazon.awssdk.services.cloudwatch.model.GetMetricStatisticsResponse
+import software.amazon.awssdk.services.cloudwatch.model.ListMetricsResponse
+import software.amazon.awssdk.services.cloudwatch.model.Metric
 import com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider
 import com.netflix.spinnaker.clouddriver.aws.model.AmazonMetricDescriptor
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
@@ -33,15 +37,15 @@ class AmazonCloudMetricProviderSpec extends Specification {
   AmazonCloudMetricProvider provider
 
   @Shared
-  AmazonCloudWatch cloudWatch
+  CloudWatchClient cloudWatch
 
   def setup() {
-    cloudWatch = Mock(AmazonCloudWatch)
+    cloudWatch = Mock(CloudWatchClient)
     CredentialsRepository credentialsRepository = Stub(CredentialsRepository) {
       getOne(_) >> Stub(NetflixAmazonCredentials)
     }
     AmazonClientProvider amazonClientProvider = Stub(AmazonClientProvider) {
-      getCloudWatch(_, _) >> cloudWatch
+      getAmazonCloudWatchV2(_, _) >> cloudWatch
     }
     AmazonCloudProvider amazonCloudProvider = Mock(AmazonCloudProvider)
     provider = new AmazonCloudMetricProvider(amazonClientProvider, credentialsRepository, amazonCloudProvider)
@@ -53,7 +57,7 @@ class AmazonCloudMetricProviderSpec extends Specification {
 
     then:
     result == null
-    1 * cloudWatch.listMetrics(_) >> new ListMetricsResult().withMetrics([])
+    1 * cloudWatch.listMetrics(_) >> ListMetricsResponse.builder().metrics([]).build()
   }
 
   void "getMetrics throws exception when multiple results found"() {
@@ -62,12 +66,12 @@ class AmazonCloudMetricProviderSpec extends Specification {
 
     then:
     thrown(IllegalArgumentException)
-    1 * cloudWatch.listMetrics(_) >> new ListMetricsResult().withMetrics([ new Metric(), new Metric() ])
+    1 * cloudWatch.listMetrics(_) >> ListMetricsResponse.builder().metrics([ Metric.builder().build(), Metric.builder().build() ]).build()
   }
 
   void "getMetrics returns a metric when one found"() {
     given:
-    Dimension dimension = new Dimension().withName("AutoScalingGroupName").withValue("asg-v001")
+    Dimension dimension = Dimension.builder().name("AutoScalingGroupName").value("asg-v001").build()
     def filters = [name: "expectedMetric", namespace: "space"]
 
     when:
@@ -78,12 +82,13 @@ class AmazonCloudMetricProviderSpec extends Specification {
     result.name == "expectedMetric"
     result.namespace == "space"
     result.dimensions == [ dimension ]
-    1 * cloudWatch.listMetrics(_) >> new ListMetricsResult().withMetrics([
-        new Metric()
-            .withMetricName("expectedMetric")
-            .withNamespace("space")
-            .withDimensions(dimension)
-    ])
+    1 * cloudWatch.listMetrics(_) >> ListMetricsResponse.builder().metrics([
+        Metric.builder()
+            .metricName("expectedMetric")
+            .namespace("space")
+            .dimensions(dimension)
+            .build()
+    ]).build()
   }
 
   void "getStatistics sends defaults for statistics, period"() {
@@ -97,13 +102,13 @@ class AmazonCloudMetricProviderSpec extends Specification {
     then:
     1 * cloudWatch.getMetricStatistics(_) >> { arguments ->
       request = arguments[0]
-      return new GetMetricStatisticsResult().withDatapoints([])
+      return GetMetricStatisticsResponse.builder().datapoints([]).build()
     }
     request != null
-    request.startTime == new Date(0)
-    request.endTime == new Date(1)
-    request.period == 600
-    request.statistics == ["Average"]
+    request.startTime() == new Date(0).toInstant()
+    request.endTime() == new Date(1).toInstant()
+    request.period() == 600
+    request.statisticsAsStrings() == ["Average"]
   }
 
   void "getStatistics throws exception if namespace is missing"() {
@@ -130,12 +135,12 @@ class AmazonCloudMetricProviderSpec extends Specification {
     then:
     1 * cloudWatch.getMetricStatistics(_) >> { arguments ->
       request = arguments[0]
-      return new GetMetricStatisticsResult().withDatapoints([])
+      return GetMetricStatisticsResponse.builder().datapoints([]).build()
     }
     request != null
-    request.dimensions.size() == 1
-    request.dimensions[0].name == "someDimension"
-    request.dimensions[0].value == "dimension!"
+    request.dimensions().size() == 1
+    request.dimensions()[0].name() == "someDimension"
+    request.dimensions()[0].value() == "dimension!"
   }
 
 

--- a/clouddriver/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/description/UpsertTitusScalingPolicyDescription.groovy
+++ b/clouddriver/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/description/UpsertTitusScalingPolicyDescription.groovy
@@ -188,10 +188,10 @@ class UpsertTitusScalingPolicyDescription extends AbstractTitusCredentialsDescri
       alarm.period = alarmConfig.periodSec?.value
       alarm.actionsEnabled = true
       alarm.evaluationPeriods = alarmConfig.evaluationPeriods?.value
-      alarm.comparisonOperator = com.amazonaws.services.cloudwatch.model.ComparisonOperator.valueOf(alarmConfig.comparisonOperator.name())
+      alarm.comparisonOperator = alarmConfig.comparisonOperator.name()
       alarm.namespace = alarmConfig.metricNamespace
       alarm.metricName = alarmConfig.metricName
-      alarm.statistic = com.amazonaws.services.cloudwatch.model.Statistic.valueOf(alarmConfig.statistic.name())
+      alarm.statistic = alarmConfig.statistic.name()
     }
 
     // Titus Target Tracking always uses customized metric specifications, so use that to determine if it's a target tracking policy


### PR DESCRIPTION
## Summary
- Converts CloudWatch alarm CRUD, CloudWatch metric read APIs, AutoScaling scaling-policy atomic operations, and the scaling-policy/alarm copier used during ASG clone from AWS SDK v1 to `software.amazon.awssdk` (v2).
- Fixes two latent production bugs found during the mechanical conversion: `CleanupAlarmsAgent`'s attached-alarms pagination request was built but never actually passed to `describePolicies`, and a copy-paste wrong-service import (`gamelift.DescribeScalingPoliciesRequest`) was used instead of AutoScaling's own `DescribePoliciesRequest`.
- Fixes a Groovy spread-operator gotcha specific to the v2 SDK: chained `*.method()*.method()` spreads (unlike `*.property*.property`) don't auto-flatten nested lists the way v1's getter-style access did, silently breaking alarm-name collection.
- Fixes silent data loss when copying alarms with non-standard/extended statistics: CloudWatch's typed `.statistic()`/`.unit()`/`.comparisonOperator()` accessors return `null` (not `UNKNOWN_TO_SDK_VERSION`) for values that don't map to a known enum constant — now uses the `AsString()` accessors when copying alarm data between AWS objects.
- Fixes a real deserialization regression: `UpsertAlarmDescription`'s `comparisonOperator`/`statistic`/`unit` fields were briefly typed as raw AWS SDK v2 enums, whose constant names (`GREATER_THAN_THRESHOLD`) don't match the wire format Deck/Orca send (`GreaterThanThreshold`) — Jackson's default enum deserializer would reject every real alarm-creation request. Kept these fields as `String` (the v2 builders already accept String overloads for all three), with regression test coverage added.

## Test plan
- [x] `./gradlew :clouddriver:clouddriver-aws:compileJava :clouddriver:clouddriver-aws:compileGroovy :clouddriver:clouddriver-aws:compileTestGroovy :clouddriver:clouddriver-aws:compileIntegrationJava`
- [x] `./gradlew :clouddriver:clouddriver-aws:test` — 1474/1474 passing
- [x] `./gradlew :clouddriver:clouddriver-aws:integrationTest` — 30/30 passing
- [x] `./gradlew :clouddriver:clouddriver-titus:test` — passing (Titus scaling-policy alarm construction depends on `UpsertAlarmDescription`)
- [x] `./gradlew :clouddriver:clouddriver-aws:spotlessApply`
- [x] Manual grep sweep for `com.amazonaws` across all touched files — clean
- [x] New regression test verified to fail against the pre-fix (v2-enum-typed) version with the exact `InvalidFormatException` Jackson would throw in production

Part of the ongoing AWS SDK v1→v2 migration; PR2 of the post-11-PR-roadmap cleanup (independent of the other in-flight PRs in this batch).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>