### PR TITLE
fix(ecs): populate imageId when scoping docker image find by account

### DIFF
--- a/deck/packages/ecs/src/serverGroup/configure/dockerImage.util.ts
+++ b/deck/packages/ecs/src/serverGroup/configure/dockerImage.util.ts
@@ -1,0 +1,29 @@
+import type { IEcsDockerImage } from './serverGroupConfiguration.service';
+
+export function buildEcsImageId(image: any): string {
+  if (image.imageId) {
+    return image.imageId;
+  }
+  if (image.fromContext) {
+    return image.imageLabelOrSha;
+  }
+  if (image.fromTrigger && !image.tag) {
+    return `${image.registry}/${image.repository} (Tag resolved at runtime)`;
+  }
+  if (image.registry && image.repository && image.tag) {
+    return `${image.registry}/${image.repository}:${image.tag}`;
+  }
+  return image.reference || image.repository || '';
+}
+
+export function normalizeEcsDockerImage(image: any): IEcsDockerImage {
+  return {
+    ...image,
+    imageId: buildEcsImageId(image),
+    message: image.message || '',
+    fromTrigger: !!image.fromTrigger,
+    fromContext: !!image.fromContext,
+    stageId: image.stageId || '',
+    imageLabelOrSha: image.imageLabelOrSha || '',
+  };
+}

--- a/deck/packages/ecs/src/serverGroup/configure/wizard/EcsCloneServerGroupModal.tsx
+++ b/deck/packages/ecs/src/serverGroup/configure/wizard/EcsCloneServerGroupModal.tsx
@@ -23,10 +23,10 @@ import {
   WizardPage,
 } from '@spinnaker/core';
 
+import { normalizeEcsDockerImage } from '../dockerImage.util';
 import { EcsClusterReader } from '../../../ecsCluster/ecsCluster.read.service';
 import { IamRoleReader } from '../../../iamRoles/iamRole.read.service';
 import { MetricAlarmReader } from '../../../metricAlarm/metricAlarm.read.service';
-import { normalizeEcsDockerImage } from '../dockerImage.util';
 import { AdvancedSettings } from './pages/AdvancedSettings';
 import { BasicSettings } from './pages/BasicSettings';
 import { ContainerSettings } from './pages/ContainerSettings';

--- a/deck/packages/ecs/src/serverGroup/configure/wizard/EcsCloneServerGroupModal.tsx
+++ b/deck/packages/ecs/src/serverGroup/configure/wizard/EcsCloneServerGroupModal.tsx
@@ -26,6 +26,7 @@ import {
 import { EcsClusterReader } from '../../../ecsCluster/ecsCluster.read.service';
 import { IamRoleReader } from '../../../iamRoles/iamRole.read.service';
 import { MetricAlarmReader } from '../../../metricAlarm/metricAlarm.read.service';
+import { normalizeEcsDockerImage } from '../dockerImage.util';
 import { AdvancedSettings } from './pages/AdvancedSettings';
 import { BasicSettings } from './pages/BasicSettings';
 import { ContainerSettings } from './pages/ContainerSettings';
@@ -380,38 +381,9 @@ export class EcsCloneServerGroupModalComponent extends React.Component<
       ...command.containerMappings.map((mapping) => mapping.imageDescription),
     ].filter(Boolean);
     return uniqBy(
-      [...images, ...commandImages].map((image) => this.normalizeImage(image)),
+      [...images, ...commandImages].map((image) => normalizeEcsDockerImage(image)),
       (image) => image.imageId || image.id || image.name,
     ).filter(Boolean);
