### PR TITLE
fix(echo): populate telemetry spinnakerVersion from resolved service version

### DIFF
--- a/echo/echo-telemetry/src/main/java/com/netflix/spinnaker/echo/config/TelemetryConfig.kt
+++ b/echo/echo-telemetry/src/main/java/com/netflix/spinnaker/echo/config/TelemetryConfig.kt
@@ -69,12 +69,13 @@ open class TelemetryConfig {
 
     companion object {
       const val DEFAULT_TELEMETRY_ENDPOINT = "https://stats.spinnaker.io"
+      const val DEFAULT_SPINNAKER_VERSION = "unknown"
     }
 
     var enabled = false
     var endpoint = DEFAULT_TELEMETRY_ENDPOINT
     var instanceId = ULID().nextULID()
-    var spinnakerVersion = "unknown"
+    var spinnakerVersion = DEFAULT_SPINNAKER_VERSION
     var deploymentMethod = DeploymentMethod()
     var connectionTimeoutMillis = 3000
     var readTimeoutMillis = 5000

--- a/echo/echo-telemetry/src/main/java/com/netflix/spinnaker/echo/telemetry/SpinnakerInstanceDataProvider.kt
+++ b/echo/echo-telemetry/src/main/java/com/netflix/spinnaker/echo/telemetry/SpinnakerInstanceDataProvider.kt
@@ -23,12 +23,17 @@ import com.netflix.spinnaker.kork.proto.stats.Application
 import com.netflix.spinnaker.kork.proto.stats.DeploymentMethod
 import com.netflix.spinnaker.kork.proto.stats.Event as StatsEvent
 import com.netflix.spinnaker.kork.proto.stats.SpinnakerInstance
+import com.netflix.spinnaker.kork.version.ServiceVersion
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Component
 
 @Component
 @ConditionalOnProperty(value = ["stats.enabled"], matchIfMissing = true)
-class SpinnakerInstanceDataProvider(private val config: TelemetryConfigProps, private val instanceIdSupplier: InstanceIdSupplier) : TelemetryEventDataProvider {
+class SpinnakerInstanceDataProvider(
+  private val config: TelemetryConfigProps,
+  private val instanceIdSupplier: InstanceIdSupplier,
+  private val serviceVersion: ServiceVersion
+) : TelemetryEventDataProvider {
   override fun populateData(echoEvent: EchoEvent, statsEvent: StatsEvent): StatsEvent {
 
     // TelemetryEventListener should ensure this is set
@@ -42,10 +47,20 @@ class SpinnakerInstanceDataProvider(private val config: TelemetryConfigProps, pr
     // ULID) provides a good level of randomness as a salt, and is not easily guessable.
     val hashedApplicationId: String = hash(applicationId, instanceId)
 
+    // `stats.spinnaker-version` is not set by the Halyard-free deployment pipeline, so fall back
+    // to the version Gradle stamped into echo's jar manifest (resolved via kork's ServiceVersion,
+    // the same mechanism used for plugin compatibility checks) unless it's been explicitly
+    // overridden in config.
+    val version = if (config.spinnakerVersion != TelemetryConfigProps.DEFAULT_SPINNAKER_VERSION) {
+      config.spinnakerVersion
+    } else {
+      serviceVersion.resolve()
+    }
+
     val application = Application.newBuilder().setId(hashedApplicationId).build()
     val spinnakerInstance: SpinnakerInstance = SpinnakerInstance.newBuilder()
       .setId(hashedInstanceId)
-      .setVersion(config.spinnakerVersion)
+      .setVersion(version)
       .setDeploymentMethod(config.deploymentMethod.toProto())
       .build()
 

--- a/echo/echo-telemetry/src/test/kotlin/com/netflix/spinnaker/echo/telemetry/SpinnakerInstanceDataProviderTest.kt
+++ b/echo/echo-telemetry/src/test/kotlin/com/netflix/spinnaker/echo/telemetry/SpinnakerInstanceDataProviderTest.kt
@@ -23,6 +23,9 @@ import com.netflix.spinnaker.echo.api.events.Metadata
 import com.netflix.spinnaker.echo.config.TelemetryConfig.TelemetryConfigProps
 import com.netflix.spinnaker.kork.proto.stats.DeploymentMethod
 import com.netflix.spinnaker.kork.proto.stats.Event as StatsEvent
+import com.netflix.spinnaker.kork.version.ServiceVersion
+import io.mockk.every
+import io.mockk.mockk
 import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -37,12 +40,16 @@ class SpinnakerInstanceDataProviderTest {
 
   private lateinit var config: TelemetryConfigProps
 
+  private lateinit var serviceVersion: ServiceVersion
+
   private lateinit var dataProvider: SpinnakerInstanceDataProvider
 
   @BeforeEach
   fun setUp() {
     config = TelemetryConfigProps()
-    dataProvider = SpinnakerInstanceDataProvider(config, InstanceIdSupplier(config, null))
+    serviceVersion = mockk()
+    every { serviceVersion.resolve() } returns "resolved.version.from.manifest"
+    dataProvider = SpinnakerInstanceDataProvider(config, InstanceIdSupplier(config, null), serviceVersion)
   }
 
   @Test
@@ -68,6 +75,16 @@ class SpinnakerInstanceDataProviderTest {
     expectThat(result.spinnakerInstance.version).isEqualTo(config.spinnakerVersion)
     expectThat(result.spinnakerInstance.deploymentMethod.type).isEqualTo(DeploymentMethod.Type.HALYARD)
     expectThat(result.spinnakerInstance.deploymentMethod.version).isEqualTo(config.deploymentMethod.version)
+  }
+
+  @Test
+  fun `falls back to resolved service version when spinnakerVersion is not configured`() {
+    val echoEvent = createLoggableEvent()
+    val statsEventInput = StatsEvent.getDefaultInstance()
+
+    val result = dataProvider.populateData(echoEvent, statsEventInput)
+
+    expectThat(result.spinnakerInstance.version).isEqualTo("resolved.version.from.manifest")
   }
 
   @ParameterizedTest


### PR DESCRIPTION
## Summary
- `stats.spinnaker-version`, sent to `stats.spinnaker.io` as part of usage telemetry, was never set by any config in this repo (no Halyard involvement — it's simply unwired), so every deployment reported version `"unknown"`.
- Gradle already stamps a real version into every service's jar manifest (`Implementation-Version`, set from CI's `ORG_GRADLE_PROJECT_version`), and kork-core's `ServiceVersion`/`SpringPackageVersionResolver` already reads it back — that mechanism just wasn't wired into `echo-telemetry`.
- `SpinnakerInstanceDataProvider` now injects kork's `ServiceVersion` bean and uses its resolved value as a fallback whenever `stats.spinnaker-version` hasn't been explicitly overridden in config, so real version data now reaches the stats payload without requiring any deployment-specific configuration.

## Test plan
- [x] `./gradlew :echo:echo-telemetry:test --tests "*SpinnakerInstanceDataProviderTest*"` — all tests pass, including a new test covering the fallback-to-resolved-version path
- [x] `./gradlew :echo:echo-telemetry:spotlessApply` — no changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DtXShry16A5KJ4cGWDkyNj