### PR TITLE
feat(orca): support additional metric tags on stage execution context

### DIFF
--- a/orca/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/StageExecutionImpl.java
+++ b/orca/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/model/StageExecutionImpl.java
@@ -139,6 +139,7 @@ public class StageExecutionImpl implements StageExecution, Serializable {
     this.requisiteStageRefIds =
         Optional.ofNullable((Collection<String>) context.remove("requisiteStageRefIds"))
             .orElse(emptySet());
+    this.additionalMetricTags = (Map<String, String>) context.remove("additionalMetricTags");
 
     this.context.putAll(context);
   }

--- a/orca/orca-core/src/test/java/com/netflix/spinnaker/orca/pipeline/model/StageExecutionImplTest.java
+++ b/orca/orca-core/src/test/java/com/netflix/spinnaker/orca/pipeline/model/StageExecutionImplTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2026 DoorDash, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.pipeline.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionType;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class StageExecutionImplTest {
+
+  @Test
+  void constructorExtractsAdditionalMetricTagsFromContext() {
+    // given
+    PipelineExecutionImpl execution =
+        new PipelineExecutionImpl(ExecutionType.PIPELINE, "test-application");
+    Map<String, Object> context = new HashMap<>();
+    context.put("refId", "1");
+    context.put("additionalMetricTags", Map.of("tag1", "value1", "tag2", "value2"));
+    context.put("someOtherField", "someValue");
+
+    // when
+    StageExecutionImpl stage = new StageExecutionImpl(execution, "testStage", context);
+
+    // then
+    assertThat(stage.getAdditionalMetricTags())
+        .isNotNull()
+        .containsEntry("tag1", "value1")
+        .containsEntry("tag2", "value2");
+
+    // additionalMetricTags should be removed from context
+    assertThat(stage.getContext()).doesNotContainKey("additionalMetricTags");
+
+    // other fields should remain in context
+    assertThat(stage.getContext()).containsEntry("someOtherField", "someValue");
+
+    // refId should also be extracted
+    assertThat(stage.getRefId()).isEqualTo("1");
+    assertThat(stage.getContext()).doesNotContainKey("refId");
+  }
+
+  @Test
+  void constructorHandlesNullAdditionalMetricTags() {
+    // given
+    PipelineExecutionImpl execution =
+        new PipelineExecutionImpl(ExecutionType.PIPELINE, "test-application");
+    Map<String, Object> context = new HashMap<>();
+    context.put("refId", "1");
+    context.put("someOtherField", "someValue");
+
+    // when
+    StageExecutionImpl stage = new StageExecutionImpl(execution, "testStage", context);
+
+    // then
+    assertThat(stage.getAdditionalMetricTags()).isNull();
+    assertThat(stage.getContext()).containsEntry("someOtherField", "someValue");
+  }
+
+  @Test
+  void constructorHandlesEmptyAdditionalMetricTags() {
+    // given
+    PipelineExecutionImpl execution =
+        new PipelineExecutionImpl(ExecutionType.PIPELINE, "test-application");
+    Map<String, Object> context = new HashMap<>();
+    context.put("refId", "1");
+    context.put("additionalMetricTags", Map.of());
+    context.put("someOtherField", "someValue");
+
+    // when
+    StageExecutionImpl stage = new StageExecutionImpl(execution, "testStage", context);
+
+    // then
+    assertThat(stage.getAdditionalMetricTags()).isNotNull().isEmpty();
+    assertThat(stage.getContext()).doesNotContainKey("additionalMetricTags");
+    assertThat(stage.getContext()).containsEntry("someOtherField", "someValue");
+  }
+}


### PR DESCRIPTION
Extract an optional additionalMetricTags map from the stage context during StageExecutionImpl construction, mirroring how other reserved context keys (e.g. requisiteStageRefIds) are already extracted.

We can now inject custom metric tags from stages into existing stage metrics

## Testing
- unit tests
- verified that the metric had the service tag showing up.
```
stage_invocations_duration_seconds_count{...,service="foo", stageType="deployManifest", status="SUCCEEDED"}
```


after adding this:
```
  "additionalMetricTags": {
    "service": "foo"
  },
  ```
  to the stage context




🤖 Generated with [Claude Code](https://claude.com/claude-code)

