### PR TITLE
fix(lambda): Lambda invoke timeout capped by shared HTTP client socket timeout

### DIFF
--- a/clouddriver/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/security/sdkclient/AwsSdkClientSupplier.java
+++ b/clouddriver/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/security/sdkclient/AwsSdkClientSupplier.java
@@ -210,6 +210,15 @@ public class AwsSdkClientSupplier {
     private final AWSCredentialsProvider awsCredentialsProvider;
     private final Region region;
     private final RequestHandler2 requestHandler;
+
+    /**
+     * Per-service tuning applied at build time. Included in {@link #equals}/{@link #hashCode} by
+     * value (via its socket timeout, max error retry, and TCP keep-alive settings) so that
+     * different tuning for the same (implClass, credentials, region, requestHandler) resolves to
+     * distinct cached clients (e.g. a short-timeout client vs a long-timeout invoke client). {@link
+     * ClientConfiguration} itself has no meaningful {@code equals()}, so we compare the handful of
+     * fields callers actually vary rather than the whole object.
+     */
     private final ClientConfiguration clientConfiguration;
 
     public AmazonClientKey(
@@ -255,7 +264,8 @@ public class AwsSdkClientSupplier {
       if (!implClass.equals(that.implClass)) return false;
       if (!awsCredentialsProvider.equals(that.awsCredentialsProvider)) return false;
       if (region != that.region) return false;
-      return Objects.equals(requestHandler, that.requestHandler);
+      if (!Objects.equals(requestHandler, that.requestHandler)) return false;
+      return clientConfigurationsEqual(clientConfiguration, that.clientConfiguration);
     }
 
     @Override
@@ -264,7 +274,28 @@ public class AwsSdkClientSupplier {
       result = 31 * result + awsCredentialsProvider.hashCode();
       result = 31 * result + (region != null ? region.hashCode() : 0);
       result = 31 * result + (requestHandler != null ? requestHandler.hashCode() : 0);
+      result = 31 * result + clientConfigurationHash(clientConfiguration);
       return result;
+    }
+
+    /**
+     * Value-compares the subset of {@link ClientConfiguration} fields that callers (e.g. Lambda's
+     * dedicated invoke client) actually vary. {@link ClientConfiguration} does not override {@code
+     * equals()}, so without this, differently-tuned configs for the same service/account/region
+     * would collide on a single cached client.
+     */
+    private static boolean clientConfigurationsEqual(ClientConfiguration a, ClientConfiguration b) {
+      if (a == b) return true;
+      if (a == null || b == null) return false;
+      return a.getSocketTimeout() == b.getSocketTimeout()
+          && a.getMaxErrorRetry() == b.getMaxErrorRetry()
+          && a.useTcpKeepAlive() == b.useTcpKeepAlive();
+    }
+
+    private static int clientConfigurationHash(ClientConfiguration cc) {
+      return cc == null
+          ? 0
+          : Objects.hash(cc.getSocketTimeout(), cc.getMaxErrorRetry(), cc.useTcpKeepAlive());
     }
   }
 }

