### PR TITLE
fix(ci): bump pinned QEMU binfmt image from v7.0.0-28 to v10.2.3-68

### DIFF
--- a/.github/actions/publish-docker/action.yml
+++ b/.github/actions/publish-docker/action.yml
@@ -61,8 +61,17 @@ runs:
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
       with:
-        ## Temporary due to bug in qemu:  https://github.com/docker/setup-qemu-action/issues/198
-        image: tonistiigi/binfmt:qemu-v7.0.0-28
+        ## Pinned to a specific tonistiigi/binfmt release rather than `latest`, which is stale by ~2 years:
+        ## https://github.com/tonistiigi/binfmt/issues/165#issuecomment-1996882334
+        ##
+        ## v10.2.3 fixes both:
+        ## - the segfault that qemu-v7.0.0-28 was previously pinned to work around
+        ##   (docker/setup-qemu-action#198, tonistiigi/binfmt#316, fixed upstream in QEMU 10.2.3/10.0.10:
+        ##   https://github.com/qemu/qemu/commit/3b68c2db2392eadfa89c64647e96a69d8490477a)
+        ## - GNU tar (patched for CVE-2025-45582) failing to extract under emulation with
+        ##   "Cannot open: Function not implemented", since it now uses openat2(), which QEMU only gained
+        ##   support for in 9.2 (tonistiigi/binfmt#285, tonistiigi/binfmt#287)
+        image: tonistiigi/binfmt:qemu-v10.2.3-68
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
## Summary

`.github/actions/publish-docker/action.yml` pins `tonistiigi/binfmt:qemu-v7.0.0-28` for QEMU-emulated `linux/arm64` builds, as a workaround for a segfault bug (`docker/setup-qemu-action#198`) in newer QEMU builds on GitHub's `ubuntu-24.04` runners.

Staying on that pin has its own cost: QEMU 7.0.0 predates `openat2()` support (added in 9.2). `ubuntu:resolute`'s GNU tar (patched for CVE-2025-45582) now requires `openat2` to extract archives, so every emulated `linux/arm64` build of a `Dockerfile.ubuntu` image that runs `tar` fails with:

```
tar: ...: Cannot open: Function not implemented
```

This currently breaks `rosco` and `clouddriver` (helm/kustomize/helmfile and gcloud-sdk extraction respectively). See #7969 for a `bsdtar`-based workaround on those two specifically, opened as a fallback.

## Why v10.2.3-68 instead of just avoiding tar

The original segfault bug has since been root-caused and fixed upstream:
- `tonistiigi/binfmt#316` traces it to a known QEMU bug (`systemd/systemd#41279`), fixed in QEMU 10.2.3 (`qemu@3b68c2db2392`) and 10.0.10 (`qemu@53946af76fd7`)
- `tonistiigi/binfmt#328` bumped the project to QEMU 10.2.3 for exactly this reason; `deploy/v10.2.3-68` (2026-06-08) is the current release, three months old with no newer tag
- No new segfault reports against `tonistiigi/binfmt` since that release
- Two independent real-world confirmations of this exact scenario (old pin + tar/openat2 break, fixed by this same version bump): `chatwork/dockerfiles#4543`, `giantswarm/architect-orb#896`
- The one issue still open against binfmt (`#364`) is a narrow `execvp()`/`PATH`-shadowing edge case in C programs calling `execvp` directly - not applicable to shell-driven Dockerfile `RUN` steps

So this pin bump appears to fix both problems at once, repo-wide (all 11 `Dockerfile.ubuntu` builds), rather than working around tar specifically in just the two currently-broken services.

## Verification

Reproduced the original failure locally against the exact pinned `qemu-v7.0.0-28` image (see #7969's description), then confirmed *unmodified* GNU tar - no `bsdtar`, no Dockerfile changes - succeeds under `qemu-v10.2.3-68` for:
- `get-helm-3`'s internal tar extraction
- the piped `curl | tar xvz -C dir/` pattern used for kustomize/helmfile
- the `tar -xzf file.tar.gz` pattern used for the gcloud SDK

## Test plan
- [ ] CI run on this branch builds all Dockerfile.ubuntu variants (rosco, clouddriver, and the other 9 services) successfully for both linux/amd64 and linux/arm64
- [ ] No segfaults reappear across the arm64 build matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DtXShry16A5KJ4cGWDkyNj