### PR TITLE
fix(deck): Instance types response filtering case-mismatch

### DIFF
--- a/deck/packages/amazon/src/instance/awsInstanceType.service.spec.js
+++ b/deck/packages/amazon/src/instance/awsInstanceType.service.spec.js
@@ -329,6 +329,25 @@ describe('Service: InstanceType', function () {
         'hs1.8xlarge',
       ]);
     });
+
+    it('matches architecture case-insensitively', function () {
+      const service = this.awsInstanceTypeService;
+      const armInstanceTypes = [
+        {
+          account: 'test',
+          region: 'eu-central-1',
+          name: 'm9gd.metal-48xl',
+          defaultVCpus: 192,
+          memoryInGiB: 768,
+          supportedArchitectures: ['ARM64'],
+          supportedVirtualizationTypes: ['hvm'],
+        },
+      ];
+
+      expect(map(service.filterInstanceTypes(armInstanceTypes, 'hvm', true, 'arm64'), 'name')).toEqual([
+        'm9gd.metal-48xl',
+      ]);
+    });
   });
 
   describe('isBurstingSupportedForAllTypes', function () {

--- a/deck/packages/amazon/src/instance/awsInstanceType.service.ts
+++ b/deck/packages/amazon/src/instance/awsInstanceType.service.ts
@@ -167,6 +167,11 @@ export class AwsInstanceTypeService {
     vpcConfigured: boolean,
     architecture: string,
   ): IAmazonInstanceType[] {
+    // Some accounts/providers report supportedArchitectures in a different case (e.g. 'ARM64')
+    // than the AMI attribute we compare against (e.g. 'arm64'), so compare case-insensitively.
+    const includesIgnoreCase = (values: string[], value: string) =>
+      values.some((v) => v.toLowerCase() === value.toLowerCase());
+
     return _.filter(instanceTypes, (i) => {
       if (virtualizationType === '*' && architecture === '*') {
         // show all instance types
@@ -185,7 +190,7 @@ export class AwsInstanceTypeService {
         return false;
       }
 
-      if (architecture && i.supportedArchitectures && !i.supportedArchitectures.includes(architecture)) {
+      if (architecture && i.supportedArchitectures && !includesIgnoreCase(i.supportedArchitectures, architecture)) {
         return false;
       }
 


### PR DESCRIPTION

   When creating (or cloning) an AWS server group and selecting **Custom Type** for the instance type, the "Select an instance type..." dropdown was empty — only the placeholder option was shown, even after a region and AMI had been selected. Other instance type categories (General Purpose, etc.) appeared populated, but this was misleading: they render their static family list regardless of availability and just mark unavailable entries, whereas Custom Type builds its options solely from the filtered, available instance types.

   ## Root Cause

   `AwsInstanceTypeService.filterInstanceTypes()` filters instance types by comparing the AMI's `architecture` attribute (returned lowercase, e.g. `"arm64"`) against each instance type's `supportedArchitectures` list using a case-sensitive `Array.includes()`. For accounts/providers where `supportedArchitectures` is reported in a different case (e.g. `["ARM64"]`), every instance type failed the match and was filtered out, leaving `command.backingData.filtered.instanceTypes` empty — which is exactly what the Custom Type dropdown renders from.

   ## Fix

   Made the `architecture` comparison in `filterInstanceTypes` case-insensitive via a small `includesIgnoreCase` helper. The `virtualizationType` comparison was left unchanged since that field is confirmed lowercase from the API.
