### PR TITLE
fix(deck): scope rxjs override so lerna publish doesn't crash

### DIFF
--- a/deck/pnpm-lock.yaml
+++ b/deck/pnpm-lock.yaml
@@ -13,6 +13,7 @@ overrides:
   react: ^16.14.0
   react-dom: ^16.14.0
   rxjs: 6.6.7
+  inquirer@12>rxjs: ^7.8.2
   typescript: 5.0.4
 
 importers:
@@ -10337,6 +10338,9 @@ packages:
     resolution: {integrity: sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==}
     engines: {npm: '>=2.0.0'}
 
+  rxjs@7.8.2:
+    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
+
   safe-array-concat@1.1.4:
     resolution: {integrity: sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==}
     engines: {node: '>=0.4'}
@@ -18741,7 +18745,7 @@ snapshots:
       '@inquirer/type': 3.0.10(@types/node@16.4.13)
       mute-stream: 2.0.0
       run-async: 4.0.6
-      rxjs: 6.6.7
+      rxjs: 7.8.2
     optionalDependencies:
       '@types/node': 16.4.13
 
@@ -22119,6 +22123,10 @@ snapshots:
   rxjs@6.6.7:
     dependencies:
       tslib: 1.14.1
+
+  rxjs@7.8.2:
+    dependencies:
+      tslib: 2.8.1
 
   safe-array-concat@1.1.4:
     dependencies:

--- a/deck/pnpm-workspace.yaml
+++ b/deck/pnpm-workspace.yaml
@@ -9,6 +9,11 @@ overrides:
   react: ^16.14.0
   react-dom: ^16.14.0
   rxjs: 6.6.7
+  # lerna's own inquirer dependency needs a modern rxjs; the blanket
+  # override above must not force it down to 6.6.7 or `lerna publish`
+  # crashes at startup (inquirer's ESM build imports `concatMap` from
+  # 'rxjs', which rxjs 6 only exposes via 'rxjs/operators').
+  inquirer@12>rxjs: ^7.8.2
   typescript: 5.0.4
 allowBuilds:
   bufferutil: true


### PR DESCRIPTION
## Summary
- The workspace-wide `rxjs: 6.6.7` pnpm override in `deck/pnpm-workspace.yaml` (added to keep the deck app bundle on a single rxjs version) was also forcing `lerna`'s own `inquirer@12.9.6` dependency down to rxjs 6.6.7.
- `inquirer@12` requires `rxjs ^7.8.2` and its ESM build does `import { concatMap } from 'rxjs'` — an export rxjs 6 only exposes via `rxjs/operators`, not the package root. Loading inquirer therefore crashed with `SyntaxError: The requested module 'rxjs' does not provide an export named 'concatMap'`, which killed the `npx lerna publish` step before any prompt logic ran.
- Observed in the deck Lerna Publish job: https://github.com/spinnaker/spinnaker/actions/runs/33989236425
- Scoped the override to `inquirer@12>rxjs: ^7.8.2` so only lerna's inquirer gets the modern rxjs; every other consumer (core, kayenta, `@uirouter/rx`, `redux-observable`, the `inquirer@7.3.3` used by graphql-codegen, etc.) stays pinned to 6.6.7.

## Test plan
- [x] `pnpm install` in `deck/` regenerates the lockfile cleanly with a single new `rxjs@7.8.2` entry scoped to inquirer's tree, no other resolution changes
- [x] Loaded the exact file that crashed CI (`inquirer/dist/esm/ui/prompt.js`) directly in Node — no error
- [x] `npx lerna --version` runs successfully
- [x] Re-running `pnpm install` shows no further drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DtXShry16A5KJ4cGWDkyNj