--- a/clouddriver/clouddriver-aws/src/test/java/com/netflix/spinnaker/clouddriver/aws/security/sdkclient/AwsSdkClientSupplierTest.java
+++ b/clouddriver/clouddriver-aws/src/test/java/com/netflix/spinnaker/clouddriver/aws/security/sdkclient/AwsSdkClientSupplierTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2026 spinnaker.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.security.sdkclient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.retry.PredefinedRetryPolicies;
+import com.amazonaws.retry.RetryPolicy;
+import com.amazonaws.services.lambda.AWSLambda;
+import com.amazonaws.services.lambda.AWSLambdaClientBuilder;
+import com.netflix.spectator.api.NoopRegistry;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.clouddriver.core.limits.ServiceLimitConfigurationBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link AwsSdkClientSupplier}, in particular the cache-key identity of {@code
+ * ClientConfiguration} tuning (see {@code LambdaClientProvider}, which requests distinct clients
+ * for regular vs. synchronous-invoke Lambda calls).
+ */
+class AwsSdkClientSupplierTest {
+
+  private AwsSdkClientSupplier supplier;
+
+  private static AWSCredentialsProvider dummyCreds() {
+    return new AWSStaticCredentialsProvider(new BasicAWSCredentials("key", "secret"));
+  }
+
+  @BeforeEach
+  void setUp() {
+    Registry registry = new NoopRegistry();
+    RateLimiterSupplier rateLimiterSupplier =
+        new RateLimiterSupplier(new ServiceLimitConfigurationBuilder().build(), registry);
+    RetryPolicy retryPolicy = PredefinedRetryPolicies.getDefaultRetryPolicy();
+    supplier =
+        new AwsSdkClientSupplier(rateLimiterSupplier, registry, retryPolicy, null, null, false);
+  }
+
+  @Test
+  void differentSocketTimeoutReturnsDifferentInstance() {
+    // A short-timeout (default) client and a long-timeout invoke client for the same account,
+    // region, and service must be distinct cached instances.
+    AWSCredentialsProvider creds = dummyCreds();
+    ClientConfiguration shortSocket = new ClientConfiguration();
+    shortSocket.setSocketTimeout(50_000);
+    ClientConfiguration longSocket = new ClientConfiguration();
+    longSocket.setSocketTimeout(15 * 60 * 1000);
+
+    AWSLambda shortClient =
+        supplier.getClient(
+            AWSLambdaClientBuilder.class, AWSLambda.class, "acct", creds, "us-east-1", shortSocket);
+    AWSLambda longClient =
+        supplier.getClient(
+            AWSLambdaClientBuilder.class, AWSLambda.class, "acct", creds, "us-east-1", longSocket);
+
+    assertThat(shortClient).isNotSameAs(longClient);
+  }
+
+  @Test
+  void equalClientConfigurationReturnsSameInstance() {
+    // Config participates in cache identity by value: equal field values reuse the cached client.
+    AWSCredentialsProvider creds = dummyCreds();
+
+    ClientConfiguration first = new ClientConfiguration();
+    first.setSocketTimeout(50_000);
+    ClientConfiguration second = new ClientConfiguration();
+    second.setSocketTimeout(50_000);
+
+    AWSLambda firstClient =
+        supplier.getClient(
+            AWSLambdaClientBuilder.class, AWSLambda.class, "acct", creds, "us-east-1", first);
+    AWSLambda secondClient =
+        supplier.getClient(
+            AWSLambdaClientBuilder.class, AWSLambda.class, "acct", creds, "us-east-1", second);
+
+    assertThat(firstClient).isSameAs(secondClient);
+  }
+}

