### PR TITLE
fix(saml):  Fixes a weird edge case where metadata doesnt specify sig…

### DIFF
--- a/gate/gate-saml/src/main/java/com/netflix/spinnaker/gate/security/saml/SAMLConfiguration.java
+++ b/gate/gate-saml/src/main/java/com/netflix/spinnaker/gate/security/saml/SAMLConfiguration.java
@@ -21,6 +21,8 @@ import com.netflix.spinnaker.gate.config.AuthConfig;
 import com.netflix.spinnaker.gate.security.AllowedAccountsSupport;
 import com.netflix.spinnaker.gate.security.SpinnakerAuthConfig;
 import com.netflix.spinnaker.gate.services.AuthenticationService;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import org.springframework.beans.factory.ObjectFactory;
@@ -42,9 +44,6 @@ import org.springframework.security.saml2.provider.service.registration.RelyingP
 import org.springframework.security.saml2.provider.service.registration.RelyingPartyRegistrations;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.savedrequest.HttpSessionRequestCache;
-
-import java.io.IOException;
-import java.security.GeneralSecurityException;
 
 @Configuration(proxyBeanMethods = false)
 @EnableConfigurationProperties(SecuritySamlProperties.class)
@@ -97,22 +96,24 @@ public class SAMLConfiguration {
       // This is used in some identity providers to sign the request.  NOT the response - response
       // is handled via the certs in metadata or up above.  This is keycloak and some others
       // TO USE THIS:  The certificate should be uploaded to the IDP to allow it to decrypt these
-      // requests. 
+      // requests.
       if (properties.isSignRequests()) {
         // THIS FORCES requests to be signed even if the metadata says they shouldn't be signed
-        // this is an edge case where some providers require signing, but their metadata doesn't set it
+        // this is an edge case where some providers require signing, but their metadata doesn't set
+        // it
         builder.authnRequestsSigned(true);
         var signingCredentials = properties.getSigningCredentials();
         if (!signingCredentials.isEmpty()) {
           builder.signingX509Credentials(c -> c.addAll(signingCredentials));
         } else if (properties.getSigningKeystore() != null) {
-          builder.signingX509Credentials(c -> {
-            try {
-              c.add(properties.getSigningKeystoreCredential());
-            } catch (IOException | GeneralSecurityException e) {
-              throw new RuntimeException(e);
-            }
-          });
+          builder.signingX509Credentials(
+              c -> {
+                try {
+                  c.add(properties.getSigningKeystoreCredential());
+                } catch (IOException | GeneralSecurityException e) {
+                  throw new RuntimeException(e);
+                }
+              });
         }
       }
       RelyingPartyRegistration registration = builder.build();
@@ -122,8 +123,11 @@ public class SAMLConfiguration {
     @Bean
     // ManagedDeliverySchemaEndpointConfiguration#schemaSecurityFilterChain should go first
     @Order(3)
-    // Make sure the registration is a bean so someone can overload it IF really needed, and make sure we use the bean generated up above which otherwise isn't needed as a bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http, RelyingPartyRegistrationRepository relyingPartyRegistrationRepository) throws Exception {
+    // Make sure the registration is a bean so someone can overload it IF really needed, and make
+    // sure we use the bean generated up above which otherwise isn't needed as a bean
+    public SecurityFilterChain securityFilterChain(
+        HttpSecurity http, RelyingPartyRegistrationRepository relyingPartyRegistrationRepository)
+        throws Exception {
       authConfig.configure(http);
       HttpSessionRequestCache requestCache = new HttpSessionRequestCache();
       requestCache.setMatchingRequestParameterName(null);

--- a/gate/gate-saml/src/main/java/com/netflix/spinnaker/gate/security/saml/SAMLConfiguration.java
+++ b/gate/gate-saml/src/main/java/com/netflix/spinnaker/gate/security/saml/SAMLConfiguration.java
@@ -43,6 +43,9 @@ import org.springframework.security.saml2.provider.service.registration.RelyingP
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.savedrequest.HttpSessionRequestCache;
 
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+
 @Configuration(proxyBeanMethods = false)
 @EnableConfigurationProperties(SecuritySamlProperties.class)
 public class SAMLConfiguration {
@@ -94,9 +97,23 @@ public class SAMLConfiguration {
       // This is used in some identity providers to sign the request.  NOT the response - response
       // is handled via the certs in metadata or up above.  This is keycloak and some others
       // TO USE THIS:  The certificate should be uploaded to the IDP to allow it to decrypt these
-      // requests
+      // requests. 
       if (properties.isSignRequests()) {
-        builder.signingX509Credentials(c -> c.addAll(properties.getSigningCredentials()));
+        // THIS FORCES requests to be signed even if the metadata says they shouldn't be signed
+        // this is an edge case where some providers require signing, but their metadata doesn't set it
+        builder.authnRequestsSigned(true);
+        var signingCredentials = properties.getSigningCredentials();
+        if (!signingCredentials.isEmpty()) {
+          builder.signingX509Credentials(c -> c.addAll(signingCredentials));
+        } else if (properties.getSigningKeystore() != null) {
+          builder.signingX509Credentials(c -> {
+            try {
+              c.add(properties.getSigningKeystoreCredential());
+            } catch (IOException | GeneralSecurityException e) {
+              throw new RuntimeException(e);
+            }
+          });
+        }
       }
       RelyingPartyRegistration registration = builder.build();
       return new InMemoryRelyingPartyRegistrationRepository(registration);
@@ -105,7 +122,8 @@ public class SAMLConfiguration {
     @Bean
     // ManagedDeliverySchemaEndpointConfiguration#schemaSecurityFilterChain should go first
     @Order(3)
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    // Make sure the registration is a bean so someone can overload it IF really needed, and make sure we use the bean generated up above which otherwise isn't needed as a bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http, RelyingPartyRegistrationRepository relyingPartyRegistrationRepository) throws Exception {
       authConfig.configure(http);
       HttpSessionRequestCache requestCache = new HttpSessionRequestCache();
       requestCache.setMatchingRequestParameterName(null);
@@ -117,7 +135,7 @@ public class SAMLConfiguration {
               saml ->
                   saml.authenticationManager(new ProviderManager(authenticationProvider))
                       .loginProcessingUrl(properties.getLoginProcessingUrl())
-                      .relyingPartyRegistrationRepository(relyingPartyRegistrationRepository()))
+                      .relyingPartyRegistrationRepository(relyingPartyRegistrationRepository))
           .requestCache(cache -> cache.requestCache(requestCache))
           .build();
     }

--- a/gate/gate-saml/src/main/java/com/netflix/spinnaker/gate/security/saml/SecuritySamlProperties.java
+++ b/gate/gate-saml/src/main/java/com/netflix/spinnaker/gate/security/saml/SecuritySamlProperties.java
@@ -69,7 +69,6 @@ public class SecuritySamlProperties {
   private String signingKeystorePassword;
   private String signingKeystoreAliasName = "mykey"; // default alias for keytool
 
-
   // the privatekey/cert location files can be generated via
   // openssl req -new -x509 -nodes -keyout private_key.pem -out certificate.pem -subj
   // "/CN=Spinnaker" -days 3650
@@ -115,7 +114,7 @@ public class SecuritySamlProperties {
   }
 
   public Saml2X509Credential getSigningKeystoreCredential()
-    throws IOException, GeneralSecurityException {
+      throws IOException, GeneralSecurityException {
     if (signingKeystore == null) {
       return null;
     }
@@ -123,7 +122,8 @@ public class SecuritySamlProperties {
       signingKeystoreType = "PKCS12";
     }
     KeyStore store = KeyStore.getInstance(signingKeystoreType);
-    char[] password = signingKeystorePassword != null ? signingKeystorePassword.toCharArray() : new char[0];
+    char[] password =
+        signingKeystorePassword != null ? signingKeystorePassword.toCharArray() : new char[0];
     try (var stream = Files.newInputStream(signingKeystore)) {
       store.load(stream, password);
     }

--- a/gate/gate-saml/src/main/java/com/netflix/spinnaker/gate/security/saml/SecuritySamlProperties.java
+++ b/gate/gate-saml/src/main/java/com/netflix/spinnaker/gate/security/saml/SecuritySamlProperties.java
@@ -59,9 +59,16 @@ import org.springframework.validation.annotation.Validated;
 public class SecuritySamlProperties {
   public static final String FILE_PREFIX = "file:";
   private Path keyStore;
+
   private String keyStoreType = "PKCS12";
   private String keyStorePassword;
   private String keyStoreAliasName = "mykey"; // default alias for keytool
+
+  private Path signingKeystore;
+  private String signingKeystoreType = "PKCS12";
+  private String signingKeystorePassword;
+  private String signingKeystoreAliasName = "mykey"; // default alias for keytool
+
 
   // the privatekey/cert location files can be generated via
   // openssl req -new -x509 -nodes -keyout private_key.pem -out certificate.pem -subj
@@ -105,6 +112,32 @@ public class SecuritySamlProperties {
     var certificate = (X509Certificate) store.getCertificate(alias);
     var privateKey = (PrivateKey) store.getKey(alias, password);
     return Saml2X509Credential.decryption(privateKey, certificate);
+  }
+
+  public Saml2X509Credential getSigningKeystoreCredential()
+    throws IOException, GeneralSecurityException {
+    if (signingKeystore == null) {
+      return null;
+    }
+    if (signingKeystoreType == null) {
+      signingKeystoreType = "PKCS12";
+    }
+    KeyStore store = KeyStore.getInstance(signingKeystoreType);
+    char[] password = signingKeystorePassword != null ? signingKeystorePassword.toCharArray() : new char[0];
+    try (var stream = Files.newInputStream(signingKeystore)) {
+      store.load(stream, password);
+    }
+    String alias = signingKeystoreAliasName;
+    if (!store.containsAlias(alias)) {
+      var aliases = caseInsensitiveSetFromAliasEnumeration(store.aliases());
+      throw new GeneralSecurityException(
+          String.format(
+              "Signing keystore '%s' does not contain alias '%s'; found aliases: %s",
+              signingKeystore, alias, aliases));
+    }
+    var certificate = (X509Certificate) store.getCertificate(alias);
+    var privateKey = (PrivateKey) store.getKey(alias, password);
+    return Saml2X509Credential.signing(privateKey, certificate);
   }
 
   private static String addFilePrefixIfNeeded(String property) {

--- a/gate/gate-saml/src/test/java/com/netflix/spinnaker/gate/security/saml/SecuritySamlPropertiesTest.java
+++ b/gate/gate-saml/src/test/java/com/netflix/spinnaker/gate/security/saml/SecuritySamlPropertiesTest.java
@@ -19,7 +19,6 @@ package com.netflix.spinnaker.gate.security.saml;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -119,8 +118,7 @@ class SecuritySamlPropertiesTest {
 
   private Path keystoreResource() {
     try {
-      return Paths.get(
-          SecuritySamlPropertiesTest.class.getResource("/saml_signing.p12").toURI());
+      return Paths.get(SecuritySamlPropertiesTest.class.getResource("/saml_signing.p12").toURI());
     } catch (URISyntaxException e) {
       throw new RuntimeException(e);
     }

--- a/gate/gate-saml/src/test/java/com/netflix/spinnaker/gate/security/saml/SecuritySamlPropertiesTest.java
+++ b/gate/gate-saml/src/test/java/com/netflix/spinnaker/gate/security/saml/SecuritySamlPropertiesTest.java
@@ -17,9 +17,13 @@
 package com.netflix.spinnaker.gate.security.saml;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.io.IOException;
+import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.security.GeneralSecurityException;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.security.saml2.core.Saml2X509Credential;
@@ -48,5 +52,77 @@ class SecuritySamlPropertiesTest {
                 currentDir.toAbsolutePath() + "/src/test/resources/certificate.pem")));
     List<Saml2X509Credential> signingCredentials = properties.getSigningCredentials();
     assertThat(signingCredentials.get(0).getPrivateKey().getAlgorithm()).isEqualTo("RSA");
+  }
+
+  @Test
+  public void verifySigningKeystoreCredentialReturnsSigning() throws Exception {
+    SecuritySamlProperties properties = new SecuritySamlProperties();
+    properties.setSigningKeystore(keystoreResource());
+    properties.setSigningKeystorePassword(null);
+    properties.setSigningKeystoreAliasName("1");
+
+    Saml2X509Credential credential = properties.getSigningKeystoreCredential();
+
+    assertThat(credential).isNotNull();
+    assertThat(credential.isSigningCredential()).isTrue();
+    assertThat(credential.isDecryptionCredential()).isFalse();
+    assertThat(credential.getPrivateKey()).isNotNull();
+    assertThat(credential.getCertificate()).isNotNull();
+  }
+
+  @Test
+  public void verifySigningKeystoreCredentialReturnsNullWhenNotConfigured() throws Exception {
+    SecuritySamlProperties properties = new SecuritySamlProperties();
+
+    assertThat(properties.getSigningKeystoreCredential()).isNull();
+  }
+
+  @Test
+  public void verifyDecryptionCredentialReturnsDecryption() throws Exception {
+    SecuritySamlProperties properties = new SecuritySamlProperties();
+    properties.setKeyStore(keystoreResource());
+    properties.setKeyStorePassword(null);
+    properties.setKeyStoreAliasName("1");
+
+    Saml2X509Credential credential = properties.getDecryptionCredential();
+
+    assertThat(credential).isNotNull();
+    assertThat(credential.isDecryptionCredential()).isTrue();
+    assertThat(credential.isSigningCredential()).isFalse();
+  }
+
+  @Test
+  public void verifyDecryptionCredentialReturnsNullWhenNotConfigured() throws Exception {
+    SecuritySamlProperties properties = new SecuritySamlProperties();
+
+    assertThat(properties.getDecryptionCredential()).isNull();
+  }
+
+  @Test
+  public void verifySigningCredentialsEmptyWhenNoneConfigured() {
+    SecuritySamlProperties properties = new SecuritySamlProperties();
+
+    assertThat(properties.getSigningCredentials()).isEmpty();
+  }
+
+  @Test
+  public void verifySigningKeystoreWrongAliasThrows() {
+    SecuritySamlProperties properties = new SecuritySamlProperties();
+    properties.setSigningKeystore(keystoreResource());
+    properties.setSigningKeystorePassword(null);
+    properties.setSigningKeystoreAliasName("nonexistent");
+
+    assertThatThrownBy(properties::getSigningKeystoreCredential)
+        .isInstanceOf(GeneralSecurityException.class)
+        .hasMessageContaining("nonexistent");
+  }
+
+  private Path keystoreResource() {
+    try {
+      return Paths.get(
+          SecuritySamlPropertiesTest.class.getResource("/saml_signing.p12").toURI());
+    } catch (URISyntaxException e) {
+      throw new RuntimeException(e);
+    }
   }
 }


### PR DESCRIPTION
NOTE:  This is targeted to releaes 2026.2.x (and older) - though I hope to not to backport it to older releases.  This is a case per request to continue to support JKS stores for these operations, as well as the ability to overriding the relying party registration entirely if needed.