### PR TITLE
fix(amazon): fix AMI selection in Create Server Group image picker

### DIFF
--- a/deck/packages/amazon/src/serverGroup/configure/AmazonImageSelectInput.spec.tsx
+++ b/deck/packages/amazon/src/serverGroup/configure/AmazonImageSelectInput.spec.tsx
@@ -1,0 +1,125 @@
+import type { ReactWrapper } from 'enzyme';
+import { mount } from 'enzyme';
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+
+import type { Application, TetheredSelect as TetheredSelectType } from '@spinnaker/core';
+import { TetheredSelect } from '@spinnaker/core';
+
+import { AmazonImageSelectInput } from './AmazonImageSelectInput';
+import type { IAmazonImage } from '../../image';
+import { AwsImageReader } from '../../image';
+
+function makeImage(imageName: string, amiId: string, region = 'us-east-1'): IAmazonImage {
+  return {
+    imageName,
+    amis: { [region]: [amiId] },
+    attributes: { virtualizationType: 'hvm', architecture: 'x86_64', creationDate: '2024-01-01T00:00:00.000Z' },
+  } as IAmazonImage;
+}
+
+describe('AmazonImageSelectInput', () => {
+  const application = ({ name: 'app' } as unknown) as Application;
+  const image1 = makeImage('app-package-1.0', 'ami-111');
+  const image2 = makeImage('app-package-2.0', 'ami-222');
+
+  beforeEach(() => {
+    spyOn(AwsImageReader.prototype, 'findImages').and.returnValue(Promise.resolve([image1, image2]));
+    spyOn(AwsImageReader.prototype, 'getImage').and.returnValue(Promise.resolve(null));
+  });
+
+  async function settle(component: ReactWrapper): Promise<void> {
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    component.update();
+  }
+
+  // The package-images dropdown's menu is only rendered by the underlying react-select
+  // instance once it's open, which normally happens via a real focus/mousedown DOM event.
+  // Driving the TetheredSelect instance directly is more reliable than simulating focus in a
+  // detached test DOM, and it's how a user's click on the control ultimately manifests anyway.
+  function openMenu(component: ReactWrapper): void {
+    (component.find(TetheredSelect).instance() as TetheredSelectType).setState({ isOpen: true });
+    component.update();
+  }
+
+  function mountInput(onChange: (image: IAmazonImage) => void, value: IAmazonImage = null) {
+    return mount(
+      <AmazonImageSelectInput
+        onChange={onChange}
+        value={value}
+        application={application}
+        credentials="test"
+        region="us-east-1"
+      />,
+    );
+  }
+
+  it('renders a single options menu wrapper, not a nested duplicate', async () => {
+    const component = mountInput(jasmine.createSpy('onChange'));
+    await settle(component);
+    openMenu(component);
+
+    // Regression test: buildImageMenu used to re-wrap its options in a second
+    // ".Select-menu-outer > .Select-menu" pair on top of react-select's own wrapper. The inner
+    // duplicate kept its default `position: absolute` styling instead of the `position: static`
+    // override TetheredSelect applies to the outermost wrapper, which broke the sizing/hit-testing
+    // of the real, Tether-positioned menu: the list was visible but clicks landed on nothing.
+    expect(component.find('.Select-menu-outer').length).toBe(1);
+  });
+
+  it('selects the clicked image from the package images dropdown', async () => {
+    const onChange = jasmine.createSpy('onChange');
+    const component = mountInput(onChange);
+    await settle(component);
+    openMenu(component);
+
+    const options = component.find('.Select-option');
+    expect(options.length).toBe(2);
+    options.first().simulate('mousedown');
+
+    expect(onChange).toHaveBeenCalledWith(jasmine.objectContaining({ imageName: image1.imageName }));
+  });
+
+  it('provides a way back from "Search All Images" to the package images dropdown', async () => {
+    const component = mountInput(jasmine.createSpy('onChange'));
+    await settle(component);
+
+    expect(component.text()).toContain('Pick an image');
+
+    component.find('button.link').simulate('click');
+    component.update();
+    expect(component.text()).toContain('Search for an image');
+
+    // Regression test: there used to be no control to switch back out of search-all-images mode.
+    const backButton = component.find('button.link');
+    expect(backButton.text()).toContain('Back to Package Images');
+    backButton.simulate('click');
+    component.update();
+
+    expect(component.text()).toContain('Pick an image');
+  });
+
+  it('selects the clicked image while searching all images', async () => {
+    const onChange = jasmine.createSpy('onChange');
+    const component = mountInput(onChange);
+    await settle(component);
+
+    component.find('button.link').simulate('click');
+    component.update();
+
+    // Populate search results directly, bypassing the debounced RxJS search pipeline, which is
+    // not what this test is exercising.
+    (component.instance() as AmazonImageSelectInput).setState({ searchString: 'app', searchResults: [image2] });
+    component.update();
+    openMenu(component);
+
+    const options = component.find('.Select-option');
+    expect(options.length).toBe(1);
+    options.first().simulate('mousedown');
+
+    expect(onChange).toHaveBeenCalledWith(jasmine.objectContaining({ imageName: image2.imageName }));
+  });
+});