--- a/clouddriver/clouddriver-lambda/src/main/java/com/netflix/spinnaker/clouddriver/lambda/deploy/ops/InvokeLambdaAtomicOperation.java
+++ b/clouddriver/clouddriver-lambda/src/main/java/com/netflix/spinnaker/clouddriver/lambda/deploy/ops/InvokeLambdaAtomicOperation.java
@@ -67,7 +67,7 @@ public class InvokeLambdaAtomicOperation
 
   private InvokeLambdaFunctionOutputDescription invokeFunction(
       String functionName, String payload) {
-    AWSLambda client = getLambdaClient();
+    AWSLambda client = getInvokeLambdaClient();
     InvokeRequest req =
         new InvokeRequest()
             .withFunctionName(functionName)

--- a/clouddriver/clouddriver-lambda/src/main/java/com/netflix/spinnaker/clouddriver/lambda/deploy/ops/LambdaClientProvider.java
+++ b/clouddriver/clouddriver-lambda/src/main/java/com/netflix/spinnaker/clouddriver/lambda/deploy/ops/LambdaClientProvider.java
@@ -24,6 +24,7 @@ import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider;
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
 import com.netflix.spinnaker.clouddriver.lambda.deploy.exception.InvalidAccountException;
 import com.netflix.spinnaker.config.LambdaServiceConfig;
+import java.util.concurrent.TimeUnit;
 import org.springframework.beans.factory.annotation.Autowired;
 
 public class LambdaClientProvider {
@@ -32,6 +33,15 @@ public class LambdaClientProvider {
   @Autowired protected LambdaServiceConfig operationsConfig;
   private String region;
   private NetflixAmazonCredentials credentials;
+
+  /**
+   * The maximum time an AWS Lambda function can run (15 minutes). Used as the socket-timeout
+   * ceiling for the dedicated invoke client so that a synchronous {@code RequestResponse} invoke —
+   * which holds the connection idle for the entire function execution — is never cut short below
+   * this hard limit. The per-request {@code sdkRequestTimeout} set by {@code
+   * InvokeLambdaAtomicOperation} remains the authoritative, tunable bound within this ceiling.
+   */
+  private static final int LAMBDA_MAX_EXECUTION_MS = (int) TimeUnit.MINUTES.toMillis(15);
 
   public LambdaClientProvider(String region, NetflixAmazonCredentials credentials) {
     this.region = region;
@@ -47,9 +57,38 @@ public class LambdaClientProvider {
   // timeouts based upon a precedent/business logic (e.g. if configured, and no account overrides
   // use region timeouts)
   protected AWSLambda getLambdaClient() {
+    return buildLambdaClient(buildClientConfiguration(operationsConfig.getInvokeTimeoutMs()));
+  }
 
+  /**
+   * Returns a Lambda client dedicated to synchronous invocations. It differs from {@link
+   * #getLambdaClient()} only in its socket timeout, which is raised to the Lambda maximum so the
+   * per-request {@code sdkRequestTimeout} governs how long an invoke may run rather than being
+   * capped by the shorter default socket timeout used for all other (short) Lambda operations.
+   *
+   * <p>The distinct {@link ClientConfiguration} resolves to a separate cached client (see {@code
+   * AwsSdkClientSupplier}), leaving the shared non-invoke client's timeouts unchanged.
+   */
+  protected AWSLambda getInvokeLambdaClient() {
+    return buildLambdaClient(buildClientConfiguration(LAMBDA_MAX_EXECUTION_MS));
+  }
+
+  private AWSLambda buildLambdaClient(ClientConfiguration clientConfiguration) {
+    if (!credentials.isLambdaEnabled()) {
+      throw new InvalidAccountException("AWS Lambda is not enabled for provided account. \n");
+    }
+    // Note this is a CACHED response call.  AKA the clientConfig is ONLY set when this is first
+    // cached/loaded for a given (account, region, clientConfig) combination.
+    return amazonClientProvider.getAmazonLambda(credentials, clientConfiguration, region);
+  }
+
+  /**
+   * Translates the Lambda operation defaults into the client tuning, applying the given socket
+   * timeout. A negative retry count defers to the SDK's default retry policy.
+   */
+  private ClientConfiguration buildClientConfiguration(int socketTimeoutMs) {
     ClientConfiguration clientConfiguration = new ClientConfiguration();
-    clientConfiguration.setSocketTimeout(operationsConfig.getInvokeTimeoutMs());
+    clientConfiguration.setSocketTimeout(socketTimeoutMs);
     clientConfiguration.setUseTcpKeepAlive(operationsConfig.isTcpKeepAlive());
     // only override if non-negative, and can't just set to the negative default :(
     if (operationsConfig.getRetry().getRetries() >= 0) {
@@ -63,14 +102,7 @@ public class LambdaClientProvider {
       // doing it here as well as in the retry policy to be safe.
       clientConfiguration.setMaxErrorRetry(operationsConfig.getRetry().getRetries());
     }
-
-    if (!credentials.isLambdaEnabled()) {
-      throw new InvalidAccountException("AWS Lambda is not enabled for provided account. \n");
-    }
-    // Note this is a CACHED response call.  AKA the clientConfig is ONLY set when this is first
-    // cached/loaded
-    // and won't be changed if OTHER requests make this.
-    return amazonClientProvider.getAmazonLambda(credentials, clientConfiguration, region);
+    return clientConfiguration;
   }
 
   protected String getRegion() {

--- a/clouddriver/clouddriver-lambda/src/test/java/com/netflix/spinnaker/clouddriver/lambda/deploy/ops/InvokeLambdaAtomicOperationTest.java
+++ b/clouddriver/clouddriver-lambda/src/test/java/com/netflix/spinnaker/clouddriver/lambda/deploy/ops/InvokeLambdaAtomicOperationTest.java
@@ -66,7 +66,7 @@ public class InvokeLambdaAtomicOperationTest implements LambdaTestingDefaults {
   void testInvokeLambda() {
 
     AWSLambda lambdaClient = mock(AWSLambda.class);
-    doReturn(lambdaClient).when(invokeOperation).getLambdaClient();
+    doReturn(lambdaClient).when(invokeOperation).getInvokeLambdaClient();
 
     ArgumentCaptor<InvokeRequest> captor = ArgumentCaptor.forClass(InvokeRequest.class);
     InvokeResult result = new InvokeResult();
@@ -87,7 +87,7 @@ public class InvokeLambdaAtomicOperationTest implements LambdaTestingDefaults {
     invokeDesc.setTimeout(55);
 
     AWSLambda lambdaClient = mock(AWSLambda.class);
-    doReturn(lambdaClient).when(invokeOperation).getLambdaClient();
+    doReturn(lambdaClient).when(invokeOperation).getInvokeLambdaClient();
 
     ArgumentCaptor<InvokeRequest> invokeCaptor = ArgumentCaptor.forClass(InvokeRequest.class);
     doReturn(new InvokeResult()).when(lambdaClient).invoke(invokeCaptor.capture());


### PR DESCRIPTION
   ## Problem

   `InvokeLambdaAtomicOperation` invokes AWS Lambda synchronously (`RequestResponse`), holding the
   underlying HTTP connection open for the full duration of the function execution. The per-request
   timeout (`InvokeRequest.setSdkRequestTimeout(...)`) was meant to be the authoritative bound, but it
   was silently capped by the client's Apache HTTP **socket timeout**, which `LambdaClientProvider` set
   to `aws.lambda.invokeTimeoutMs` (default **50s**).

   On top of that, `AwsSdkClientSupplier`'s client cache key (`AmazonClientKey`) **ignored
   `ClientConfiguration` entirely** when deciding whether to reuse a cached client. So even fixing the
   socket timeout value wouldn't help — whichever `ClientConfiguration` was used to build the *first*
   cached Lambda client for an account/region would be reused for all later requests, regardless of
   what config was passed afterward.

   This mirrors a bug already fixed on `main` (AWS SDK v2, commit `f98dcccb`) during the v1→v2 Lambda
   migration. This change applies the equivalent fix here, since this branch (`release-2026.2.x`) still
   uses AWS SDK v1 for Lambda.

   ## Fix

   ### `AwsSdkClientSupplier.java` (clouddriver-aws)
   `AmazonClientKey.equals()`/`hashCode()` now value-compares `ClientConfiguration` on the three fields
   callers actually vary (`socketTimeout`, `maxErrorRetry`, `useTcpKeepAlive`) instead of ignoring it.
   `ClientConfiguration` has no meaningful `equals()`, so this uses hand-written field comparisons
   rather than relying on the object itself. Differently-tuned configs for the same (service,
   credentials, region) now resolve to **distinct cached clients**.

   *This is a no-op for every other AWS service in the codebase — Lambda is the only caller that ever
   passes a non-null `ClientConfiguration` through this path, so `null == null` keeps their cache
   behavior unchanged.*

   ### `LambdaClientProvider.java` (clouddriver-lambda)
   - Added `getInvokeLambdaClient()`, a client dedicated to synchronous invokes, with socket timeout
     raised to `LAMBDA_MAX_EXECUTION_MS` (15 minutes — AWS Lambda's hard execution ceiling) instead of
     `invokeTimeoutMs`.
   - `getLambdaClient()` (used by all other Lambda operations: create, update, publish, delete, etc.)
     is unchanged.
   - Refactored the shared config-building logic into `buildClientConfiguration(socketTimeoutMs)` /
     `buildLambdaClient(config)` helpers, used by both accessors.

   ### `InvokeLambdaAtomicOperation.java`
   Switched to `getInvokeLambdaClient()` for the actual invoke call. No other operation classes were
   touched.

   ## Result

   - The invoke client's socket timeout is now well above any realistic Lambda execution time, so
     `sdkRequestTimeout` (the pipeline-configurable per-request value) is the real, effective timeout —
     not the shared HTTP client's socket timeout.
   - The default/non-invoke Lambda client's tuning is untouched.
