### PR TITLE
chore(aws): Migrate Route53 to AWS SDK v2

### DIFF
--- a/clouddriver/clouddriver-aws/clouddriver-aws.gradle
+++ b/clouddriver/clouddriver-aws/clouddriver-aws.gradle
@@ -43,6 +43,7 @@ dependencies {
   api "software.amazon.awssdk:iam"
   api "software.amazon.awssdk:iam-policy-builder"
   api "software.amazon.awssdk:lambda"
+  api "software.amazon.awssdk:route53"
   api "software.amazon.awssdk:secretsmanager"
   api "software.amazon.awssdk:servicediscovery"
   api "software.amazon.awssdk:shield"

--- a/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/dns/UpsertAmazonDNSAtomicOperation.groovy
+++ b/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/dns/UpsertAmazonDNSAtomicOperation.groovy
@@ -16,7 +16,12 @@
 
 package com.netflix.spinnaker.clouddriver.aws.deploy.ops.dns
 
-import com.amazonaws.services.route53.model.*
+import software.amazon.awssdk.services.route53.model.Change
+import software.amazon.awssdk.services.route53.model.ChangeAction
+import software.amazon.awssdk.services.route53.model.ChangeBatch
+import software.amazon.awssdk.services.route53.model.ChangeResourceRecordSetsRequest
+import software.amazon.awssdk.services.route53.model.ResourceRecord
+import software.amazon.awssdk.services.route53.model.ResourceRecordSet
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
@@ -52,14 +57,18 @@ class UpsertAmazonDNSAtomicOperation implements AtomicOperation<UpsertAmazonDNSR
       description.target = priorElb.loadBalancers?.values()?.getAt(0)?.dnsName
     }
 
-    def route53 = amazonClientProvider.getAmazonRoute53(description.credentials, null, true)
-    def hostedZone = route53.listHostedZones().hostedZones.find { it.name == description.hostedZoneName }
+    def route53 = amazonClientProvider.getAmazonRoute53V2(description.credentials, null)
+    def hostedZone = route53.listHostedZones().hostedZones().find { it.name() == description.hostedZoneName }
 
-    def recordSet = new ResourceRecordSet(description.name, description.type)
-      .withResourceRecords(new ResourceRecord(description.target)).withTTL(60)
-    def change = new Change(action: ChangeAction.UPSERT, resourceRecordSet: recordSet)
-    def batch = new ChangeBatch([change])
-    def request = new ChangeResourceRecordSetsRequest(hostedZone.id, batch)
+    def recordSet = ResourceRecordSet.builder()
+      .name(description.name)
+      .type(description.type)
+      .resourceRecords(ResourceRecord.builder().value(description.target).build())
+      .ttl(60L)
+      .build()
+    def change = Change.builder().action(ChangeAction.UPSERT).resourceRecordSet(recordSet).build()
+    def batch = ChangeBatch.builder().changes([change]).build()
+    def request = ChangeResourceRecordSetsRequest.builder().hostedZoneId(hostedZone.id()).changeBatch(batch).build()
 
     task.updateStatus BASE_PHASE, "Upserting record..."
     route53.changeResourceRecordSets(request)

