### PR TITLE
ci(cleanup): fix worklow and use Go binary instead of broken Docker image

### DIFF
--- a/.github/workflows/clean-untagged-images.yml
+++ b/.github/workflows/clean-untagged-images.yml
@@ -18,24 +18,31 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 'stable'
+
+      - name: Install gcr-cleaner-cli
+        run: go install github.com/GoogleCloudPlatform/gcr-cleaner/cmd/gcr-cleaner-cli@latest
+
       # delete untaggd images older than 48 hours
       - name: Clean images
-        uses: 'docker://us-docker.pkg.dev/gcr-cleaner/gcr-cleaner/gcr-cleaner-cli'
-        with:
-          args: >-
-            -repo=ghcr.io/spinnaker/clouddriver
-            -repo=ghcr.io/spinnaker/deck
-            -repo=ghcr.io/spinnaker/echo
-            -repo=ghcr.io/spinnaker/fiat
-            -repo=ghcr.io/spinnaker/front50
-            -repo=ghcr.io/spinnaker/gate
-            -repo=ghcr.io/spinnaker/halyard
-            -repo=ghcr.io/spinnaker/igor
-            -repo=ghcr.io/spinnaker/kayenta
-            -repo=ghcr.io/spinnaker/keel
-            -repo=ghcr.io/spinnaker/orca
-            -repo=ghcr.io/spinnaker/rosco
-            -grace=48h
+        run: |
+          $(go env GOPATH)/bin/gcr-cleaner-cli \
+            -repo=ghcr.io/spinnaker/clouddriver \
+            -repo=ghcr.io/spinnaker/deck \
+            -repo=ghcr.io/spinnaker/echo \
+            -repo=ghcr.io/spinnaker/fiat \
+            -repo=ghcr.io/spinnaker/front50 \
+            -repo=ghcr.io/spinnaker/gate \
+            -repo=ghcr.io/spinnaker/halyard \
+            -repo=ghcr.io/spinnaker/igor \
+            -repo=ghcr.io/spinnaker/kayenta \
+            -repo=ghcr.io/spinnaker/keel \
+            -repo=ghcr.io/spinnaker/orca \
+            -repo=ghcr.io/spinnaker/rosco \
+            -grace=48h \
             -dry-run=false
 
   gcr-cleaner:
@@ -50,10 +57,18 @@ jobs:
           password: ${{ secrets.GAR_JSON_KEY }}
 
 
-      # delete untaggd images older than 48 hours
-      - uses: 'docker://us-docker.pkg.dev/gcr-cleaner/gcr-cleaner/gcr-cleaner-cli'
+      - name: Set up Go
+        uses: actions/setup-go@v5
         with:
-          args: >-
-            -repo=us-docker.pkg.dev/spinnaker-community/docker
-            -grace=48h
+          go-version: 'stable'
+
+      - name: Install gcr-cleaner-cli
+        run: go install github.com/GoogleCloudPlatform/gcr-cleaner/cmd/gcr-cleaner-cli@latest
+
+      # delete untaggd images older than 48 hours
+      - name: Clean images
+        run: |
+          $(go env GOPATH)/bin/gcr-cleaner-cli \
+            -repo=us-docker.pkg.dev/spinnaker-community/docker \
+            -grace=48h \
             -dry-run=true

--- a/.github/workflows/clean-untagged-images.yml
+++ b/.github/workflows/clean-untagged-images.yml
@@ -43,7 +43,7 @@ jobs:
             -repo=ghcr.io/spinnaker/orca \
             -repo=ghcr.io/spinnaker/rosco \
             -grace=48h \
-            -dry-run=false
+            -dry-run=true
 
   gcr-cleaner:
     runs-on: 'ubuntu-latest'


### PR DESCRIPTION
## Summary
The `clean-untagged-images.yml` workflow was failing because the `docker://us-docker.pkg.dev/gcr-cleaner/gcr-cleaner/gcr-cleaner-cli` image can no longer be pulled. This mirrors a fix we have used in our workflows, which switched from the Docker image to installing the Go binary directly.

## Changes
- Added `actions/setup-go` step to both the `ghcr-cleaner` and `gcr-cleaner` jobs.
- Replaced the `docker://.../gcr-cleaner-cli` action step with `go install github.com/GoogleCloudPlatform/gcr-cleaner/cmd/gcr-cleaner-cli@latest` followed by invoking the installed binary directly (note: the upstream project moved from `sethvargo/gcr-cleaner` to `GoogleCloudPlatform/gcr-cleaner`).
- Preserved all existing `-repo=...`, `-grace=48h` flags.
- Set `-dry-run=true` on both jobs for safe testing before re-enabling real deletions.

## Testing
- Validated workflow YAML syntax with `yaml.safe_load`.
- Ran secret scanning and CodeQL checks on the changed file (no issues found).
- Not yet run in CI (dry-run is enabled intentionally for verification before switching back to `dry-run=false`).