-  }
-
-  private normalizeImage(image: any): IEcsDockerImage {
-    const imageId = this.buildImageId(image);
-    return {
-      ...image,
-      imageId,
-      message: image.message || '',
-      fromTrigger: !!image.fromTrigger,
-      fromContext: !!image.fromContext,
-      stageId: image.stageId || '',
-      imageLabelOrSha: image.imageLabelOrSha || '',
-    };
-  }
-
-  private buildImageId(image: any): string {
-    if (image.imageId) {
-      return image.imageId;
-    }
-    if (image.fromContext) {
-      return image.imageLabelOrSha;
-    }
-    if (image.fromTrigger && !image.tag) {
-      return `${image.registry}/${image.repository} (Tag resolved at runtime)`;
-    }
-    if (image.registry && image.repository && image.tag) {
-      return `${image.registry}/${image.repository}:${image.tag}`;
-    }
-    return image.reference || image.repository || '';
   }
 
   private getSubnetTypes(command: IEcsServerGroupCommand, subnets: ISubnet[]): ISubnet[] {

--- a/deck/packages/ecs/src/serverGroup/configure/wizard/container/Container.spec.tsx
+++ b/deck/packages/ecs/src/serverGroup/configure/wizard/container/Container.spec.tsx
@@ -73,8 +73,20 @@ describe('Container', () => {
       await flushPromises();
       wrapper.update();
 
-      expect((wrapper.instance() as Container).state.dockerImages).toEqual(dockerImages as IEcsDockerImage[]);
-      expect(command.backingData.filtered.images).toEqual(dockerImages as IEcsDockerImage[]);
+      const expectedImages = [
+        {
+          ...dockerImages[0],
+          imageId: 'my-registry/my-repo:latest',
+          message: '',
+          fromTrigger: false,
+          fromContext: false,
+          stageId: '',
+          imageLabelOrSha: '',
+        },
+      ];
+
+      expect((wrapper.instance() as Container).state.dockerImages).toEqual(expectedImages as IEcsDockerImage[]);
+      expect(command.backingData.filtered.images).toEqual(expectedImages as IEcsDockerImage[]);
     });
 
     it('clears existing images immediately when account changes', () => {

--- a/deck/packages/ecs/src/serverGroup/configure/wizard/container/Container.tsx
+++ b/deck/packages/ecs/src/serverGroup/configure/wizard/container/Container.tsx
@@ -7,6 +7,7 @@ import type { IAccountDetails } from '@spinnaker/core';
 import { AccountService, HelpField, TetheredSelect } from '@spinnaker/core';
 import { DockerImageReader } from '@spinnaker/docker';
 
+import { normalizeEcsDockerImage } from '../../dockerImage.util';
 import type {
   IEcsDockerImage,
   IEcsServerGroupCommand,
@@ -144,7 +145,7 @@ export class Container extends React.Component<IContainerProps, IContainerState>
     this.props.command.backingData.filtered.images = [];
     this.setState({ selectedDockerAccount: account, dockerImages: [] });
     DockerImageReader.findImages({ provider: 'dockerRegistry', account, count: 50 }).then((images) => {
-      const ecsImages = images as IEcsDockerImage[];
+      const ecsImages = images.map((image) => normalizeEcsDockerImage(image));
       this.props.command.backingData.filtered.images = ecsImages;
       this.setState({ dockerImages: ecsImages });
     });

--- a/deck/packages/ecs/src/serverGroup/configure/wizard/taskDefinition/TaskDefinition.spec.tsx
+++ b/deck/packages/ecs/src/serverGroup/configure/wizard/taskDefinition/TaskDefinition.spec.tsx
@@ -78,8 +78,20 @@ describe('TaskDefinition', () => {
       await flushPromises();
       wrapper.update();
 
-      expect((wrapper.instance() as TaskDefinition).state.dockerImages).toEqual(dockerImages as IEcsDockerImage[]);
-      expect(command.backingData.filtered.images).toEqual(dockerImages as IEcsDockerImage[]);
+      const expectedImages = [
+        {
+          ...dockerImages[0],
+          imageId: 'my-registry/my-repo:latest',
+          message: '',
+          fromTrigger: false,
+          fromContext: false,
+          stageId: '',
+          imageLabelOrSha: '',
+        },
+      ];
+
+      expect((wrapper.instance() as TaskDefinition).state.dockerImages).toEqual(expectedImages as IEcsDockerImage[]);
+      expect(command.backingData.filtered.images).toEqual(expectedImages as IEcsDockerImage[]);
     });
 
     it('clears existing images immediately when account changes', () => {

--- a/deck/packages/ecs/src/serverGroup/configure/wizard/taskDefinition/TaskDefinition.tsx
+++ b/deck/packages/ecs/src/serverGroup/configure/wizard/taskDefinition/TaskDefinition.tsx
@@ -15,6 +15,7 @@ import {
 } from '@spinnaker/core';
 import { DockerImageReader } from '@spinnaker/docker';
 
+import { normalizeEcsDockerImage } from '../../dockerImage.util';
 import type {
   IEcsContainerMapping,
   IEcsDockerImage,
@@ -107,7 +108,7 @@ export class TaskDefinition extends React.Component<ITaskDefinitionProps, ITaskD
     this.props.command.backingData.filtered.images = [];
     this.setState({ selectedDockerAccount: account, dockerImages: [] });
     DockerImageReader.findImages({ provider: 'dockerRegistry', account, count: 50 }).then((images) => {
-      const ecsImages = images as IEcsDockerImage[];
+      const ecsImages = images.map((image) => normalizeEcsDockerImage(image));
       this.props.command.backingData.filtered.images = ecsImages;
       this.setState({ dockerImages: ecsImages });
     });


### PR DESCRIPTION
## Summary
- The account-scoped docker image lookup added by #7746 (`updateDockerRegistryAccount` in `Container.tsx`/`TaskDefinition.tsx`) cast the raw `/images/find` response directly to `IEcsDockerImage`, but that response never included an `imageId` field (only `account`/`registry`/`repository`/`tag`/`artifact`).
- Every dropdown option ended up with the same `undefined` label/value, so the ECS create/clone server group "Container Image" picker showed only `(undefined)` entries and selecting one had no effect.
- Extracted the existing `imageId` derivation logic from `EcsCloneServerGroupModal` into a shared `dockerImage.util.ts` and reused it in both `Container.tsx` and `TaskDefinition.tsx` so images fetched via the account picker get a proper `imageId`.

## Test plan
- [x] `./gradlew :deck:test` — BUILD SUCCESSFUL, includes updated `Container.spec.tsx` / `TaskDefinition.spec.tsx` unit tests asserting the normalized image shape (with `imageId` populated) after selecting a docker registry account.

https://claude.ai/code/session_016hcp89wpNQVdMi9dmUifXQ