--- a/deck/packages/amazon/src/serverGroup/configure/AmazonImageSelectInput.tsx
+++ b/deck/packages/amazon/src/serverGroup/configure/AmazonImageSelectInput.tsx
@@ -215,15 +215,19 @@ export class AmazonImageSelectInput extends React.Component<IAmazonImageSelector
   private buildImageMenu = (params: MenuRendererProps): HandlerRendererResult => {
     const { ImageMenuHeading, ImageLabel } = this;
     const { options } = params;
+    // Note: react-select's renderOuter() already wraps whatever this returns in its own
+    // ".Select-menu-outer > .Select-menu" pair (which is what TetheredSelect repositions
+    // via Tether). Re-wrapping here duplicates that structure with a second ".Select-menu-outer",
+    // which keeps its default `position: absolute` styling and collapses the real, tethered
+    // container's height - the list still renders, but the clickable area no longer lines up
+    // with what's painted on screen, so selecting an option silently does nothing.
     return (
-      <div className="Select-menu-outer">
-        <div className="Select-menu" role="listbox">
-          {options.length > 0 && <ImageMenuHeading />}
-          {options.map((o) => (
-            <ImageLabel key={o.imageName} option={o} params={params} />
-          ))}
-        </div>
-      </div>
+      <>
+        {options.length > 0 && <ImageMenuHeading />}
+        {options.map((o) => (
+          <ImageLabel key={o.imageName} option={o} params={params} />
+        ))}
+      </>
     );
   };
 
@@ -270,7 +274,13 @@ export class AmazonImageSelectInput extends React.Component<IAmazonImageSelector
     return (
       <div
         key={option.imageName}
-        onClick={() => params.selectValue(option)}
+        onMouseDown={(event) => {
+          // Match react-select's own Option component: select on mousedown (not click) and
+          // prevent the default browser action so the input doesn't blur/close the menu first.
+          event.preventDefault();
+          event.stopPropagation();
+          params.selectValue(option);
+        }}
         onMouseOver={() => params.focusOption(option)}
         className={`Select-option ${
           params.focusedOption && params.focusedOption.imageName === option.imageName ? 'is-focused' : ''
@@ -367,6 +377,14 @@ export class AmazonImageSelectInput extends React.Component<IAmazonImageSelector
             onChange={onChange}
           />
           {error}
+          <button
+            type="button"
+            className="link"
+            onClick={() => this.setState({ selectionMode: 'packageImages', searchString: '', searchResults: null })}
+          >
+            Back to Package Images
+          </button>{' '}
+          <HelpField id="aws.serverGroup.allImages" />
         </div>
       );
     } else if (isPackageImagesLoaded) {

--- a/deck/packages/amazon/src/serverGroup/configure/AmazonImageSelectInput.tsx
+++ b/deck/packages/amazon/src/serverGroup/configure/AmazonImageSelectInput.tsx
@@ -39,7 +39,7 @@ export class AmazonImageSelectInput extends React.Component<IAmazonImageSelector
     errorMessage: null,
     selectionMode: 'packageImages',
     searchString: '',
-    searchResults: null,
+    searchResults: [],
     isSearching: false,
     packageImages: null,
     isLoadingPackageImages: true,

--- a/deck/packages/amazon/src/serverGroup/configure/AmazonImageSelectInput.tsx
+++ b/deck/packages/amazon/src/serverGroup/configure/AmazonImageSelectInput.tsx
@@ -369,7 +369,7 @@ export class AmazonImageSelectInput extends React.Component<IAmazonImageSelector
             placeholder="Search for an image..."
             filterOptions={false as any}
             noResultsText={searchNoResultsText}
-            options={searchResults}
+            options={searchResults ?? []}
             onInputChange={(searchInput) => {
               this.searchInput$.next(searchInput);
               return searchInput;


### PR DESCRIPTION
## Summary
- The AMI picker in the AWS Create/Clone Server Group wizard shows images in the dropdown, but clicking one didn't set the value, and "Search All Images" had no way back to the plain dropdown.
- Root cause: `AmazonImageSelectInput`'s custom `menuRenderer` re-wrapped its options in a second `.Select-menu-outer > .Select-menu` pair on top of react-select's own wrapper. `TetheredSelect` only overrides the *outermost* wrapper's position to `static` so Tether can position it; the duplicate inner wrapper kept its default `position: absolute`, pulling it out of flow and collapsing the real, Tether-positioned menu's hit-testable area. The list rendered, but clicks landed on nothing. This is the only place in the app that supplies a custom `menuRenderer` to `TetheredSelect`, which is why every other select was unaffected.
- Also switched the option's selection handler from `onClick` to `onMouseDown` with `preventDefault`/`stopPropagation`, matching react-select's own `Option` component, for defense in depth.
- Added a "Back to Package Images" control so `selectionMode` can return from `searchAllImages` to the normal dropdown, which previously had no way back.

## Test plan
- [x] Added `AmazonImageSelectInput.spec.tsx` covering: no duplicate menu wrapper, selecting an image from the package-images dropdown, switching to/back from "Search All Images", and selecting an image while searching all images.
- [x] `./gradlew :deck:karma` — 3478/3478 passing.
- [ ] Manual smoke test of the Create Server Group wizard in a running app (not done in this session - no local backend was available).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_01DtXShry16A5KJ4cGWDkyNj