### PR TITLE
fix(deck): ensure kubernetes manifest deployment details link shows up in the UI

### DIFF
--- a/deck/packages/kubernetes/src/pipelines/stages/deployManifest/manifestStatus/ManifestDetailsLink.spec.tsx
+++ b/deck/packages/kubernetes/src/pipelines/stages/deployManifest/manifestStatus/ManifestDetailsLink.spec.tsx
@@ -6,18 +6,51 @@ import { AccountService } from '@spinnaker/core';
 import { ManifestDetailsLinkComponent } from './ManifestDetailsLink';
 
 describe('Kubernetes ManifestDetailsLink', () => {
-  it('builds its link through the injected state service', async () => {
+  const render = (manifest: any, accountId = 'test-account', href = jasmine.createSpy('href')) => {
+    const component = shallow(
+      <ManifestDetailsLinkComponent
+        {...({ router: {}, stateParams: {}, stateService: { href } } as any)}
+        accountId={accountId}
+        linkName="Manifest"
+        manifest={manifest}
+      />,
+    );
+    return component;
+  };
+
+  it('uses the "name" parameter (not "serverGroupManager") for Deployment manifests', async () => {
+    spyOn(AccountService, 'getAccountDetails').and.returnValue(
+      Promise.resolve({ spinnakerKindMap: { Deployment: 'serverGroupManagers' } } as any) as any,
+    );
+    const href = jasmine.createSpy('href').and.returnValue('#/manifest');
+    const component = render(
+      { manifest: { kind: 'Deployment', metadata: { annotations: {}, name: 'test-v001' } } },
+      'test-account',
+      href,
+    );
+
+    await Promise.resolve();
+    component.update();
+
+    expect(href).toHaveBeenCalledWith('home.applications.application.insight.clusters.serverGroupManager', {
+      accountId: 'test-account',
+      provider: 'kubernetes',
+      reg: '',
+      region: '_',
+      name: 'deployment test-v001',
+    });
+    expect(component.find('a').prop('href')).toBe('#/manifest');
+  });
+
+  it('builds its link through the injected state service for a ReplicaSet manifest', async () => {
     spyOn(AccountService, 'getAccountDetails').and.returnValue(
       Promise.resolve({ spinnakerKindMap: { Deployment: 'serverGroups' } } as any) as any,
     );
     const href = jasmine.createSpy('href').and.returnValue('#/manifest');
-    const component = shallow(
-      <ManifestDetailsLinkComponent
-        {...({ router: {}, stateParams: {}, stateService: { href } } as any)}
-        accountId="test-account"
-        linkName="Manifest"
-        manifest={{ manifest: { kind: 'Deployment', metadata: { annotations: {}, name: 'test-v001' } } } as any}
-      />,
+    const component = render(
+      { manifest: { kind: 'Deployment', metadata: { annotations: {}, name: 'test-v001' } } },
+      'test-account',
+      href,
     );
 
     await Promise.resolve();
@@ -31,5 +64,74 @@ describe('Kubernetes ManifestDetailsLink', () => {
       serverGroup: 'deployment test-v001',
     });
     expect(component.find('a').prop('href')).toBe('#/manifest');
+  });
+
+  it('uses the "kubernetesResource" parameter for unmapped kinds', async () => {
+    spyOn(AccountService, 'getAccountDetails').and.returnValue(Promise.resolve({ spinnakerKindMap: {} } as any) as any);
+    const href = jasmine.createSpy('href').and.returnValue('#/manifest');
+    const component = render(
+      {
+        manifest: {
+          kind: 'ConfigMap',
+          metadata: { annotations: { 'artifact.spinnaker.io/location': 'my-namespace' }, name: 'my-configmap' },
+        },
+      },
+      'test-account',
+      href,
+    );
+
+    await Promise.resolve();
+    component.update();
+
+    expect(href).toHaveBeenCalledWith('home.applications.application.insight.clusters.kubernetesResource', {
+      accountId: 'test-account',
+      provider: 'kubernetes',
+      reg: 'my-namespace',
+      region: 'my-namespace',
+      kubernetesResource: 'configmap my-configmap',
+    });
+  });
+
+  it('uses the resource name as region for an unmapped Namespace manifest', async () => {
+    spyOn(AccountService, 'getAccountDetails').and.returnValue(Promise.resolve({ spinnakerKindMap: {} } as any) as any);
+    const href = jasmine.createSpy('href').and.returnValue('#/manifest');
+    const component = render(
+      { manifest: { kind: 'Namespace', metadata: { annotations: {}, name: 'my-namespace' } } },
+      'test-account',
+      href,
+    );
+
+    await Promise.resolve();
+    component.update();
+
+    expect(href).toHaveBeenCalledWith(
+      'home.applications.application.insight.clusters.kubernetesResource',
+      jasmine.objectContaining({ region: 'my-namespace' }),
+    );
+  });
+
+  it('does not render a link when the manifest is missing', () => {
+    spyOn(AccountService, 'getAccountDetails').and.returnValue(Promise.resolve({ spinnakerKindMap: {} } as any) as any);
+    const href = jasmine.createSpy('href');
+    const component = render({ manifest: null }, 'test-account', href);
+
+    expect(component.find('a').exists()).toBeFalsy();
+  });
+
+  it('does not render a link when the generated URL is empty', async () => {
+    spyOn(AccountService, 'getAccountDetails').and.returnValue(
+      Promise.resolve({ spinnakerKindMap: { Deployment: 'serverGroupManagers' } } as any) as any,
+    );
+    const href = jasmine.createSpy('href').and.returnValue('');
+    const component = render(
+      { manifest: { kind: 'Deployment', metadata: { annotations: {}, name: 'test-v001' } } },
+      'test-account',
+      href,
+    );
+
+    await Promise.resolve();
+    component.update();
+
+    expect(component.find('a').exists()).toBeFalsy();
   });
 });

--- a/deck/packages/kubernetes/src/pipelines/stages/deployManifest/manifestStatus/ManifestDetailsLink.tsx
+++ b/deck/packages/kubernetes/src/pipelines/stages/deployManifest/manifestStatus/ManifestDetailsLink.tsx
@@ -79,6 +79,9 @@ export class ManifestDetailsLinkComponent extends React.Component<
   }
 
   private loadUrl() {
+    if (!this.props.manifest.manifest) {
+      return;
+    }
     const kind: string = get(this.props, ['manifest', 'manifest', 'kind'], '');
     const { accountId } = this.props;
     AccountService.getAccountDetails(accountId).then((account) => {

--- a/deck/packages/kubernetes/src/pipelines/stages/deployManifest/manifestStatus/ManifestDetailsLink.tsx
+++ b/deck/packages/kubernetes/src/pipelines/stages/deployManifest/manifestStatus/ManifestDetailsLink.tsx
@@ -22,8 +22,15 @@ export class ManifestDetailsLinkComponent extends React.Component<
 > {
   private spinnakerKindStateMap: { [k: string]: string } = {
     // keys from clouddriver's KubernetesSpinnakerKindMap
+    // values are the state names to navigate to
     serverGroupManagers: 'serverGroupManager',
     serverGroups: 'serverGroup',
+  };
+
+  // Map of state names to their URL parameter names
+  // Most states use the state name as the parameter, but serverGroupManager uses 'name'
+  private stateParamMap: { [k: string]: string } = {
+    serverGroupManager: 'name',
   };
 
   constructor(props: IManifestDetailsProps & IRouterInjectedProps) {
@@ -53,12 +60,14 @@ export class ManifestDetailsLinkComponent extends React.Component<
     const kind = this.props.manifest.manifest.kind.toLowerCase();
     const name = this.props.manifest.manifest.metadata.name;
     const region = this.resourceRegion();
+    // Use the mapped parameter name if it exists, otherwise use the state key
+    const paramKey = this.stateParamMap[stateKey] || stateKey;
     const params: { [k: string]: string } = {
       accountId: this.props.accountId,
       provider: 'kubernetes',
       region,
       reg: region, // Filters the list of clusters on the Clusters screen to those in the same namespace
-      [stateKey]: `${kind} ${name}`,
+      [paramKey]: `${kind} ${name}`,
     };
     if (!params.region && kind === 'namespace' && stateKey === UNMAPPED_K8S_RESOURCE_STATE_KEY) {
       params.region = name;


### PR DESCRIPTION
## Motivation

The 'Details' link doesn't show up for Deployment K8s Resource for some reason as shown below. This PR fixes that.
<img width="796" height="310" alt="Screenshot 2026-09-11 at 5 53 10 PM" src="https://github.com/user-attachments/assets/04710195-bd5d-4cf3-a2e8-13ea28d764cb" />
