### PR TITLE
fix(ecs): fix Create Server Group crash on ECS applications

### DIFF
--- a/deck/packages/ecs/src/serverGroup/configure/serverGroupCommandBuilder.service.js
+++ b/deck/packages/ecs/src/serverGroup/configure/serverGroupCommandBuilder.service.js
@@ -58,7 +58,8 @@ function findTriggerImages(triggers) {
     }));
 }
 
-function buildNewServerGroupCommand(application, defaults = {}) {
+function buildNewServerGroupCommand(application, defaults) {
+  defaults = defaults || {};
   const defaultCredentials = defaults.account || application.defaultCredentials.ecs;
   const defaultRegion = defaults.region || application.defaultRegions.ecs;
 

--- a/deck/packages/ecs/src/serverGroup/configure/serverGroupCommandBuilder.service.spec.ts
+++ b/deck/packages/ecs/src/serverGroup/configure/serverGroupCommandBuilder.service.spec.ts
@@ -3,6 +3,23 @@ import { AccountService } from '@spinnaker/core';
 import { EcsServerGroupCommandBuilder } from './serverGroupCommandBuilder.service';
 
 describe('EcsServerGroupCommandBuilder', () => {
+  it('builds a new server group command when no defaults are provided (create flow passes null)', async () => {
+    spyOn(AccountService, 'getAvailabilityZonesForAccountAndRegion').and.returnValue(Promise.resolve(['us-west-2a']));
+    spyOn(AccountService, 'getCredentialsKeyedByAccount').and.returnValue(Promise.resolve({}));
+
+    const command = await new EcsServerGroupCommandBuilder().buildNewServerGroupCommand(
+      {
+        defaultCredentials: { ecs: 'ecs-prod' },
+        defaultRegions: { ecs: 'us-west-2' },
+        name: 'api',
+      } as any,
+      null,
+    );
+
+    expect(command.credentials).toBe('ecs-prod');
+    expect(command.region).toBe('us-west-2');
+  });
+
   it('builds pipeline commands when availability zones are missing', async () => {
     spyOn(AccountService, 'getAvailabilityZonesForAccountAndRegion').and.returnValue(Promise.resolve(['us-west-2a']));
     spyOn(AccountService, 'getCredentialsKeyedByAccount').and.returnValue(Promise.resolve({}));


### PR DESCRIPTION
## Summary
- `EcsServerGroupCommandBuilder.buildNewServerGroupCommand` used an ES6 default parameter (`defaults = {}`), which only substitutes when the caller passes `undefined`. The generic "Create Server Group" button (`AllClusters.tsx`) explicitly passes `null` for a brand-new server group, so `defaults.account` threw `Cannot read properties of null (reading 'account')` and the button failed on ECS-configured applications.
- Fixed by normalizing `defaults` in the function body (`defaults = defaults || {}`), matching the existing pattern already used by the AWS and Google server group command builders.
- Audited all other providers' server-group and load-balancer command builders for the same class of bug; ECS was the only offender.

## Test plan
- [x] Added a regression test asserting `buildNewServerGroupCommand` builds a valid command when `null` defaults are passed (reproduces the create-flow call), verified it fails against the old code and passes against the fix.
- [x] `./gradlew :deck:karma` — all 3469 specs pass.
- [x] `./gradlew :deck:lint` passes.
- [ ] Manually verify "Create Server Group" on an ECS application in a running Deck instance.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01DtXShry16A5KJ4cGWDkyNj