### PR TITLE
fix(rosco,clouddriver): use bsdtar to unblock arm64 Dockerfile.ubuntu builds

### DIFF
--- a/clouddriver/Dockerfile.ubuntu
+++ b/clouddriver/Dockerfile.ubuntu
@@ -8,6 +8,11 @@ ENV KUBECTL_RELEASES="${KUBECTL_DEFAULT_RELEASE} 1.31.14 1.32.13 1.33.13"
 ENV AWS_CLI_VERSION=2.35.22
 ENV AWS_AIM_AUTHENTICATOR_VERSION=0.7.18
 
+# libarchive-tools' bsdtar replaces GNU tar as /usr/bin/tar below: GNU tar (patched for CVE-2025-45582) now
+# extracts via openat2(), which QEMU 7.0.0 (pinned in .github/actions/publish-docker/action.yml as a workaround
+# for a different, unrelated bug - docker/setup-qemu-action#198) doesn't implement, breaking every arm64
+# (QEMU-emulated) build with "tar: ...: Cannot open: Function not implemented". bsdtar doesn't use openat2.
+# See: https://github.com/tonistiigi/binfmt/issues/285, https://github.com/abiosoft/colima/issues/1613
 RUN apt-get update && apt-get install -y curl gnupg && \
   curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
   echo "deb https://packages.cloud.google.com/apt cloud-sdk  main" > /etc/apt/sources.list.d/cloud-sdk.list && \
@@ -21,7 +26,9 @@ RUN apt-get update && apt-get install -y curl gnupg && \
   python3 \
   git \
   openssh-client \
-  unzip && \
+  unzip \
+  libarchive-tools && \
+  ln -sf "$(command -v bsdtar)" /usr/bin/tar && \
   rm -rf ~/.config/gcloud
 
 # AWS CLI 2

--- a/rosco/Dockerfile.ubuntu
+++ b/rosco/Dockerfile.ubuntu
@@ -13,7 +13,13 @@ ARG PACKER_PLUGINS="amazon azure googlecompute"
 
 WORKDIR /packer
 
-RUN apt-get update && apt-get -y install openjdk-17-jre-headless wget unzip curl git openssh-client && \
+# libarchive-tools' bsdtar replaces GNU tar as /usr/bin/tar below: GNU tar (patched for CVE-2025-45582) now
+# extracts via openat2(), which QEMU 7.0.0 (pinned in .github/actions/publish-docker/action.yml as a workaround
+# for a different, unrelated bug - docker/setup-qemu-action#198) doesn't implement, breaking every arm64
+# (QEMU-emulated) build with "tar: ...: Cannot open: Function not implemented". bsdtar doesn't use openat2.
+# See: https://github.com/tonistiigi/binfmt/issues/285, https://github.com/abiosoft/colima/issues/1613
+RUN apt-get update && apt-get -y install openjdk-17-jre-headless wget unzip curl git openssh-client libarchive-tools && \
+  ln -sf "$(command -v bsdtar)" /usr/bin/tar && \
   wget https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_${TARGETARCH}.zip && \
   unzip packer_${PACKER_VERSION}_linux_${TARGETARCH}.zip && \
   rm packer_${PACKER_VERSION}_linux_${TARGETARCH}.zip
@@ -36,25 +42,25 @@ RUN wget https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get &&
 # DEPRECATED: kustomize v3 is end-of-life upstream; removal planned for the 2026.4.x releases
 RUN mkdir kustomize && \
   curl -s -L https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_${TARGETARCH}.tar.gz|\
-  tar xvz -C kustomize/ && \
+  tar xvz -f - -C kustomize/ && \
   mv ./kustomize/kustomize /usr/local/bin/kustomize && \
   rm -rf ./kustomize
 
 RUN mkdir kustomize && \
   curl -s -L https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${KUSTOMIZE4_VERSION}/kustomize_v${KUSTOMIZE4_VERSION}_linux_${TARGETARCH}.tar.gz|\
-  tar xvz -C kustomize/ && \
+  tar xvz -f - -C kustomize/ && \
   mv ./kustomize/kustomize /usr/local/bin/kustomize4 && \
   rm -rf ./kustomize
 
 RUN mkdir kustomize && \
   curl -s -L https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${KUSTOMIZE5_VERSION}/kustomize_v${KUSTOMIZE5_VERSION}_linux_${TARGETARCH}.tar.gz|\
-  tar xvz -C kustomize/ && \
+  tar xvz -f - -C kustomize/ && \
   mv ./kustomize/kustomize /usr/local/bin/kustomize5 && \
   rm -rf ./kustomize
 
 RUN mkdir helmfile && \
   curl -s -L https://github.com/helmfile/helmfile/releases/download/v${HELMFILE_VERSION}/helmfile_${HELMFILE_VERSION}_linux_${TARGETARCH}.tar.gz|\
-  tar xvz -C helmfile/ && \
+  tar xvz -f - -C helmfile/ && \
   mv ./helmfile/helmfile /usr/local/bin/helmfile && \
   rm -rf ./helmfile
 


### PR DESCRIPTION
## Summary

`rosco` and `clouddriver`'s `Dockerfile.ubuntu` (`ubuntu:resolute`) arm64 builds are broken: `ubuntu:resolute` ships a GNU tar patched for CVE-2025-45582, which now extracts via `openat2()`. The QEMU version pinned in `.github/actions/publish-docker/action.yml` (`qemu-v7.0.0-28`, pinned as a workaround for an unrelated segfault bug, `docker/setup-qemu-action#198`) predates QEMU's `openat2` support, so every emulated `linux/arm64` build fails during helm/kustomize/helmfile/gcloud-sdk extraction with:

```
tar: ...: Cannot open: Function not implemented
```

## Fix

Swap `bsdtar` (via `libarchive-tools`) in for GNU tar in the two affected Dockerfiles. `bsdtar` doesn't use `openat2`, so it sidesteps the incompatibility without touching CI topology or the QEMU pin.

Verified locally against the exact pinned `qemu-v7.0.0-28` image: reproduced the failure with GNU tar, then confirmed `bsdtar` succeeds for `get-helm-3`, the piped kustomize/helmfile extraction, and the gcloud-sdk tarball extraction.

## Status

This is a backup/fallback fix. The preferred fix (bumping the QEMU pin itself to `qemu-v10.2.3-68`, which appears to resolve both this bug and the original segfault bug it was pinned to avoid) is being pursued separately off `main`. Opening this as a draft in case that path doesn't pan out.

## Test plan
- [ ] CI run on this branch builds rosco and clouddriver's ubuntu-variant arm64 images successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DtXShry16A5KJ4cGWDkyNj