### PR TITLE
fix(deck): Case-insensitve on virtualizationType comparison

### DIFF
--- a/deck/packages/amazon/src/instance/awsInstanceType.service.spec.js
+++ b/deck/packages/amazon/src/instance/awsInstanceType.service.spec.js
@@ -348,6 +348,27 @@ describe('Service: InstanceType', function () {
         'm9gd.metal-48xl',
       ]);
     });
+
+    it('matches virtualization type case-insensitively when the AMI attribute is uppercase', function () {
+      const service = this.awsInstanceTypeService;
+      const armInstanceTypes = [
+        {
+          account: 'test',
+          region: 'us-west-2',
+          name: 'x8i.metal-48xl',
+          defaultVCpus: 192,
+          memoryInGiB: 3072,
+          supportedArchitectures: ['X86_64'],
+          supportedVirtualizationTypes: ['hvm'],
+        },
+      ];
+
+      // AMI attributes (e.g. command.virtualizationType / command.amiArchitecture) can come back
+      // uppercase (e.g. 'HVM', 'ARM64') while the instance types API reports lowercase values.
+      expect(map(service.filterInstanceTypes(armInstanceTypes, 'HVM', true, 'X86_64'), 'name')).toEqual([
+        'x8i.metal-48xl',
+      ]);
+    });
   });
 
   describe('isBurstingSupportedForAllTypes', function () {

--- a/deck/packages/amazon/src/instance/awsInstanceType.service.ts
+++ b/deck/packages/amazon/src/instance/awsInstanceType.service.ts
@@ -167,8 +167,10 @@ export class AwsInstanceTypeService {
     vpcConfigured: boolean,
     architecture: string,
   ): IAmazonInstanceType[] {
-    // Some accounts/providers report supportedArchitectures in a different case (e.g. 'ARM64')
-    // than the AMI attribute we compare against (e.g. 'arm64'), so compare case-insensitively.
+    // The casing of virtualizationType/architecture can differ between the AMI attributes we
+    // compare against (e.g. 'HVM', 'ARM64') and the supportedVirtualizationTypes/supportedArchitectures
+    // reported for instance types (e.g. 'hvm', 'X86_64'), depending on the account/provider. Compare
+    // both case-insensitively to avoid filtering out every instance type due to a casing mismatch.
     const includesIgnoreCase = (values: string[], value: string) =>
       values.some((v) => v.toLowerCase() === value.toLowerCase());
 
@@ -185,7 +187,7 @@ export class AwsInstanceTypeService {
       if (
         virtualizationType &&
         i.supportedVirtualizationTypes &&
-        !i.supportedVirtualizationTypes.includes(virtualizationType)
+        !includesIgnoreCase(i.supportedVirtualizationTypes, virtualizationType)
       ) {
         return false;
       }


### PR DESCRIPTION
Follow up fix of  https://github.com/spinnaker/spinnaker/pull/7963 it turns out that the virtualization type had a similar issue in some architecture selection.  Tested and verified that the instanceTypes are now populated per api response