### PR TITLE
fix(clouddriver): Fix UnsupportedOperationException/NullPointerException regressions from AWS SDK v2 migration

### DIFF
--- a/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/CopyLastAsgAtomicOperation.groovy
+++ b/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/CopyLastAsgAtomicOperation.groovy
@@ -109,11 +109,13 @@ class CopyLastAsgAtomicOperation implements AtomicOperation<DeploymentResult> {
       boolean sourceIsTarget = sourceRegion == targetRegion && sourceAsgCredentials.name == description.credentials.name
       def sourceRegionScopedProvider = regionScopedProviderFactory.forRegion(sourceAsgCredentials, sourceRegion)
       Closure<List<String>> translateSecurityGroupIds = { List<String> ids ->
+        // ids may be an unmodifiable list straight off an AWS SDK v2 model (e.g.
+        // ResponseLaunchTemplateData.securityGroups()), so always return a mutable copy.
         if (!sourceIsTarget) {
-          return ids
+          return ids == null ? ids : new ArrayList<>(ids)
         }
         if (!ids) {
-          return ids
+          return ids == null ? ids : new ArrayList<>(ids)
         }
         sourceRegionScopedProvider.getSecurityGroupService().getSecurityGroupNamesFromIds(ids).keySet().toList()
       }
@@ -251,7 +253,7 @@ class CopyLastAsgAtomicOperation implements AtomicOperation<DeploymentResult> {
         newDescription.amiName = description.amiName ?: imageId
         newDescription.availabilityZones = [(targetRegion): description.availabilityZones[targetRegion] ?: ancestorAsg.availabilityZones()]
         newDescription.instanceType = description.instanceType ?: instanceType
-        newDescription.loadBalancers = description.loadBalancers != null ? description.loadBalancers : ancestorAsg.loadBalancerNames()
+        newDescription.loadBalancers = description.loadBalancers != null ? description.loadBalancers : new ArrayList<>(ancestorAsg.loadBalancerNames())
         newDescription.targetGroups = description.targetGroups
         if (newDescription.targetGroups == null && ancestorAsg.targetGroupARNs() && ancestorAsg.targetGroupARNs().size() > 0) {
           def targetGroups = sourceRegionScopedProvider.getElasticLoadBalancingV2Client().describeTargetGroups(DescribeTargetGroupsRequest.builder().targetGroupArns(ancestorAsg.targetGroupARNs()).build()).targetGroups()
@@ -270,7 +272,7 @@ class CopyLastAsgAtomicOperation implements AtomicOperation<DeploymentResult> {
         newDescription.healthCheckGracePeriod = description.healthCheckGracePeriod != null ? description.healthCheckGracePeriod : ancestorAsg.healthCheckGracePeriod()
         newDescription.healthCheckType = description.healthCheckType ?: ancestorAsg.healthCheckType()
         newDescription.suspendedProcesses = description.suspendedProcesses != null ? description.suspendedProcesses : ancestorAsg.suspendedProcesses()*.processName
-        newDescription.terminationPolicies = description.terminationPolicies != null ? description.terminationPolicies : ancestorAsg.terminationPolicies()
+        newDescription.terminationPolicies = description.terminationPolicies != null ? description.terminationPolicies : new ArrayList<>(ancestorAsg.terminationPolicies())
         newDescription.kernelId = description.kernelId ?: (kernelId ?: null)
         newDescription.ramdiskId = description.ramdiskId ?: (ramdiskId ?: null)
         newDescription.instanceMonitoring = description.instanceMonitoring != null ? description.instanceMonitoring : instanceMonitoring

--- a/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/CopyLastAsgAtomicOperationUnitSpec.groovy
+++ b/clouddriver/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/CopyLastAsgAtomicOperationUnitSpec.groovy
@@ -487,6 +487,169 @@ class CopyLastAsgAtomicOperationUnitSpec extends Specification {
                                                                                                                                                             defaultResult: AmazonAsgLifecycleHook.DefaultResult.ABANDON)]
   }
 
+  void "operation copies ancestor asg's load balancer names into a mutable list"() {
+    given:
+    description.availabilityZones = ['us-east-1': []]
+
+    def launchTemplateVersion = LaunchTemplateVersion.builder()
+      .launchTemplateName("foo")
+      .launchTemplateId("foo")
+      .versionNumber(0L)
+      .launchTemplateData(ResponseLaunchTemplateData.builder().keyName("key-pair-name").build())
+      .build()
+
+    def launchTemplateSpec = LaunchTemplateSpecification.builder()
+      .launchTemplateName(launchTemplateVersion.launchTemplateName)
+      .launchTemplateId(launchTemplateVersion.launchTemplateId)
+      .version(launchTemplateVersion.versionNumber.toString())
+      .build()
+
+    regionScopedProviderStub.getLaunchTemplateService() >> Mock(LaunchTemplateService) {
+      getLaunchTemplateVersion(launchTemplateSpec) >> Optional.of(launchTemplateVersion)
+    }
+
+    when:
+    op.operate([])
+
+    then:
+    1 * mockAutoScaling.describeAutoScalingGroups(_) >> {
+      def mockAsg = AutoScalingGroup.builder()
+        .autoScalingGroupName("asgard-stack-v000")
+        .minSize(0)
+        .maxSize(2)
+        .desiredCapacity(4)
+        .launchTemplate(launchTemplateSpec)
+        .loadBalancerNames(["ancestor-elb"])
+        .build()
+      DescribeAutoScalingGroupsResponse.builder().autoScalingGroups([mockAsg]).build()
+    }
+    1 * serverGroupNameResolver.resolveLatestServerGroupName("asgard-stack") >> { "asgard-stack-v000" }
+    0 * serverGroupNameResolver._
+    1 * deployHandler.handle(_ as BasicAmazonDeployDescription, _) >> { arguments ->
+      BasicAmazonDeployDescription actualDesc = arguments[0]
+
+      assert actualDesc.loadBalancers == ["ancestor-elb"]
+      // this must not throw UnsupportedOperationException, as BasicAmazonDeployHandler
+      // mutates description.loadBalancers via addAll()
+      actualDesc.loadBalancers.addAll(["supplied-elb"])
+      assert actualDesc.loadBalancers == ["ancestor-elb", "supplied-elb"]
+
+      new DeploymentResult(serverGroupNames: ['asgard-stack-v001'], serverGroupNameByRegion: ['us-east-1': 'asgard-stack-v001'])
+    }
+  }
+
+  void "operation copies ancestor asg's termination policies into a mutable list"() {
+    given:
+    description.availabilityZones = ['us-east-1': []]
+
+    def launchTemplateVersion = LaunchTemplateVersion.builder()
+      .launchTemplateName("foo")
+      .launchTemplateId("foo")
+      .versionNumber(0L)
+      .launchTemplateData(ResponseLaunchTemplateData.builder().keyName("key-pair-name").build())
+      .build()
+
+    def launchTemplateSpec = LaunchTemplateSpecification.builder()
+      .launchTemplateName(launchTemplateVersion.launchTemplateName)
+      .launchTemplateId(launchTemplateVersion.launchTemplateId)
+      .version(launchTemplateVersion.versionNumber.toString())
+      .build()
+
+    regionScopedProviderStub.getLaunchTemplateService() >> Mock(LaunchTemplateService) {
+      getLaunchTemplateVersion(launchTemplateSpec) >> Optional.of(launchTemplateVersion)
+    }
+
+    when:
+    op.operate([])
+
+    then:
+    1 * mockAutoScaling.describeAutoScalingGroups(_) >> {
+      def mockAsg = AutoScalingGroup.builder()
+        .autoScalingGroupName("asgard-stack-v000")
+        .minSize(0)
+        .maxSize(2)
+        .desiredCapacity(4)
+        .launchTemplate(launchTemplateSpec)
+        .terminationPolicies(["OldestInstance"])
+        .build()
+      DescribeAutoScalingGroupsResponse.builder().autoScalingGroups([mockAsg]).build()
+    }
+    1 * serverGroupNameResolver.resolveLatestServerGroupName("asgard-stack") >> { "asgard-stack-v000" }
+    0 * serverGroupNameResolver._
+    1 * deployHandler.handle(_ as BasicAmazonDeployDescription, _) >> { arguments ->
+      BasicAmazonDeployDescription actualDesc = arguments[0]
+
+      assert actualDesc.terminationPolicies == ["OldestInstance"]
+      // must not throw UnsupportedOperationException if a caller mutates this list
+      actualDesc.terminationPolicies.add("Default")
+      assert actualDesc.terminationPolicies == ["OldestInstance", "Default"]
+
+      new DeploymentResult(serverGroupNames: ['asgard-stack-v001'], serverGroupNameByRegion: ['us-east-1': 'asgard-stack-v001'])
+    }
+  }
+
+  void "operation copies ancestor asg's launch template security groups into a mutable list when cloning across accounts"() {
+    given:
+    description.availabilityZones = ['us-east-1': []]
+    description.securityGroups = null
+    description.source = new BasicAmazonDeployDescription.Source(
+      account: 'other-account',
+      region: 'us-east-1',
+      asgName: 'asgard-stack-v000'
+    )
+
+    def otherAccountCredentials = TestCredential.named('other-account')
+    def mockCredentialsRepository = Mock(com.netflix.spinnaker.credentials.CredentialsRepository)
+    op.credentialsRepository = mockCredentialsRepository
+
+    def launchTemplateVersion = LaunchTemplateVersion.builder()
+      .launchTemplateName("foo")
+      .launchTemplateId("foo")
+      .versionNumber(0L)
+      .launchTemplateData(ResponseLaunchTemplateData.builder()
+        .keyName("key-pair-name")
+        .securityGroups(["sg-ancestor"])
+        .build())
+      .build()
+
+    def launchTemplateSpec = LaunchTemplateSpecification.builder()
+      .launchTemplateName(launchTemplateVersion.launchTemplateName)
+      .launchTemplateId(launchTemplateVersion.launchTemplateId)
+      .version(launchTemplateVersion.versionNumber.toString())
+      .build()
+
+    def mockAncestorAsg = AutoScalingGroup.builder()
+      .autoScalingGroupName("asgard-stack-v000")
+      .minSize(0)
+      .maxSize(2)
+      .desiredCapacity(4)
+      .launchTemplate(launchTemplateSpec)
+      .build()
+
+    regionScopedProviderStub.getLaunchTemplateService() >> Mock(LaunchTemplateService) {
+      getLaunchTemplateVersion(launchTemplateSpec) >> Optional.of(launchTemplateVersion)
+    }
+
+    when:
+    op.operate([])
+
+    then:
+    1 * mockCredentialsRepository.getOne('other-account') >> otherAccountCredentials
+    1 * mockAutoScaling.describeAutoScalingGroups(_) >> {
+      DescribeAutoScalingGroupsResponse.builder().autoScalingGroups([mockAncestorAsg]).build()
+    }
+    1 * deployHandler.handle(_ as BasicAmazonDeployDescription, _) >> { arguments ->
+      BasicAmazonDeployDescription actualDesc = arguments[0]
+
+      assert actualDesc.securityGroups == ["sg-ancestor"]
+      // must not throw UnsupportedOperationException if a caller mutates this list
+      actualDesc.securityGroups.add("sg-added")
+      assert actualDesc.securityGroups == ["sg-ancestor", "sg-added"]
+
+      new DeploymentResult(serverGroupNames: ['asgard-stack-v001'], serverGroupNameByRegion: ['us-east-1': 'asgard-stack-v001'])
+    }
+  }
+
   private static BasicAmazonDeployDescription expectedDescription(
           String expectedSpotPrice = null,
           String region,

--- a/clouddriver/clouddriver-lambda/src/main/java/com/netflix/spinnaker/clouddriver/lambda/cache/model/LambdaApplication.java
+++ b/clouddriver/clouddriver-lambda/src/main/java/com/netflix/spinnaker/clouddriver/lambda/cache/model/LambdaApplication.java
@@ -16,6 +16,7 @@
 package com.netflix.spinnaker.clouddriver.lambda.cache.model;
 
 import com.netflix.spinnaker.clouddriver.model.Application;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import lombok.AllArgsConstructor;
@@ -28,6 +29,10 @@ import lombok.NoArgsConstructor;
 public class LambdaApplication implements Application {
   private String name;
   private Map<String, String> attributes;
-  private Map<String, Set<String>> clusterNames;
-  private Map<String, Set<String>> clusterNameMetadata;
+
+  // Application.getClusterNames() is documented as never returning null (@Empty); Lambda
+  // applications have no ASG-backed clusters, so default to an empty map rather than leaving
+  // this null, which previously caused a NullPointerException in ClusterController.mergeClusters.
+  private Map<String, Set<String>> clusterNames = new HashMap<>();
+  private Map<String, Set<String>> clusterNameMetadata = new HashMap<>();
 }

--- a/clouddriver/clouddriver-lambda/src/test/java/com/netflix/spinnaker/clouddriver/lambda/provider/agent/LambdaApplicationProviderTest.java
+++ b/clouddriver/clouddriver-lambda/src/test/java/com/netflix/spinnaker/clouddriver/lambda/provider/agent/LambdaApplicationProviderTest.java
@@ -141,6 +141,11 @@ public class LambdaApplicationProviderTest {
     assertThat(app.getAttributes()).containsEntry("region", "us-west-2");
     assertThat(app.getAttributes()).containsEntry("accountId", "123456789");
     assertThat(app.getAttributes()).containsEntry("count", "42");
+
+    // Application.getClusterNames() must never be null (see @Empty on Application#getClusterNames),
+    // since callers like ClusterController.mergeClusters() call .entrySet() on it unconditionally.
+    assertThat(app.getClusterNames()).isNotNull().isEmpty();
+    assertThat(app.getClusterNameMetadata()).isNotNull().isEmpty();
   }
 
   @Test


### PR DESCRIPTION
## Summary

   The migration to AWS SDK v2 changed the mutability contract of several collection-returning
   getters on generated model classes (e.g. `AutoScalingGroup.loadBalancerNames()`,
   `.terminationPolicies()`, `ResponseLaunchTemplateData.securityGroups()`), which now return
   **unmodifiable** lists instead of the mutable `ArrayList`s SDK v1 returned. Code that assigned
   these directly into description/config fields — expecting to mutate them later — now throws
   `UnsupportedOperationException` at runtime.

   Separately, a `Lambda`-only bug  left  `LambdaApplication.clusterNames` / `clusterNameMetadata` uninitialized, violating the   `Application` interface's `@Empty`-documented non-null contract and causing a   `NullPointerException` in `ClusterController.mergeClusters`.

   ## Root causes & fixes

   ### 1. `CopyLastAsgAtomicOperation` — mutating immutable AWS SDK v2 collections

   When cloning an ASG (`CopyLastAsgAtomicOperation`), several `BasicAmazonDeployDescription` fields
   were populated directly from ancestor-ASG/launch-template getters without copying:

   - `loadBalancers = ancestorAsg.loadBalancerNames()` — later mutated via
     `description.loadBalancers.addAll(...)` in `BasicAmazonDeployHandler.handle()`, throwing
     `UnsupportedOperationException` whenever the ancestor ASG already had load balancers attached.
     **This was the reported production crash**
     (`CopyLastAsgAtomicOperation.groovy:320` → `BasicAmazonDeployHandler.groovy:123`).
   - `terminationPolicies = ancestorAsg.terminationPolicies()` — same latent pattern, not yet
     triggered by any current mutator but one feature change away from the same crash.
   - `translateSecurityGroupIds()` returning the raw immutable `ids` list unchanged (used for
     `securityGroups` / `classicLinkVpcSecurityGroups`) when cloning cross-region/cross-account.

   **Fix:** wrap each of these in `new ArrayList<>(...)` so a genuinely mutable copy flows
   downstream, regardless of what AWS SDK version produced the source list.

   ### 2. `LambdaApplication` — null fields violating the `Application` contract

   `LambdaApplicationProvider.mapCacheDataToLambdaApplication()` never set `clusterNames` /
   `clusterNameMetadata`, leaving them `null` (default for the `@NoArgsConstructor`/`@Data` fields).
   `Application.getClusterNames()` is documented `@Empty` (must never return null), and
   `ClusterController.mergeClusters()` calls `.entrySet()` on it unconditionally — causing an NPE
   for any application that only has Lambda functions (no ASG-backed clusters).

   **Fix:** default `clusterNames` / `clusterNameMetadata` to empty `HashMap`s on the field itself.