### PR TITLE
chore(aws): Migrate S3 to AWS SDK v2

### DIFF
--- a/clouddriver/clouddriver-aws/clouddriver-aws.gradle
+++ b/clouddriver/clouddriver-aws/clouddriver-aws.gradle
@@ -43,6 +43,7 @@ dependencies {
   api "software.amazon.awssdk:iam"
   api "software.amazon.awssdk:iam-policy-builder"
   api "software.amazon.awssdk:lambda"
+  api "software.amazon.awssdk:s3"
   api "software.amazon.awssdk:secretsmanager"
   api "software.amazon.awssdk:servicediscovery"
   api "software.amazon.awssdk:shield"

--- a/clouddriver/clouddriver-aws/clouddriver-aws.gradle
+++ b/clouddriver/clouddriver-aws/clouddriver-aws.gradle
@@ -91,6 +91,8 @@ dependencies {
   testImplementation "org.springframework.boot:spring-boot-starter-test"
   testImplementation "org.springframework:spring-test"
   testImplementation "org.testcontainers:testcontainers"
+  testImplementation "org.testcontainers:junit-jupiter"
+  testImplementation "org.testcontainers:testcontainers-minio"
   testImplementation "com.squareup.retrofit2:retrofit-mock"
 
   integrationImplementation project(":clouddriver-web")

--- a/clouddriver/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonS3DataProvider.java
+++ b/clouddriver/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonS3DataProvider.java
@@ -19,8 +19,6 @@ package com.netflix.spinnaker.clouddriver.aws.provider.view;
 import static com.netflix.spinnaker.clouddriver.aws.provider.view.AmazonS3StaticDataProviderConfiguration.AdhocRecord;
 import static com.netflix.spinnaker.clouddriver.aws.provider.view.AmazonS3StaticDataProviderConfiguration.StaticRecord;
 
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.model.S3Object;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
@@ -45,6 +43,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Component;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 
 @Component
 public class AmazonS3DataProvider implements DataProvider {
@@ -63,7 +65,7 @@ public class AmazonS3DataProvider implements DataProvider {
               new CacheLoader<String, Object>() {
                 public Object load(String id) throws IOException {
                   StaticRecord record = configuration.getStaticRecord(id);
-                  S3Object s3Object =
+                  ResponseInputStream<GetObjectResponse> s3Object =
                       fetchObject(
                           record.getBucketAccount(),
                           record.getBucketRegion(),
@@ -72,12 +74,12 @@ public class AmazonS3DataProvider implements DataProvider {
 
                   switch (record.getType()) {
                     case list:
-                      return objectMapper.readValue(s3Object.getObjectContent(), List.class);
+                      return objectMapper.readValue(s3Object, List.class);
                     case object:
-                      return objectMapper.readValue(s3Object.getObjectContent(), Map.class);
+                      return objectMapper.readValue(s3Object, Map.class);
                   }
 
-                  return IOUtils.toString(s3Object.getObjectContent());
+                  return IOUtils.toString(s3Object);
                 }
               });
 
@@ -144,8 +146,9 @@ public class AmazonS3DataProvider implements DataProvider {
     }
 
     try {
-      S3Object s3Object = fetchObject(bucketAccount, bucketRegion, bucketName, objectId);
-      IOUtils.copy(s3Object.getObjectContent(), outputStream);
+      ResponseInputStream<GetObjectResponse> s3Object =
+          fetchObject(bucketAccount, bucketRegion, bucketName, objectId);
+      IOUtils.copy(s3Object, outputStream);
     } catch (IOException e) {
       throw new IllegalStateException(e);
     }
@@ -180,13 +183,13 @@ public class AmazonS3DataProvider implements DataProvider {
     return staticCache.stats();
   }
 
-  protected S3Object fetchObject(
+  protected ResponseInputStream<GetObjectResponse> fetchObject(
       String bucketAccount, String bucketRegion, String bucketName, String objectId) {
     NetflixAmazonCredentials account =
         (NetflixAmazonCredentials) accountCredentialsRepository.getOne(bucketAccount);
 
-    AmazonS3 amazonS3 = amazonClientProvider.getAmazonS3(account, bucketRegion);
-    return amazonS3.getObject(bucketName, objectId);
+    S3Client amazonS3 = amazonClientProvider.getAmazonS3V2(account, bucketRegion);
+    return amazonS3.getObject(GetObjectRequest.builder().bucket(bucketName).key(objectId).build());
   }
 
   private String getAccountName(String accountIdOrName) {

--- a/clouddriver/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/security/AmazonClientProvider.java
+++ b/clouddriver/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/security/AmazonClientProvider.java
@@ -38,8 +38,6 @@ import com.amazonaws.services.identitymanagement.AmazonIdentityManagement;
 import com.amazonaws.services.identitymanagement.AmazonIdentityManagementClientBuilder;
 import com.amazonaws.services.route53.AmazonRoute53;
 import com.amazonaws.services.route53.AmazonRoute53ClientBuilder;
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.secretsmanager.AWSSecretsManager;
 import com.amazonaws.services.secretsmanager.AWSSecretsManagerClientBuilder;
 import com.amazonaws.services.servicediscovery.AWSServiceDiscovery;
@@ -71,6 +69,7 @@ import software.amazon.awssdk.services.elasticloadbalancing.ElasticLoadBalancing
 import software.amazon.awssdk.services.elasticloadbalancingv2.ElasticLoadBalancingV2Client;
 import software.amazon.awssdk.services.iam.IamClient;
 import software.amazon.awssdk.services.lambda.LambdaClient;
+import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 import software.amazon.awssdk.services.servicediscovery.ServiceDiscoveryClient;
 import software.amazon.awssdk.services.shield.ShieldClient;
@@ -439,11 +438,6 @@ public class AmazonClientProvider {
     // AmazonIdentityManagement.class, accountName, awsCredentialsProvider, region);
   }
 
-  public AmazonS3 getAmazonS3(NetflixAmazonCredentials amazonCredentials, String region) {
-    return proxyHandlerBuilder.getProxyHandler(
-        AmazonS3.class, AmazonS3ClientBuilder.class, amazonCredentials, region, true);
-  }
-
   public AmazonAutoScaling getAutoScaling(
       NetflixAmazonCredentials amazonCredentials, String region) {
     return getAutoScaling(amazonCredentials, region, false);
@@ -745,6 +739,20 @@ public class AmazonClientProvider {
     return awsSdkV2ClientSupplier.getClient(
         CloudWatchClient::builder,
         CloudWatchClient.class,
+        amazonCredentials.getV2CredentialsProvider(),
+        region,
+        amazonCredentials.getName());
+  }
+
+  /**
+   * Returns an AWS SDK v2 {@link S3Client} for the given account and region.
+   *
+   * <p>No {@code skipEdda} parameter: Edda interception is v1-only (see {@link #getAmazonEcsV2}).
+   */
+  public S3Client getAmazonS3V2(NetflixAmazonCredentials amazonCredentials, String region) {
+    return awsSdkV2ClientSupplier.getClient(
+        S3Client::builder,
+        S3Client.class,
         amazonCredentials.getV2CredentialsProvider(),
         region,
         amazonCredentials.getName());

--- a/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonS3DataProviderSpec.groovy
+++ b/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonS3DataProviderSpec.groovy
@@ -16,13 +16,13 @@
 
 package com.netflix.spinnaker.clouddriver.aws.provider.view
 
-import com.amazonaws.services.s3.model.S3Object
-import com.amazonaws.services.s3.model.S3ObjectInputStream
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
 import com.netflix.spinnaker.credentials.CredentialsRepository
 import org.springframework.security.access.AccessDeniedException
+import software.amazon.awssdk.core.ResponseInputStream
+import software.amazon.awssdk.services.s3.model.GetObjectResponse
 import spock.lang.Specification
 import spock.lang.Subject
 import spock.lang.Unroll
@@ -49,7 +49,12 @@ class AmazonS3DataProviderSpec extends Specification {
     )
   ])
 
-  def s3Object = Mock(S3Object)
+  static ResponseInputStream<GetObjectResponse> responseStream(String content) {
+    new ResponseInputStream<GetObjectResponse>(
+      GetObjectResponse.builder().build(),
+      new ByteArrayInputStream(content.bytes)
+    )
+  }
 
   @Subject
   def dataProvider = Spy(AmazonS3DataProvider, constructorArgs: [
@@ -117,10 +122,7 @@ class AmazonS3DataProviderSpec extends Specification {
 
     then:
     1 * dataProvider.fetchObject("accountName", "us-east-1", "my_restricted_bucket", "magic/my_object") >> {
-      return s3Object
-    }
-    1 * s3Object.getObjectContent() >> {
-      return new S3ObjectInputStream(new ByteArrayInputStream("my example output!".bytes), null)
+      return responseStream("my example output!")
     }
     new String(outputStream.toByteArray(), "UTF-8") == "my example output!"
   }
@@ -145,10 +147,7 @@ class AmazonS3DataProviderSpec extends Specification {
 
     then:
     1 * dataProvider.fetchObject("accountName", "us-east-1", "bucket", "key") >> {
-      return s3Object
-    }
-    1 * s3Object.getObjectContent() >> {
-      return new S3ObjectInputStream(new ByteArrayInputStream("my example output!".bytes), null)
+      return responseStream("my example output!")
     }
     dataProvider.getStaticCacheStats().hitCount() == 0
     result == "my example output!"
@@ -174,12 +173,7 @@ class AmazonS3DataProviderSpec extends Specification {
 
     then:
     1 * dataProvider.fetchObject("accountName", "us-east-1", "bucket", "listKey") >> {
-      return s3Object
-    }
-    1 * s3Object.getObjectContent() >> {
-      return new S3ObjectInputStream(
-        new ByteArrayInputStream(resultsJson.bytes), null
-      )
+      return responseStream(resultsJson)
     }
     result == [
       [name: "bar", id: 2]
@@ -190,12 +184,7 @@ class AmazonS3DataProviderSpec extends Specification {
 
     then:
     1 * dataProvider.fetchObject("accountName", "us-east-1", "bucket", "key") >> {
-      return s3Object
-    }
-    1 * s3Object.getObjectContent() >> {
-      return new S3ObjectInputStream(
-        new ByteArrayInputStream(resultsJson.bytes), null
-      )
+      return responseStream(resultsJson)
     }
 
     // if type != list than all results should be returned as-is w/o filtering

--- a/clouddriver/clouddriver-aws/src/test/java/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonS3DataProviderMinioTest.java
+++ b/clouddriver/clouddriver-aws/src/test/java/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonS3DataProviderMinioTest.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2026 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.provider.view;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.clouddriver.aws.provider.view.AmazonS3StaticDataProviderConfiguration.StaticRecord;
+import com.netflix.spinnaker.clouddriver.aws.provider.view.AmazonS3StaticDataProviderConfiguration.StaticRecordType;
+import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider;
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
+import com.netflix.spinnaker.credentials.CredentialsRepository;
+import java.io.ByteArrayOutputStream;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.MinIOContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Configuration;
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+/**
+ * Validates that {@link AmazonS3DataProvider}'s AWS SDK v2 {@code fetchObject()} call (added by the
+ * S3 v1-&gt;v2 migration) actually round-trips real bytes against an S3-compatible API, exercising
+ * the real {@link software.amazon.awssdk.services.s3.model.GetObjectRequest} construction and
+ * {@link ResponseInputStream} consumption end-to-end through {@link
+ * AmazonS3DataProvider#getStaticData} -- not just mocked interactions.
+ *
+ * <p>Uses testcontainers' MinIO module (same pattern as {@code
+ * kayenta-s3/S3StorageServiceIntegrationTest}) rather than LocalStack -- MinIO is a plain
+ * S3-compatible object server with no Lambda/ECS docker-in-docker machinery, so it needs no host
+ * docker.sock bind-mount and starts reliably across Docker runtimes (including Colima).
+ */
+@Testcontainers
+class AmazonS3DataProviderMinioTest {
+
+  private static final String MINIO_IMAGE = "minio/minio:RELEASE.2023-09-04T19-57-37Z";
+  private static final String BUCKET_NAME = "s3-migration-test-bucket";
+  private static final String ACCOUNT_NAME = "test";
+  private static final String REGION = "us-east-1";
+
+  @Container static final MinIOContainer minio = new MinIOContainer(MINIO_IMAGE);
+
+  private static S3Client s3Client;
+  private static AmazonS3DataProvider dataProvider;
+
+  @BeforeAll
+  static void setupOnce() {
+    s3Client =
+        S3Client.builder()
+            .endpointOverride(URI.create(minio.getS3URL()))
+            .credentialsProvider(
+                StaticCredentialsProvider.create(
+                    AwsBasicCredentials.create(minio.getUserName(), minio.getPassword())))
+            .region(Region.of(REGION))
+            .serviceConfiguration(S3Configuration.builder().pathStyleAccessEnabled(true).build())
+            .build();
+
+    s3Client.createBucket(CreateBucketRequest.builder().bucket(BUCKET_NAME).build());
+    putString("string-key", "hello from minio s3");
+    putString("object-key", "{\"foo\":\"bar\"}");
+    putString("list-key", "[{\"name\":\"a\"},{\"name\":\"b\"}]");
+
+    NetflixAmazonCredentials credentials =
+        new ObjectMapper()
+            .convertValue(
+                Map.of(
+                    "name", ACCOUNT_NAME,
+                    "environment", ACCOUNT_NAME,
+                    "accountType", ACCOUNT_NAME,
+                    "accountId", "123456789012",
+                    "regions", List.of(Map.of("name", REGION, "availabilityZones", List.of()))),
+                NetflixAmazonCredentials.class);
+
+    AmazonClientProvider mockAmazonClientProvider = mock(AmazonClientProvider.class);
+    when(mockAmazonClientProvider.getAmazonS3V2(eq(credentials), any())).thenReturn(s3Client);
+
+    @SuppressWarnings("unchecked")
+    CredentialsRepository<NetflixAmazonCredentials> mockCredentialsRepository =
+        mock(CredentialsRepository.class);
+    when(mockCredentialsRepository.getOne(ACCOUNT_NAME)).thenReturn(credentials);
+
+    AmazonS3StaticDataProviderConfiguration configuration =
+        new AmazonS3StaticDataProviderConfiguration(
+            List.of(
+                staticRecord("stringRecordId", StaticRecordType.string, "string-key"),
+                staticRecord("objectRecordId", StaticRecordType.object, "object-key"),
+                staticRecord("listRecordId", StaticRecordType.list, "list-key")),
+            Collections.emptyList());
+
+    dataProvider =
+        new AmazonS3DataProvider(
+            new ObjectMapper(), mockAmazonClientProvider, mockCredentialsRepository, configuration);
+  }
+
+  private static void putString(String key, String contents) {
+    s3Client.putObject(
+        PutObjectRequest.builder().bucket(BUCKET_NAME).key(key).build(),
+        RequestBody.fromString(contents, StandardCharsets.UTF_8));
+  }
+
+  private static StaticRecord staticRecord(String id, StaticRecordType type, String key) {
+    return new StaticRecord(id, type, ACCOUNT_NAME, REGION, BUCKET_NAME, key);
+  }
+
+  @Test
+  void fetchObjectRoundTripsRealBytesThroughAwsSdkV2() throws Exception {
+    try (ResponseInputStream<GetObjectResponse> s3Object =
+        dataProvider.fetchObject(ACCOUNT_NAME, REGION, BUCKET_NAME, "string-key")) {
+      ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+      s3Object.transferTo(outputStream);
+      assertThat(outputStream.toString(StandardCharsets.UTF_8)).isEqualTo("hello from minio s3");
+    }
+  }
+
+  @Test
+  void getStaticDataReturnsRawStringForStringRecords() {
+    Object result = dataProvider.getStaticData("stringRecordId", Map.of());
+    assertThat(result).isEqualTo("hello from minio s3");
+  }
+
+  @Test
+  void getStaticDataParsesJsonObjectForObjectRecords() {
+    Object result = dataProvider.getStaticData("objectRecordId", Map.of());
+    assertThat(result).isInstanceOf(Map.class);
+    assertThat(((Map<?, ?>) result).get("foo")).isEqualTo("bar");
+  }
+
+  @Test
+  void getStaticDataParsesAndFiltersJsonListForListRecords() {
+    Object result = dataProvider.getStaticData("listRecordId", Map.of("name", "b"));
+    assertThat(result).isInstanceOf(List.class);
+    List<?> list = (List<?>) result;
+    assertThat(list).hasSize(1);
+    assertThat(((Map<?, ?>) list.get(0)).get("name")).isEqualTo("b");
+  }
+}

--- a/clouddriver/clouddriver-aws/src/test/java/com/netflix/spinnaker/clouddriver/aws/security/AmazonClientProviderV2Test.java
+++ b/clouddriver/clouddriver-aws/src/test/java/com/netflix/spinnaker/clouddriver/aws/security/AmazonClientProviderV2Test.java
@@ -33,6 +33,7 @@ import software.amazon.awssdk.services.ecr.EcrClient;
 import software.amazon.awssdk.services.ecs.EcsClient;
 import software.amazon.awssdk.services.elasticloadbalancing.ElasticLoadBalancingClient;
 import software.amazon.awssdk.services.iam.IamClient;
+import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 import software.amazon.awssdk.services.servicediscovery.ServiceDiscoveryClient;
 import software.amazon.awssdk.services.shield.ShieldClient;
@@ -95,6 +96,12 @@ class AmazonClientProviderV2Test {
   void getAmazonCloudWatchV2ReturnsCloudWatchClient() {
     CloudWatchClient client = provider.getAmazonCloudWatchV2(creds, REGION);
     assertThat(client).isNotNull().isInstanceOf(CloudWatchClient.class);
+  }
+
+  @Test
+  void getAmazonS3V2ReturnsS3Client() {
+    S3Client client = provider.getAmazonS3V2(creds, REGION);
+    assertThat(client).isNotNull().isInstanceOf(S3Client.class);
   }
 
   @Test

--- a/kayenta/kayenta-s3/kayenta-s3.gradle
+++ b/kayenta/kayenta-s3/kayenta-s3.gradle
@@ -15,6 +15,6 @@ dependencies {
   testImplementation "com.fasterxml.jackson.core:jackson-databind"
   testImplementation "org.testcontainers:testcontainers"
   testImplementation "org.testcontainers:junit-jupiter"
-  testImplementation "org.testcontainers:testcontainers-minio:2.0.5"
+  testImplementation "org.testcontainers:testcontainers-minio"
   testRuntimeOnly "ch.qos.logback:logback-classic"
 }

--- a/kork/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/kork/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -33,6 +33,7 @@ ext {
     logback          : "1.5.37",
     tomcat           : "10.1.56",
     commonsCompress  : "1.27.1",
+    testcontainersMinio : "2.0.5",
   ]
 }
 
@@ -185,6 +186,7 @@ dependencies {
     api("org.pf4j:pf4j:3.14.1")
     api("org.pf4j:pf4j-update:2.3.0")
     api("org.springdoc:springdoc-openapi-starter-webmvc-ui:${versions.springdocs}")
+    api("org.testcontainers:testcontainers-minio:${versions.testcontainersMinio}")
     api("org.threeten:threeten-extra:1.0")
   }
 }


### PR DESCRIPTION
## Summary
- Adds a `getAmazonS3V2` accessor on `AmazonClientProvider` (`software.amazon.awssdk:s3` newly added to `clouddriver-aws.gradle`, following the same pattern used by `front50-s3`/`clouddriver-artifacts-s3`/`kork-artifacts`/`kayenta-s3`).
- Converts `AmazonS3DataProvider`'s sole S3 call site (`fetchObject()`) to the v2 client. v2's `S3Client.getObject()` already returns a `ResponseInputStream`, which is itself an `InputStream`, so callers no longer need the intermediate `.getObjectContent()` unwrap that v1's `S3Object` required.
- Deletes the now-dead v1 `getAmazonS3` accessor on `AmazonClientProvider` (confirmed zero remaining callers repo-wide) and its now-unused imports.

## Test plan
- [x] `./gradlew :clouddriver:clouddriver-aws:compileJava :clouddriver:clouddriver-aws:compileGroovy :clouddriver:clouddriver-aws:compileTestGroovy :clouddriver:clouddriver-aws:compileTestJava`
- [x] `./gradlew :clouddriver:clouddriver-aws:test` — 1474/1474 passing
- [x] `./gradlew :clouddriver:clouddriver-aws:integrationTest` — 30/30 passing
- [x] `./gradlew :clouddriver:clouddriver-aws:spotlessApply`
- [x] Manual grep sweep for `com.amazonaws.services.s3` — clean
- [x] Added `getAmazonS3V2ReturnsS3Client` to `AmazonClientProviderV2Test`, matching the existing per-accessor test pattern

Part of the ongoing AWS SDK v1→v2 migration; PR3 of the post-11-PR-roadmap cleanup, independent of the other in-flight PRs in this batch (PR1 #7936 merged, PR2 #7937 open).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>