### PR TITLE
fix(orca): make orca's redis queue handling more robust

### DIFF
--- a/orca/keiko-redis-spring/src/main/kotlin/com/netflix/spinnaker/config/RedisQueueConfiguration.kt
+++ b/orca/keiko-redis-spring/src/main/kotlin/com/netflix/spinnaker/config/RedisQueueConfiguration.kt
@@ -111,7 +111,8 @@ class RedisQueueConfiguration {
       deadMessageHandlers = listOf(deadMessageHandler),
       publisher = publisher,
       ackTimeout = Duration.ofSeconds(redisQueueProperties.ackTimeoutSeconds.toLong()),
-      serializationMigrator = serializationMigrator
+      serializationMigrator = serializationMigrator,
+      retryConfig = redisQueueProperties.retry
     )
 
   @Bean
@@ -175,7 +176,8 @@ class RedisQueueConfiguration {
       deadMessageHandlers = listOf(deadMessageHandler),
       publisher = publisher,
       ackTimeout = Duration.ofSeconds(redisQueueProperties.ackTimeoutSeconds.toLong()),
-      serializationMigrator = serializationMigrator
+      serializationMigrator = serializationMigrator,
+      retryConfig = redisQueueProperties.retry
     )
 
   @Bean

--- a/orca/keiko-redis-spring/src/main/kotlin/com/netflix/spinnaker/config/RedisQueueProperties.kt
+++ b/orca/keiko-redis-spring/src/main/kotlin/com/netflix/spinnaker/config/RedisQueueProperties.kt
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.config
 
+import com.netflix.spinnaker.q.redis.RedisRetryConfig
 import org.springframework.boot.context.properties.ConfigurationProperties
 
 @ConfigurationProperties("keiko.queue.redis")
@@ -24,4 +25,5 @@ class RedisQueueProperties {
   var deadLetterQueueName: String = "keiko.queue.deadLetters"
   var ackTimeoutSeconds: Int = 60
   var shards: Int = 1
+  var retry: RedisRetryConfig = RedisRetryConfig()
 }

--- a/orca/keiko-redis/src/main/kotlin/com/netflix/spinnaker/q/redis/AbstractRedisQueue.kt
+++ b/orca/keiko-redis/src/main/kotlin/com/netflix/spinnaker/q/redis/AbstractRedisQueue.kt
@@ -17,6 +17,7 @@ import java.util.Optional
 import org.slf4j.Logger
 import redis.clients.jedis.Jedis
 import redis.clients.jedis.Transaction