--- a/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/UpsertAmazonDNSDescriptionValidator.groovy
+++ b/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/UpsertAmazonDNSDescriptionValidator.groovy
@@ -44,9 +44,9 @@ class UpsertAmazonDNSDescriptionValidator extends AmazonDescriptionValidationSup
     } else if (!ALLOWED_TYPES.contains(description.type)) {
       errors.rejectValue("type", "upsertAmazonDNSDescription.type.invalid")
     } else if (ALLOWED_TYPES.contains(description.type) && description.target && description.hostedZoneName) {
-      def route53 = amazonClientProvider.getAmazonRoute53(description.credentials, null, true)
-      def allowedNames = route53.listHostedZones().hostedZones.collect {
-        it.name
+      def route53 = amazonClientProvider.getAmazonRoute53V2(description.credentials, null)
+      def allowedNames = route53.listHostedZones().hostedZones().collect {
+        it.name()
       }
       if (!allowedNames.contains(description.hostedZoneName)) {
         errors.rejectValue("hostedZoneName", "upsertAmazonDNSDescription.hostedZoneName.invalid")

--- a/clouddriver/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/security/AmazonClientProvider.java
+++ b/clouddriver/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/security/AmazonClientProvider.java
@@ -36,10 +36,6 @@ import com.amazonaws.services.elasticloadbalancing.AmazonElasticLoadBalancing;
 import com.amazonaws.services.elasticloadbalancing.AmazonElasticLoadBalancingClientBuilder;
 import com.amazonaws.services.identitymanagement.AmazonIdentityManagement;
 import com.amazonaws.services.identitymanagement.AmazonIdentityManagementClientBuilder;
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3ClientBuilder;
-import com.amazonaws.services.route53.AmazonRoute53;
-import com.amazonaws.services.route53.AmazonRoute53ClientBuilder;
 import com.amazonaws.services.secretsmanager.AWSSecretsManager;
 import com.amazonaws.services.secretsmanager.AWSSecretsManagerClientBuilder;
 import com.amazonaws.services.servicediscovery.AWSServiceDiscovery;
@@ -727,10 +723,7 @@ public class AmazonClientProvider {
         amazonCredentials.getName());
   }
 
-  /**
-   * Returns an AWS SDK v2 {@link Route53Client} for the given account and region.
-   *
-   */
+  /** Returns an AWS SDK v2 {@link Route53Client} for the given account and region. */
   public Route53Client getAmazonRoute53V2(
       NetflixAmazonCredentials amazonCredentials, String region) {
     return awsSdkV2ClientSupplier.getClient(
@@ -741,10 +734,7 @@ public class AmazonClientProvider {
         amazonCredentials.getName());
   }
 
-  /**
-   * Returns an AWS SDK v2 {@link S3Client} for the given account and region.
-   *
-   */
+  /** Returns an AWS SDK v2 {@link S3Client} for the given account and region. */
   public S3Client getAmazonS3V2(NetflixAmazonCredentials amazonCredentials, String region) {
     return awsSdkV2ClientSupplier.getClient(
         S3Client::builder,

--- a/clouddriver/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/security/AmazonClientProvider.java
+++ b/clouddriver/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/security/AmazonClientProvider.java
@@ -36,8 +36,6 @@ import com.amazonaws.services.elasticloadbalancing.AmazonElasticLoadBalancing;
 import com.amazonaws.services.elasticloadbalancing.AmazonElasticLoadBalancingClientBuilder;
 import com.amazonaws.services.identitymanagement.AmazonIdentityManagement;
 import com.amazonaws.services.identitymanagement.AmazonIdentityManagementClientBuilder;
-import com.amazonaws.services.route53.AmazonRoute53;
-import com.amazonaws.services.route53.AmazonRoute53ClientBuilder;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.secretsmanager.AWSSecretsManager;
@@ -71,6 +69,7 @@ import software.amazon.awssdk.services.elasticloadbalancing.ElasticLoadBalancing
 import software.amazon.awssdk.services.elasticloadbalancingv2.ElasticLoadBalancingV2Client;
 import software.amazon.awssdk.services.iam.IamClient;
 import software.amazon.awssdk.services.lambda.LambdaClient;
+import software.amazon.awssdk.services.route53.Route53Client;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 import software.amazon.awssdk.services.servicediscovery.ServiceDiscoveryClient;
 import software.amazon.awssdk.services.shield.ShieldClient;
@@ -469,26 +468,6 @@ public class AmazonClientProvider {
         region);
   }
 
-  public AmazonRoute53 getAmazonRoute53(NetflixAmazonCredentials amazonCredentials, String region) {
-    return getAmazonRoute53(amazonCredentials, region, false);
-  }
-
-  public AmazonRoute53 getAmazonRoute53(
-      NetflixAmazonCredentials amazonCredentials, String region, boolean skipEdda) {
-    return proxyHandlerBuilder.getProxyHandler(
-        AmazonRoute53.class, AmazonRoute53ClientBuilder.class, amazonCredentials, region, skipEdda);
-  }
-
-  public AmazonRoute53 getAmazonRoute53(
-      String accountName, AWSCredentialsProvider awsCredentialsProvider, String region) {
-    return awsSdkClientSupplier.getClient(
-        AmazonRoute53ClientBuilder.class,
-        AmazonRoute53.class,
-        accountName,
-        awsCredentialsProvider,
-        region);
-  }
-
   public AmazonElasticLoadBalancing getAmazonElasticLoadBalancing(
       String accountName, AWSCredentialsProvider awsCredentialsProvider, String region) {
     return awsSdkClientSupplier.getClient(
@@ -745,6 +724,21 @@ public class AmazonClientProvider {
     return awsSdkV2ClientSupplier.getClient(
         CloudWatchClient::builder,
         CloudWatchClient.class,
+        amazonCredentials.getV2CredentialsProvider(),
+        region,
+        amazonCredentials.getName());
+  }
+
+  /**
+   * Returns an AWS SDK v2 {@link Route53Client} for the given account and region.
+   *
+   * <p>No {@code skipEdda} parameter: Edda interception is v1-only (see {@link #getAmazonEcsV2}).
+   */
+  public Route53Client getAmazonRoute53V2(
+      NetflixAmazonCredentials amazonCredentials, String region) {
+    return awsSdkV2ClientSupplier.getClient(
+        Route53Client::builder,
+        Route53Client.class,
         amazonCredentials.getV2CredentialsProvider(),
         region,
         amazonCredentials.getName());

--- a/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/dns/UpsertAmazonDNSAtomicOperationSpec.groovy
+++ b/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/dns/UpsertAmazonDNSAtomicOperationSpec.groovy
@@ -16,10 +16,10 @@
 
 package com.netflix.spinnaker.clouddriver.aws.deploy.ops.dns
 
-import com.amazonaws.services.route53.AmazonRoute53
-import com.amazonaws.services.route53.model.ChangeResourceRecordSetsRequest
-import com.amazonaws.services.route53.model.HostedZone
-import com.amazonaws.services.route53.model.ListHostedZonesResult
+import software.amazon.awssdk.services.route53.Route53Client
+import software.amazon.awssdk.services.route53.model.ChangeResourceRecordSetsRequest
+import software.amazon.awssdk.services.route53.model.HostedZone
+import software.amazon.awssdk.services.route53.model.ListHostedZonesResponse
 import com.netflix.spinnaker.clouddriver.aws.deploy.ops.dns.UpsertAmazonDNSAtomicOperation
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.data.task.Task
@@ -36,9 +36,9 @@ class UpsertAmazonDNSAtomicOperationSpec extends Specification {
 
   void "operation inherits prior-deployed elb dns name when no target explicitly specified"() {
     setup:
-    def mockClient = Mock(AmazonRoute53)
+    def mockClient = Mock(Route53Client)
     def mockAmazonClientProvider = Mock(AmazonClientProvider)
-    mockAmazonClientProvider.getAmazonRoute53(_, _, true) >> mockClient
+    mockAmazonClientProvider.getAmazonRoute53V2(_, _) >> mockClient
     def op = new UpsertAmazonDNSAtomicOperation(new UpsertAmazonDNSDescription())
     op.amazonClientProvider = mockAmazonClientProvider
     def elbDeploy = Mock(UpsertAmazonLoadBalancerResult)
@@ -50,22 +50,20 @@ class UpsertAmazonDNSAtomicOperationSpec extends Specification {
     then:
     1 * mockClient.listHostedZones() >> {
       def zone = Mock(HostedZone)
-      zone.getId() >> "1234"
-      def result = Mock(ListHostedZonesResult)
-      result.getHostedZones() >> [zone]
-      result
+      zone.id() >> "1234"
+      ListHostedZonesResponse.builder().hostedZones([zone]).build()
     }
     1 * mockClient.changeResourceRecordSets(_) >> { ChangeResourceRecordSetsRequest request ->
-      assert request.changeBatch.changes.first().resourceRecordSet.resourceRecords.first().value == "elb"
+      assert request.changeBatch().changes().first().resourceRecordSet().resourceRecords().first().value() == "elb"
     }
 
   }
 
   void "operation calls out to route53 to UPSERT dns record"() {
     setup:
-    def mockClient = Mock(AmazonRoute53)
+    def mockClient = Mock(Route53Client)
     def mockAmazonClientProvider = Mock(AmazonClientProvider)
-    mockAmazonClientProvider.getAmazonRoute53(_, _, true) >> mockClient
+    mockAmazonClientProvider.getAmazonRoute53V2(_, _) >> mockClient
     def op = new UpsertAmazonDNSAtomicOperation(new UpsertAmazonDNSDescription())
     op.amazonClientProvider = mockAmazonClientProvider
 
@@ -75,10 +73,8 @@ class UpsertAmazonDNSAtomicOperationSpec extends Specification {
     then:
     1 * mockClient.listHostedZones() >> {
       def zone = Mock(HostedZone)
-      zone.getId() >> "1234"
-      def result = Mock(ListHostedZonesResult)
-      result.getHostedZones() >> [zone]
-      result
+      zone.id() >> "1234"
+      ListHostedZonesResponse.builder().hostedZones([zone]).build()
     }
     1 * mockClient.changeResourceRecordSets(_)
 

--- a/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/UpsertAmazonDNSDescriptionValidatorSpec.groovy
+++ b/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/UpsertAmazonDNSDescriptionValidatorSpec.groovy
@@ -16,9 +16,9 @@
 
 package com.netflix.spinnaker.clouddriver.aws.deploy.validators
 
-import com.amazonaws.services.route53.AmazonRoute53
-import com.amazonaws.services.route53.model.HostedZone
-import com.amazonaws.services.route53.model.ListHostedZonesResult
+import software.amazon.awssdk.services.route53.Route53Client
+import software.amazon.awssdk.services.route53.model.HostedZone
+import software.amazon.awssdk.services.route53.model.ListHostedZonesResponse
 import com.netflix.spinnaker.clouddriver.aws.deploy.validators.UpsertAmazonDNSDescriptionValidator
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.UpsertAmazonLoadBalancerDescription
@@ -86,9 +86,9 @@ class UpsertAmazonDNSDescriptionValidatorSpec extends Specification {
     description.target = "foo.netflix.net."
     description.hostedZoneName = "netflix.net."
     def errors = Mock(ValidationErrors)
-    def route53 = Mock(AmazonRoute53)
+    def route53 = Mock(Route53Client)
     validator.amazonClientProvider = Mock(AmazonClientProvider)
-    validator.amazonClientProvider.getAmazonRoute53(_, _, true) >> route53
+    validator.amazonClientProvider.getAmazonRoute53V2(_, _) >> route53
 
     when:
     validator.validate([], description, errors)
@@ -96,8 +96,8 @@ class UpsertAmazonDNSDescriptionValidatorSpec extends Specification {
     then:
     1 * route53.listHostedZones() >> {
       def zone = Mock(HostedZone)
-      zone.getName() >> "netflix.net."
-      new ListHostedZonesResult().withHostedZones(zone)
+      zone.name() >> "netflix.net."
+      ListHostedZonesResponse.builder().hostedZones([zone]).build()
     }
   }
 }

--- a/clouddriver/clouddriver-aws/src/test/java/com/netflix/spinnaker/clouddriver/aws/security/AmazonClientProviderV2Test.java
+++ b/clouddriver/clouddriver-aws/src/test/java/com/netflix/spinnaker/clouddriver/aws/security/AmazonClientProviderV2Test.java
@@ -103,6 +103,7 @@ class AmazonClientProviderV2Test {
   void getAmazonRoute53V2ReturnsRoute53Client() {
     Route53Client client = provider.getAmazonRoute53V2(creds, REGION);
     assertThat(client).isNotNull().isInstanceOf(Route53Client.class);
+  }
 
   @Test
   void getAmazonS3V2ReturnsS3Client() {

--- a/clouddriver/clouddriver-aws/src/test/java/com/netflix/spinnaker/clouddriver/aws/security/AmazonClientProviderV2Test.java
+++ b/clouddriver/clouddriver-aws/src/test/java/com/netflix/spinnaker/clouddriver/aws/security/AmazonClientProviderV2Test.java
@@ -33,13 +33,14 @@ import software.amazon.awssdk.services.ecr.EcrClient;
 import software.amazon.awssdk.services.ecs.EcsClient;
 import software.amazon.awssdk.services.elasticloadbalancing.ElasticLoadBalancingClient;
 import software.amazon.awssdk.services.iam.IamClient;
+import software.amazon.awssdk.services.route53.Route53Client;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 import software.amazon.awssdk.services.servicediscovery.ServiceDiscoveryClient;
 import software.amazon.awssdk.services.shield.ShieldClient;
 
 /**
- * Unit tests verifying the nine v2 getter methods on {@link AmazonClientProvider} produce the
- * correct v2 client types and delegate to the v2 supplier correctly.
+ * Unit tests verifying the v2 getter methods on {@link AmazonClientProvider} produce the correct v2
+ * client types and delegate to the v2 supplier correctly.
  */
 class AmazonClientProviderV2Test {
 
@@ -95,6 +96,12 @@ class AmazonClientProviderV2Test {
   void getAmazonCloudWatchV2ReturnsCloudWatchClient() {
     CloudWatchClient client = provider.getAmazonCloudWatchV2(creds, REGION);
     assertThat(client).isNotNull().isInstanceOf(CloudWatchClient.class);
+  }
+
+  @Test
+  void getAmazonRoute53V2ReturnsRoute53Client() {
+    Route53Client client = provider.getAmazonRoute53V2(creds, REGION);
+    assertThat(client).isNotNull().isInstanceOf(Route53Client.class);
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Adds a `getAmazonRoute53V2` accessor on `AmazonClientProvider` (`software.amazon.awssdk:route53` newly added to `clouddriver-aws.gradle` -- first use of this artifact anywhere in the repo, resolves to `2.29.52` matching the version used elsewhere).
- Converts both real call sites to it: `UpsertAmazonDNSAtomicOperation`'s hosted-zone lookup + `changeResourceRecordSets()` upsert, and `UpsertAmazonDNSDescriptionValidator`'s hosted-zone-name validation lookup.
- Deletes the now-dead v1 `getAmazonRoute53` accessor family on `AmazonClientProvider` (all 3 overloads -- confirmed zero remaining callers repo-wide) and its imports, following the same dead-accessor cleanup pattern used in PR1/PR3.

## Test plan
- [x] `./gradlew :clouddriver:clouddriver-aws:compileJava :clouddriver:clouddriver-aws:compileGroovy :clouddriver:clouddriver-aws:compileTestGroovy :clouddriver:clouddriver-aws:compileTestJava`
- [x] `./gradlew :clouddriver:clouddriver-aws:test` -- all passing
- [x] `./gradlew :clouddriver:clouddriver-aws:integrationTest` -- 30/30 passing
- [x] `./gradlew :clouddriver:clouddriver-aws:spotlessApply`
- [x] Manual grep sweep for `com.amazonaws.services.route53`/`AmazonRoute53` -- clean
- [x] Added `getAmazonRoute53V2ReturnsRoute53Client` to `AmazonClientProviderV2Test`, matching the existing per-accessor test pattern

Part of the ongoing AWS SDK v1->v2 migration; PR4 of the post-11-PR-roadmap cleanup, independent of the other in-flight PRs in this batch (PR1 #7936 merged, PR2 #7937 and PR3 #7938 open).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

