### PR TITLE
fix(ui): fix crash in CreatableSelect when used as a single-value select

### DIFF
--- a/deck/packages/core/src/presentation/forms/inputs/ReactSelectInput.spec.tsx
+++ b/deck/packages/core/src/presentation/forms/inputs/ReactSelectInput.spec.tsx
@@ -1,0 +1,75 @@
+import { mount } from 'enzyme';
+import React from 'react';
+import { Creatable } from 'react-select';
+
+import { ReactSelectInput } from './ReactSelectInput';
+
+const noop = () => {};
+
+describe('<ReactSelectInput />', () => {
+  describe('CREATABLE mode', () => {
+    it('renders when used as a single-value select with a string value not present in options', () => {
+      // Regression test: single-select (non-multi) CREATABLE usage passes a plain string as
+      // `value`, not an array. This previously crashed with "value.filter is not a function"
+      // because CreatableSelect assumed `value` was always an array.
+      const render = () =>
+        mount(
+          <ReactSelectInput
+            name="account-type"
+            mode="CREATABLE"
+            stringOptions={['kubernetes', 'aws']}
+            value="some-custom-type"
+            onChange={noop}
+            clearable={false}
+          />,
+        );
+      expect(render).not.toThrow();
+    });
+
+    it('includes a created value not present in stringOptions among the rendered options', () => {
+      const wrapper = mount(
+        <ReactSelectInput
+          name="account-type"
+          mode="CREATABLE"
+          stringOptions={['kubernetes', 'aws']}
+          value="some-custom-type"
+          onChange={noop}
+          clearable={false}
+        />,
+      );
+      const values = wrapper.find(Creatable).prop('options') as Array<{ value: string }>;
+      expect(values.map((o) => o.value)).toContain('some-custom-type');
+    });
+
+    it('renders without a value', () => {
+      const render = () =>
+        mount(
+          <ReactSelectInput
+            name="account-type"
+            mode="CREATABLE"
+            stringOptions={['kubernetes', 'aws']}
+            value={undefined}
+            onChange={noop}
+            clearable={false}
+          />,
+        );
+      expect(render).not.toThrow();
+    });
+
+    it('still works for multi-select usage with an array value', () => {
+      const wrapper = mount(
+        <ReactSelectInput
+          name="account-types"
+          mode="CREATABLE"
+          multi={true}
+          stringOptions={['kubernetes', 'aws']}
+          value={['kubernetes', 'some-custom-type']}
+          onChange={noop}
+          clearable={false}
+        />,
+      );
+      const values = wrapper.find(Creatable).prop('options') as Array<{ value: string }>;
+      expect(values.map((o) => o.value)).toContain('some-custom-type');
+    });
+  });
+});

--- a/deck/packages/core/src/presentation/forms/inputs/ReactSelectInput.tsx
+++ b/deck/packages/core/src/presentation/forms/inputs/ReactSelectInput.tsx
@@ -112,7 +112,8 @@ function CreatableSelect(props: IReactSelectInputProps<any>) {
   const options = React.useMemo(() => {
     const options = props.options ?? [];
     const optionsValues = options.map((o) => o.value);
-    const createdOptions = ((props.value as string[]) ?? [])
+    const currentValues = Array.isArray(props.value) ? props.value : props.value ? [props.value] : [];
+    const createdOptions = currentValues
       .filter((val) => !optionsValues.includes(val))
       .map((opt) => ({ label: opt, value: opt }));
     return options.concat(createdOptions);


### PR DESCRIPTION
## Summary
- #7954 introduced `ReactSelectInput` in `CREATABLE` mode for the account-type field in the new account management UI (`AccountManagementPage.tsx` and `CreateEditAccountModal.tsx`), used as a single-value select.
- `CreatableSelect`'s internal helper assumed `props.value` was always an array and called `.filter()` on it directly. For a single-value select, `value` is a plain string, so the page crashed with `(intermediate value)....filter is not a function` whenever the account-type field rendered.
- Normalizes `props.value` to an array before filtering, so it works for both single-value strings and multi-select arrays.

## Test plan
- [x] Added `ReactSelectInput.spec.tsx` regression tests: single-value `CREATABLE` render (crashes without the fix), created-option inclusion, empty value, and multi-select array value still works
- [x] `./gradlew :deck:karma` — all tests pass
- [x] `pnpm prettier:check` on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DtXShry16A5KJ4cGWDkyNj