+import redis.clients.jedis.exceptions.JedisException
 import redis.clients.jedis.commands.JedisCommands
 
 abstract class AbstractRedisQueue(
@@ -27,7 +28,8 @@ abstract class AbstractRedisQueue(
   override val ackTimeout: TemporalAmount = Duration.ofMinutes(1),
   override val deadMessageHandlers: List<DeadMessageCallback>,
   override val canPollMany: Boolean = false,
-  override val publisher: EventPublisher
+  override val publisher: EventPublisher,
+  private val retryConfig: RedisRetryConfig = RedisRetryConfig()
 
 ) : MonitorableQueue {
   internal abstract val queueKey: String
@@ -45,6 +47,27 @@ abstract class AbstractRedisQueue(
 
   abstract fun cacheScript()
   abstract var readMessageWithLockScriptSha: String
+
+  protected fun <T> retry(block: () -> T): T {
+    var lastException: JedisException? = null
+    repeat(retryConfig.maxAttempts) { attempt ->
+      try {
+        return block()
+      } catch (e: JedisException) {
+        lastException = e
+        log.warn("Redis operation failed (attempt ${attempt + 1}/${retryConfig.maxAttempts})", e)
+        if (attempt < retryConfig.maxAttempts - 1) {
+          val delay = if (retryConfig.exponentialBackoff) {
+            retryConfig.backoffMs * (1L shl attempt)
+          } else {
+            retryConfig.backoffMs
+          }
+          Thread.sleep(delay)
+        }
+      }
+    }
+    throw lastException!!
+  }
 
   internal fun runSerializationMigration(json: String): String {
     if (serializationMigrator.isPresent) {

--- a/orca/keiko-redis/src/main/kotlin/com/netflix/spinnaker/q/redis/RedisClusterQueue.kt
+++ b/orca/keiko-redis/src/main/kotlin/com/netflix/spinnaker/q/redis/RedisClusterQueue.kt
@@ -52,7 +52,8 @@ class RedisClusterQueue(
   override val ackTimeout: TemporalAmount = Duration.ofMinutes(1),
   override val deadMessageHandlers: List<DeadMessageCallback>,
   override val canPollMany: Boolean = false,
-  override val publisher: EventPublisher
+  override val publisher: EventPublisher,
+  private val retryConfig: RedisRetryConfig = RedisRetryConfig()
 ) : AbstractRedisQueue(
   clock,
   lockTtlSeconds,
@@ -61,7 +62,8 @@ class RedisClusterQueue(
   ackTimeout,
   deadMessageHandlers,
   canPollMany,
-  publisher
+  publisher,
+  retryConfig
 ) {
 
   final override val log: Logger = LoggerFactory.getLogger(javaClass)
@@ -112,17 +114,19 @@ class RedisClusterQueue(
   }
 
   override fun push(message: Message, delay: TemporalAmount) {
-    jedisCluster.firstFingerprint(queueKey, message.fingerprint()).also { fingerprint ->
-      if (fingerprint != null) {
-        log.info(
-          "Re-prioritizing message as an identical one is already on the queue: " +
-            "$fingerprint, message: $message"
-        )
-        jedisCluster.zadd(queueKey, score(delay), fingerprint, zAddParams().xx())
-        fire(MessageDuplicate(message))
-      } else {
-        jedisCluster.queueMessage(message, delay)
-        fire(MessagePushed(message))
+    retry {
+      jedisCluster.firstFingerprint(queueKey, message.fingerprint()).also { fingerprint ->
+        if (fingerprint != null) {
+          log.info(
+            "Re-prioritizing message as an identical one is already on the queue: " +
+              "$fingerprint, message: $message"
+          )
+          jedisCluster.zadd(queueKey, score(delay), fingerprint, zAddParams().xx())
+          fire(MessageDuplicate(message))
+        } else {
+          jedisCluster.queueMessage(message, delay)
+          fire(MessagePushed(message))
+        }
       }
     }
   }

--- a/orca/keiko-redis/src/main/kotlin/com/netflix/spinnaker/q/redis/RedisQueue.kt
+++ b/orca/keiko-redis/src/main/kotlin/com/netflix/spinnaker/q/redis/RedisQueue.kt
@@ -68,7 +68,8 @@ class RedisQueue(
   override val ackTimeout: TemporalAmount = Duration.ofMinutes(1),
   override val deadMessageHandlers: List<DeadMessageCallback>,
   override val canPollMany: Boolean = false,
-  override val publisher: EventPublisher
+  override val publisher: EventPublisher,
+  private val retryConfig: RedisRetryConfig = RedisRetryConfig()
 ) : AbstractRedisQueue(
   clock,
   lockTtlSeconds,
@@ -77,7 +78,8 @@ class RedisQueue(
   ackTimeout,
   deadMessageHandlers,
   canPollMany,
-  publisher
+  publisher,
+  retryConfig
 ) {
 
   override val log: Logger = LoggerFactory.getLogger(javaClass)
@@ -135,21 +137,23 @@ class RedisQueue(
   }
 
   override fun push(message: Message, delay: TemporalAmount) {
-    pool.resource.use { redis ->
-      redis.firstFingerprint(queueKey, message.fingerprint()).also { fingerprint ->
-        if (fingerprint != null) {
-          log.info(
-            "Re-prioritizing message as an identical one is already on the queue: " +
-              "$fingerprint, message: $message"
-          )
-          redis.zadd(queueKey, score(delay), fingerprint, zAddParams().xx())
-          fire(MessageDuplicate(message))
-        } else {
-          redis.queueMessage(message, delay)
-          log.info("Successfully pushed message with fingerprint ${message.fingerprint()}, " +
-            "payload $message, acknowledgement timeout ${message.ackTimeoutMs}ms " +
-            "and attributes ${message.attributes}")
-          fire(MessagePushed(message))
+    retry {
+      pool.resource.use { redis ->
+        redis.firstFingerprint(queueKey, message.fingerprint()).also { fingerprint ->
+          if (fingerprint != null) {
+            log.info(
+              "Re-prioritizing message as an identical one is already on the queue: " +
+                "$fingerprint, message: $message"
+            )
+            redis.zadd(queueKey, score(delay), fingerprint, zAddParams().xx())
+            fire(MessageDuplicate(message))
+          } else {
+            redis.queueMessage(message, delay)
+            log.info("Successfully pushed message with fingerprint ${message.fingerprint()}, " +
+              "payload $message, acknowledgement timeout ${message.ackTimeoutMs}ms " +
+              "and attributes ${message.attributes}")
+            fire(MessagePushed(message))
+          }
         }
       }
     }

--- a/orca/keiko-redis/src/main/kotlin/com/netflix/spinnaker/q/redis/RedisRetryConfig.kt
+++ b/orca/keiko-redis/src/main/kotlin/com/netflix/spinnaker/q/redis/RedisRetryConfig.kt
@@ -1,0 +1,7 @@
+package com.netflix.spinnaker.q.redis
+
+data class RedisRetryConfig(
+  var maxAttempts: Int = 3,
+  var backoffMs: Long = 100,
+  var exponentialBackoff: Boolean = true
+)

--- a/orca/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/AbortStageHandler.kt
+++ b/orca/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/AbortStageHandler.kt
@@ -43,14 +43,23 @@ class AbortStageHandler(
   override fun handle(message: AbortStage) {
     message.withStage { stage ->
       if (stage.status in setOf(RUNNING, NOT_STARTED)) {
+        val originalStatus = stage.status
         stage.status = TERMINAL
         stage.endTime = clock.millis()
         repository.storeStage(stage)
-        queue.push(CancelStage(message))
-        if (stage.parentStageId == null) {
-          queue.push(CompleteExecution(message))
-        } else {
-          queue.push(CompleteStage(stage.parent()))
+        try {
+          queue.push(CancelStage(message))
+          if (stage.parentStageId == null) {
+            queue.push(CompleteExecution(message))
+          } else {
+            queue.push(CompleteStage(stage.parent()))
+          }
+        } catch (e: Exception) {
+          // Restore original status so the ack-timeout retried AbortStage
+          // message isn't dropped by the status guard above.
+          stage.status = originalStatus
+          repository.storeStage(stage)
+          throw e
         }
         publisher.publishEvent(StageComplete(this, stage))
       }

--- a/orca/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteStageHandler.kt
+++ b/orca/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteStageHandler.kt
@@ -84,6 +84,7 @@ class CompleteStageHandler(
   override fun handle(message: CompleteStage) {
     message.withStage { stage ->
       if (stage.status in setOf(RUNNING, NOT_STARTED)) {
+        val originalStatus = stage.status
         var status = stage.determineStatus()
         if (stage.shouldFailOnFailedExpressionEvaluation()) {
           log.warn(
@@ -151,20 +152,28 @@ class CompleteStageHandler(
         stage.includeExpressionEvaluationSummary()
         repository.storeStage(stage)
 
-        // When a synthetic stage ends with FAILED_CONTINUE, propagate that status up to the stage's
-        // parent so that no more of the parent's synthetic children will run.
-        if (stage.status == FAILED_CONTINUE && stage.syntheticStageOwner != null && !stage.allowSiblingStagesToContinueOnFailure) {
-          queue.push(message.copy(stageId = stage.parentStageId!!))
-        } else if (stage.status in listOf(SUCCEEDED, FAILED_CONTINUE, SKIPPED)) {
-          stage.startNext()
-        } else {
-          queue.push(CancelStage(message))
-          if (stage.syntheticStageOwner == null) {
-            log.debug("Stage has no synthetic owner and status is '${stage.status}', completing execution (original message: $message)")
-            queue.push(CompleteExecution(message))
-          } else {
+        try {
+          // When a synthetic stage ends with FAILED_CONTINUE, propagate that status up to the stage's
+          // parent so that no more of the parent's synthetic children will run.
+          if (stage.status == FAILED_CONTINUE && stage.syntheticStageOwner != null && !stage.allowSiblingStagesToContinueOnFailure) {
             queue.push(message.copy(stageId = stage.parentStageId!!))
+          } else if (stage.status in listOf(SUCCEEDED, FAILED_CONTINUE, SKIPPED)) {
+            stage.startNext()
+          } else {
+            queue.push(CancelStage(message))
+            if (stage.syntheticStageOwner == null) {
+              log.debug("Stage has no synthetic owner and status is '${stage.status}', completing execution (original message: $message)")
+              queue.push(CompleteExecution(message))
+            } else {
+              queue.push(message.copy(stageId = stage.parentStageId!!))
+            }
           }
+        } catch (e: Exception) {
+          // Restore original status so the ack-timeout retried CompleteStage
+          // message isn't dropped by the status guard above.
+          stage.status = originalStatus
+          repository.storeStage(stage)
+          throw e
         }
 
         publisher.publishEvent(StageComplete(this, stage))

--- a/orca/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/SkipStageHandler.kt
+++ b/orca/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/SkipStageHandler.kt
@@ -43,6 +43,7 @@ class SkipStageHandler(
   override fun handle(message: SkipStage) {
     message.withStage { stage ->
       if (stage.status in setOf(RUNNING, NOT_STARTED) || stage.isManuallySkipped()) {
+        val originalStatus = stage.status
         stage.status = SKIPPED
         if (stage.isManuallySkipped()) {
           stage.recursiveSyntheticStages().forEach {
@@ -56,7 +57,15 @@ class SkipStageHandler(
         }
         stage.endTime = clock.millis()
         repository.storeStage(stage)
-        stage.startNext()
+        try {
+          stage.startNext()
+        } catch (e: Exception) {
+          // Restore original status so the ack-timeout retried SkipStage
+          // message isn't dropped by the status guard above.
+          stage.status = originalStatus
+          repository.storeStage(stage)
+          throw e
+        }
         publisher.publishEvent(StageComplete(this, stage))
       }
     }

--- a/orca/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/StartExecutionHandler.kt
+++ b/orca/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/StartExecutionHandler.kt
@@ -97,7 +97,15 @@ class StartExecutionHandler(
       } else {
         execution.updateStatus(RUNNING)
         repository.updateStatus(execution)
-        initialStages.forEach { queue.push(StartStage(it)) }
+        try {
+          initialStages.forEach { queue.push(StartStage(it)) }
+        } catch (e: Exception) {
+          // Restore to NOT_STARTED so the ack-timeout retried StartExecution
+          // message isn't dropped by the status guard above.
+          execution.updateStatus(NOT_STARTED)
+          repository.updateStatus(execution)
+          throw e
+        }
         publisher.publishEvent(ExecutionStarted(this, execution))
       }
     }

--- a/orca/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/StartStageHandler.kt
+++ b/orca/orca-queue/src/main/kotlin/com/netflix/spinnaker/orca/q/handler/StartStageHandler.kt
@@ -84,6 +84,8 @@ class StartStageHandler(
           log.warn("Tried to start stage ${stage.id} but something upstream had failed (executionId: ${message.executionId})")
           queue.push(CompleteExecution(message))
         } else if (stage.allUpstreamStagesComplete()) {
+          // guard to prevent this start stage from being processed multiple times. Only
+          // process it if the status is NOT_STARTED
           if (stage.status != NOT_STARTED) {
             log.warn("Ignoring $message as stage is already ${stage.status}")
           } else if (stage.shouldSkip()) {
@@ -97,6 +99,10 @@ class StartStageHandler(
                 // Set the startTime in case we throw an exception.
                 stage.startTime = clock.millis()
                 stage.plan()
+
+                // StartTask handler (or downstream logic) would see the stage is still NOT_STARTED instead
+                // of RUNNING, which could cause it to be treated as not yet started or behave unexpectedly.
+                // Hence marking it as running and persisting it in the db here before we call stage.start().
                 stage.status = RUNNING
                 repository.storeStage(stage)
 
@@ -110,6 +116,10 @@ class StartStageHandler(
                   val attempts = message.getAttribute<AttemptsAttribute>()?.attempts ?: 0
                   log.warn("Error planning ${stage.type} stage for ${message.executionType}[${message.executionId}] (attempts: $attempts)")
 
+                  // Reset status to NOT_STARTED so the retried StartStage message
+                  // isn't silently dropped by the status != NOT_STARTED guard above.
+                  stage.status = NOT_STARTED
+                  repository.storeStage(stage)
                   message.setAttribute(MaxAttemptsAttribute(40))
                   queue.push(message, retryDelay)
                 } else {
@@ -130,16 +140,23 @@ class StartStageHandler(
         }
 
       } catch (e: Exception) {
-        log.error("Error running ${stage.type}[${stage.id}] stage for ${message.executionType}[${message.executionId}]", e)
-
-        stage.apply {
-          val exceptionDetails = exceptionHandlers.shouldRetry(e, stage.name)
-          context["exception"] = exceptionDetails
-          context["beforeStagePlanningFailed"] = true
+        val exceptionDetails = exceptionHandlers.shouldRetry(e, stage.name)
+        if (exceptionDetails?.shouldRetry == true) {
+          log.warn("Transient error in ${stage.type}[${stage.id}] stage for ${message.executionType}[${message.executionId}], will be retried via ack-timeout", e)
+          // Reset status to NOT_STARTED via SQL (works even when Redis is down)
+          // so the ack-timeout retried message isn't dropped by the status guard.
+          stage.status = NOT_STARTED
+          repository.storeStage(stage)
+          throw e
+        } else {
+          log.error("Error running ${stage.type}[${stage.id}] stage for ${message.executionType}[${message.executionId}]", e)
+          stage.apply {
+            context["exception"] = exceptionDetails
+            context["beforeStagePlanningFailed"] = true
+          }
+          repository.storeStage(stage)
+          queue.push(CompleteStage(message))
         }
-
-        repository.storeStage(stage)
-        queue.push(CompleteStage(message))
       }
     }
   }

--- a/orca/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/AbortStageHandlerTest.kt
+++ b/orca/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/AbortStageHandlerTest.kt
@@ -34,12 +34,15 @@ import com.netflix.spinnaker.time.fixedClock
 import org.mockito.kotlin.any
 import org.mockito.kotlin.check
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.isA
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.reset
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
+import redis.clients.jedis.exceptions.JedisConnectionException
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.given
@@ -193,6 +196,45 @@ object AbortStageHandlerTest : SubjectSpek<AbortStageHandler>({
             assertThat(it.stage.status).isEqualTo(TERMINAL)
           }
         )
+      }
+    }
+  }
+
+  describe("handling transient Redis exceptions") {
+    given("a JedisConnectionException is thrown during queue.push") {
+      val pipeline = pipeline {
+        application = "whatever"
+        stage {
+          refId = "1"
+          type = "whatever"
+          status = RUNNING
+        }
+      }
+      val message = AbortStage(pipeline.stageByRef("1"))
+
+      beforeGroup {
+        whenever(repository.retrieve(PIPELINE, pipeline.id)) doReturn pipeline
+        whenever(queue.push(isA<CancelStage>())) doThrow JedisConnectionException("Read timed out")
+      }
+
+      afterGroup(::resetMocks)
+
+      var thrownException: Exception? = null
+
+      on("receiving a message") {
+        try {
+          subject.handle(message)
+        } catch (e: Exception) {
+          thrownException = e
+        }
+      }
+
+      it("rethrows the exception so the message is not acked") {
+        assertThat(thrownException).isInstanceOf(JedisConnectionException::class.java)
+      }
+
+      it("restores stage status to the original value") {
+        assertThat(pipeline.stageByRef("1").status).isEqualTo(RUNNING)
       }
     }
   }

--- a/orca/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteStageHandlerTest.kt
+++ b/orca/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/CompleteStageHandlerTest.kt
@@ -75,6 +75,7 @@ import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.atLeastOnce
 import org.mockito.kotlin.check
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.isA
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
@@ -84,6 +85,7 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
+import redis.clients.jedis.exceptions.JedisConnectionException
 import java.time.Duration.ZERO
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.fail
@@ -1745,6 +1747,47 @@ object CompleteStageHandlerTest : SubjectSpek<CompleteStageHandler>({
         it("updates the stage status") {
           assertThat(pipeline.stageById(message.stageId).status).isEqualTo(TERMINAL)
         }
+      }
+    }
+  }
+
+  describe("handling transient Redis exceptions") {
+    given("a JedisConnectionException is thrown during startNext()") {
+      val pipeline = pipeline {
+        application = "foo"
+        stage {
+          refId = "1"
+          type = singleTaskStage.type
+          singleTaskStage.plan(this)
+          tasks[0].status = SUCCEEDED
+          status = RUNNING
+        }
+      }
+      val message = CompleteStage(pipeline.stageByRef("1"))
+
+      beforeGroup {
+        whenever(repository.retrieve(PIPELINE, message.executionId)) doReturn pipeline
+        whenever(queue.push(isA<CompleteExecution>())) doThrow JedisConnectionException("Read timed out")
+      }
+
+      afterGroup(::resetMocks)
+
+      var thrownException: Exception? = null
+
+      on("receiving a message") {
+        try {
+          subject.handle(message)
+        } catch (e: Exception) {
+          thrownException = e
+        }
+      }
+
+      it("rethrows the exception so the message is not acked") {
+        assertThat(thrownException).isInstanceOf(JedisConnectionException::class.java)
+      }
+
+      it("restores stage status to the original value") {
+        assertThat(pipeline.stageByRef("1").status).isEqualTo(RUNNING)
       }
     }
   }

--- a/orca/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/SkipStageHandlerTest.kt
+++ b/orca/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/SkipStageHandlerTest.kt
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.orca.q.handler
 
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus.FAILED_CONTINUE
+import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus.NOT_STARTED
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus.RUNNING
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus.SKIPPED
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus.SUCCEEDED
@@ -37,6 +38,8 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.check
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.isA
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.reset
@@ -44,6 +47,7 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
+import redis.clients.jedis.exceptions.JedisConnectionException
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.given
@@ -347,6 +351,45 @@ object SkipStageHandlerTest : SubjectSpek<SkipStageHandler>({
         it("retains the synthetic stage's status") {
           assertThat(pipeline.stageByRef("1<1").status).isEqualTo(childStageStatus)
         }
+      }
+    }
+  }
+
+  describe("handling transient Redis exceptions") {
+    given("a JedisConnectionException is thrown during startNext()") {
+      val pipeline = pipeline {
+        application = "foo"
+        stage {
+          refId = "1"
+          type = "whatever"
+          status = RUNNING
+        }
+      }
+      val message = SkipStage(pipeline.stageByRef("1"))
+
+      beforeGroup {
+        whenever(repository.retrieve(PIPELINE, message.executionId)) doReturn pipeline
+        whenever(queue.push(isA<CompleteExecution>())) doThrow JedisConnectionException("Read timed out")
+      }
+
+      afterGroup(::resetMocks)
+
+      var thrownException: Exception? = null
+
+      on("receiving a message") {
+        try {
+          subject.handle(message)
+        } catch (e: Exception) {
+          thrownException = e
+        }
+      }
+
+      it("rethrows the exception so the message is not acked") {
+        assertThat(thrownException).isInstanceOf(JedisConnectionException::class.java)
+      }
+
+      it("restores stage status to the original value") {
+        assertThat(pipeline.stageByRef("1").status).isEqualTo(RUNNING)
       }
     }
   }

--- a/orca/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/StartExecutionHandlerTest.kt
+++ b/orca/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/StartExecutionHandlerTest.kt
@@ -39,6 +39,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.check
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.isA
 import org.mockito.kotlin.mock
@@ -48,6 +49,7 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
+import redis.clients.jedis.exceptions.JedisConnectionException
 import java.util.UUID
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.spek.api.dsl.describe
@@ -576,6 +578,42 @@ object StartExecutionHandlerTest : SubjectSpek<StartExecutionHandler>({
         }
       }
 
+    }
+  }
+
+  describe("handling transient Redis exceptions") {
+    given("a JedisConnectionException is thrown during queue.push(StartStage)") {
+      val pipeline = pipeline {
+        stage {
+          type = singleTaskStage.type
+        }
+      }
+      val message = StartExecution(pipeline)
+
+      beforeGroup {
+        whenever(repository.retrieve(message.executionType, message.executionId)) doReturn pipeline
+        whenever(queue.push(isA<StartStage>())) doThrow JedisConnectionException("Read timed out")
+      }
+
+      afterGroup(::resetMocks)
+
+      var thrownException: Exception? = null
+
+      on("receiving a message") {
+        try {
+          subject.handle(message)
+        } catch (e: Exception) {
+          thrownException = e
+        }
+      }
+
+      it("rethrows the exception so the message is not acked") {
+        assertThat(thrownException).isInstanceOf(JedisConnectionException::class.java)
+      }
+
+      it("restores execution status to NOT_STARTED") {
+        assertThat(pipeline.status).isEqualTo(NOT_STARTED)
+      }
     }
   }
 })

--- a/orca/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/StartStageHandlerTest.kt
+++ b/orca/orca-queue/src/test/kotlin/com/netflix/spinnaker/orca/q/handler/StartStageHandlerTest.kt
@@ -23,6 +23,7 @@ import com.netflix.spinnaker.assertj.assertSoftly
 import com.netflix.spinnaker.orca.DefaultStageResolver
 import com.netflix.spinnaker.orca.NoOpTaskImplementationResolver
 import com.netflix.spinnaker.orca.api.pipeline.SyntheticStageOwner.STAGE_BEFORE
+import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus.NOT_STARTED
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus.FAILED_CONTINUE
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus.RUNNING
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus.SUCCEEDED
@@ -93,6 +94,7 @@ import org.jetbrains.spek.api.dsl.on
 import org.jetbrains.spek.api.lifecycle.CachingMode.GROUP
 import org.jetbrains.spek.subject.SubjectSpek
 import org.springframework.context.ApplicationEventPublisher
+import redis.clients.jedis.exceptions.JedisConnectionException
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
@@ -1353,6 +1355,114 @@ object StartStageHandlerTest : SubjectSpek<StartStageHandler>({
 
       it("emits an error event") {
         verify(queue).push(isA<InvalidStageId>())
+      }
+    }
+  }
+
+  describe("handling transient Redis exceptions") {
+    given("a JedisConnectionException is thrown during stage.start()") {
+      val pipeline = pipeline {
+        application = "test"
+        stage {
+          refId = "1"
+          type = singleTaskStage.type
+        }
+      }
+      val message = StartStage(pipeline.stageByRef("1"))
+
+      and("the exception handler marks it as retryable") {
+        val retryableResponse = ExceptionHandler.Response(
+          "JedisConnectionException",
+          "dummy",
+          ExceptionHandler.responseDetails("Transient Redis Failure"),
+          true
+        )
+
+        beforeGroup {
+          whenever(repository.retrieve(PIPELINE, message.executionId)) doReturn pipeline
+          whenever(exceptionHandler.handles(any())) doReturn true
+          whenever(exceptionHandler.handle(anyOrNull(), any())) doReturn retryableResponse
+          whenever(queue.push(isA<StartTask>())) doThrow JedisConnectionException("Read timed out")
+        }
+
+        afterGroup(::resetMocks)
+
+        on("receiving a message") {
+          subject.handle(message)
+        }
+
+        it("retries via queue push with delay instead of completing the stage") {
+          verify(queue).push(eq(message), eq(retryDelay))
+        }
+
+        it("does not push CompleteStage") {
+          verify(queue, never()).push(isA<CompleteStage>())
+        }
+
+        it("resets stage status to NOT_STARTED") {
+          assertThat(pipeline.stageByRef("1").status).isEqualTo(NOT_STARTED)
+        }
+
+        it("does not mark the stage as permanently failed") {
+          assertThat(pipeline.stageByRef("1").context["beforeStagePlanningFailed"]).isNull()
+        }
+      }
+    }
+
+    given("a JedisConnectionException is thrown in the outer catch block") {
+      val pipeline = pipeline {
+        application = "test"
+        stage {
+          refId = "1"
+          type = singleTaskStage.type
+        }
+      }
+      val message = StartStage(pipeline.stageByRef("1"))
+
+      and("both the initial push and the retry push fail with JedisConnectionException") {
+        val retryableResponse = ExceptionHandler.Response(
+          "JedisConnectionException",
+          "dummy",
+          ExceptionHandler.responseDetails("Transient Redis Failure"),
+          true
+        )
+
+        var thrownException: Exception? = null
+
+        beforeGroup {
+          whenever(repository.retrieve(PIPELINE, message.executionId)) doReturn pipeline
+          whenever(exceptionHandler.handles(any())) doReturn true
+          whenever(exceptionHandler.handle(anyOrNull(), any())) doReturn retryableResponse
+          whenever(queue.push(isA<StartTask>())) doThrow JedisConnectionException("Read timed out")
+          whenever(queue.push(any(), any<Duration>())) doThrow JedisConnectionException("Read timed out")
+        }
+
+        afterGroup(::resetMocks)
+
+        on("receiving a message") {
+          try {
+            subject.handle(message)
+          } catch (e: Exception) {
+            thrownException = e
+          }
+        }
+
+        it("rethrows the exception so the message is not acked") {
+          assertThat(thrownException).isInstanceOf(JedisConnectionException::class.java)
+        }
+
+        it("resets stage status to NOT_STARTED") {
+          assertThat(pipeline.stageByRef("1").status).isEqualTo(NOT_STARTED)
+        }
+
+        it("does not push CompleteStage") {
+          verify(queue, never()).push(isA<CompleteStage>())
+        }
+
+        it("does not bake permanent failure into stage context") {
+          assertThat(pipeline.stageByRef("1").context["beforeStagePlanningFailed"]).isNull()
+          assertThat(pipeline.stageByRef("1").context["exception"]).isNull()
+        }
       }
     }
   }

--- a/orca/orca-redis/src/main/java/com/netflix/spinnaker/orca/config/JedisExceptionHandler.java
+++ b/orca/orca-redis/src/main/java/com/netflix/spinnaker/orca/config/JedisExceptionHandler.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 DoorDash, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.config;
+
+import static java.lang.String.format;
+
+import com.google.common.base.Throwables;
+import com.netflix.spinnaker.orca.exceptions.ExceptionHandler;
+import java.util.Collections;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import redis.clients.jedis.exceptions.JedisException;
+
+/**
+ * Handles transient Redis/Jedis connection exceptions and marks them as retryable. This prevents
+ * pipelines from getting permanently stuck when a momentary Redis hiccup occurs during queue
+ * operations.
+ */
+public class JedisExceptionHandler implements ExceptionHandler {
+  private static final Logger log = LoggerFactory.getLogger(JedisExceptionHandler.class);
+
+  @Override
+  public boolean handles(Exception e) {
+    Throwable current = e;
+    while (current != null) {
+      if (current instanceof JedisException) {
+        return true;
+      }
+      current = current.getCause();
+    }
+    return false;
+  }
+
+  @Override
+  public ExceptionHandler.Response handle(String taskName, Exception e) {
+    Map<String, Object> exceptionDetails =
+        ExceptionHandler.responseDetails(
+            "Transient Redis Failure", Collections.singletonList(e.getMessage()));
+    exceptionDetails.put("stackTrace", Throwables.getStackTraceAsString(e));
+    log.warn(format("Transient Redis failure during task %s, will retry", taskName), e);
+    return new ExceptionHandler.Response(
+        e.getClass().getSimpleName(), taskName, exceptionDetails, true);
+  }
+}

--- a/orca/orca-redis/src/main/java/com/netflix/spinnaker/orca/config/RedisConfiguration.java
+++ b/orca/orca-redis/src/main/java/com/netflix/spinnaker/orca/config/RedisConfiguration.java
@@ -132,4 +132,9 @@ public class RedisConfiguration {
         Optional.empty(),
         Optional.empty());
   }
+
+  @Bean
+  public JedisExceptionHandler jedisExceptionHandler() {
+    return new JedisExceptionHandler();
+  }
 }

--- a/orca/orca-redis/src/test/java/com/netflix/spinnaker/orca/config/JedisExceptionHandlerTest.java
+++ b/orca/orca-redis/src/test/java/com/netflix/spinnaker/orca/config/JedisExceptionHandlerTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2026 DoorDash, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.netflix.spinnaker.orca.exceptions.ExceptionHandler;
+import java.net.SocketTimeoutException;
+import org.junit.jupiter.api.Test;
+import redis.clients.jedis.exceptions.JedisConnectionException;
+import redis.clients.jedis.exceptions.JedisException;
+
+class JedisExceptionHandlerTest {
+
+  private final JedisExceptionHandler handler = new JedisExceptionHandler();
+
+  @Test
+  void handlesJedisConnectionException() {
+    var ex = new JedisConnectionException("Read timed out");
+    assertThat(handler.handles(ex)).isTrue();
+  }
+
+  @Test
+  void handlesJedisException() {
+    var ex = new JedisException("Connection reset");
+    assertThat(handler.handles(ex)).isTrue();
+  }
+
+  @Test
+  void handlesWrappedJedisExceptionInCauseChain() {
+    var jedisEx = new JedisConnectionException("Read timed out");
+    var wrapper = new RuntimeException("Queue push failed", jedisEx);
+    assertThat(handler.handles(wrapper)).isTrue();
+  }
+
+  @Test
+  void doesNotHandleUnrelatedExceptions() {
+    assertThat(handler.handles(new IllegalArgumentException("bad arg"))).isFalse();
+    assertThat(handler.handles(new NullPointerException("null"))).isFalse();
+    assertThat(handler.handles(new RuntimeException("generic"))).isFalse();
+  }
+
+  @Test
+  void doesNotHandleStandaloneSocketTimeoutException() {
+    var ex = new RuntimeException("http timeout", new SocketTimeoutException("Read timed out"));
+    assertThat(handler.handles(ex)).isFalse();
+  }
+
+  @Test
+  void handleReturnsShouldRetryTrue() {
+    var ex = new JedisConnectionException("Read timed out");
+    ExceptionHandler.Response response = handler.handle("checkPrecondition", ex);
+
+    assertThat(response.isShouldRetry()).isTrue();
+    assertThat(response.getExceptionType()).isEqualTo("JedisConnectionException");
+    assertThat(response.getOperation()).isEqualTo("checkPrecondition");
+    assertThat(response.getDetails()).containsKey("error");
+    assertThat(response.getDetails()).containsKey("stackTrace");
+  }
+}


### PR DESCRIPTION
## Motivation

We saw multiple stuck/zombie executions with these stacktraces:
```
redis.clients.jedis.exceptions.JedisConnectionException: java.net.SocketTimeoutException: Read timed out

java.lang.IllegalArgumentException: Unable to map context to class com.netflix.spinnaker.orca.clouddriver.tasks.manifest.WaitForManifestStableContext. Error: Cannot construct instance of `java.util.ArrayList` (although at least one Creator exists): no String-argument constructor/factory method to deserialize from String value ('redis.clients.jedis.exceptions.JedisConnectionException: java.net.SocketTimeoutException: Read timed out

Suppressed: redis.clients.jedis.exceptions.JedisConnectionException: Attempting to read from a broken connection

Caused by: com.fasterxml.jackson.databind.exc.MismatchedInputException: Cannot construct instance of `java.util.ArrayList` (although at least one Creator exists): no String-argument constructor/factory method to deserialize from String value ('java.lang.IllegalArgumentException: Unable to map context to class com.netflix.spinnaker.orca.clouddriver.tasks.manifest.WaitForManifestStableContext. Error: Cannot construct instance of `java.util.ArrayList` (although at least one Creator exists): no String-argument constructor/factory method to deserialize from String value ('redis.clients.jedis.exceptions.JedisConnectionException: java.net.SocketTimeoutException: Read timed out

Caused by: com.fasterxml.jackson.databind.exc.MismatchedInputException: Cannot construct instance of `java.util.ArrayList` (although at least one Creator exists): no String-argument constructor/factory method to deserialize from String value ('redis.clients.jedis.exceptions.JedisConnectionException: java.net.SocketTimeoutException: Read timed out

java.lang.IllegalArgumentException: Unable to map context to class com.netflix.spinnaker.orca.clouddriver.tasks.manifest.WaitForManifestStableContext. Error: Cannot construct instance of `java.util.ArrayList` (although at least one Creator exists): no String-argument constructor/factory method to deserialize from String value ('redis.clients.jedis.exceptions.JedisConnectionException: java.net.SocketTimeoutException: Read timed out
```

The stacktrace showed:
```
"exception": {
"details": {
"error": "Unexpected Task Failure",
"errors": [
"java.net.SocketTimeoutException: Read timed out"
],
"stackTrace": "redis.clients.jedis.exceptions.JedisConnectionException: java.net.SocketTimeoutException: Read timed out\n\tat redis.clients.jedis.util.RedisInputStream.ensureFill(RedisInputStream.java:205)\n\tat redis.clients.jedis.util.RedisInputStream.readByte(RedisInputStream.java:43)\n\tat redis.clients.jedis.Protocol.process(Protocol.java:165)\n\tat redis.clients.jedis.Protocol.read(Protocol.java:230)\n\tat redis.clients.jedis.Connection.readProtocolWithCheckingBroken(Connection.java:352)\n\tat redis.clients.jedis.Connection.getMany(Connection.java:364)\n\tat redis.clients.jedis.Transaction.exec(Transaction.java:42)\n\tat com.netflix.spinnaker.q.redis.AbstractRedisQueue.multi$keiko_redis(AbstractRedisQueue.kt:76)\n\tat com.netflix.spinnaker.q.redis.RedisQueue.queueMessage$keiko_redis(RedisQueue.kt:304)\n\tat com.netflix.spinnaker.q.redis.RedisQueue.push(RedisQueue.kt:144)\n\tat com.netflix.spinnaker.q.Queue$DefaultImpls.push(Queue.kt:57)\n\tat com.netflix.spinnaker.q.metrics.MonitorableQueue$DefaultImpls.push(MonitorableQueue.kt:26)\n\tat com.netflix.spinnaker.q.redis.AbstractRedisQueue.push(AbstractRedisQueue.kt:23)\n\tat com.netflix.spinnaker.orca.q.handler.StartStageHandler$handle$1$1.invoke(StartStageHandler.kt:122)\n\tat com.netflix.spinnaker.orca.q.handler.StartStageHandler$handle$1$1.invoke(StartStageHandler.kt:95)\n\tat com.netflix.spinnaker.orca.q.handler.AuthenticationAware$DefaultImpls.withAuth$lambda-0(AuthenticationAware.kt:51)\n\tat com.netflix.spinnaker.security.AuthenticatedRequest.lambda$wrapCallableForPrincipal$0(AuthenticatedRequest.java:272)\n\tat com.netflix.spinnaker.orca.q.handler.AuthenticationAware$DefaultImpls.withAuth(AuthenticationAware.kt:51)\n\tat com.netflix.spinnaker.orca.q.handler.StartStageHandler.withAuth(StartStageHandler.kt:61)\n\tat com.netflix.spinnaker.orca.q.handler.StartStageHandler$handle$1.invoke(StartStageHandler.kt:95)\n\tat com.netflix.spinnaker.orca.q.handler.StartStageHandler$handle$1.invoke(StartStageHandler.kt:80)\n\tat com.netflix.spinnaker.orca.q.handler.OrcaMessageHandler$withStage$1.invoke(OrcaMessageHandler.kt:86)\n\tat com.netflix.spinnaker.orca.q.handler.OrcaMessageHandler$withStage$1.invoke(OrcaMessageHandler.kt:75)\n\tat com.netflix.spinnaker.orca.q.handler.OrcaMessageHandler$DefaultImpls.withExecution(OrcaMessageHandler.kt:96)\n\tat com.netflix.spinnaker.orca.q.handler.StartStageHandler.withExecution(StartStageHandler.kt:61)\n\tat com.netflix.spinnaker.orca.q.handler.OrcaMessageHandler$DefaultImpls.withStage(OrcaMessageHandler.kt:75)\n\tat com.netflix.spinnaker.orca.q.handler.StartStageHandler.withStage(StartStageHandler.kt:61)\n\tat com.netflix.spinnaker.orca.q.handler.StartStageHandler.handle(StartStageHandler.kt:80)\n\tat com.netflix.spinnaker.orca.q.handler.StartStageHandler.handle(StartStageHandler.kt:61)\n\tat com.netflix.spinnaker.q.MessageHandler$DefaultImpls.invoke(MessageHandler.kt:36)\n\tat com.netflix.spinnaker.orca.q.handler.OrcaMessageHandler$DefaultImpls.invoke(OrcaMessageHandler.kt:46)\n\tat com.netflix.spinnaker.orca.q.handler.StartStageHandler.invoke(StartStageHandler.kt:61)\n\tat com.netflix.spinnaker.orca.q.audit.ExecutionTrackingMessageHandlerPostProcessor$ExecutionTrackingMessageHandlerProxy.invoke(ExecutionTrackingMessageHandlerPostProcessor.kt:72)\n\tat com.netflix.spinnaker.q.QueueProcessor$callback$1.invoke$lambda-0(QueueProcessor.kt:90)\n\tat java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)\n\tat java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)\n\tat java.base/java.lang.Thread.run(Thread.java:840)\n\tSuppressed: redis.clients.jedis.exceptions.JedisConnectionException: Attempting to read from a broken connection\n\t\tat redis.clients.jedis.Connection.readProtocolWithCheckingBroken(Connection.java:348)\n\t\tat redis.clients.jedis.Connection.getMany(Connection.java:364)\n\t\tat redis.clients.jedis.Transaction.discard(Transaction.java:83)\n\t\tat redis.clients.jedis.Transaction.clear(Transaction.java:36)\n\t\tat redis.clients.jedis.Transaction.close(Transaction.java:96)\n\t\tat kotlin.io.CloseableKt.closeFinally(Closeable.kt:59)\n\t\tat com.netflix.spinnaker.q.redis.AbstractRedisQueue.multi$keiko_redis(AbstractRedisQueue.kt:74)\n\t\t... 29 more\nCaused by: java.net.SocketTimeoutException: Read timed out\n\tat java.base/sun.nio.ch.NioSocketImpl.timedRead(NioSocketImpl.java:288)\n\tat java.base/sun.nio.ch.NioSocketImpl.implRead(NioSocketImpl.java:314)\n\tat java.base/sun.nio.ch.NioSocketImpl.read(NioSocketImpl.java:355)\n\tat java.base/sun.nio.ch.NioSocketImpl$1.read(NioSocketImpl.java:808)\n\tat java.base/java.net.Socket$SocketInputStream.read(Socket.java:966)\n\tat java.base/java.io.InputStream.read(InputStream.java:218)\n\tat redis.clients.jedis.util.RedisInputStream.ensureFill(RedisInputStream.java:199)\n\t... 36 more\n"
},
"exceptionType": "JedisConnectionException",
"operation": "Check precondition (expression)",
"shouldRetry": false,
"timestamp": 1775665189165
}
```


- This leads to us to believe that redis connectivity issues are another contributing factor in some pipeline executions becoming stuck or zombies.


 ## Changes
 
 ### Layer 1: Redis Queue Retry with Exponential Backoff

####   Problem: RedisQueue.push() had no retry logic. A single transient JedisConnectionException during queue.push() would immediately propagate up, potentially leaving pipelines stuck.

 #### New files:
  - keiko-redis/RedisRetryConfig.kt — Config data class with maxAttempts=3, backoffMs=100, exponentialBackoff=true.

####  Modified files:
  - keiko-redis/AbstractRedisQueue.kt — Added retryConfig constructor param and a retry() method that wraps a block with up to maxAttempts retries, exponential backoff, and catches JedisException.
  - keiko-redis/RedisQueue.kt — Passes retryConfig to super, wraps push() body in retry { }.
  - keiko-redis/RedisClusterQueue.kt — Same changes as RedisQueue.
  - keiko-redis-spring/RedisQueueProperties.kt — Added var retry: RedisRetryConfig property, configurable via keiko.queue.redis.retry.*.
  - keiko-redis-spring/RedisQueueConfiguration.kt — Passes redisQueueProperties.retry to both RedisQueue and RedisClusterQueue constructors.

 --- 
 ### Layer 2: JedisExceptionHandler Safety Net

####  Problem: When all queue-level retries are exhausted, the JedisConnectionException reaches the handler's catch blocks. Without an ExceptionHandler that recognizes Jedis exceptions as retryable, StartStageHandler would permanently fail the stage.

####  New files:
  - orca-redis/JedisExceptionHandler.java — Implements ExceptionHandler. Walks the cause chain using instanceof JedisException (proper type check since it's in orca-redis which has Jedis on classpath). Returns
  shouldRetry=true.

####  Modified files:
  - orca-redis/RedisConfiguration.java — Registers JedisExceptionHandler as a Spring bean.

  ---
###  Layer 3: Handler Status Reset + Rethrow

####  Problem: When a handler persists a status change (e.g., RUNNING → SUCCEEDED) then fails on a subsequent queue.push(), keiko's ack-timeout retries the message. But the handler's status guard (e.g., stage.status in setOf(RUNNING, NOT_STARTED)) blocks the retried message because the status was already changed. Pipeline is permanently stuck.

  Fix pattern: Save originalStatus before mutating, wrap queue operations in try/catch, restore exact original status on failure, persist via SQL, rethrow so keiko's ack-timeout retries the message.

 #### StartStageHandler.kt

  - Inner catch (retryable path): Added stage.status = NOT_STARTED + repository.storeStage(stage) before queue.push(message, retryDelay) so the retried message passes the status != NOT_STARTED guard.
  - Outer catch: Changed from unconditionally marking failure to checking exceptionDetails?.shouldRetry. If retryable: resets status to NOT_STARTED, persists, rethrows (so QueueProcessor doesn't ack). If not
  retryable: existing path (mark beforeStagePlanningFailed, push CompleteStage).
  - Added comments explaining the status guard and the ordering of stage.status = RUNNING before stage.start().

  #### SkipStageHandler.kt

  - Saves originalStatus before setting SKIPPED.
  - Wraps stage.startNext() in try/catch. On failure: restores originalStatus, persists, rethrows.

  #### CompleteStageHandler.kt

  - Saves originalStatus at top of the if (stage.status in setOf(RUNNING, NOT_STARTED)) block.
  - Wraps the entire queue operations block (startNext(), CancelStage, CompleteExecution, parent propagation) in try/catch. On failure: restores originalStatus, persists, rethrows.

  #### AbortStageHandler.kt

  - Saves originalStatus before setting TERMINAL.
  - Wraps queue operations (CancelStage, CompleteExecution/CompleteStage) in try/catch. On failure: restores originalStatus, persists, rethrows.

  #### StartExecutionHandler.kt

  - Wraps initialStages.forEach { queue.push(StartStage(it)) } in try/catch. On failure: restores execution to NOT_STARTED, persists, rethrows. (Duplicate StartStage messages from partial pushes are safe —
  StartStageHandler's guard drops them once the stage moves to RUNNING.)

  ---
##  Tests

  Each handler's existing Spek test file got a new describe("handling transient Redis exceptions") block:

  - StartStageHandlerTest.kt (+110 lines) — Two scenarios: (1) inner catch resets to NOT_STARTED and retries via queue push with delay; (2) outer catch resets to NOT_STARTED and rethrows JedisConnectionException.
  - SkipStageHandlerTest.kt (+43 lines) — startNext() throws → status restored to RUNNING, exception rethrown.
  - CompleteStageHandlerTest.kt (+43 lines) — startNext() throws via CompleteExecution push → status restored to RUNNING, exception rethrown.
  - AbortStageHandlerTest.kt (+42 lines) — CancelStage push throws → status restored to RUNNING, exception rethrown.
  - StartExecutionHandlerTest.kt (+38 lines) — StartStage push throws → execution status restored to NOT_STARTED, exception rethrown.